### PR TITLE
M1: Hello World migration from steam-loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.cache/
+loadout
+
+# Logs
+*.log
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Coverage
+coverage/
+*.lcov
+
+# Editor
+.vscode-test
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# ESLint / Prettier cache
+.eslintcache

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.cache
+coverage
+**/build/**
+**/webview-dist/**

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/apps/overlay/electrobun.config.ts
+++ b/apps/overlay/electrobun.config.ts
@@ -1,0 +1,33 @@
+import pkg from "./package.json" with { type: "json" };
+
+export default {
+  app: {
+    name: "loadout",
+    identifier: "com.loadout.overlay",
+    version: pkg.version,
+    description: "Loadout overlay",
+  },
+  build: {
+    bun: {
+      entrypoint: "src/bun/index.ts",
+    },
+    copy: {
+      "webview-dist": "views/overlay",
+    },
+    targets: "linux-x64,linux-arm64",
+    linux: {
+      bundleCEF: true,
+      defaultRenderer: "cef",
+      chromiumFlags: {
+        "remote-debugging-port": "9222",
+        "remote-allow-origins": "*",
+        "enable-logging": "stderr",
+        "log-severity": "info",
+        "touch-events": "enabled",
+        "disable-features": "FieldTrialConfig,Variations,GlicActorUi,LensOverlay",
+        "disable-field-trial-config": "",
+        "disable-component-update": "",
+      },
+    },
+  },
+};

--- a/apps/overlay/package.json
+++ b/apps/overlay/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@loadout/app-overlay",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "electrobun dev",
+    "build": "vite build && electrobun build --release",
+    "build:dev": "vite build && electrobun build",
+    "webview:dev": "vite",
+    "webview:build": "vite build"
+  },
+  "dependencies": {
+    "@loadout/exec": "*",
+    "@loadout/server": "*",
+    "@loadout/types": "*",
+    "@loadout/ui": "*",
+    "@loadout/overlay-shell": "*",
+    "@loadout/device": "*",
+    "@noriginmedia/norigin-spatial-navigation": "^3.0.0",
+    "daisyui": "^5.5.19",
+    "electrobun": "^1.0.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "tailwindcss": "^4.0.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/overlay/src/bun/index.ts
+++ b/apps/overlay/src/bun/index.ts
@@ -1,0 +1,253 @@
+// Bun main process for the Loadout overlay. Owns:
+//   - the single overlay BrowserWindow (hidden on boot)
+//   - the @loadout/server Bun.serve instance (spawned in-process)
+//   - RPC handlers registered via Electrobun's defineRPC
+//   - the evdev input interceptor (F16 toggle, EVIOCGRAB, NavController)
+//   - the X11 / Gamescope atom loop
+//   - SIGINT/SIGTERM shutdown
+//
+// DISPLAY detection must run BEFORE `electrobun/bun` is imported — the
+// native wrapper dlopens libNativeWrapper.so on module load and that
+// triggers GTK's X11 connection via its ctor. ES module imports run in
+// source order, so this side-effect import is first.
+
+import "./native/display-detect";
+import { detectOverlayDisplay } from "./native/display-detect";
+const DISPLAY = detectOverlayDisplay();
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — resolved at runtime once electrobun is installed.
+import { BrowserWindow, BrowserView, GlobalShortcut } from "electrobun/bun";
+import type { ControllerShortcuts } from "../webview/lib/electrobun";
+import { GamescopeAtoms } from "./native/gamescope-atoms";
+import {
+  startInputIntercept,
+  type InputInterceptHandle,
+  type WakeEvent,
+} from "./native/input-intercept";
+import type { WebviewMessages } from "@loadout/types";
+import { findSteamPid, suspendSteam, resumeSteam } from "./native/process-control";
+import { trace } from "./native/trace";
+import { createOverlayState } from "./lib/overlay-state";
+import { routeWake } from "./lib/wake-routing";
+import { buildRpcHandlers } from "./rpc-handlers";
+import { overlayManagementLoop, shutdown } from "./lifecycle";
+import { startServer } from "@loadout/server";
+import { join } from "node:path";
+
+// ---- Server (in-process) ---------------------------------------------------
+// Boot the HTTP+WS server before opening the window so the webview's first
+// fetch of /api/token succeeds.
+
+const projectRoot = process.env.LOADOUT_PROJECT_ROOT ?? process.cwd();
+const pluginsDir = process.env.LOADOUT_PLUGINS_DIR ?? join(projectRoot, "plugins");
+
+const serverPromise = startServer({ projectRoot, pluginsDir }).catch((err) => {
+  console.error("[overlay] server failed to start:", err);
+  process.exit(1);
+});
+
+// ---- Desktop dev shortcut ---------------------------------------------------
+// Set LOADOUT_OVERLAY_DESKTOP_DEV=1 to start the window visible immediately
+// without a QAM press. Gaming-mode / Gamescope uses the hidden+toggle flow.
+const DESKTOP_DEV = process.env.LOADOUT_OVERLAY_DESKTOP_DEV === "1";
+
+const state = createOverlayState(DESKTOP_DEV);
+
+const shortcuts: { current: ControllerShortcuts } = {
+  current: {
+    guide_a: { type: "None" },
+    guide_b: { type: "None" },
+    guide_x: { type: "ToggleOverlay" },
+    guide_y: { type: "None" },
+  },
+};
+
+function detectGamescopeMode(): boolean {
+  return !!process.env.GAMESCOPE_DISPLAY || !!process.env.GAMESCOPE_WAYLAND_DISPLAY;
+}
+const gamescopeMode = detectGamescopeMode();
+
+// ---- Singleton refs --------------------------------------------------------
+const steamPid: { current: number | null } = { current: null };
+const pendingResumeTimer: { current: ReturnType<typeof setTimeout> | null } = { current: null };
+const intercept: { current: InputInterceptHandle | null } = { current: null };
+
+// ---- RPC + Window ----------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — defineRPC schema is typed generically at runtime.
+const rpc = BrowserView.defineRPC({
+  handlers: buildRpcHandlers({ state, shortcuts, gamescopeMode }),
+});
+
+type RpcSendable = { send?: (name: string, payload: unknown) => void };
+function sendToWebview<K extends keyof WebviewMessages>(
+  name: K,
+  payload: WebviewMessages[K],
+): void {
+  try {
+    (rpc as unknown as RpcSendable).send?.(name, payload);
+  } catch (err) {
+    console.warn(`[overlay] rpc.send(${name}) failed:`, err);
+  }
+}
+
+const overlay = new BrowserWindow({
+  title: "Loadout Overlay",
+  frame: { x: 0, y: 0, width: 1280, height: 800 },
+  titleBarStyle: "default",
+  transparent: false,
+  hidden: !DESKTOP_DEV,
+  url: process.env.ELECTROBUN_DEV_URL ?? "views://overlay/index.html",
+  rpc,
+});
+
+// ---- Gamescope atoms -------------------------------------------------------
+const atoms = new GamescopeAtoms({
+  display: DISPLAY,
+  windowName: "Loadout Overlay",
+  forceXprop: process.env.LOADOUT_OVERLAY_FORCE_XPROP === "1",
+});
+
+setTimeout(() => {
+  atoms.prepare().catch((e) => console.warn("[overlay] atoms.prepare:", e));
+}, 500);
+
+// ---- Toggle ----------------------------------------------------------------
+
+function broadcastOverlayVisibility(): void {
+  sendToWebview("overlay-visibility", { isOpen: state.isOpen });
+}
+
+const SUSPEND_STEAM_ENABLED = process.env.LOADOUT_OVERLAY_SUSPEND_STEAM === "1";
+const TOGGLE_DEBOUNCE_MS = 600;
+let lastToggleAt = 0;
+
+function toggleOverlay(source: string) {
+  const now = performance.now();
+  if (now - lastToggleAt < TOGGLE_DEBOUNCE_MS) {
+    trace(`[toggle] ${source} → IGNORED (debounced, ${Math.round(now - lastToggleAt)}ms)`);
+    return;
+  }
+  lastToggleAt = now;
+
+  if (state.isOpen) {
+    overlay.minimize();
+    atoms.hide().catch((e) => console.warn("[overlay] atoms.hide:", e));
+    intercept.current?.release();
+    if (steamPid.current === null) steamPid.current = findSteamPid();
+    if (steamPid.current !== null) {
+      const pid = steamPid.current;
+      if (pendingResumeTimer.current !== null) clearTimeout(pendingResumeTimer.current);
+      pendingResumeTimer.current = setTimeout(() => {
+        pendingResumeTimer.current = null;
+        resumeSteam(pid);
+      }, 250);
+    }
+    state.isOpen = false;
+    broadcastOverlayVisibility();
+    trace(`[toggle] ${source} → MINIMIZE`);
+  } else {
+    if (SUSPEND_STEAM_ENABLED) {
+      if (steamPid.current === null) steamPid.current = findSteamPid();
+      if (steamPid.current !== null) suspendSteam(steamPid.current);
+    }
+    intercept.current?.grab();
+    overlay.show();
+    atoms.show().catch((e) => console.warn("[overlay] atoms.show:", e));
+    state.isOpen = true;
+    broadcastOverlayVisibility();
+    trace(`[toggle] ${source} → SHOW`);
+  }
+}
+
+// ---- Wake event routing ----------------------------------------------------
+function onWake(event: WakeEvent): void {
+  const action = routeWake(event, shortcuts.current);
+  if (action.kind === "ignore") return;
+  if (action.kind === "toggle") {
+    toggleOverlay(action.reason);
+    return;
+  }
+  if (!state.isOpen) toggleOverlay(action.reason);
+  if (action.kind === "open-plugin") {
+    sendToWebview("overlay-open-plugin", { pluginId: action.pluginId });
+    return;
+  }
+  if (action.kind === "open-settings") {
+    sendToWebview("overlay-open-settings", {});
+    return;
+  }
+  if (action.kind === "open-home") {
+    sendToWebview("overlay-open-home", {});
+    return;
+  }
+  if (action.kind === "toggle-keyboard") {
+    sendToWebview("overlay-toggle-keyboard", {});
+    return;
+  }
+}
+
+// ---- Input intercept -------------------------------------------------------
+startInputIntercept({
+  onWake,
+  onAction: (action) => sendToWebview("overlay-action", { action }),
+  onAxis: (axis, value) => sendToWebview("overlay-scroll", { axis, value }),
+  onReady: (c) =>
+    console.log(
+      `[overlay] input intercept ready — ${c.controllers} controller(s), ${c.keyboards} keyboard(s), ${c.qam} qam device(s)`,
+    ),
+})
+  .then((handle) => {
+    intercept.current = handle;
+  })
+  .catch((err) => {
+    console.error("[overlay] input intercept failed to start:", err);
+  });
+
+// ---- Desktop global shortcut backup ----------------------------------------
+const TOGGLE_ACCELERATOR =
+  process.env.LOADOUT_OVERLAY_TOGGLE ?? "CommandOrControl+Shift+O";
+const shortcutRegistered = GlobalShortcut.register(TOGGLE_ACCELERATOR, () =>
+  toggleOverlay(TOGGLE_ACCELERATOR),
+);
+if (!shortcutRegistered) {
+  console.warn(
+    `[overlay] failed to register ${TOGGLE_ACCELERATOR} global shortcut — ` +
+      "another process may already have it grabbed.",
+  );
+}
+
+// ---- Management loop + shutdown --------------------------------------------
+const managementLoopRunning: { current: boolean } = { current: true };
+
+overlayManagementLoop({
+  state,
+  running: managementLoopRunning,
+  toggleOverlay,
+}).catch((e) => {
+  console.error("[overlay] management loop crashed:", e);
+  process.exit(1);
+});
+
+function runShutdown(): Promise<void> {
+  return shutdown({
+    running: managementLoopRunning,
+    pendingResumeTimer,
+    steamPid,
+    atoms,
+    intercept,
+    globalShortcut: GlobalShortcut,
+  });
+}
+process.on("SIGINT", runShutdown);
+process.on("SIGTERM", runShutdown);
+
+// Hold the server reference so it's not GC'd. Server lifecycle is bound
+// to the process — shutdown above lets it die with the parent.
+serverPromise.then((srv) => {
+  if (srv) {
+    process.on("exit", () => srv.close());
+  }
+});

--- a/apps/overlay/src/bun/index.ts
+++ b/apps/overlay/src/bun/index.ts
@@ -1,6 +1,6 @@
 // Bun main process for the Loadout overlay. Owns:
-//   - the single overlay BrowserWindow (hidden on boot)
 //   - the @loadout/server Bun.serve instance (spawned in-process)
+//   - the single overlay BrowserWindow (hidden on boot)
 //   - RPC handlers registered via Electrobun's defineRPC
 //   - the evdev input interceptor (F16 toggle, EVIOCGRAB, NavController)
 //   - the X11 / Gamescope atom loop
@@ -36,13 +36,14 @@ import { startServer } from "@loadout/server";
 import { join } from "node:path";
 
 // ---- Server (in-process) ---------------------------------------------------
-// Boot the HTTP+WS server before opening the window so the webview's first
-// fetch of /api/token succeeds.
+// Block at boot until the server is up. The webview will read its session
+// token from window.location.search (passed in the BrowserWindow URL), so
+// we must have the token in hand before constructing the window.
 
 const projectRoot = process.env.LOADOUT_PROJECT_ROOT ?? process.cwd();
 const pluginsDir = process.env.LOADOUT_PLUGINS_DIR ?? join(projectRoot, "plugins");
 
-const serverPromise = startServer({ projectRoot, pluginsDir }).catch((err) => {
+const serverHandle = await startServer({ projectRoot, pluginsDir }).catch((err) => {
   console.error("[overlay] server failed to start:", err);
   process.exit(1);
 });
@@ -93,13 +94,20 @@ function sendToWebview<K extends keyof WebviewMessages>(
   }
 }
 
+// Token is injected into the webview via the URL search params instead of
+// an unauthenticated /api/token endpoint. CEF's custom-scheme URLs aren't
+// shared with any other local process, so this stays local-only.
+const baseUrl =
+  process.env.ELECTROBUN_DEV_URL ?? "views://overlay/index.html";
+const overlayUrl = `${baseUrl}${baseUrl.includes("?") ? "&" : "?"}token=${encodeURIComponent(serverHandle.token)}`;
+
 const overlay = new BrowserWindow({
   title: "Loadout Overlay",
   frame: { x: 0, y: 0, width: 1280, height: 800 },
   titleBarStyle: "default",
   transparent: false,
   hidden: !DESKTOP_DEV,
-  url: process.env.ELECTROBUN_DEV_URL ?? "views://overlay/index.html",
+  url: overlayUrl,
   rpc,
 });
 
@@ -231,7 +239,12 @@ overlayManagementLoop({
   process.exit(1);
 });
 
-function runShutdown(): Promise<void> {
+async function runShutdown(): Promise<void> {
+  try {
+    serverHandle.close();
+  } catch (err) {
+    console.warn("[overlay] server close error:", err);
+  }
   return shutdown({
     running: managementLoopRunning,
     pendingResumeTimer,
@@ -243,11 +256,3 @@ function runShutdown(): Promise<void> {
 }
 process.on("SIGINT", runShutdown);
 process.on("SIGTERM", runShutdown);
-
-// Hold the server reference so it's not GC'd. Server lifecycle is bound
-// to the process — shutdown above lets it die with the parent.
-serverPromise.then((srv) => {
-  if (srv) {
-    process.on("exit", () => srv.close());
-  }
-});

--- a/apps/overlay/src/bun/lib/overlay-state.ts
+++ b/apps/overlay/src/bun/lib/overlay-state.ts
@@ -1,0 +1,123 @@
+// Overlay open/close state machine. Extracted from index.ts so the pure
+// flag-flipping logic is testable without booting the full Electrobun
+// main process (which dlopens libNativeWrapper.so + opens X11 on
+// `import "electrobun/bun"`). The RPC handlers in index.ts call
+// `requestShow` / `requestHide` / `requestToggle` to flip flags; the
+// overlay-management loop polls those flags and triggers the actual
+// window + atom + intercept side effects.
+//
+// Audit B-006: the orchestrator in index.ts is 25+ commits old and has
+// zero unit tests for the toggle debounce + flag lifecycle. The shape
+// here is deliberately the same PendingFlags object index.ts already
+// owns — extraction is structural, not behavioural.
+
+/**
+ * Triple-flag state used by the QAM / show / hide / toggle paths in
+ * index.ts. `isOpen` is the source of truth for "is the overlay window
+ * up right now"; the two `pending*` flags are one-shot requests
+ * produced by the RPC handlers and consumed by `overlayManagementLoop`.
+ */
+export interface OverlayState {
+  pendingToggle: boolean;
+  pendingClose: boolean;
+  isOpen: boolean;
+}
+
+/**
+ * Construct a fresh state object. `initialIsOpen` is wired so
+ * desktop-smoke-test mode can boot already-visible without having to
+ * mutate the returned object before passing it around.
+ */
+export function createOverlayState(initialIsOpen = false): OverlayState {
+  return {
+    pendingToggle: false,
+    pendingClose: false,
+    isOpen: initialIsOpen,
+  };
+}
+
+/**
+ * RPC `show` handler. If the overlay is already up, this is a no-op —
+ * a redundant `pendingToggle` would still get cleared by the loop's
+ * leftover-flag sweep, but skipping the write keeps the state object
+ * stable for callers observing it directly (tests, future devtools).
+ */
+export function requestShow(state: OverlayState): void {
+  if (!state.isOpen) state.pendingToggle = true;
+}
+
+/**
+ * RPC `hide` handler. Always sets `pendingClose` — even when the
+ * overlay is already hidden, matching the original index.ts behaviour
+ * (the leftover-flag sweep in the management loop will clear it on
+ * the next tick).
+ */
+export function requestHide(state: OverlayState): void {
+  state.pendingClose = true;
+}
+
+/**
+ * RPC `toggle` handler. Returns the desired open state after the toggle
+ * so the webview's RPC client can update its local UI optimistically
+ * without waiting for the `overlay-visibility` broadcast.
+ */
+export function requestToggle(state: OverlayState): boolean {
+  if (state.isOpen) {
+    state.pendingClose = true;
+    return false;
+  }
+  state.pendingToggle = true;
+  return true;
+}
+
+/**
+ * Result of one iteration of the management loop's flag sweep. The
+ * loop in index.ts will translate the action into the real
+ * side-effects (window.show/minimize, atoms, intercept, Steam SIGCONT),
+ * but the decision of *what* to do given the current flags is pure —
+ * and tested here.
+ */
+export type SweepAction = "show" | "hide" | "none";
+
+/**
+ * One iteration of the management loop's flag sweep. Returns the
+ * action the caller should run, *and* clears the consumed flag plus
+ * any stale flags that no longer match the current `isOpen` state.
+ *
+ * Mirrors the four-branch sequence in `overlayManagementLoop`:
+ *   1. pendingToggle && !isOpen → show
+ *   2. pendingClose && isOpen   → hide
+ *   3. pendingToggle && isOpen  → stale, clear
+ *   4. pendingClose && !isOpen  → stale, clear
+ *
+ * Crucially this does *not* flip `isOpen` itself — the caller does
+ * that after the side-effect succeeds (window.show()/minimize() can
+ * throw under Gamescope teardown; we don't want to wedge the flag
+ * machine if it does).
+ */
+export function sweepPendingFlags(state: OverlayState): SweepAction {
+  let action: SweepAction = "none";
+  if (state.pendingToggle && !state.isOpen) {
+    state.pendingToggle = false;
+    action = "show";
+  } else if (state.pendingClose && state.isOpen) {
+    state.pendingClose = false;
+    action = "hide";
+  }
+  // Drop leftover flags that no longer match the current state so the
+  // loop doesn't spin on them forever.
+  if (state.pendingToggle && state.isOpen) state.pendingToggle = false;
+  if (state.pendingClose && !state.isOpen) state.pendingClose = false;
+  return action;
+}
+
+/**
+ * True if the management loop should be polling at the faster 50ms
+ * cadence rather than the idle 500ms cadence. Active = overlay is
+ * visible OR a pending request is in flight. Extracted so a test can
+ * cover the edge: the loop must NOT idle while a `pendingClose` is
+ * waiting to fire, even though `isOpen` is already false.
+ */
+export function isActiveTick(state: OverlayState): boolean {
+  return state.isOpen || state.pendingToggle || state.pendingClose;
+}

--- a/apps/overlay/src/bun/lib/wake-routing.ts
+++ b/apps/overlay/src/bun/lib/wake-routing.ts
@@ -1,0 +1,117 @@
+// Wake-event → action routing. Extracted from index.ts::onWake so the
+// pure decision logic — which wake events toggle the overlay, which
+// are reserved by Steam, which look up a user-configurable shortcut —
+// is testable without booting the full main process.
+//
+// Audit B-006: index.ts orchestrator had no unit tests for the
+// onWake() branch table. The bug surface here is real: the original
+// pre-fix version had Guide+X hardcoded to ToggleOverlay even when
+// the user's shortcut config said something else.
+
+import type { WakeEvent } from "../native/input-intercept";
+import type {
+  ControllerShortcuts,
+  ShortcutAction,
+} from "../../webview/lib/electrobun";
+
+/**
+ * Decision returned by `routeWake`. The caller (index.ts) translates
+ * each variant into the appropriate side-effects:
+ *   - `toggle`           → toggleOverlay(reason)
+ *   - `open-plugin`      → toggleOverlay if closed, then sendToWebview(
+ *                          "overlay-open-plugin", { pluginId })
+ *   - `open-settings`    → toggleOverlay if closed, then sendToWebview(
+ *                          "overlay-open-settings", {})
+ *   - `open-home`        → toggleOverlay if closed, then sendToWebview(
+ *                          "overlay-open-home", {})
+ *   - `toggle-keyboard`  → toggleOverlay if closed, then sendToWebview(
+ *                          "overlay-toggle-keyboard", {}) — webview flips
+ *                          OSK visibility on receipt
+ *   - `ignore`           → no-op (reserved key, unbound shortcut,
+ *                          unknown action type)
+ */
+export type WakeAction =
+  | { kind: "toggle"; reason: WakeEvent }
+  | { kind: "open-plugin"; reason: WakeEvent; pluginId: string }
+  | { kind: "open-settings"; reason: WakeEvent }
+  | { kind: "open-home"; reason: WakeEvent }
+  | { kind: "toggle-keyboard"; reason: WakeEvent }
+  | { kind: "ignore"; reason: "hardcoded-toggle-skip" | "reserved" | "unbound" | "unknown-action" };
+
+/**
+ * Wake events whose action is hardcoded (not configurable). These are
+ * keyboard-scoped triggers (F16 / Ctrl+3 / Ctrl+4) rather than
+ * controller buttons.
+ */
+const HARDCODED_TOGGLE_EVENTS = new Set<WakeEvent>([
+  "QamToggle",
+  "CtrlThree",
+  "CtrlFour",
+]);
+
+/**
+ * Wake events reserved by Steam / InputPlumber on Bazzite. Even if a
+ * saved user config has them bound, we ignore them to avoid the
+ * focus-flicker bug where our overlay and Steam's QAM/guide menu
+ * fight over focus.
+ */
+const RESERVED_EVENTS = new Set<WakeEvent>(["GuideA", "GuideY"]);
+
+/**
+ * Map a wake event to the configurable shortcut slot, if any. Returns
+ * null for events that don't go through the user-configurable map
+ * (hardcoded toggles + reserved keys are filtered out by their own
+ * predicates before this is consulted).
+ */
+function shortcutForEvent(
+  event: WakeEvent,
+  shortcuts: ControllerShortcuts,
+): ShortcutAction | null {
+  if (event === "GuideB") return shortcuts.guide_b;
+  if (event === "GuideX") return shortcuts.guide_x;
+  return null;
+}
+
+/**
+ * Decide what side-effect (if any) a wake event should produce.
+ * Pure — same inputs produce the same outputs, no state mutation. The
+ * caller is responsible for actually running the side-effect.
+ *
+ * Order matches the original onWake() in index.ts:
+ *   1. Hardcoded keyboard wakes → toggle
+ *   2. Steam-reserved Guide combos → ignore
+ *   3. User-configurable Guide combos → look up `shortcuts`:
+ *        - None / unknown   → ignore
+ *        - ToggleOverlay    → toggle
+ *        - OpenPlugin       → open-plugin (only if `value` is set)
+ */
+export function routeWake(
+  event: WakeEvent,
+  shortcuts: ControllerShortcuts,
+): WakeAction {
+  if (HARDCODED_TOGGLE_EVENTS.has(event)) {
+    return { kind: "toggle", reason: event };
+  }
+  if (RESERVED_EVENTS.has(event)) {
+    return { kind: "ignore", reason: "reserved" };
+  }
+  const action = shortcutForEvent(event, shortcuts);
+  if (!action) return { kind: "ignore", reason: "unbound" };
+  if (action.type === "ToggleOverlay") {
+    return { kind: "toggle", reason: event };
+  }
+  if (action.type === "OpenPlugin" && action.value) {
+    return { kind: "open-plugin", reason: event, pluginId: action.value };
+  }
+  if (action.type === "OpenSettings") {
+    return { kind: "open-settings", reason: event };
+  }
+  if (action.type === "OpenHome") {
+    return { kind: "open-home", reason: event };
+  }
+  if (action.type === "ToggleKeyboard") {
+    return { kind: "toggle-keyboard", reason: event };
+  }
+  // "None", "OpenPlugin" with no value, or any future unknown type.
+  return { kind: "ignore", reason: "unknown-action" };
+}

--- a/apps/overlay/src/bun/lifecycle.ts
+++ b/apps/overlay/src/bun/lifecycle.ts
@@ -1,0 +1,156 @@
+// Lifecycle plumbing for the overlay main process — the X11 / Gamescope
+// management loop and the SIGINT/SIGTERM-driven shutdown ladder.
+// Extracted from index.ts so the orchestrator stays a wire-up file,
+// not a 600-LOC monolith. Both functions need to read/write the same
+// pieces of module-global state index.ts owns (steamPid cache, the
+// pending close-path SIGCONT timer, the management-loop running flag),
+// so they take dependency-injected refs rather than touching the
+// orchestrator's bindings directly. `{ current: T }` wrappers match
+// the pattern used inside this codebase for the same problem.
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — resolved at runtime once electrobun is installed.
+import type { GlobalShortcut as GlobalShortcutType } from "electrobun/bun";
+import { resumeSteam } from "./native/process-control";
+import type { GamescopeAtoms } from "./native/gamescope-atoms";
+import type { InputInterceptHandle } from "./native/input-intercept";
+import {
+  isActiveTick,
+  sweepPendingFlags,
+  type OverlayState,
+} from "./lib/overlay-state";
+
+/**
+ * `{ current: T }` ref wrapper — same shape React uses for mutable
+ * singletons. Used here so the management loop + shutdown can read and
+ * write the same value index.ts owns without re-exporting a setter for
+ * every field.
+ */
+export interface Ref<T> {
+  current: T;
+}
+
+// ---- Management loop -------------------------------------------------------
+
+export interface ManagementLoopDeps {
+  /** Triple-flag state from lib/overlay-state.ts. */
+  state: OverlayState;
+  /**
+   * Audit B-023: running flag lets shutdown() break the otherwise-
+   * infinite loop. Wrapped in a ref so the loop and shutdown share the
+   * exact same boolean — no setter dance.
+   */
+  running: Ref<boolean>;
+  /**
+   * Forwarded to toggleOverlay() in index.ts. The decision of *what* to
+   * do given the current flags is pure (sweepPendingFlags); the loop
+   * just dispatches to the orchestrator's toggle which handles the
+   * window + atom + intercept side effects.
+   */
+  toggleOverlay: (source: string) => void;
+}
+
+/**
+ * Replaces overlay_management_loop() in main.rs. 50 ms when active
+ * (overlay open or transitioning), 500 ms when idle — matches the
+ * Rust cadence so responsiveness is identical.
+ *
+ * The sweep + flag cleanup logic lives in lib/overlay-state.ts. Both
+ * pending paths route through toggleOverlay() — same code path the
+ * QAM/F16 watcher + GlobalShortcut use.
+ */
+export async function overlayManagementLoop(
+  deps: ManagementLoopDeps,
+): Promise<void> {
+  while (deps.running.current) {
+    const active = isActiveTick(deps.state);
+
+    const action = sweepPendingFlags(deps.state);
+    if (action === "show") deps.toggleOverlay("rpc:show");
+    else if (action === "hide") deps.toggleOverlay("rpc:hide");
+
+    await new Promise((r) => setTimeout(r, active ? 50 : 500));
+  }
+}
+
+// ---- Shutdown --------------------------------------------------------------
+
+export interface ShutdownDeps {
+  /** Audit B-023: flipped to false so the management loop drops out. */
+  running: Ref<boolean>;
+  /**
+   * Audit B-027: the close-path 250 ms deferred SIGCONT timer. Held so
+   * shutdown can cancel it; otherwise the deferred resume fires post-
+   * exit and the helper logs spurious "process exited" noise.
+   */
+  pendingResumeTimer: Ref<ReturnType<typeof setTimeout> | null>;
+  /** Cached Steam PID — null if we never opened the overlay this session. */
+  steamPid: Ref<number | null>;
+  /** Gamescope X11 atoms object; .hide() zeroes STEAM_OVERLAY=1. */
+  atoms: GamescopeAtoms;
+  /** Input interceptor handle — may be null if it failed to start. */
+  intercept: Ref<InputInterceptHandle | null>;
+  /** Electrobun GlobalShortcut module — we unregister whatever we grabbed. */
+  globalShortcut: typeof GlobalShortcutType;
+}
+
+/**
+ * Clean shutdown driven by SIGINT/SIGTERM. Releases the gamepad grab,
+ * resumes Steam, and zeroes the Gamescope atoms — in that order, since
+ * leaving Steam TASK_STOPPED or STEAM_OVERLAY=1 set on exit strands
+ * the user with no recovery short of a reboot.
+ */
+export async function shutdown(deps: ShutdownDeps): Promise<void> {
+  console.log("[overlay] shutting down");
+  // Audit B-023: tell the management loop to stop so it doesn't fire
+  // one last toggleOverlay() against an atoms object we've already
+  // shut down below.
+  deps.running.current = false;
+  // Audit B-027: cancel the pending close-path SIGCONT timer. Steam is
+  // resumed unconditionally below; running the deferred resume after
+  // process.exit(0) is harmless but logs a benign "process exited"
+  // error from the resumeSteam helper, which is noise on shutdown.
+  if (deps.pendingResumeTimer.current !== null) {
+    clearTimeout(deps.pendingResumeTimer.current);
+    deps.pendingResumeTimer.current = null;
+  }
+  try {
+    // Critical #1: RESUME STEAM. If we exit with Steam still in
+    // TASK_STOPPED, the whole machine looks frozen to the user and
+    // the only recovery is a hard reboot. Do this FIRST, before any
+    // other teardown that might hang. SIGCONT on a running process
+    // is a no-op, so calling this unconditionally is safe.
+    if (deps.steamPid.current !== null) resumeSteam(deps.steamPid.current);
+    // Critical #2: zero the Gamescope atoms so we never exit with
+    // STEAM_OVERLAY=1 still on the window — that would leave the
+    // overlay visually on top with no way for the user to dismiss it.
+    // We retry once: the first attempt can race with the
+    // window-manager teardown when shutdown is SIGTERM-driven from
+    // session exit. Failure to clear the atom strands the user
+    // (no input until reboot), so it's worth surfacing in the log
+    // rather than swallowing — `journalctl --user -u
+    // loadout-overlay` will then show why.
+    try {
+      await deps.atoms.hide();
+    } catch (err) {
+      console.warn("[overlay] atoms.hide failed on shutdown, retrying:", err);
+      try {
+        await deps.atoms.hide();
+      } catch (err2) {
+        console.error(
+          "[overlay] atoms.hide failed twice on shutdown — gamescope may keep STEAM_OVERLAY=1 set:",
+          err2,
+        );
+      }
+    }
+    // Release + close all evdev grabs + FDs. Kernel would release
+    // them on process death anyway, but explicit shutdown avoids a
+    // window where another process can't grab them because we
+    // haven't fully exited yet.
+    deps.intercept.current?.shutdown();
+    deps.globalShortcut.unregisterAll();
+    deps.atoms.shutdown();
+  } finally {
+    process.exit(0);
+  }
+}

--- a/apps/overlay/src/bun/native/device-hotplug.ts
+++ b/apps/overlay/src/bun/native/device-hotplug.ts
@@ -1,0 +1,111 @@
+// Watches /dev/input for event-node create / delete via inotify so
+// controllers paired mid-session (most commonly a Bluetooth pad
+// connected after the overlay is already running) surface to the
+// input interceptor without an overlay restart.
+//
+// The watcher does not maintain its own thread — pollOnce() drains
+// the non-blocking fd from the existing input-intercept poll tick.
+// On IN_CREATE we wait a short settling delay before notifying so
+// /proc/bus/input/devices has caught up with the new node (the
+// kernel publishes the devfs entry and proc-fs entry asynchronously).
+
+import {
+  libc,
+  IN_CLOEXEC,
+  IN_NONBLOCK,
+  IN_CREATE,
+  IN_DELETE,
+  INOTIFY_EVENT_HEADER_SIZE,
+} from "./ffi";
+
+const WATCH_DIR = "/dev/input";
+const READ_BUF_SIZE = 4096;
+
+// Delay between the inotify CREATE event and asking the caller to
+// re-enumerate. /proc/bus/input/devices lags devfs by tens of
+// milliseconds in practice on Bazzite — without this, the first
+// read after a Bluetooth pair hits the kernel before the proc-fs
+// entry exists and the device is silently dropped.
+const PROCFS_SETTLE_MS = 100;
+
+const EVENT_NAME_RE = /^event\d+$/;
+
+export interface DeviceHotplugOptions {
+  onAdded: (eventPath: string) => void;
+  onRemoved: (eventPath: string) => void;
+}
+
+export interface DeviceHotplugHandle {
+  /** Drain pending inotify events. Safe to call from the existing
+   *  poll tick — the fd is non-blocking, so this returns immediately
+   *  when nothing has fired. */
+  poll(): void;
+  /** Close the inotify fd. */
+  shutdown(): void;
+}
+
+export function startDeviceHotplug(
+  opts: DeviceHotplugOptions,
+): DeviceHotplugHandle | null {
+  const fd = libc.symbols.inotify_init1(IN_CLOEXEC | IN_NONBLOCK);
+  if (fd < 0) {
+    console.warn(
+      "[device-hotplug] inotify_init1 failed — hot-plug disabled",
+    );
+    return null;
+  }
+  const dirBuf = Buffer.from(WATCH_DIR + "\0");
+  const wd = libc.symbols.inotify_add_watch(fd, dirBuf, IN_CREATE | IN_DELETE);
+  if (wd < 0) {
+    console.warn(
+      `[device-hotplug] inotify_add_watch on ${WATCH_DIR} failed — hot-plug disabled`,
+    );
+    libc.symbols.close(fd);
+    return null;
+  }
+  console.log(`[device-hotplug] watching ${WATCH_DIR}`);
+
+  const buf = new Uint8Array(READ_BUF_SIZE);
+  const view = new DataView(buf.buffer);
+  const decoder = new TextDecoder();
+
+  function pollOnce(): void {
+    for (;;) {
+      const n = Number(libc.symbols.read(fd, buf, BigInt(buf.byteLength)));
+      if (n <= 0) return; // EAGAIN on a non-blocking fd is the steady state.
+      let off = 0;
+      while (off + INOTIFY_EVENT_HEADER_SIZE <= n) {
+        const mask = view.getUint32(off + 4, true);
+        const len = view.getUint32(off + 12, true);
+        let name = "";
+        if (len > 0) {
+          // `len` is the padded byte count reserved for `name`; the
+          // actual string is NUL-terminated inside that window.
+          let end = off + INOTIFY_EVENT_HEADER_SIZE;
+          const limit = end + len;
+          while (end < limit && buf[end] !== 0) end++;
+          name = decoder.decode(
+            buf.subarray(off + INOTIFY_EVENT_HEADER_SIZE, end),
+          );
+        }
+        off += INOTIFY_EVENT_HEADER_SIZE + len;
+
+        if (!EVENT_NAME_RE.test(name)) continue;
+        const eventPath = `${WATCH_DIR}/${name}`;
+        if (mask & IN_CREATE) {
+          setTimeout(() => opts.onAdded(eventPath), PROCFS_SETTLE_MS);
+        }
+        if (mask & IN_DELETE) {
+          opts.onRemoved(eventPath);
+        }
+      }
+    }
+  }
+
+  return {
+    poll: pollOnce,
+    shutdown: () => {
+      libc.symbols.close(fd);
+    },
+  };
+}

--- a/apps/overlay/src/bun/native/devices.ts
+++ b/apps/overlay/src/bun/native/devices.ts
@@ -1,0 +1,240 @@
+// Port of src-tauri/src/device_monitor.rs.
+//
+// Enumerates /proc/bus/input/devices and classifies each entry as
+// controller / keyboard / QAM by inspecting the kernel's reported key
+// capability bitmask (the `B: KEY=` line of /proc/bus/input/devices).
+// This is more robust than name heuristics — a device without "gamepad"
+// or "xbox" in its name still classifies as a controller if it reports
+// BTN_A/B/X/Y/SELECT/MODE, and a device named "Keyboard" that doesn't
+// have Ctrl/3/4 keys won't masquerade as one.
+//
+// A single device can be multiple things at once (Steam Deck's QAM
+// button is exposed on the same virtual keyboard that also has Ctrl),
+// so `flags` is a bitmask, not a single enum.
+
+import { readFile } from "node:fs/promises";
+
+// ---- linux/input-event-codes.h ---------------------------------------------
+
+// Gamepad buttons
+const BTN_A = 0x130;
+const BTN_B = 0x131;
+const BTN_X = 0x133;
+const BTN_Y = 0x134;
+const BTN_SELECT = 0x13a;
+const BTN_MODE = 0x13c;
+
+// Keyboard keys
+const KEY_LEFTCTRL = 29;
+const KEY_3 = 4;
+const KEY_4 = 5;
+const KEY_F16 = 0xba;
+
+/** Minimum set of buttons a device must report to be treated as a controller. */
+const CONTROLLER_REQUIRED_BUTTONS = [
+  BTN_SELECT,
+  BTN_MODE,
+  BTN_A,
+  BTN_B,
+  BTN_X,
+  BTN_Y,
+] as const;
+
+/** Minimum set of keys to qualify as a "shortcut-capable" keyboard. Excludes
+ *  the PC AT laptop keyboard — it has Ctrl/3/4 but we don't want its shortcut
+ *  modifiers firing in the overlay. */
+const KEYBOARD_REQUIRED_KEYS = [KEY_LEFTCTRL, KEY_3, KEY_4] as const;
+
+/** Vendor/product for Steam Input's VIRTUAL Xbox 360 pad — we must never
+ *  grab this (it's how Steam's own UI gets input) and never treat it as a
+ *  physical controller for interception. */
+const STEAM_VENDOR = 0x28de;
+const STEAM_PRODUCT = 0x11ff;
+
+// ---- Types -----------------------------------------------------------------
+
+/** Deprecated — single-class view kept for callers that haven't moved to
+ *  {@link DeviceFlags}. Derived from flags on parse. */
+export type DeviceClass = "controller" | "keyboard" | "qam" | "unknown";
+
+/** Capability-bit classification (matches device_monitor.rs::DeviceClass). */
+export interface DeviceFlags {
+  isController: boolean;
+  isKeyboard: boolean;
+  isQam: boolean;
+}
+
+export interface InputDevice {
+  eventPath: string; // "/dev/input/event7"
+  name: string;
+  vendor: string; // lowercase hex, no prefix — e.g. "28de"
+  product: string;
+  /** Primary classification for legacy callers; prefer {@link flags}. */
+  class: DeviceClass;
+  flags: DeviceFlags;
+  /** Stable hash across reconnects — djb2 over name+vendor+product so the
+   *  NavController can key per-controller state (key repeat, modifier) by a
+   *  value that survives unplug/replug without growing a Map key per
+   *  reboot. */
+  hash: number;
+  /** Parsed EV_KEY capability bitmask. Empty if the B: KEY= line is absent
+   *  (non-input devices). */
+  keyCaps: Uint8Array;
+  /** True for Steam Input's virtual Xbox 360 pad. Interception MUST skip
+   *  it — grabbing it would mean our overlay's own CEF Gamepad API and
+   *  Steam's BPM nav both lose input. */
+  isSteamVirtual: boolean;
+}
+
+// ---- Enumeration -----------------------------------------------------------
+
+export async function enumerateDevices(): Promise<InputDevice[]> {
+  const raw = await readFile("/proc/bus/input/devices", "utf8");
+  return parseDevices(raw);
+}
+
+/** Exposed for tests — pure function over the raw /proc content. */
+export function parseDevices(raw: string): InputDevice[] {
+  const blocks = raw.split(/\n\n+/).filter((b) => b.trim().length > 0);
+  const devices: InputDevice[] = [];
+  for (const block of blocks) {
+    const name = matchLine(block, /^N:\s+Name="([^"]*)"$/m) ?? "";
+    const vendor = (matchLine(block, /Vendor=([0-9a-f]+)/i) ?? "").toLowerCase();
+    const product =
+      (matchLine(block, /Product=([0-9a-f]+)/i) ?? "").toLowerCase();
+    const handlers = matchLine(block, /^H:\s+Handlers=(.*)$/m) ?? "";
+    const eventName = handlers.split(/\s+/).find((h) => h.startsWith("event"));
+    if (!eventName) continue;
+    const keyLine = matchLine(block, /^B:\s+KEY=(.*)$/m) ?? "";
+    const keyCaps = parseKeyBitmask(keyLine);
+    const flags = classifyByCaps(name, keyCaps);
+    const isSteamVirtual =
+      parseInt(vendor, 16) === STEAM_VENDOR &&
+      parseInt(product, 16) === STEAM_PRODUCT;
+    devices.push({
+      eventPath: `/dev/input/${eventName}`,
+      name,
+      vendor,
+      product,
+      class: flagsToLegacyClass(flags, name),
+      flags,
+      hash: djb2(`${name}|${vendor}|${product}`),
+      keyCaps,
+      isSteamVirtual,
+    });
+  }
+  return devices;
+}
+
+function matchLine(block: string, re: RegExp): string | undefined {
+  const m = block.match(re);
+  return m?.[1];
+}
+
+// ---- Capability parsing ----------------------------------------------------
+
+/**
+ * Parse the `B: KEY=...` line into a little-endian bitmask indexed by
+ * linux/input-event-codes.h key codes.
+ *
+ * The kernel formats this as space-separated 64-bit words in **big-endian
+ * hex**, written most-significant-word first. To get a byte array indexable
+ * by `code >> 3`, we serialize each word as BE bytes then reverse the whole
+ * array. (Same algorithm as device_monitor.rs's `B:`-case parser.)
+ */
+export function parseKeyBitmask(keyLine: string): Uint8Array {
+  if (!keyLine.trim()) return new Uint8Array(0);
+  const words = keyLine.trim().split(/\s+/);
+  const bytes: number[] = [];
+  for (const word of words) {
+    // Pad to a full 64-bit width so partial leading words don't shift
+    // the bitmap. Then serialize as BE bytes — the kernel writes MSW
+    // first within each word too, so we keep the natural order and
+    // reverse the whole array at the end.
+    const padded = word.padStart(16, "0");
+    for (let i = 0; i < padded.length; i += 2) {
+      bytes.push(parseInt(padded.slice(i, i + 2), 16));
+    }
+  }
+  bytes.reverse();
+  return new Uint8Array(bytes);
+}
+
+export function hasCapability(caps: Uint8Array, code: number): boolean {
+  const byteIdx = code >> 3;
+  const bitIdx = code & 0x07;
+  if (byteIdx >= caps.length) return false;
+  return (caps[byteIdx] & (1 << bitIdx)) !== 0;
+}
+
+/**
+ * Capability-based classification. Matches device_monitor.rs::classify_device
+ * exactly:
+ *   - Controller: reports all of BTN_SELECT, BTN_MODE, BTN_A/B/X/Y.
+ *   - Keyboard: reports Ctrl/3/4 *and* isn't "AT Translated Set 2 keyboard"
+ *     (built-in laptop keyboard — shortcut modifiers on it open the overlay
+ *     during normal typing, which is not what we want).
+ *   - QAM: reports KEY_F16 (emitted by InputPlumber / Handheld Daemon virtual
+ *     keyboards when the QAM button is pressed).
+ */
+export function classifyByCaps(name: string, caps: Uint8Array): DeviceFlags {
+  const isController = CONTROLLER_REQUIRED_BUTTONS.every((c) =>
+    hasCapability(caps, c),
+  );
+  const isKeyboard =
+    !name.startsWith("AT Translated") &&
+    KEYBOARD_REQUIRED_KEYS.every((c) => hasCapability(caps, c));
+  const isQam = hasCapability(caps, KEY_F16);
+  return { isController, isKeyboard, isQam };
+}
+
+function flagsToLegacyClass(flags: DeviceFlags, name: string): DeviceClass {
+  // "controller" wins over keyboard wins over qam — same priority the
+  // name-based classifier used to pick, keeps the behaviour of legacy
+  // callers (`class === "controller"` filters) intact.
+  if (flags.isController) return "controller";
+  if (flags.isKeyboard) return "keyboard";
+  if (flags.isQam) return "qam";
+  // Fallback to the old name heuristic so the legacy `class` field still
+  // returns something meaningful for devices that don't advertise any
+  // interesting caps (e.g. "Handheld QAM Button" that lies about its
+  // capabilities).
+  return classifyByName(name);
+}
+
+/**
+ * Pure name-heuristic classification, kept for the legacy single-class
+ * view and for tests that predate the capability-based classifier.
+ * Prefer classifyByCaps for real decisions.
+ */
+export function classify(name: string): DeviceClass {
+  return classifyByName(name);
+}
+
+function classifyByName(name: string): DeviceClass {
+  const n = name.toLowerCase();
+  if (
+    n.includes("xbox") ||
+    n.includes("controller") ||
+    n.includes("gamepad") ||
+    n.includes("steam")
+  ) {
+    return "controller";
+  }
+  if (n.includes("keyboard")) return "keyboard";
+  if (n.includes("qam")) return "qam";
+  return "unknown";
+}
+
+// ---- djb2 -----------------------------------------------------------------
+
+function djb2(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    // h * 33 + c, kept as a 32-bit unsigned int so it hashes identically
+    // regardless of engine. Shifts are 32-bit signed in JS — Math.imul is
+    // the portable way to get wrap-around arithmetic.
+    h = (Math.imul(h, 33) + s.charCodeAt(i)) | 0;
+  }
+  return h >>> 0;
+}

--- a/apps/overlay/src/bun/native/display-detect.ts
+++ b/apps/overlay/src/bun/native/display-detect.ts
@@ -1,0 +1,121 @@
+// Pick the X11 display this overlay should run on. Must be called BEFORE
+// `new BrowserWindow(...)` because Electrobun's GTK/CEF init reads DISPLAY
+// via getenv() during window construction — anything later is too late.
+//
+// Port of overlay_display.rs::detect_gamescope_display from the Tauri
+// overlay, minus the /tmp/.X11-unix socket scan (which only matters in
+// obscure fallback cases where no session env is around).
+//
+// Detection order:
+//   1. $GAMESCOPE_DISPLAY          (gamescope-session-plus sets this on
+//                                    its own process; rarely in systemd
+//                                    user env unless imported)
+//   2. /proc/<steam-pid>/environ's GAMESCOPE_DISPLAY — Steam inherits
+//      the gamescope inner X display, this is the reliable signal when
+//      we're running under gamescope-session
+//   3. Current $DISPLAY — regular desktop session path
+//   4. ":0" — last-resort fallback
+//
+// We log the chosen value (and why) so it's obvious from the journal
+// which branch fired on a given boot.
+
+import { readFileSync, readdirSync } from "node:fs";
+
+function fromGamescopeEnv(): string | null {
+  const v = process.env.GAMESCOPE_DISPLAY;
+  return v && v.length > 0 ? v : null;
+}
+
+function fromSteamEnviron(): string | null {
+  // Use /proc instead of `pgrep` so we don't depend on procps being
+  // installed (unlikely to be missing, but a spawn every boot is waste).
+  let steamPid: number | null = null;
+  try {
+    for (const entry of readdirSync("/proc")) {
+      const pid = Number(entry);
+      if (!Number.isFinite(pid)) continue;
+      try {
+        const comm = readFileSync(`/proc/${pid}/comm`, "utf8").trim();
+        if (comm === "steam") {
+          steamPid = pid;
+          break;
+        }
+      } catch {
+        // Process might have exited between readdir and readFileSync.
+      }
+    }
+  } catch {
+    return null;
+  }
+  if (steamPid === null) return null;
+
+  try {
+    const raw = readFileSync(`/proc/${steamPid}/environ`);
+    // NUL-separated key=value list.
+    for (const entry of raw.toString("utf8").split("\0")) {
+      if (entry.startsWith("GAMESCOPE_DISPLAY=")) {
+        const value = entry.slice("GAMESCOPE_DISPLAY=".length);
+        if (value.length > 0) return value;
+      }
+    }
+  } catch {
+    // /proc/<pid>/environ is readable by the owner; if systemd runs us
+    // under a different user this will fail silently — fine, fall through.
+  }
+  return null;
+}
+
+export function detectOverlayDisplay(): string {
+  const gs = fromGamescopeEnv();
+  if (gs) {
+    console.log(`[display-detect] using $GAMESCOPE_DISPLAY=${gs}`);
+    return gs;
+  }
+
+  const fromSteam = fromSteamEnviron();
+  if (fromSteam) {
+    console.log(
+      `[display-detect] using GAMESCOPE_DISPLAY=${fromSteam} from steam /proc env`,
+    );
+    return fromSteam;
+  }
+
+  const display = process.env.DISPLAY;
+  if (display) {
+    console.log(`[display-detect] using $DISPLAY=${display}`);
+    return display;
+  }
+
+  console.log("[display-detect] no X display found in env, defaulting to :0");
+  return ":0";
+}
+
+/**
+ * Run detection and mutate process.env.DISPLAY so Electrobun's GTK/CEF
+ * init sees the right value when BrowserWindow is constructed. Call this
+ * at the top of bun/index.ts, before importing electrobun/bun.
+ */
+export function applyDetectedDisplay(): string {
+  const display = detectOverlayDisplay();
+  process.env.DISPLAY = display;
+  return display;
+}
+
+// ---- Side-effect import hook ------------------------------------------------
+//
+// ES module semantics resolve imports in source order BEFORE any of the
+// importer's own top-level code runs. Electrobun's `electrobun/bun` entry
+// dlopens libNativeWrapper.so during its module load, which triggers the
+// X11 connection through GTK's ctor path. If we only expose functions
+// here, the importer has no opportunity to run them before the electrobun
+// import happens.
+//
+// So we run detection eagerly on module load. `import "./native/display-detect"`
+// (before the electrobun import) is all the caller needs — this block fires
+// and DISPLAY is already set by the time libNativeWrapper dlopens.
+//
+// LOADOUT_OVERLAY_DISPLAY_DETECT_SKIP=1 skips it — useful in tests or if the
+// caller wants to control detection order manually.
+if (process.env.LOADOUT_OVERLAY_DISPLAY_DETECT_SKIP !== "1") {
+  applyDetectedDisplay();
+}

--- a/apps/overlay/src/bun/native/ffi.ts
+++ b/apps/overlay/src/bun/native/ffi.ts
@@ -1,0 +1,207 @@
+// Shared bun:ffi bindings for libc and libxcb.
+//
+// Centralised so evdev.ts and x11.ts don't each reach into dlopen separately.
+// ioctl numbers are the Linux-specific _IOW-encoded constants lifted from
+// input-event-codes.h — identical to the ones declared in
+// src-tauri/src/input_interceptor.rs.
+
+import { dlopen, FFIType } from "bun:ffi";
+
+// ---- libc -------------------------------------------------------------------
+
+const libcPath = `libc.so.6`;
+
+export const libc = dlopen(libcPath, {
+  ioctl: {
+    // int ioctl(int fd, unsigned long request, ... /* arg */);
+    args: [FFIType.i32, FFIType.u64, FFIType.ptr],
+    returns: FFIType.i32,
+  },
+  open: {
+    args: [FFIType.cstring, FFIType.i32],
+    returns: FFIType.i32,
+  },
+  close: {
+    args: [FFIType.i32],
+    returns: FFIType.i32,
+  },
+  read: {
+    args: [FFIType.i32, FFIType.ptr, FFIType.u64],
+    returns: FFIType.i64,
+  },
+  epoll_create1: {
+    args: [FFIType.i32],
+    returns: FFIType.i32,
+  },
+  epoll_ctl: {
+    args: [FFIType.i32, FFIType.i32, FFIType.i32, FFIType.ptr],
+    returns: FFIType.i32,
+  },
+  epoll_wait: {
+    args: [FFIType.i32, FFIType.ptr, FFIType.i32, FFIType.i32],
+    returns: FFIType.i32,
+  },
+  inotify_init1: {
+    args: [FFIType.i32],
+    returns: FFIType.i32,
+  },
+  inotify_add_watch: {
+    args: [FFIType.i32, FFIType.cstring, FFIType.u32],
+    returns: FFIType.i32,
+  },
+  kill: {
+    // int kill(pid_t pid, int sig);  — used by process-control.ts to
+    // SIGSTOP / SIGCONT the Steam process on overlay open/close so
+    // gamepad input can't reach the game underneath.
+    args: [FFIType.i32, FFIType.i32],
+    returns: FFIType.i32,
+  },
+  free: {
+    // void free(void *ptr);  — used by x11.ts to release malloc'd
+    // xcb reply buffers (xcb_get_property_reply, xcb_intern_atom_reply
+    // etc. all return malloc()d pointers that the caller must free).
+    args: [FFIType.ptr],
+    returns: FFIType.void,
+  },
+});
+
+// ---- libxcb -----------------------------------------------------------------
+//
+// We'll use libxcb (not libX11) because it's leaner and the C API maps 1:1
+// onto FFI without having to deal with Xlib's nested callback model.
+
+const libxcbPath = `libxcb.so.1`;
+
+export const xcb = dlopen(libxcbPath, {
+  xcb_connect: {
+    args: [FFIType.cstring, FFIType.ptr],
+    returns: FFIType.ptr,
+  },
+  xcb_disconnect: {
+    args: [FFIType.ptr],
+    returns: FFIType.void,
+  },
+  xcb_connection_has_error: {
+    args: [FFIType.ptr],
+    returns: FFIType.i32,
+  },
+  xcb_intern_atom: {
+    args: [FFIType.ptr, FFIType.u8, FFIType.u16, FFIType.cstring],
+    returns: FFIType.u32, // xcb_intern_atom_cookie_t is { uint32_t sequence }
+  },
+  xcb_intern_atom_reply: {
+    args: [FFIType.ptr, FFIType.u32, FFIType.ptr],
+    returns: FFIType.ptr,
+  },
+  xcb_change_property: {
+    args: [
+      FFIType.ptr, // connection
+      FFIType.u8,  // mode
+      FFIType.u32, // window
+      FFIType.u32, // property atom
+      FFIType.u32, // type atom
+      FFIType.u8,  // format (8/16/32)
+      FFIType.u32, // data_len
+      FFIType.ptr, // data
+    ],
+    returns: FFIType.u32,
+  },
+  xcb_get_property: {
+    args: [
+      FFIType.ptr, // connection
+      FFIType.u8,  // delete
+      FFIType.u32, // window
+      FFIType.u32, // property
+      FFIType.u32, // type
+      FFIType.u32, // offset
+      FFIType.u32, // length
+    ],
+    returns: FFIType.u32,
+  },
+  xcb_get_property_reply: {
+    args: [FFIType.ptr, FFIType.u32, FFIType.ptr],
+    returns: FFIType.ptr,
+  },
+  xcb_query_tree: {
+    args: [FFIType.ptr, FFIType.u32],
+    returns: FFIType.u32,
+  },
+  xcb_query_tree_reply: {
+    args: [FFIType.ptr, FFIType.u32, FFIType.ptr],
+    returns: FFIType.ptr,
+  },
+  xcb_flush: {
+    args: [FFIType.ptr],
+    returns: FFIType.i32,
+  },
+  // Subscribe a window to PropertyChangeMask events so XSelectInput-style
+  // event-driven atom monitoring works. Replaces our old 100ms polling
+  // reclaim watcher with a "react when Steam actually changes" model
+  // (matches HHD's approach).
+  //
+  // C signature: xcb_void_cookie_t xcb_change_window_attributes(
+  //     xcb_connection_t *c, xcb_window_t window,
+  //     uint32_t value_mask, const uint32_t *value_list);
+  xcb_change_window_attributes: {
+    args: [FFIType.ptr, FFIType.u32, FFIType.u32, FFIType.ptr],
+    returns: FFIType.u32,
+  },
+  // Drain pending events from the X server's incoming queue without
+  // blocking. Returns NULL if no event ready. Each non-null pointer
+  // must be free()'d.
+  // C signature: xcb_generic_event_t *xcb_poll_for_event(xcb_connection_t *c);
+  xcb_poll_for_event: {
+    args: [FFIType.ptr],
+    returns: FFIType.ptr,
+  },
+});
+
+// X11 event mask values (from /usr/include/X11/X.h).
+export const XCB_EVENT_MASK_PROPERTY_CHANGE = 0x00400000;
+
+// X11 event response_type values we care about (low 7 bits of byte 0
+// of any xcb_generic_event_t).
+export const XCB_PROPERTY_NOTIFY = 28;
+
+// xcb_property_notify_event_t layout (32 bytes):
+//   uint8_t  response_type;  // 0
+//   uint8_t  pad0;           // 1
+//   uint16_t sequence;       // 2
+//   xcb_window_t window;     // 4  (uint32_t)
+//   xcb_atom_t atom;         // 8  (uint32_t)
+//   xcb_timestamp_t time;    // 12 (uint32_t)
+//   uint8_t state;           // 16 (0 = NewValue, 1 = Deleted)
+//   uint8_t pad1[15];        // 17..31
+export const XCB_PROPERTY_NOTIFY_WINDOW_OFF = 4;
+export const XCB_PROPERTY_NOTIFY_ATOM_OFF = 8;
+export const XCB_GENERIC_EVENT_SIZE = 32;
+
+// ---- ioctl numbers (linux/input.h) -----------------------------------------
+// Lifted verbatim from src-tauri/src/input_interceptor.rs. These are the
+// _IOW-encoded values, not symbolic — do not change without updating both.
+
+export const EVIOCGRAB = 0x40044590n;   // _IOW('E', 0x90, int)
+export const EVIOCSMASK = 0x40104593n;  // _IOW('E', 0x93, struct input_mask)
+
+// ---- inotify (linux/inotify.h) ---------------------------------------------
+// Used by device-hotplug.ts to watch /dev/input for event* node create/remove.
+
+export const IN_CLOEXEC = 0x80000;
+export const IN_NONBLOCK = 0x800;
+export const IN_CREATE = 0x100;
+export const IN_DELETE = 0x200;
+
+// struct inotify_event header is 16 bytes on x86_64:
+//   __s32 wd;       /* 4 bytes */
+//   __u32 mask;     /* 4 bytes */
+//   __u32 cookie;   /* 4 bytes */
+//   __u32 len;      /* 4 bytes */
+//   char  name[];   /* `len` bytes, NUL-terminated, padded to align */
+export const INOTIFY_EVENT_HEADER_SIZE = 16;
+
+// struct input_event is 24 bytes on x86_64:
+//   struct timeval time;  /* 16 bytes */
+//   __u16 type;           /*  2 bytes */
+//   __u16 code;           /*  2 bytes */
+//   __s32 value;          /*  4 bytes */
+export const INPUT_EVENT_SIZE = 24;

--- a/apps/overlay/src/bun/native/gamescope-atoms.ts
+++ b/apps/overlay/src/bun/native/gamescope-atoms.ts
@@ -1,0 +1,1080 @@
+// Shell-out to xprop / xdotool to drive the Gamescope atom lifecycle on our
+// overlay window. This is the Bun-side equivalent of the Tauri overlay's
+// overlay_display.rs — minimal enough to unblock gaming-mode testing, not
+// yet a full FFI port (that's TODO(stage-2), see native/x11.ts stubs).
+//
+// Why shell out? xprop is tiny and always present on any system running
+// gamescope. A real port uses bun:ffi against libxcb, but:
+//   - we're still in scaffold territory;
+//   - xprop's surface is stable;
+//   - the hot path is one-shot on open/close — spawn cost is fine.
+//
+// The magic numbers here match overlay_display.rs's constants exactly.
+
+import { run as _runRaw, commandExists } from "@loadout/exec";
+import { trace } from "./trace";
+import { X11Connection } from "./x11";
+import { dismissSteamQuickAccessIfOpen } from "./steam-quick-access";
+
+// From overlay_display.rs
+const OVERLAY_APP_ID = 0x534c; // 21324, "SL"
+const OPACITY_VISIBLE = 0xffffffff;
+const OPACITY_HIDDEN = 0;
+
+// Hard cap on every xprop / xdotool subprocess this module spawns.
+// Without it, a single hung X server query (gamescope wedged in some
+// state) blocks Bun's event loop for the entire overlay process —
+// observed as 20+ seconds of process silence after a show() in the
+// trace, during which the user's own toggle button presses also
+// failed to register and the whole device looked frozen. 1.5s is well
+// past any healthy xprop round-trip but short enough that the user
+// can hit the toggle again and recover.
+const X11_SUBPROC_TIMEOUT_MS = 1500;
+
+/** Wrapper around exec.run that always applies a timeout. Prevents a
+ *  stuck X server from hanging Bun's event loop. */
+function run(
+  cmd: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  return _runRaw(cmd, { timeoutMs: X11_SUBPROC_TIMEOUT_MS });
+}
+// gamescope::TouchClickModes enum values from gamescope/src/backend.h:
+//   0=Hover, 1=Left, 2=Right, 3=Middle, 4=Passthrough, 5=Disabled, 6=Trackpad.
+// "Passthrough" = touches forward to the focused window (overlay or game).
+const TOUCH_MODE_OVERLAY = 4;
+// Gap between flipping the focus atoms and writing touch mode — mirrors
+// the flush/sync/sleep(100ms) in overlay_display.rs::show_overlay(). Gives
+// Gamescope a chance to process the focus change before we redirect touch.
+const TOUCH_MODE_APPLY_DELAY_MS = 100;
+
+// Reclaim-focus watcher cadence. Polling fallback for the xprop path
+// only. Under libxcb we use PropertyChangeMask events instead — no
+// idle traffic, react only when Steam actually changes state.
+const RECLAIM_WATCH_INTERVAL_MS = 100;
+// Event-drain cadence for the libxcb path. Cheap (just `xcb_poll_for_event`
+// — non-blocking, returns immediately when the queue is empty), so we
+// can run it fairly fast without generating any X server load.
+const RECLAIM_EVENT_DRAIN_INTERVAL_MS = 50;
+// If we read Steam's atoms as 0/0 for this many consecutive ticks we
+// re-run findSteamWindow() on the assumption we latched onto the wrong
+// candidate — steamwebhelper spawns several windows and only one of
+// them is the real BPM / QAM host. 20 ticks × 100ms = 2 s of "quiet"
+// before we re-resolve, which is well below any realistic human
+// perception of flicker.
+const RECLAIM_RERESOLVE_AFTER_QUIET_TICKS = 20;
+
+export interface AtomTargetOptions {
+  /** Which X display to talk to. On Bazzite gamescope-session, :0 is the
+   *  inner X where Steam BPM + overlays live. :1 is the outer (konsole). */
+  display: string;
+  /** The window name xdotool should search for. Electrobun doesn't let us
+   *  set a stable WM_CLASS, so we look up by the window title instead. */
+  windowName: string;
+  /** Force the xprop-subprocess fallback path even if libxcb is
+   *  available. Kill switch for the libxcb migration — set
+   *  `OVERLAY_FORCE_XPROP=1` in the environment to flip this. */
+  forceXprop?: boolean;
+}
+
+export class GamescopeAtoms {
+  private display: string;
+  private windowName: string;
+  /** Cached window id; re-resolved on first failure. */
+  private windowId: string | null = null;
+  /** Cached Steam Big Picture window id — re-resolved on show(). */
+  private steamWindowId: string | null = null;
+  /** libxcb connection for the atom-write hot path. null = use xprop
+   *  fallback (either because OVERLAY_FORCE_XPROP=1 was set, or because
+   *  xcb_connect failed at startup — desktop dev without an X server,
+   *  WSL, etc.). When non-null, show()/hide()/reclaim batch all writes
+   *  on this connection and flush in one round-trip — eliminates the
+   *  ~60ms multi-subprocess race window where flicker happens. */
+  private x11: X11Connection | null = null;
+  /** Cached interned id for STEAM_OVERLAY — used by the event-driven
+   *  reclaim watcher to filter PropertyNotify events down to the one
+   *  atom we actually care about. 0 means "not yet looked up". */
+  private steamOverlayAtomId = 0;
+  /** Snapshot of STEAM_TOUCH_CLICK_MODE on root before show() overwrote it.
+   *  Restored on hide(). null means either no prior value was set or it was
+   *  already TOUCH_MODE_OVERLAY, in which case we don't restore. Matches
+   *  SteamAtomSnapshot::touch_mode in overlay_display.rs. */
+  private snapshotTouchMode: number | null = null;
+
+  /** Snapshot of Steam's BPM window atoms (STEAM_OVERLAY /
+   *  STEAM_INPUT_FOCUS / STEAM_NOTIFICATION) taken in show() before our
+   *  reclaim loop starts hammering them down to zero. Restored in hide()
+   *  so Steam's QAM comes back to whatever state it was in before we
+   *  took over. Without this, closing our overlay left Steam in a state
+   *  where its QAM was conceptually open but STEAM_INPUT_FOCUS=0, so
+   *  gamescope refused to route input and Steam looked frozen. */
+  private snapshotSteamAtoms: Map<string, number> | null = null;
+
+  /** Reclaim-focus watcher handle. Set while the overlay is shown — polls
+   *  Steam's atoms and counter-asserts ours if Steam re-grabs them. Null
+   *  between hide() and the next show(). */
+  private reclaimTimer: ReturnType<typeof setInterval> | null = null;
+  /** Reentrancy guard — skip a tick if the previous xprop round-trip is
+   *  still in flight. Prevents stacking up xprop subprocess calls on a stuck
+   *  gamescope (e.g. during display hotplug). */
+  private reclaimInFlight = false;
+  /** Consecutive reclaim ticks where Steam's atoms read as 0/0. When
+   *  this crosses RECLAIM_RERESOLVE_AFTER_QUIET_TICKS we re-resolve
+   *  steamWindowId in case we latched onto the wrong steamwebhelper
+   *  child window on the first pass. */
+  private reclaimQuietTicks = 0;
+
+  constructor(opts: AtomTargetOptions) {
+    this.display = opts.display;
+    this.windowName = opts.windowName;
+
+    // Try to open a libxcb connection up front. Failure (server down,
+    // wrong display, libxcb missing) is non-fatal — we silently fall
+    // back to spawning xprop subprocesses.
+    if (!opts.forceXprop) {
+      const x11 = new X11Connection();
+      if (x11.connect(this.display)) {
+        this.x11 = x11;
+        trace(`[gamescope-atoms] libxcb connection opened on ${this.display}`);
+      } else {
+        trace(
+          `[gamescope-atoms] libxcb connect failed on ${this.display}; falling back to xprop subprocess path`,
+        );
+      }
+    }
+  }
+
+  /** Convert an "0x..." hex window id to its numeric uint32 form.
+   *  Returns null on parse failure. Not cached — the conversion is
+   *  cheap and caching invited stale-value bugs across re-resolves. */
+  private _windowIdNumFor(kind: "own" | "steam"): number | null {
+    const hex = kind === "own" ? this.windowId : this.steamWindowId;
+    if (hex === null) return null;
+    const n = Number(hex);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  /**
+   * Snapshot the win-id via xdotool. Returns a hex id like "0x2e00001"
+   * (xprop's preferred format). Called once on prepare and again on
+   * each open in case the window was torn down and rebuilt.
+   */
+  async findWindow(): Promise<string | null> {
+    if (!(await commandExists("xdotool"))) {
+      console.warn("[gamescope-atoms] xdotool not found on PATH");
+      return null;
+    }
+    try {
+      const { stdout, exitCode } = await run([
+        "env",
+        `DISPLAY=${this.display}`,
+        "xdotool",
+        "search",
+        "--name",
+        this.windowName,
+      ]);
+      if (exitCode !== 0) return null;
+      const id = stdout.split("\n")[0]?.trim();
+      if (!id) return null;
+      this.windowId = "0x" + Number(id).toString(16);
+      return this.windowId;
+    } catch (err) {
+      console.warn("[gamescope-atoms] findWindow failed:", err);
+      return null;
+    }
+  }
+
+  /**
+   * Look up Steam's Big Picture window.
+   *
+   * Live xprop survey of an Apex in BPM (May 2026) showed a handful of
+   * Steam-owned windows present at the same time: the real BPM window, the
+   * steamwebhelper renderer, a "VRStream" 32×32, MENU/tooltip 64×24
+   * popups, plus 10×10 utility windows. We have to pick the right one or
+   * we end up zeroing atoms on a window gamescope ignores.
+   *
+   * Heuristic, in priority order — strongest signal first:
+   *
+   *   1. WM_NAME = "Steam Big Picture Mode" — only the actual BPM window
+   *      has this exact name; if we find one, take it and stop.
+   *   2. Otherwise, score candidates that pass ALL of:
+   *        - WM_CLASS includes "steamwebhelper"
+   *        - _NET_WM_WINDOW_TYPE = _NET_WM_WINDOW_TYPE_NORMAL set
+   *        - STEAM_GAME = 769 (Steam's own appID — set on real BPM, not
+   *          on the renderer-only helper)
+   *      Among those, prefer one currently asserting overlay/focus.
+   *   3. Fallback: first managed window we found (preserves legacy /
+   *      desktop-Steam behaviour for shapes we haven't surveyed).
+   *
+   * The previous implementation skipped step 1, fell through to a
+   * non-deterministic pool[0] when no window asserted overlay/focus, and
+   * frequently latched onto the wrong steamwebhelper child — so the
+   * reclaim watcher was monitoring a window gamescope ignores.
+   */
+  async findSteamWindow(): Promise<string | null> {
+    if (!(await commandExists("xdotool"))) return null;
+
+    // Collect candidates from --class steamwebhelper + steam.
+    // Empirically xdotool's --name regex doesn't match BPM's
+    // _NET_WM_NAME-only "Steam Big Picture Mode" title (only WM_NAME
+    // gets indexed for --name in some xdotool builds), so we always
+    // enumerate by class and filter ourselves by reading WM_NAME via
+    // xprop on each.
+    const allIds = new Set<string>();
+    for (const cls of ["steamwebhelper", "steam"]) {
+      for (const id of await this._xdotoolSearchClass(cls)) {
+        allIds.add(id);
+      }
+    }
+    if (allIds.size === 0) return null;
+    const candidates = [...allIds];
+
+    // 1. Strongest signal: WM_NAME = "Steam Big Picture Mode".
+    for (const id of candidates) {
+      const name = await this._readWmName(id);
+      if (name === "Steam Big Picture Mode") {
+        this.steamWindowId = id;
+        trace(
+          `[gamescope-atoms] findSteamWindow → ${id} (by WM_NAME) candidates=${candidates.length}`,
+        );
+        return id;
+      }
+    }
+
+    // 2. Scored fallback for non-BPM scenarios (e.g. desktop Steam,
+    //    older Steam shapes that label BPM differently).
+    const chosen = await this._pickBpmWindow(candidates);
+    this.steamWindowId = chosen;
+    trace(
+      `[gamescope-atoms] findSteamWindow → ${chosen} (scored, candidates: ${candidates.join(",")})`,
+    );
+    return chosen;
+  }
+
+  /** Read a window's WM_NAME / _NET_WM_NAME via xprop. Returns the
+   *  string body or null if neither is set. */
+  private async _readWmName(windowId: string): Promise<string | null> {
+    try {
+      const { stdout, exitCode } = await run([
+        "env",
+        `DISPLAY=${this.display}`,
+        "xprop",
+        "-id",
+        windowId,
+        "_NET_WM_NAME",
+        "WM_NAME",
+      ]);
+      if (exitCode !== 0) return null;
+      // Output looks like:
+      //   _NET_WM_NAME(UTF8_STRING) = "Steam Big Picture Mode"
+      //   WM_NAME(STRING) = "Steam"
+      // Or: "_NET_WM_NAME:  not found." if absent.
+      // Prefer _NET_WM_NAME (UTF-8) when both are present.
+      const lines = stdout.split("\n");
+      for (const prefix of ["_NET_WM_NAME", "WM_NAME"]) {
+        for (const line of lines) {
+          if (!line.startsWith(prefix + "(")) continue;
+          const m = line.match(/=\s*"((?:[^"\\]|\\.)*)"/);
+          if (m) return m[1];
+        }
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Pick the BPM window from a set of Steam-owned X windows. See
+   *  findSteamWindow()'s doc for the heuristic. */
+  private async _pickBpmWindow(candidates: readonly string[]): Promise<string> {
+    // Filter to candidates that pass the structural BPM signature:
+    // managed window (WM_TYPE_NORMAL set) AND tagged with STEAM_GAME=769.
+    // Either alone is too weak — managed alone also matches VRStream,
+    // STEAM_GAME=769 alone also matches the 200×200 renderer helper.
+    const managed: string[] = [];
+    for (const id of candidates) {
+      const hasWindowType = await this._hasAtom(id, "_NET_WM_WINDOW_TYPE");
+      if (!hasWindowType) continue;
+      const atoms = await this._readAtoms(id, ["STEAM_GAME"]);
+      if ((atoms.get("STEAM_GAME") ?? 0) === 769) {
+        managed.push(id);
+      }
+    }
+    const pool = managed.length > 0 ? managed : candidates;
+
+    // Prefer a pool window currently claiming overlay/focus.
+    for (const id of pool) {
+      const atoms = await this._readAtoms(id, [
+        "STEAM_OVERLAY",
+        "STEAM_INPUT_FOCUS",
+      ]);
+      if (
+        (atoms.get("STEAM_OVERLAY") ?? 0) !== 0 ||
+        (atoms.get("STEAM_INPUT_FOCUS") ?? 0) !== 0
+      ) {
+        return id;
+      }
+    }
+    return pool[0];
+  }
+
+  /** True if `atom` is set on `windowId`. Uses xprop output to
+   *  distinguish "not found" from a zero-value atom. */
+  private async _hasAtom(windowId: string, atom: string): Promise<boolean> {
+    try {
+      const { stdout, exitCode } = await run([
+        "env",
+        `DISPLAY=${this.display}`,
+        "xprop",
+        "-id",
+        windowId,
+        atom,
+      ]);
+      if (exitCode !== 0) return false;
+      return !stdout.includes("not found");
+    } catch {
+      return false;
+    }
+  }
+
+  private async _xdotoolSearchClass(cls: string): Promise<string[]> {
+    try {
+      const { stdout, exitCode } = await run([
+        "env",
+        `DISPLAY=${this.display}`,
+        "xdotool",
+        "search",
+        "--class",
+        cls,
+      ]);
+      if (exitCode !== 0) return [];
+      return stdout
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .map((decimal) => "0x" + Number(decimal).toString(16));
+    } catch (err) {
+      console.warn(
+        `[gamescope-atoms] _xdotoolSearchClass(${cls}) failed:`,
+        err,
+      );
+      return [];
+    }
+  }
+
+  /**
+   * One-time setup — sets atoms that mark this window as a Loadout
+   * overlay. Defaults to hidden (opacity 0) so Gamescope doesn't render
+   * it until the user toggles.
+   */
+  async prepare(): Promise<void> {
+    if (!this.windowId) await this.findWindow();
+    if (!this.windowId) return;
+    // Only set atoms gamescope actually reads. Verified against
+    // steamcompmgr.cpp:7772-7811 (May 2026): STEAM_NOTIFICATION and
+    // GAMESCOPE_NO_FOCUS that the Rust prior art set are NOT registered
+    // in gamescope's atom table — writing them was a no-op.
+    await this._set("STEAM_GAME", OVERLAY_APP_ID);
+    await this._set("STEAM_BIGPICTURE", 1);
+    await this._set("_NET_WM_WINDOW_OPACITY", OPACITY_HIDDEN);
+    await this._set("STEAM_OVERLAY", 0);
+    await this._set("STEAM_INPUT_FOCUS", 0);
+    this._flush();
+    // Warm the Steam window cache so the first show() doesn't pay a
+    // ~40ms cold xdotool/xprop survey. Best-effort: if Steam isn't up
+    // yet at boot, show() still falls back to a lazy resolve.
+    if (!this.steamWindowId) {
+      this.findSteamWindow().catch(() => {});
+    }
+  }
+
+  /** Show: tell Gamescope to composite us on top + route input to us.
+   *  Also repositions the window onto the currently-primary monitor so
+   *  unplugging an external HDMI display (and re-plugging one) still
+   *  lands the overlay where the user is looking. Under gamescope's
+   *  inner X there's only one output, so this is a no-op there; under
+   *  KDE/GNOME multi-monitor it matters.
+   *
+   *  Atom write order matters when Steam's QAM is already open. If we
+   *  flip our opacity visible BEFORE zeroing Steam's atoms, gamescope
+   *  sees two windows claiming STEAM_OVERLAY=1 for the duration of our
+   *  own-window atom writes (~60ms of xprop subprocess spawns) and
+   *  oscillates compositing between them — visible as a brief flicker.
+   *  Zero Steam first, then claim our atoms, then flip opacity — by
+   *  the time we're visible, Steam is already yielding. */
+  async show(): Promise<void> {
+    if (!this.windowId) await this.findWindow();
+    if (!this.windowId) return;
+    await this._positionOnPrimary();
+    // 1. Snapshot Steam's current BPM atoms BEFORE we touch them, so
+    //    hide() can put them back. Without this, the reclaim watcher
+    //    keeps Steam's atoms at 0 for the whole time our overlay is
+    //    open, and on close Steam's QAM is stuck visually open with
+    //    STEAM_INPUT_FOCUS=0 — gamescope refuses to route input to it
+    //    and Steam "looks frozen."
+    await this._snapshotSteamAtoms();
+    // 1.5. If the snapshot shows Steam is asserting STEAM_OVERLAY=1
+    //      on BPM, Steam is in "menu-over-game" mode — that's the
+    //      trigger scenario for the device-wide compositor freeze
+    //      (gamescope can't handle our overlay competing for the
+    //      slot when Steam's already there with a game in baselayer).
+    //      Send Escape to BPM to dismiss its menu before we proceed.
+    //      Using snapshot-derived signal instead of STEAM_GAMES_RUNNING
+    //      because Steam doesn't reliably write that atom — empirically
+    //      observed it unset even when a game is genuinely running and
+    //      Steam IS asserting overlay (the only signal we can trust).
+    await this._maybeDismissSteamMenu();
+    // 2. Suppress Steam's QAM atoms BEFORE we become visible. Resolved
+    //    lazily: Steam's window may not exist in standalone desktop
+    //    dev — optional, we still composite fine without it.
+    //
+    //    Skip the 3 xprop -set calls (~30ms) when the snapshot already
+    //    shows Steam isn't claiming overlay/focus/notification — i.e.
+    //    user opened our overlay without Steam's QAM up. The reclaim
+    //    watcher will catch any subsequent re-assertion within 100ms.
+    if (this._steamSnapshotIsAsserted()) {
+      await this._zeroSteamFocusAtoms();
+    }
+    // 3. Claim overlay status on our own window.
+    await this._set("STEAM_OVERLAY", 1);
+    await this._set("STEAM_INPUT_FOCUS", 1);
+    // 4. Flip to visible. Gamescope sees exactly one STEAM_OVERLAY=1
+    //    claimant and composites us unambiguously.
+    await this._set("_NET_WM_WINDOW_OPACITY", OPACITY_VISIBLE);
+    // 5. Flush the entire show() write batch in one X11 round-trip.
+    //    Gamescope sees [Steam=0,0,0; ours overlay=1, focus=1, opac=visible]
+    //    as a single sequence of PropertyNotify events and runs
+    //    DetermineAndApplyFocus once on the final state. No intermediate
+    //    "both at STEAM_OVERLAY=1" frame → no flicker. (No-op on the
+    //    xprop fallback path; each subprocess auto-flushes.)
+    this._flush();
+    await this._applyOverlayTouchMode();
+    // Steam's BPM re-asserts STEAM_OVERLAY=1 whenever its internal
+    // state says "QAM should be open" (e.g. the user opened Steam's
+    // QAM before ours via a different hotkey). Without a
+    // counter-assertion loop, gamescope oscillates between focusing
+    // Steam and focusing us, visible as fast flicker. Matches the
+    // Rust overlay's per-tick steam_reclaimed/reclaim_focus check
+    // from main.rs — the piece that never got ported when we moved
+    // from Tauri to Electrobun.
+    this._startReclaimWatcher();
+  }
+
+  /** True if Steam's BPM has STEAM_OVERLAY=1 in the most recent
+   *  snapshot. Used by show() to skip a no-op zero pass when Steam
+   *  isn't claiming the overlay slot. */
+  private _steamSnapshotIsAsserted(): boolean {
+    return (this.snapshotSteamAtoms?.get("STEAM_OVERLAY") ?? 0) !== 0;
+  }
+
+  /**
+   * Zero only STEAM_OVERLAY on Steam's BPM window — leave INPUT_FOCUS
+   * and NOTIFICATION alone.
+   *
+   * STEAM_OVERLAY drives gamescope's overlay-slot arbitration; we
+   * zero it so we win the contest. STEAM_INPUT_FOCUS, however, is
+   * Steam's CEF-UI self-state signal ("am I the active overlay?") —
+   * Steam toggles it on its own window when its menu/QAM is open and
+   * uses it to decide whether to process menu inputs. If we zero it,
+   * Steam's UI keeps the menu visually rendered but stops handling
+   * inputs (the user-reported "Steam UI frozen" failure mode).
+   *
+   * Gamescope only consults STEAM_INPUT_FOCUS on the *overlay window*
+   * (steamcompmgr.cpp:4201). Since we've zeroed Steam's STEAM_OVERLAY,
+   * BPM is not the overlay window from gamescope's POV, so leaving
+   * its INPUT_FOCUS at 1 is invisible to gamescope's input routing.
+   *
+   * No-op when Steam isn't running (desktop dev) or its window hasn't
+   * been mapped yet.
+   */
+  private async _zeroSteamFocusAtoms(): Promise<void> {
+    if (!this.steamWindowId) await this.findSteamWindow();
+    if (!this.steamWindowId) return;
+    await this._setOn(this.steamWindowId, "STEAM_OVERLAY", 0);
+  }
+
+  /**
+   * If Steam's Quick Access Menu (QAM) is currently open, dismiss it
+   * via Chrome DevTools Protocol before we open our overlay.
+   *
+   * Why this hook exists at all: when the user has Steam's QAM open
+   * in BPM home with a game alive in baselayer, and they then toggle
+   * our overlay, gamescope's compositor reliably wedges into a
+   * device-wide input freeze that requires reboot. Empirically the
+   * trigger is the QAM-open state, not Steam's STEAM_OVERLAY atom or
+   * any X11-visible signal — the QAM is a CEF browser_view popup
+   * INSIDE Steam BPM's existing X window, with no separate window we
+   * can manipulate via X atoms.
+   *
+   * Earlier shapes of this hook tried to detect the trigger via
+   * STEAM_GAMES_RUNNING (Steam writes it inconsistently — observed
+   * unset even with a game running) and via the snapshot's
+   * STEAM_OVERLAY (Steam doesn't assert it on BPM in this scenario).
+   * Both signals missed the trigger state. The reliable path is to
+   * ask Steam's CEF directly: connect to its CDP at localhost:8080,
+   * find the `QuickAccess_uid2` page, check if it's visible, and if
+   * so dispatch Escape into it via Input.dispatchKeyEvent.
+   *
+   * No-op if Steam's CDP isn't reachable, the QAM page isn't found,
+   * or the QAM is already hidden. The CDP operation has its own
+   * 800ms timeout so a stalled Steam doesn't block our show() path.
+   */
+  private async _maybeDismissSteamMenu(): Promise<void> {
+    try {
+      const dismissed = await dismissSteamQuickAccessIfOpen();
+      if (dismissed) {
+        trace(`[gamescope-atoms] pre-show: dismissed Steam QAM via CDP`);
+      }
+    } catch (err) {
+      console.warn("[gamescope-atoms] _maybeDismissSteamMenu:", err);
+    }
+  }
+
+  /**
+   * Read STEAM_OVERLAY / STEAM_INPUT_FOCUS / STEAM_NOTIFICATION off
+   * Steam's BPM window into `snapshotSteamAtoms` so hide() can restore
+   * them. No-op without a resolvable Steam window. Stores zeros for
+   * any atom that wasn't set — the restore path treats "not in map"
+   * and "zero" identically, so either shape is fine.
+   */
+  private async _snapshotSteamAtoms(): Promise<void> {
+    this.snapshotSteamAtoms = null;
+    if (!this.steamWindowId) await this.findSteamWindow();
+    if (!this.steamWindowId) return;
+    // Only snapshot STEAM_OVERLAY — that's the only one we manage on
+    // Steam's window. INPUT_FOCUS and NOTIFICATION are Steam's
+    // self-state signals; we never write them, so we don't need to
+    // remember them.
+    const atoms = await this._readAtoms(this.steamWindowId, [
+      "STEAM_OVERLAY",
+    ]);
+    this.snapshotSteamAtoms = atoms;
+    trace(
+      `[gamescope-atoms] snapshot Steam STEAM_OVERLAY=${atoms.get("STEAM_OVERLAY") ?? 0}`,
+    );
+  }
+
+  /**
+   * Restore Steam's STEAM_OVERLAY on hide based on whether a game is
+   * running. Leaves STEAM_INPUT_FOCUS and STEAM_NOTIFICATION untouched
+   * — those are Steam's self-state signals (see _zeroSteamFocusAtoms
+   * doc) and must not be disturbed.
+   *
+   * Two regimes, picked by STEAM_GAMES_RUNNING on root:
+   *
+   * **No game running** (BPM home, no game in baselayer):
+   *   Force STEAM_OVERLAY=0. Restoring overlay=1 would make BPM the
+   *   only isOverlay window with no focusWindow → gamescope nulls
+   *   overlayWindow + inputFocusWindow (steamcompmgr.cpp:4192-4209) →
+   *   device-wide input halt.
+   *
+   * **Game running** (game in baselayer):
+   *   Restore the snapshotted STEAM_OVERLAY value. The game is a
+   *   focusWindow candidate, so making BPM isOverlay again is fine —
+   *   gamescope gives BPM the overlay slot, BPM's INPUT_FOCUS (which
+   *   we never touched) routes inputs into Steam's CEF UI.
+   */
+  private async _maybeRestoreSteamAtoms(): Promise<void> {
+    const snap = this.snapshotSteamAtoms;
+    this.snapshotSteamAtoms = null;
+    if (!this.steamWindowId) await this.findSteamWindow();
+    if (!this.steamWindowId) return;
+
+    const gamesRunning = await this._getRootAtom("STEAM_GAMES_RUNNING");
+    const gameAlive = gamesRunning !== null && gamesRunning > 0;
+    const snapOverlay = snap?.get("STEAM_OVERLAY") ?? 0;
+
+    const targetOverlay = gameAlive ? snapOverlay : 0;
+    await this._setOn(this.steamWindowId, "STEAM_OVERLAY", targetOverlay);
+    trace(
+      `[gamescope-atoms] hide: gameAlive=${gameAlive} (count=${gamesRunning ?? "unset"}), wrote STEAM_OVERLAY=${targetOverlay} (snap was ${snapOverlay}); INPUT_FOCUS/NOTIFICATION left untouched`,
+    );
+  }
+
+  /**
+   * Start event-driven monitoring of Steam's STEAM_OVERLAY atom.
+   *
+   * Subscribes to PropertyChangeMask on Steam's BPM window via libxcb,
+   * then polls the X event queue at a slow cadence. We only react when
+   * Steam actually sets STEAM_OVERLAY=1 — there's no atom write traffic
+   * in steady state. Matches HHD's approach (`win.change_attributes(
+   * event_mask=Xlib.X.PropertyChangeMask)` + `process_events(disp)`).
+   *
+   * The previous 100ms-poll-and-write reclaim loop generated up to
+   * ~30 atom operations per second and appeared to overwhelm
+   * gamescope's compositor under repeated overlay-toggle cycles —
+   * device-wide input freezes. Event-driven reduces idle traffic to
+   * zero and reactive traffic to one read + maybe one write per
+   * actual Steam-side change.
+   *
+   * Falls back to the old polling loop on the xprop path (no libxcb
+   * connection / events). No-op if already running.
+   */
+  private _startReclaimWatcher(): void {
+    if (this.reclaimTimer !== null) return;
+
+    // libxcb path: subscribe to PropertyChangeMask, poll events.
+    if (this.x11 && this.steamWindowId) {
+      const idNum = this._windowIdNumFor("steam");
+      if (idNum !== null) {
+        this.x11.selectPropertyChanges(idNum);
+        this.steamOverlayAtomId = this.x11.internAtom("STEAM_OVERLAY");
+        const timer = setInterval(() => {
+          void this._drainPropertyEvents();
+        }, RECLAIM_EVENT_DRAIN_INTERVAL_MS);
+        (timer as unknown as { unref?: () => void }).unref?.();
+        this.reclaimTimer = timer;
+        trace(
+          `[gamescope-atoms] reclaim watcher: event-driven (PropertyChangeMask on ${this.steamWindowId}, atom=${this.steamOverlayAtomId})`,
+        );
+        return;
+      }
+    }
+
+    // Fallback (xprop path or steam-window not resolved): old polling.
+    this.reclaimQuietTicks = 0;
+    const timer = setInterval(() => {
+      void this._reclaimTick();
+    }, RECLAIM_WATCH_INTERVAL_MS);
+    (timer as unknown as { unref?: () => void }).unref?.();
+    this.reclaimTimer = timer;
+    trace(
+      `[gamescope-atoms] reclaim watcher: polling (xprop fallback at ${RECLAIM_WATCH_INTERVAL_MS}ms)`,
+    );
+  }
+
+  /** Stop the reclaim watcher. Safe to call multiple times. */
+  private _stopReclaimWatcher(): void {
+    if (this.reclaimTimer === null) return;
+    clearInterval(this.reclaimTimer);
+    this.reclaimTimer = null;
+  }
+
+  /**
+   * Drain pending PropertyNotify events from the X server. Called on
+   * the event-driven path only. If we see STEAM_OVERLAY change on the
+   * BPM window, read its current value; if 1, counter-zero + re-assert
+   * ours. Single read + (conditional) single write per actual change.
+   *
+   * Audit B-025: mirrors `_reclaimTick`'s `reclaimInFlight` guard.
+   * Without it a rapid burst of PropertyNotify events can interleave
+   * two zero-then-reassert sequences and end up writing STEAM_OVERLAY=0
+   * after the second reassert lands — leaving us unfocused.
+   */
+  private async _drainPropertyEvents(): Promise<void> {
+    if (!this.x11) return;
+    if (!this.steamWindowId) return;
+    if (this.reclaimInFlight) return;
+    const events = this.x11.pollPropertyChanges();
+    if (events.length === 0) return;
+    const steamIdNum = this._windowIdNumFor("steam");
+    if (steamIdNum === null) return;
+    // Did the STEAM_OVERLAY atom on Steam's BPM window change?
+    const sawOverlay = events.some(
+      (e) =>
+        e.window === steamIdNum &&
+        this.steamOverlayAtomId !== 0 &&
+        e.atom === this.steamOverlayAtomId,
+    );
+    if (!sawOverlay) return;
+    // Read current value; only counter-write if it's actually 1.
+    const v = this.x11.getCardinals(steamIdNum, ["STEAM_OVERLAY"]);
+    const overlay = v.get("STEAM_OVERLAY") ?? 0;
+    if (overlay === 0) return;
+    this.reclaimInFlight = true;
+    try {
+      trace(
+        `[gamescope-atoms] PropertyNotify: Steam re-asserted STEAM_OVERLAY=1 — taking it back`,
+      );
+      await this._zeroSteamFocusAtoms();
+      if (this.windowId) {
+        await this._setOn(this.windowId, "STEAM_OVERLAY", 1, true);
+      }
+      this._flush();
+    } finally {
+      this.reclaimInFlight = false;
+    }
+  }
+
+  /**
+   * Polling fallback for the xprop path (no libxcb event queue).
+   * Reads Steam's STEAM_OVERLAY; if Steam re-asserted it, counter-zero
+   * and re-claim ours. Identical to the previous reclaim implementation.
+   */
+  private async _reclaimTick(): Promise<void> {
+    if (this.reclaimInFlight) return;
+    if (!this.steamWindowId) {
+      await this.findSteamWindow();
+      if (!this.steamWindowId) return;
+    }
+    this.reclaimInFlight = true;
+    try {
+      const atoms = await this._readAtoms(this.steamWindowId, [
+        "STEAM_OVERLAY",
+      ]);
+      const stole = (atoms.get("STEAM_OVERLAY") ?? 0) !== 0;
+      if (!stole) {
+        this.reclaimQuietTicks++;
+        if (this.reclaimQuietTicks >= RECLAIM_RERESOLVE_AFTER_QUIET_TICKS) {
+          trace(
+            `[gamescope-atoms] reclaim quiet for ${this.reclaimQuietTicks} ticks — re-resolving Steam window`,
+          );
+          this.reclaimQuietTicks = 0;
+          this.steamWindowId = null;
+        }
+        return;
+      }
+      this.reclaimQuietTicks = 0;
+      trace(
+        `[gamescope-atoms] Steam reclaimed STEAM_OVERLAY — taking it back`,
+      );
+      await this._zeroSteamFocusAtoms();
+      if (this.windowId) {
+        await this._setOn(this.windowId, "STEAM_OVERLAY", 1, true);
+      }
+      this._flush();
+    } finally {
+      this.reclaimInFlight = false;
+    }
+  }
+
+  /**
+   * Read several CARDINAL atoms off a specific window in one xprop call.
+   * Returns a map of atom name → numeric value for every atom that was
+   * set and parseable. Missing / malformed entries are omitted rather
+   * than surfaced as nulls so callers can treat "no entry" identically
+   * to "not set".
+   */
+  private async _readAtoms(
+    windowId: string,
+    names: readonly string[],
+  ): Promise<Map<string, number>> {
+    if (names.length === 0) return new Map();
+
+    // libxcb path: pipelined reads on the persistent connection. Issues
+    // all cookies first, collects replies — one round-trip total.
+    if (this.x11) {
+      // Decide which cached numeric id maps to this hex string. The
+      // reclaim loop and snapshot path read off Steam's window; show()
+      // reads off our own. Any other window id (rare) we still
+      // accept by parsing on the fly.
+      let idNum: number | null = null;
+      if (windowId === this.steamWindowId) {
+        idNum = this._windowIdNumFor("steam");
+      } else if (windowId === this.windowId) {
+        idNum = this._windowIdNumFor("own");
+      } else {
+        const n = Number(windowId);
+        if (Number.isFinite(n)) idNum = n;
+      }
+      if (idNum !== null) {
+        return this.x11.getCardinals(idNum, names);
+      }
+      // Fall through to xprop on parse failure — rare.
+    }
+
+    // xprop fallback path.
+    const out = new Map<string, number>();
+    try {
+      const { stdout, exitCode } = await run([
+        "env",
+        `DISPLAY=${this.display}`,
+        "xprop",
+        "-id",
+        windowId,
+        ...names,
+      ]);
+      if (exitCode !== 0) return out;
+      for (const line of stdout.split("\n")) {
+        // "NAME(CARDINAL) = 1" — match name and value. Absent atoms
+        // print as "NAME:  not found." and don't match this regex.
+        const m = line.match(/^(\w+)\([^)]+\)\s*=\s*(-?\d+)/);
+        if (!m) continue;
+        const n = Number(m[2]);
+        if (Number.isFinite(n)) out.set(m[1], n);
+      }
+    } catch (err) {
+      console.warn(
+        `[gamescope-atoms] xprop read ${names.join(",")} on ${windowId} failed:`,
+        err,
+      );
+    }
+    return out;
+  }
+
+  /** Move the window onto the primary monitor's geometry. Best-effort —
+   *  if xrandr isn't on PATH, or there's only one output, this is a
+   *  no-op. Called on every show() so hot-plug/unplug of external
+   *  displays gets picked up at the next overlay open. */
+  private async _positionOnPrimary(): Promise<void> {
+    if (!this.windowId) return;
+    if (!(await commandExists("xrandr")) || !(await commandExists("xdotool"))) {
+      return;
+    }
+    try {
+      const { stdout, exitCode } = await run([
+        "env",
+        `DISPLAY=${this.display}`,
+        "xrandr",
+        "--current",
+        "--query",
+      ]);
+      if (exitCode !== 0) return;
+      // Line we're looking for: "HDMI-1 connected primary 1920x1080+0+0 ..."
+      // Under gamescope's inner X usually: "DP-1 connected 2560x1440+0+0 ..."
+      const geom = this._pickMonitorGeometry(stdout);
+      if (!geom) return;
+      // windowmove + windowsize: center the overlay in the monitor.
+      const x = geom.x + Math.max(0, Math.floor((geom.w - 1280) / 2));
+      const y = geom.y + Math.max(0, Math.floor((geom.h - 800) / 2));
+      await run([
+        "env",
+        `DISPLAY=${this.display}`,
+        "xdotool",
+        "windowmove",
+        this.windowId,
+        String(x),
+        String(y),
+      ]);
+    } catch (err) {
+      console.warn("[gamescope-atoms] _positionOnPrimary:", err);
+    }
+  }
+
+  private _pickMonitorGeometry(
+    xrandr: string,
+  ): { x: number; y: number; w: number; h: number } | null {
+    // Each monitor line looks roughly:
+    //   "<name> connected [primary] <W>x<H>+<X>+<Y> ..."
+    // We prefer the line marked "primary"; otherwise the first connected
+    // output with a concrete geometry.
+    const geomRe = /(\d+)x(\d+)\+(\d+)\+(\d+)/;
+    let primary: RegExpMatchArray | null = null;
+    let firstConnected: RegExpMatchArray | null = null;
+    for (const line of xrandr.split("\n")) {
+      if (!line.includes(" connected")) continue;
+      const m = line.match(geomRe);
+      if (!m) continue;
+      if (line.includes(" primary ")) {
+        primary = m;
+        break;
+      }
+      if (!firstConnected) firstConnected = m;
+    }
+    const m = primary ?? firstConnected;
+    if (!m) return null;
+    return {
+      w: Number(m[1]),
+      h: Number(m[2]),
+      x: Number(m[3]),
+      y: Number(m[4]),
+    };
+  }
+
+  /** Hide: zero our atoms, drop opacity, force Steam's atoms back to 0,
+   *  restore touch mode. Order matters:
+   *    1. Stop the reclaim watcher so it can't race us
+   *    2. Clear our overlay/focus claims FIRST so we're no longer an
+   *       overlay candidate from gamescope's perspective
+   *    3. Drop our opacity so we're no longer painted
+   *    4. Force-zero Steam's atoms (see _forceZeroSteamAtoms doc — we do
+   *       NOT restore the snapshot; that path was the regression that
+   *       caused the "Steam frozen / QAM stuck open" bug)
+   *    5. Restore root STEAM_TOUCH_CLICK_MODE if we changed it
+   */
+  async hide(): Promise<void> {
+    this._stopReclaimWatcher();
+    if (!this.windowId) await this.findWindow();
+    if (!this.windowId) return;
+    await this._set("STEAM_INPUT_FOCUS", 0);
+    await this._set("STEAM_OVERLAY", 0);
+    await this._set("_NET_WM_WINDOW_OPACITY", OPACITY_HIDDEN);
+    await this._maybeRestoreSteamAtoms();
+    // Flush the whole hide batch in one round-trip — gamescope sees
+    // our atoms drop to 0/0/0 and Steam's atoms restored to their
+    // pre-show values in one PropertyNotify burst. Steam's UI logic
+    // sees its self-state signals come back, picks back up where it
+    // was; gamescope arbitrates input routing once on the final state.
+    this._flush();
+    await this._restoreTouchMode();
+  }
+
+  /**
+   * Snapshot the current root STEAM_TOUCH_CLICK_MODE and overwrite it with
+   * TOUCH_MODE_OVERLAY so Gamescope routes touch straight to our window
+   * instead of synthesizing a fake mouse cursor. Writes unconditionally —
+   * even when the atom is unset ("not found"), because under Gamescope the
+   * atom may simply not have been populated yet (e.g. fresh gamescope-session
+   * boot before BPM touched any touch-aware UI). Skipping the write there
+   * leaves Gamescope with no target for touch and our overlay never sees
+   * finger input.
+   *
+   * On hide() we only restore when we captured a non-null, non-4 prior —
+   * there's nothing meaningful to restore to otherwise. Steam BPM reasserts
+   * the atom whenever it needs a different mode.
+   */
+  private async _applyOverlayTouchMode(): Promise<void> {
+    const prior = await this._getRootAtom("STEAM_TOUCH_CLICK_MODE");
+    // Snapshot whatever prior was (including TOUCH_MODE_OVERLAY=4 if
+    // Steam's QAM was already up) so hide() can restore it. null prior
+    // (fresh gamescope session, atom never set) means there's nothing
+    // to restore to — leave snapshot null, let hide() leave the atom
+    // at our value.
+    this.snapshotTouchMode = prior;
+    // 100ms gives gamescope time to settle our STEAM_OVERLAY=1 /
+    // Steam=0 before we fiddle with root touch routing — empirically
+    // necessary to avoid a brief overlay flicker when Steam's QAM is
+    // already open at show() time.
+    await new Promise((r) => setTimeout(r, TOUCH_MODE_APPLY_DELAY_MS));
+    await this._setRootAtom("STEAM_TOUCH_CLICK_MODE", TOUCH_MODE_OVERLAY);
+  }
+
+  /**
+   * Restore root STEAM_TOUCH_CLICK_MODE to its pre-show value.
+   *
+   * Always verbatim — even if the snapshot was TOUCH_MODE_OVERLAY (4).
+   * Pairs with _restoreSteamAtoms (which also restores Steam's
+   * STEAM_OVERLAY / STEAM_INPUT_FOCUS): if Steam's menu was open at
+   * our show() time, BOTH the touch routing AND the per-window flags
+   * need to come back together — otherwise BPM ends up with stale
+   * mismatched state and its menu UI stops processing inputs.
+   */
+  private async _restoreTouchMode(): Promise<void> {
+    if (this.snapshotTouchMode === null) return;
+    await this._setRootAtom(
+      "STEAM_TOUCH_CLICK_MODE",
+      this.snapshotTouchMode,
+    );
+    trace(
+      `[gamescope-atoms] touch_mode restored to ${this.snapshotTouchMode}`,
+    );
+    this.snapshotTouchMode = null;
+  }
+
+  /**
+   * Read a CARDINAL atom off the screen root via `xprop -root`.
+   * Returns null for the "not found" case, for parse failures, and for
+   * any subprocess error — all callers treat those identically.
+   */
+  private async _getRootAtom(atom: string): Promise<number | null> {
+    try {
+      const { stdout, exitCode } = await run([
+        "env",
+        `DISPLAY=${this.display}`,
+        "xprop",
+        "-root",
+        atom,
+      ]);
+      if (exitCode !== 0) return null;
+      // Output for a set CARDINAL atom looks like:
+      //   "STEAM_TOUCH_CLICK_MODE(CARDINAL) = 1"
+      // For an unset atom:
+      //   "STEAM_TOUCH_CLICK_MODE:  not found."
+      const m = stdout.match(/=\s*(-?\d+)/);
+      if (!m) return null;
+      const n = Number(m[1]);
+      return Number.isFinite(n) ? n : null;
+    } catch (err) {
+      console.warn(`[gamescope-atoms] xprop -root ${atom} read failed:`, err);
+      return null;
+    }
+  }
+
+  /** Write a CARDINAL atom to the screen root via `xprop -root -set`. */
+  private async _setRootAtom(atom: string, value: number): Promise<void> {
+    try {
+      const { exitCode } = await run([
+        "env",
+        `DISPLAY=${this.display}`,
+        "xprop",
+        "-root",
+        "-f",
+        atom,
+        "32c",
+        "-set",
+        atom,
+        String(value),
+      ]);
+      if (exitCode !== 0) {
+        console.warn(
+          `[gamescope-atoms] xprop -root set ${atom}=${value} exited ${exitCode}`,
+        );
+      }
+    } catch (err) {
+      console.warn(`[gamescope-atoms] xprop -root ${atom} failed:`, err);
+    }
+  }
+
+  private async _set(atom: string, value: number): Promise<void> {
+    if (!this.windowId) return;
+    await this._setOn(this.windowId, atom, value, /* isOwnWindow */ true);
+  }
+
+  private async _setOn(
+    windowId: string,
+    atom: string,
+    value: number,
+    isOwnWindow = false,
+  ): Promise<void> {
+    // Fast path: libxcb queues the write on a persistent connection.
+    // Doesn't actually hit the X server until _flush() is called, so
+    // multiple writes batched in show()/hide() land on gamescope's
+    // event queue back-to-back — eliminating the multi-subprocess race
+    // window where Steam re-asserts STEAM_OVERLAY=1 mid-sequence.
+    if (this.x11) {
+      const idNum = isOwnWindow
+        ? this._windowIdNumFor("own")
+        : this._windowIdNumFor("steam");
+      if (idNum !== null) {
+        this.x11.setCardinal(idNum, atom, value);
+        return;
+      }
+      // Fall through to xprop if for some reason we don't have a
+      // numeric id (parse failure on a malformed cache entry).
+    }
+
+    // Slow path: shell-out fallback. Used when libxcb isn't available
+    // (no DISPLAY, gamescope down at startup, OVERLAY_FORCE_XPROP=1).
+    try {
+      const { exitCode } = await run([
+        "env",
+        `DISPLAY=${this.display}`,
+        "xprop",
+        "-id",
+        windowId,
+        "-f",
+        atom,
+        "32c",
+        "-set",
+        atom,
+        String(value),
+      ]);
+      if (exitCode !== 0) {
+        console.warn(
+          `[gamescope-atoms] xprop set ${atom}=${value} on ${windowId} exited ${exitCode}`,
+        );
+        // Invalidate the matching cache so the next call re-resolves.
+        // Steam's BPM window can be recreated between sessions too.
+        if (isOwnWindow) this.windowId = null;
+        else this.steamWindowId = null;
+      }
+    } catch (err) {
+      console.warn(`[gamescope-atoms] xprop ${atom} failed:`, err);
+      if (isOwnWindow) this.windowId = null;
+      else this.steamWindowId = null;
+    }
+  }
+
+  /** Dispatch any libxcb-queued property writes to the X server. No-op
+   *  when running on the xprop fallback (each xprop subprocess flushes
+   *  itself). Safe to call multiple times. */
+  private _flush(): void {
+    this.x11?.flush();
+  }
+
+  /** Free libxcb resources. Called from index.ts on process exit so we
+   *  don't leak the X connection. */
+  shutdown(): void {
+    this.x11?.disconnect();
+    this.x11 = null;
+  }
+}

--- a/apps/overlay/src/bun/native/input-intercept.ts
+++ b/apps/overlay/src/bun/native/input-intercept.ts
@@ -1,0 +1,863 @@
+// Port of src-tauri/src/input_interceptor.rs.
+//
+// Single long-running read loop over all /dev/input/event* nodes.
+// Two modes per device, toggled on overlay open/close:
+//
+//   - idle mode: EVIOCSMASK filters events down to just the wake
+//     shortcuts (F16 for QAM, Guide+B / Ctrl+4 combos). Kernel drops
+//     everything else before we see it, so we're not burning CPU on
+//     every stick wiggle while the user is gaming.
+//
+//   - intercept mode: EVIOCGRAB takes exclusive access of physical
+//     controllers. While the overlay is open the game + Steam BPM
+//     see nothing — events flow only to us, and we hand them to the
+//     NavController which emits NavActions the webview turns into
+//     synthetic KeyboardEvents.
+//
+// Why this lives alongside the atom manipulation in gamescope-atoms.ts
+// and not inside it: atoms tell Gamescope which window should get FOCUS
+// (compositor-level). EVIOCGRAB operates at the KERNEL level and stops
+// events reaching ANY userspace process. Belt-and-braces under
+// Gamescope, where atom-only routing has been flaky.
+//
+// What we intentionally do NOT grab:
+//   - Steam Input's VIRTUAL Xbox 360 pad (vendor 28de / product 11ff).
+//     Grabbing it would cut CEF's Gamepad API (overlay webview reads
+//     it too) and break Steam BPM when the overlay closes.
+//   - Physical keyboards. The user might want to type into the overlay
+//     UI or use external shortcuts while it's open.
+//   - The InputPlumber virtual keyboard for F16 — handled separately
+//     so the QAM button can still toggle us off.
+
+import { ptr } from "bun:ffi";
+import {
+  libc,
+  EVIOCGRAB,
+  EVIOCSMASK,
+  INPUT_EVENT_SIZE,
+} from "./ffi";
+import {
+  enumerateDevices,
+  type InputDevice,
+} from "./devices";
+import { NavController, type InputEvent } from "./nav-controller";
+import { trace } from "./trace";
+import {
+  startDeviceHotplug,
+  type DeviceHotplugHandle,
+} from "./device-hotplug";
+
+// ---- linux/input-event-codes.h (subset used by the wake + nav detection) ---
+
+const EV_SYN = 0x00;
+const EV_KEY = 0x01;
+const EV_ABS = 0x03;
+
+// Gamepad buttons
+const BTN_A = 0x130;
+const BTN_B = 0x131;
+const BTN_X = 0x133;
+const BTN_Y = 0x134;
+const BTN_TL = 0x136;
+const BTN_TR = 0x137;
+const BTN_SELECT = 0x13a;
+const BTN_MODE = 0x13c;
+
+// Axes
+const ABS_X = 0x00;
+const ABS_Y = 0x01;
+const ABS_RX = 0x03;
+const ABS_RY = 0x04;
+const ABS_HAT0X = 0x10;
+const ABS_HAT0Y = 0x11;
+
+// Keyboard keys
+const KEY_LEFTCTRL = 29;
+const KEY_3 = 4;
+const KEY_4 = 5;
+const KEY_F16 = 0xba;
+
+// fcntl.h — same as f16-watcher.ts/input-grab.ts used.
+const O_RDONLY = 0;
+const O_NONBLOCK = 2048;
+
+// ---- Hotplug warning -------------------------------------------------------
+
+/**
+ * Audit B-024: log a one-line warning when `startDeviceHotplug` returned
+ * null (i.e. inotify is unavailable on this kernel/sandbox). The
+ * device-hotplug module logs its own init-failure messages but the
+ * operational consequence — "controllers added mid-session won't be
+ * picked up until the next 2s reconcile poll" — lives here.
+ *
+ * Exported for tests.
+ */
+export function warnIfHotplugDisabled(
+  hotplug: DeviceHotplugHandle | null,
+  log: (msg: string) => void = console.warn,
+): void {
+  if (hotplug === null) {
+    log(
+      "[input-intercept] inotify unavailable — controllers added mid-session " +
+        "will only be picked up by the 2s reconcile poll",
+    );
+  }
+}
+
+// ---- Wake events -----------------------------------------------------------
+
+/** Wake shortcuts that should open/close the overlay. Subset of
+ *  nav_controller.rs::WakeEvent. */
+export type WakeEvent =
+  | "QamToggle"
+  | "GuideA"
+  | "GuideB"
+  | "GuideX"
+  | "GuideY"
+  | "CtrlThree"
+  | "CtrlFour";
+
+// ---- Tuning ---------------------------------------------------------------
+
+/** Read-loop interval. Tauri's epoll has a 100ms timeout and bursts on
+ *  demand; we approximate with fixed 25ms polling while intercepting and
+ *  100ms while idle — both sides are cheap and within frame-time. */
+const POLL_ACTIVE_MS = 25;
+const POLL_IDLE_MS = 100;
+
+/** Buffer = 64 events per device per tick. Way bigger than any realistic
+ *  25 ms burst; small enough that per-device allocation stays negligible. */
+const READ_BATCH = 64;
+const READ_BUF_SIZE = INPUT_EVENT_SIZE * READ_BATCH;
+
+// Safety timeout removed 2026-05-11. The original Rust port had a 5s
+// "if no events forwarded, auto-release" bail-out to handle a "stuck
+// grab" pathology (overlay window vanished / hide() raced without
+// doRelease() firing → user's whole machine sees dead controllers).
+//
+// The cure was worse than the disease:
+//
+//   - `lastForward` only ticks when NavController emits an action.
+//     A user who reads the overlay UI for >5s without pressing a
+//     controller button (very normal — overlay is meant to be read)
+//     trips the bail-out, doRelease fires, controller appears dead.
+//     Touch kept working (CEF, not evdev), so the user could hide+show
+//     to re-grab. Reported by maintainer 2026-05-11.
+//
+//   - **Worse:** on a controller-only handheld with no touchscreen,
+//     once the timeout fires the wake keys also route away from us
+//     (they go to Steam now), so the user is permanently stranded
+//     until they restart the service.
+//
+// What the timeout was protecting against is better handled by:
+//   1. The kernel itself: on process death, all fds close and EVIOCGRAB
+//      auto-releases. So a crashed overlay never leaves controllers stuck.
+//   2. Making doGrab/doRelease strictly paired with overlay show/hide.
+//      Any "stuck grab" is a bug in that pairing — fix it where it
+//      actually leaks, not by papering over with a timer.
+//
+// If the pathological case re-surfaces, the right next step is a
+// webview→bun heartbeat to detect a hung overlay window, not a
+// blanket time-based bail-out.
+
+// ---- Kernel event-mask helpers (EVIOCSMASK) --------------------------------
+//
+// EVIOCSMASK takes a `struct input_mask { __u32 type; __u32 codes_size;
+// __u64 codes_ptr; }` (16 bytes). `codes_ptr` is a pointer to a bitmask
+// indexed by event code. Kernel ignores events NOT in the mask before
+// they reach read(2), so we save a read-side syscall per ignored event.
+
+interface InputMask {
+  type_: number;
+  codesSize: number;
+  codesPtr: bigint;
+}
+
+function encodeInputMask(m: InputMask): Uint8Array {
+  // 16 bytes, little-endian on x86_64.
+  const buf = new ArrayBuffer(16);
+  const view = new DataView(buf);
+  view.setUint32(0, m.type_, true);
+  view.setUint32(4, m.codesSize, true);
+  view.setBigUint64(8, m.codesPtr, true);
+  return new Uint8Array(buf);
+}
+
+/** Build a bitmask (aligned to 8-byte boundary) from a list of event codes. */
+function buildBitmask(codes: readonly number[]): Uint8Array {
+  if (codes.length === 0) return new Uint8Array(0);
+  const maxCode = codes.reduce((a, b) => (a > b ? a : b), 0);
+  let byteLen = (maxCode >> 3) + 1;
+  if (byteLen % 8 !== 0) byteLen += 8 - (byteLen % 8);
+  if (byteLen < 8) byteLen = 8;
+  const bits = new Uint8Array(byteLen);
+  for (const code of codes) {
+    bits[code >> 3] |= 1 << (code & 7);
+  }
+  return bits;
+}
+
+function setEventMask(
+  fd: number,
+  evType: number,
+  codes: readonly number[],
+): void {
+  const bits = buildBitmask(codes);
+  // `codesPtr` may legitimately be null when codes is empty (tells the
+  // kernel "filter everything of this EV_TYPE"). Bun's ptr() needs a
+  // non-empty buffer, so we pass a 1-byte dummy and codesSize=0 — the
+  // kernel ignores the pointer when size is 0.
+  const dummy = new Uint8Array(1);
+  const mask: InputMask = {
+    type_: evType,
+    codesSize: bits.length,
+    codesPtr: BigInt(bits.length === 0 ? ptr(dummy) : ptr(bits)),
+  };
+  const maskBuf = encodeInputMask(mask);
+  libc.symbols.ioctl(fd, EVIOCSMASK, ptr(maskBuf));
+  // Errors are expected on older kernels that don't support EVIOCSMASK —
+  // we silently fall back to reading + discarding in userspace.
+}
+
+// ---- Wake-button codes for each mode --------------------------------------
+
+/** Buttons monitored during idle mode — guide/select + the four face
+ *  buttons for combo detection. */
+const WAKE_BUTTON_CODES: readonly number[] = [
+  BTN_MODE,
+  BTN_SELECT,
+  BTN_A,
+  BTN_B,
+  BTN_X,
+  BTN_Y,
+];
+
+/** All buttons forwarded to the NavController during intercept. */
+const NAV_BUTTON_CODES: readonly number[] = [
+  BTN_A,
+  BTN_B,
+  BTN_X,
+  BTN_Y,
+  BTN_TL,
+  BTN_TR,
+  BTN_SELECT,
+  BTN_MODE,
+];
+
+/** Keyboard wake keys. */
+const SHORTCUT_KEY_CODES: readonly number[] = [
+  KEY_LEFTCTRL,
+  KEY_3,
+  KEY_4,
+];
+
+/** QAM wake key. */
+const QAM_KEY_CODES: readonly number[] = [KEY_F16];
+
+/** Axes forwarded during intercept. Right stick (ABS_RX/RY) is included
+ *  so the webview can drive analog scroll of the main content area. */
+const NAV_AXIS_CODES: readonly number[] = [
+  ABS_X,
+  ABS_Y,
+  ABS_RX,
+  ABS_RY,
+  ABS_HAT0X,
+  ABS_HAT0Y,
+];
+
+function applyIdleMasks(fd: number, dev: InputDevice): void {
+  // Controllers get wake buttons; keyboards get ctrl/3/4; qam gets F16.
+  // A single device can be multiple (InputPlumber keyboard is both
+  // keyboard + qam) — union all that apply.
+  const codes: number[] = [];
+  if (dev.flags.isController) codes.push(...WAKE_BUTTON_CODES);
+  if (dev.flags.isKeyboard) codes.push(...SHORTCUT_KEY_CODES);
+  if (dev.flags.isQam) codes.push(...QAM_KEY_CODES);
+  setEventMask(fd, EV_KEY, codes);
+
+  // Suppress axes + misc in idle — we only care about wake button
+  // presses to bring the overlay up.
+  setEventMask(fd, EV_ABS, []);
+  setEventMask(fd, 0x02 /* EV_REL */, []);
+  setEventMask(fd, 0x04 /* EV_MSC */, []);
+}
+
+function applyInterceptMasks(fd: number): void {
+  // Broaden to everything nav needs: face buttons, shoulder bumpers,
+  // modifiers, shortcut modifiers, and nav axes.
+  const keys = [
+    ...SHORTCUT_KEY_CODES,
+    ...WAKE_BUTTON_CODES,
+    ...NAV_BUTTON_CODES,
+  ];
+  setEventMask(fd, EV_KEY, keys);
+  setEventMask(fd, EV_ABS, NAV_AXIS_CODES);
+}
+
+// ---- Raw event read --------------------------------------------------------
+
+interface RawEvent {
+  type: number;
+  code: number;
+  value: number;
+}
+
+function readRawEvents(fd: number, buf: Uint8Array, view: DataView): RawEvent[] {
+  const n = Number(libc.symbols.read(fd, buf, BigInt(buf.byteLength)));
+  if (n <= 0) return [];
+  const count = Math.floor(n / INPUT_EVENT_SIZE);
+  const out: RawEvent[] = new Array(count);
+  for (let j = 0; j < count; j++) {
+    const off = j * INPUT_EVENT_SIZE;
+    out[j] = {
+      type: view.getUint16(off + 16, true),
+      code: view.getUint16(off + 18, true),
+      value: view.getInt32(off + 20, true),
+    };
+  }
+  return out;
+}
+
+// ---- Axis calibration (EVIOCGABS) -----------------------------------------
+//
+// Sticks + triggers report raw values in whatever range their kernel driver
+// uses (e.g. -32768..32767 for a Sony pad, 0..255 for an Xbox trigger).
+// NavController wants normalized -1..1 on the stick axes, so we query
+// each device's min/max via EVIOCGABS once at open.
+
+interface AxisCal {
+  min: number;
+  max: number;
+}
+
+/** EVIOCGABS(code) = _IOR('E', 0x40 + code, struct input_absinfo). */
+function eviocgabs(code: number): bigint {
+  return 0x80184540n + BigInt(code);
+}
+
+function readAxisCalibration(fd: number): Map<number, AxisCal> {
+  const cal = new Map<number, AxisCal>();
+  for (const code of NAV_AXIS_CODES) {
+    // struct input_absinfo: __s32 value, min, max, fuzz, flat, resolution (24 bytes).
+    const buf = new Uint8Array(24);
+    const rc = libc.symbols.ioctl(fd, eviocgabs(code), ptr(buf));
+    if (rc !== 0) continue;
+    const view = new DataView(buf.buffer);
+    const min = view.getInt32(4, true);
+    const max = view.getInt32(8, true);
+    cal.set(code, { min, max });
+  }
+  return cal;
+}
+
+function normalizeAxis(code: number, raw: number, cal: Map<number, AxisCal>): number {
+  const c = cal.get(code);
+  if (!c || c.max === c.min) return 0;
+  const n = (raw - c.min) / (c.max - c.min);
+  return Math.min(1, Math.max(0, n)) * 2 - 1;
+}
+
+// ---- Combo detection (guide+button + ctrl+3/4) -----------------------------
+
+/** How long the combo modifier + button must overlap. Matches
+ *  nav_controller.rs's COMBO_MAX_DURATION. */
+const COMBO_MAX_DURATION_MS = 300;
+
+interface ComboState {
+  guideHeld: boolean;
+  selectHeld: boolean;
+  pressedAt: Partial<Record<"a" | "b" | "x" | "y", number>>;
+}
+
+function newComboState(): ComboState {
+  return { guideHeld: false, selectHeld: false, pressedAt: {} };
+}
+
+interface ShortcutState {
+  ctrlHeld: boolean;
+}
+
+function newShortcutState(): ShortcutState {
+  return { ctrlHeld: false };
+}
+
+function processCombo(
+  state: ComboState,
+  code: number,
+  value: number,
+  now: number,
+): WakeEvent | null {
+  if (code === BTN_MODE) {
+    state.guideHeld = value !== 0;
+    return null;
+  }
+  if (code === BTN_SELECT) {
+    state.selectHeld = value !== 0;
+    return null;
+  }
+  if (!state.guideHeld && !state.selectHeld) return null;
+
+  const letter =
+    code === BTN_A ? "a" :
+    code === BTN_B ? "b" :
+    code === BTN_X ? "x" :
+    code === BTN_Y ? "y" : null;
+  if (!letter) return null;
+
+  if (value !== 0) {
+    state.pressedAt[letter] = now;
+    return null;
+  }
+  const pressedAt = state.pressedAt[letter];
+  delete state.pressedAt[letter];
+  if (pressedAt === undefined) return null;
+  if (now - pressedAt >= COMBO_MAX_DURATION_MS) return null;
+  switch (letter) {
+    case "a": return "GuideA";
+    case "b": return "GuideB";
+    case "x": return "GuideX";
+    case "y": return "GuideY";
+  }
+}
+
+function processShortcut(
+  state: ShortcutState,
+  code: number,
+  value: number,
+): WakeEvent | null {
+  if (code === KEY_LEFTCTRL) {
+    state.ctrlHeld = value !== 0;
+    return null;
+  }
+  if (value === 0) return null; // key release doesn't fire
+  if (!state.ctrlHeld) return null;
+  if (code === KEY_3) return "CtrlThree";
+  if (code === KEY_4) return "CtrlFour";
+  return null;
+}
+
+// ---- Raw → InputEvent ------------------------------------------------------
+
+function toInputEvents(
+  events: RawEvent[],
+  cal: Map<number, AxisCal>,
+): InputEvent[] {
+  const out: InputEvent[] = [];
+  for (const e of events) {
+    if (e.type === EV_SYN) continue;
+    if (e.type === EV_KEY) {
+      const btn =
+        e.code === BTN_A ? "A" :
+        e.code === BTN_B ? "B" :
+        e.code === BTN_X ? "X" :
+        e.code === BTN_Y ? "Y" :
+        e.code === BTN_TL ? "LB" :
+        e.code === BTN_TR ? "RB" :
+        e.code === BTN_MODE ? "Mode" :
+        e.code === BTN_SELECT ? "Select" :
+        null;
+      if (btn) out.push({ kind: "button", button: btn, pressed: e.value !== 0 });
+    } else if (e.type === EV_ABS) {
+      const axis =
+        e.code === ABS_X ? "LeftStickX" :
+        e.code === ABS_Y ? "LeftStickY" :
+        e.code === ABS_RX ? "RightStickX" :
+        e.code === ABS_RY ? "RightStickY" :
+        e.code === ABS_HAT0X ? "HatX" :
+        e.code === ABS_HAT0Y ? "HatY" :
+        null;
+      if (axis) {
+        out.push({
+          kind: "axis",
+          axis,
+          // Hat axes report raw -1/0/1 from the kernel already; passing
+          // them through normalizeAxis would collapse them via the
+          // deadzone if calibration didn't come back. Hats never have
+          // EVIOCGABS calibration on most kernels anyway, so fall back
+          // to raw when cal is missing.
+          value: cal.has(e.code) ? normalizeAxis(e.code, e.value, cal) : e.value,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+// ---- Tracked device --------------------------------------------------------
+
+interface TrackedDevice {
+  fd: number;
+  path: string;
+  dev: InputDevice;
+  grabbed: boolean;
+  combo: ComboState;
+  shortcut: ShortcutState;
+  cal: Map<number, AxisCal>;
+}
+
+// ---- Public API ------------------------------------------------------------
+
+export interface InputInterceptOptions {
+  /** Fires on wake shortcuts (F16, guide+B, ctrl+4 etc). The index.ts
+   *  orchestrator decides whether to open or close the overlay. */
+  onWake: (event: WakeEvent) => void;
+  /** Fires for every NavAction while intercept is active. Wire this up
+   *  to `overlay.rpc.send("overlay-action", {action})`. */
+  onAction: (action: string) => void;
+  /** Fires for continuous-analog axes (right stick) while intercept is
+   *  active. Wire this up to `overlay.rpc.send("overlay-scroll", …)`. */
+  onAxis?: (axis: "RightStickX" | "RightStickY", value: number) => void;
+  /** Optional — number of controllers that were opened. For diagnostic logs. */
+  onReady?: (counts: { controllers: number; keyboards: number; qam: number }) => void;
+}
+
+export interface InputInterceptHandle {
+  /** Start intercept — EVIOCGRAB physical controllers, broaden their
+   *  event masks, reset NavController state. Safe to call multiple times. */
+  grab(): void;
+  /** Stop intercept — release grabs, narrow masks back to idle. */
+  release(): void;
+  /** Close all FDs, release any outstanding grabs. Call from shutdown. */
+  shutdown(): void;
+  /** For diagnostic logs. */
+  readonly deviceCount: number;
+}
+
+export async function startInputIntercept(
+  opts: InputInterceptOptions,
+): Promise<InputInterceptHandle> {
+  const devices = (await enumerateDevices()).filter(
+    (d) => (d.flags.isController && !d.isSteamVirtual) ||
+           d.flags.isKeyboard ||
+           d.flags.isQam,
+  );
+
+  const tracked: TrackedDevice[] = [];
+
+  function openAndTrack(dev: InputDevice): TrackedDevice | null {
+    const pathBuf = Buffer.from(dev.eventPath + "\0");
+    const fd = libc.symbols.open(pathBuf, O_RDONLY | O_NONBLOCK);
+    if (fd < 0) {
+      console.warn(
+        `[input-intercept] open failed for ${dev.eventPath} (${dev.name})`,
+      );
+      return null;
+    }
+    applyIdleMasks(fd, dev);
+    const cal = dev.flags.isController ? readAxisCalibration(fd) : new Map();
+    const t: TrackedDevice = {
+      fd,
+      path: dev.eventPath,
+      dev,
+      grabbed: false,
+      combo: newComboState(),
+      shortcut: newShortcutState(),
+      cal,
+    };
+    tracked.push(t);
+    const kinds = [
+      dev.flags.isController ? "controller" : null,
+      dev.flags.isKeyboard ? "keyboard" : null,
+      dev.flags.isQam ? "qam" : null,
+    ].filter(Boolean).join("+");
+    console.log(
+      `[input-intercept] opened ${dev.eventPath} '${dev.name}' (${kinds})`,
+    );
+    return t;
+  }
+
+  for (const dev of devices) {
+    openAndTrack(dev);
+  }
+
+  opts.onReady?.({
+    controllers: tracked.filter((t) => t.dev.flags.isController).length,
+    keyboards: tracked.filter((t) => t.dev.flags.isKeyboard).length,
+    qam: tracked.filter((t) => t.dev.flags.isQam).length,
+  });
+
+  let intercepting = false;
+  let generation = 0;
+
+  const nav = new NavController({
+    emit: (a) => {
+      opts.onAction(a);
+    },
+    emitAxis: (axis, value) => {
+      opts.onAxis?.(axis, value);
+    },
+  });
+
+  const buf = new Uint8Array(READ_BUF_SIZE);
+  const view = new DataView(buf.buffer);
+
+  function pollOnce(): void {
+    // Drain any pending hot-plug events before reading from the
+    // tracked devices — adds/removes mutate `tracked`, and we want
+    // a fresh list when the read loop runs below.
+    hotplug?.poll();
+
+    const now = performance.now();
+
+    for (const t of tracked) {
+      const events = readRawEvents(t.fd, buf, view);
+
+      // Wake detection runs in every mode on every device.
+      for (const e of events) {
+        if (e.type !== EV_KEY) continue;
+        if (t.dev.flags.isController) {
+          const wake = processCombo(t.combo, e.code, e.value, now);
+          if (wake) {
+            trace(
+              `[input-intercept] wake=${wake} from '${t.dev.name}' (${t.path})`,
+            );
+            opts.onWake(wake);
+          }
+        }
+        if (t.dev.flags.isKeyboard) {
+          const wake = processShortcut(t.shortcut, e.code, e.value);
+          if (wake) {
+            trace(
+              `[input-intercept] wake=${wake} from '${t.dev.name}' (${t.path})`,
+            );
+            opts.onWake(wake);
+          }
+        }
+        if (t.dev.flags.isQam && e.code === KEY_F16 && e.value === 1) {
+          trace(
+            `[input-intercept] wake=QamToggle from '${t.dev.name}' (${t.path})`,
+          );
+          opts.onWake("QamToggle");
+        }
+      }
+
+      // During intercept, forward nav-relevant events to NavController.
+      // Always call processEvents (even with []) so held buttons keep
+      // key-repeating.
+      if (intercepting && t.dev.flags.isController) {
+        const cid = `${t.dev.hash}_${generation}`;
+        const input = toInputEvents(events, t.cal);
+        nav.processEvents(cid, input);
+      }
+    }
+  }
+
+  let timer: ReturnType<typeof setInterval> | null = null;
+  function startTimer(): void {
+    if (timer) clearInterval(timer);
+    timer = setInterval(pollOnce, intercepting ? POLL_ACTIVE_MS : POLL_IDLE_MS);
+  }
+  startTimer();
+
+  function doGrab(): void {
+    if (intercepting) return;
+    intercepting = true;
+    generation += 1;
+    nav.reset();
+    for (const t of tracked) {
+      if (!t.dev.flags.isController) continue;
+      applyInterceptMasks(t.fd);
+      if (!t.grabbed) {
+        const intBuf = new Int32Array([1]);
+        const rc = libc.symbols.ioctl(t.fd, EVIOCGRAB, ptr(intBuf));
+        if (rc === 0) {
+          t.grabbed = true;
+          console.log(`[input-intercept] grabbed ${t.path} '${t.dev.name}'`);
+        } else {
+          // EBUSY is normal if another app (old overlay instance,
+          // steamcompmgr) has it — log and move on.
+          console.warn(
+            `[input-intercept] grab failed for ${t.path} (rc=${rc})`,
+          );
+        }
+      }
+    }
+    startTimer();
+  }
+
+  function doRelease(): void {
+    if (!intercepting) return;
+    intercepting = false;
+    for (const t of tracked) {
+      if (!t.dev.flags.isController) continue;
+      if (t.grabbed) {
+        // Kernel semantics (drivers/input/evdev.c): EVIOCGRAB treats the
+        // ioctl arg as a pointer and only checks null-vs-non-null — any
+        // non-null value GRABS, null RELEASES. Passing ptr() of a buffer
+        // (even one containing zero) gives a valid heap address → kernel
+        // would grab again. Pass literal null so bun:ffi marshals it as
+        // NULL and the kernel ungrabs.
+        libc.symbols.ioctl(t.fd, EVIOCGRAB, null);
+        t.grabbed = false;
+      }
+      applyIdleMasks(t.fd, t.dev);
+    }
+    nav.reset();
+    console.log(
+      `[input-intercept] released ${tracked.filter((t) => t.dev.flags.isController).length} controller(s)`,
+    );
+    startTimer();
+  }
+
+  // ---- Hot-plug -----------------------------------------------------------
+  //
+  // Bluetooth pads paired mid-session create a new /dev/input/eventN node
+  // after startInputIntercept has already run, so the snapshot enumeration
+  // above misses them. The inotify watcher fires onAdded for each new node;
+  // we re-enumerate /proc to get the device's name + capability bitmask
+  // and, if it qualifies, open + (if currently intercepting) grab it
+  // exactly as the boot-time path does.
+
+  async function handleDeviceAdded(eventPath: string): Promise<void> {
+    if (tracked.some((t) => t.path === eventPath)) return;
+    let fresh: InputDevice | undefined;
+    try {
+      const all = await enumerateDevices();
+      fresh = all.find((d) => d.eventPath === eventPath);
+    } catch (err) {
+      console.warn(
+        `[input-intercept] hotplug: enumerate failed for ${eventPath}:`,
+        err,
+      );
+      return;
+    }
+    if (!fresh) return;
+    const eligible =
+      (fresh.flags.isController && !fresh.isSteamVirtual) ||
+      fresh.flags.isKeyboard ||
+      fresh.flags.isQam;
+    if (!eligible) return;
+    const t = openAndTrack(fresh);
+    if (!t) return;
+    // If the overlay is open, the new controller has to participate in
+    // the intercept the same way the boot-time controllers do:
+    // broaden masks + EVIOCGRAB. Keyboards / qam don't get grabbed.
+    if (intercepting && t.dev.flags.isController) {
+      applyInterceptMasks(t.fd);
+      const intBuf = new Int32Array([1]);
+      const rc = libc.symbols.ioctl(t.fd, EVIOCGRAB, ptr(intBuf));
+      if (rc === 0) {
+        t.grabbed = true;
+        console.log(
+          `[input-intercept] hotplug grabbed ${t.path} '${t.dev.name}'`,
+        );
+      } else {
+        console.warn(
+          `[input-intercept] hotplug grab failed for ${t.path} (rc=${rc})`,
+        );
+      }
+    }
+  }
+
+  function handleDeviceRemoved(eventPath: string): void {
+    const idx = tracked.findIndex((t) => t.path === eventPath);
+    if (idx < 0) return;
+    const [t] = tracked.splice(idx, 1);
+    if (t.grabbed) {
+      libc.symbols.ioctl(t.fd, EVIOCGRAB, null);
+      t.grabbed = false;
+    }
+    libc.symbols.close(t.fd);
+    console.log(`[input-intercept] hotplug removed ${t.path} '${t.dev.name}'`);
+  }
+
+  const hotplug: DeviceHotplugHandle | null = startDeviceHotplug({
+    onAdded: (path) => {
+      handleDeviceAdded(path).catch((e) =>
+        console.warn(`[input-intercept] hotplug add threw for ${path}:`, e),
+      );
+    },
+    onRemoved: handleDeviceRemoved,
+  });
+  warnIfHotplugDisabled(hotplug);
+
+  // Belt-and-braces reconciliation: poll /proc/bus/input/devices every
+  // few seconds and diff against `tracked`. inotify is the fast path
+  // (instant response) but on some kernels / sandbox configs the events
+  // never reach our read() loop, so we cannot rely on it alone. The
+  // proc-fs scan is cheap (~10 KB read, few regex matches per block) and
+  // catches anything inotify missed.
+  const RECONCILE_INTERVAL_MS = 2000;
+  let reconcileTimer: ReturnType<typeof setInterval> | null = null;
+  async function reconcileTracked(): Promise<void> {
+    let all: InputDevice[];
+    try {
+      all = await enumerateDevices();
+    } catch (err) {
+      console.warn("[input-intercept] reconcile: enumerate failed:", err);
+      return;
+    }
+    const seen = new Set(all.map((d) => d.eventPath));
+    // Removals: tracked entries whose eventPath has vanished from /proc.
+    for (const t of [...tracked]) {
+      if (!seen.has(t.path)) {
+        console.log(
+          `[input-intercept] reconcile: ${t.path} '${t.dev.name}' gone — removing`,
+        );
+        handleDeviceRemoved(t.path);
+      }
+    }
+    // Additions: eligible /proc entries we don't already track.
+    const trackedPaths = new Set(tracked.map((t) => t.path));
+    for (const dev of all) {
+      if (trackedPaths.has(dev.eventPath)) continue;
+      const eligible =
+        (dev.flags.isController && !dev.isSteamVirtual) ||
+        dev.flags.isKeyboard ||
+        dev.flags.isQam;
+      if (!eligible) continue;
+      console.log(
+        `[input-intercept] reconcile: ${dev.eventPath} '${dev.name}' new — opening`,
+      );
+      const t = openAndTrack(dev);
+      if (t && intercepting && t.dev.flags.isController) {
+        applyInterceptMasks(t.fd);
+        const intBuf = new Int32Array([1]);
+        const rc = libc.symbols.ioctl(t.fd, EVIOCGRAB, ptr(intBuf));
+        if (rc === 0) {
+          t.grabbed = true;
+          console.log(
+            `[input-intercept] reconcile grabbed ${t.path} '${t.dev.name}'`,
+          );
+        }
+      }
+    }
+  }
+  reconcileTimer = setInterval(() => {
+    reconcileTracked().catch((e) =>
+      console.warn("[input-intercept] reconcile threw:", e),
+    );
+  }, RECONCILE_INTERVAL_MS);
+
+  return {
+    grab: doGrab,
+    release: doRelease,
+    shutdown: () => {
+      if (timer) clearInterval(timer);
+      timer = null;
+      if (reconcileTimer) clearInterval(reconcileTimer);
+      reconcileTimer = null;
+      hotplug?.shutdown();
+      if (intercepting) doRelease();
+      for (const t of tracked) libc.symbols.close(t.fd);
+      tracked.length = 0;
+    },
+    get deviceCount() {
+      return tracked.length;
+    },
+  };
+}
+
+// ---- Test helpers (exported for unit tests only) ---------------------------
+
+export const __testing__ = {
+  buildBitmask,
+  encodeInputMask,
+  processCombo,
+  processShortcut,
+  newComboState,
+  newShortcutState,
+  toInputEvents,
+  normalizeAxis,
+  eviocgabs,
+};

--- a/apps/overlay/src/bun/native/nav-controller.ts
+++ b/apps/overlay/src/bun/native/nav-controller.ts
@@ -1,0 +1,337 @@
+// Port of src-tauri/src/nav_controller.rs.
+//
+// Turns raw gamepad input events (from the evdev read loop) into
+// high-level NavActions that the webview maps onto synthetic
+// KeyboardEvents for norigin-spatial-navigation. Handles:
+//
+//   - key repeat: 500 ms initial delay, 200 ms thereafter (matches OS
+//     keyboard-repeat defaults so norigin feels like a native input).
+//   - axis → dpad: analog stick tilt past |0.5| fires a directional
+//     keyboardEvent. Deadzone = 0.5 on the -1..1 normalized range.
+//   - modifier suppression: while Mode/Select is held the combo detector
+//     owns the event stream, so nothing is emitted here.
+//   - B-on-release: prevents a phantom Escape leaking into Steam BPM
+//     immediately after SIGCONT (if we ever bring SIGSTOP back).
+//   - X press+release: X emits "x" on press, "x_up" on release so the
+//     frontend can track hold-duration (used for long-press actions).
+//
+// Pure TS — no FFI. The evdev reader calls processEvents() with raw
+// button/axis updates; emitAction is whatever bridge you wire up (in
+// our case, RPC-send to the webview which dispatches a KeyboardEvent).
+
+// ---- Timing constants (match nav_controller.rs exactly) ---------------------
+
+export const REPEAT_DELAY_MS = 500;
+export const REPEAT_RATE_MS = 200;
+export const AXIS_DEADZONE = 0.5;
+
+// ---- Input event shapes ----------------------------------------------------
+
+export type GamepadButton =
+  | "A"
+  | "B"
+  | "X"
+  | "Y"
+  | "LB"
+  | "RB"
+  | "Mode"
+  | "Select";
+
+export type GamepadAxis =
+  | "LeftStickX"
+  | "LeftStickY"
+  | "RightStickX"
+  | "RightStickY"
+  | "HatX"
+  | "HatY";
+
+export type InputEvent =
+  | { kind: "button"; button: GamepadButton; pressed: boolean }
+  | { kind: "axis"; axis: GamepadAxis; value: number };
+
+/** Actions emitted to the webview. Mirrors the `NavAction` enum in Rust
+ *  PLUS "x_up" for the press+release split that frontend long-press UX
+ *  relies on. */
+export type NavAction =
+  | "up"
+  | "down"
+  | "left"
+  | "right"
+  | "a"
+  | "b"
+  | "x"
+  | "x_up"
+  | "y"
+  | "lb"
+  | "rb";
+
+// ---- Key-repeat tracker ----------------------------------------------------
+
+/**
+ * Timestamp of the next firing for a held action. `advance()` returns true
+ * each time `now >= nextFire`, stepping `nextFire` forward by REPEAT_RATE_MS.
+ * Matches RepeatTracker in nav_controller.rs exactly — the initial delay
+ * (REPEAT_DELAY_MS) is longer than the steady-state rate to avoid misfires
+ * when the user is already about to release.
+ */
+class RepeatTracker {
+  nextFire: number;
+
+  constructor(now: number) {
+    this.nextFire = now + REPEAT_DELAY_MS;
+  }
+
+  checkAndAdvance(now: number): boolean {
+    if (now >= this.nextFire) {
+      this.nextFire = now + REPEAT_RATE_MS;
+      return true;
+    }
+    return false;
+  }
+}
+
+// Actions that participate in key repeat — excludes x_up (release-only)
+// and the combo modifiers (Mode/Select).
+type RepeatableAction =
+  | "up"
+  | "down"
+  | "left"
+  | "right"
+  | "a"
+  | "b"
+  | "x"
+  | "y"
+  | "lb"
+  | "rb";
+
+// ---- Per-controller state --------------------------------------------------
+
+interface ControllerState {
+  held: Map<RepeatableAction, RepeatTracker>;
+  modeHeld: boolean;
+  selectHeld: boolean;
+  /** Last value emitted for each continuous-analog axis (right stick).
+   *  Used to dedupe rebroadcast events from the kernel so we don't spam
+   *  the webview with identical scroll messages. */
+  lastAnalog: Partial<Record<AnalogAxis, number>>;
+}
+
+function newControllerState(): ControllerState {
+  return { held: new Map(), modeHeld: false, selectHeld: false, lastAnalog: {} };
+}
+
+/** Continuous-analog axes — bypass the dpad/deadzone path and get
+ *  forwarded verbatim via emitAxis so the webview can drive smooth
+ *  scrolling. */
+export type AnalogAxis = "RightStickX" | "RightStickY";
+
+function isAnalogAxis(axis: GamepadAxis): axis is AnalogAxis {
+  return axis === "RightStickX" || axis === "RightStickY";
+}
+
+// ---- NavController ---------------------------------------------------------
+
+export interface NavControllerOptions {
+  /** Called whenever a NavAction fires. The Bun-side overlay wires this to
+   *  `rpc.send("overlay-action", {action})` which the webview catches and
+   *  translates into a synthetic KeyboardEvent. */
+  emit: (action: NavAction) => void;
+  /** Called for continuous-analog axes (right stick). The Bun-side overlay
+   *  wires this to `rpc.send("overlay-scroll", {axis, value})`; the webview
+   *  runs its own rAF loop with momentum to scroll the main content area.
+   *  Skipped entirely for axes that go through the dpad path (left stick
+   *  and hat). */
+  emitAxis?: (axis: AnalogAxis, value: number) => void;
+  /** Injected for tests — defaults to performance.now(). */
+  now?: () => number;
+}
+
+/**
+ * NavController — one instance for the whole app. Tracks per-controller
+ * state keyed by an opaque controller id (we use `${device.hash}_${generation}`
+ * so reconnects reset state).
+ *
+ * This class is synchronous and single-threaded. Call processEvents() from
+ * the input-read loop for every batch of events, and pump() regularly
+ * (e.g. every 50 ms) to service key repeat for held buttons.
+ */
+export class NavController {
+  private emit: (action: NavAction) => void;
+  private emitAxis?: (axis: AnalogAxis, value: number) => void;
+  private now: () => number;
+  private controllers = new Map<string, ControllerState>();
+
+  constructor(opts: NavControllerOptions) {
+    this.emit = opts.emit;
+    this.emitAxis = opts.emitAxis;
+    this.now = opts.now ?? (() => performance.now());
+  }
+
+  /**
+   * Feed a batch of events from a single controller. Call this from the
+   * read loop after every read() — even with an empty array, so key repeat
+   * has a chance to fire without needing a separate pump.
+   */
+  processEvents(controllerId: string, events: InputEvent[]): void {
+    let st = this.controllers.get(controllerId);
+    if (!st) {
+      st = newControllerState();
+      this.controllers.set(controllerId, st);
+    }
+
+    // Pending edge-triggered emissions — (action, isPress). Key-repeat
+    // ticks go into the same list below. Held action bookkeeping must
+    // be done before the modifier-suppression short-circuit so the
+    // Mode/Select flags are up to date for subsequent events.
+    const edges: Array<[RepeatableAction, boolean]> = [];
+    const now = this.now();
+
+    for (const ev of events) {
+      if (ev.kind === "axis") {
+        this.applyAxis(st, ev.axis, ev.value, now, edges);
+      } else {
+        // button
+        if (ev.button === "Mode") {
+          st.modeHeld = ev.pressed;
+          continue;
+        }
+        if (ev.button === "Select") {
+          st.selectHeld = ev.pressed;
+          continue;
+        }
+        const action = buttonToAction(ev.button);
+        if (!action) continue;
+        const wasHeld = st.held.has(action);
+        if (ev.pressed && !wasHeld) {
+          st.held.set(action, new RepeatTracker(now));
+          edges.push([action, true]);
+        } else if (!ev.pressed && wasHeld) {
+          st.held.delete(action);
+          edges.push([action, false]);
+        }
+      }
+    }
+
+    // Modifier suppression: while Mode or Select is held the combo
+    // detector in the input-intercept module owns the event stream —
+    // don't fire navigation on top of it.
+    if (st.modeHeld || st.selectHeld) return;
+
+    // Key repeat for held actions. Mutates nextFire inside the tracker.
+    for (const [action, tracker] of st.held) {
+      if (tracker.checkAndAdvance(now)) {
+        edges.push([action, true]);
+      }
+    }
+
+    // Final emit with per-button special cases.
+    for (const [action, isPress] of edges) {
+      switch (action) {
+        // B fires on RELEASE only. nav_controller.rs's comment: prevents
+        // a phantom Escape getting into Steam when we're resuming it
+        // from SIGSTOP and our B-press raced the SIGCONT. Even without
+        // SIGSTOP, release-triggering makes B feel more like a "commit
+        // to close" action and less like it's always-firing on held B.
+        case "b":
+          if (!isPress) this.emit("b");
+          break;
+        // X emits both press and release as distinct actions so the UI
+        // can tell a tap from a long-press (e.g. QAM quick-swap vs a
+        // held-X context menu).
+        case "x":
+          this.emit(isPress ? "x" : "x_up");
+          break;
+        default:
+          if (isPress) this.emit(action);
+      }
+    }
+  }
+
+  /** Reset all per-controller state. Called when the overlay opens or
+   *  closes so a half-held button from last session doesn't spam the
+   *  first frame of the new one. */
+  reset(): void {
+    this.controllers.clear();
+  }
+
+  /**
+   * Axis → dpad conversion with deadzone. Writes to `edges` and updates
+   * `state.held` in place.
+   *
+   * Right-stick axes (RightStickX/Y) short-circuit before the dpad
+   * switch — they're continuous analog input for scrolling, not
+   * direction triggers, so they must skip key-repeat / `state.held`
+   * entirely and go straight to `emitAxis`.
+   */
+  private applyAxis(
+    state: ControllerState,
+    axis: GamepadAxis,
+    value: number,
+    now: number,
+    edges: Array<[RepeatableAction, boolean]>,
+  ): void {
+    if (isAnalogAxis(axis)) {
+      if (state.lastAnalog[axis] === value) return;
+      state.lastAnalog[axis] = value;
+      this.emitAxis?.(axis, value);
+      return;
+    }
+
+    let posAction: RepeatableAction;
+    let negAction: RepeatableAction;
+    switch (axis) {
+      case "LeftStickX":
+      case "HatX":
+        posAction = "right";
+        negAction = "left";
+        break;
+      case "LeftStickY":
+      case "HatY":
+        posAction = "down";
+        negAction = "up";
+        break;
+    }
+
+    const posActive = value > AXIS_DEADZONE;
+    const negActive = value < -AXIS_DEADZONE;
+
+    const wasPos = state.held.has(posAction);
+    const wasNeg = state.held.has(negAction);
+
+    if (posActive && !wasPos) {
+      state.held.set(posAction, new RepeatTracker(now));
+      edges.push([posAction, true]);
+    } else if (!posActive && wasPos) {
+      state.held.delete(posAction);
+      edges.push([posAction, false]);
+    }
+
+    if (negActive && !wasNeg) {
+      state.held.set(negAction, new RepeatTracker(now));
+      edges.push([negAction, true]);
+    } else if (!negActive && wasNeg) {
+      state.held.delete(negAction);
+      edges.push([negAction, false]);
+    }
+  }
+}
+
+function buttonToAction(b: GamepadButton): RepeatableAction | null {
+  switch (b) {
+    case "A":
+      return "a";
+    case "B":
+      return "b";
+    case "X":
+      return "x";
+    case "Y":
+      return "y";
+    case "LB":
+      return "lb";
+    case "RB":
+      return "rb";
+    case "Mode":
+    case "Select":
+      return null;
+  }
+}

--- a/apps/overlay/src/bun/native/process-control.ts
+++ b/apps/overlay/src/bun/native/process-control.ts
@@ -1,0 +1,111 @@
+// Suspend / resume the Steam process while the overlay is open, so
+// gamepad and keyboard events can't bleed through to the game underneath.
+// Port of src-tauri/src/process_control.rs from the Tauri overlay.
+//
+// Only the main `steam` PID is frozen — NOT the game process, NOT
+// steamwebhelper (a child of steam that shows the UI). Game continues
+// running in the background; the OS just stops delivering input events
+// while its parent Steam is in TASK_STOPPED state.
+//
+// Pair this with native/f16-watcher.ts (+ the upcoming controller grab)
+// so input is blocked at two layers: evdev-grab on the controller
+// device AND process-level SIGSTOP on Steam.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { libc } from "./ffi";
+
+// From <signal.h> on Linux amd64/arm64. Don't use kill(2)'s string
+// names via a spawn — we're already in a hot path during overlay
+// toggle, and bun:ffi kill() is a direct syscall.
+const SIGTERM = 15;
+const SIGKILL = 9;
+const SIGCONT = 18;
+const SIGSTOP = 19;
+
+/**
+ * Scan /proc for a process whose comm is exactly "steam". Steam's
+ * kernel comm name is 5 chars, so the 15-char TASK_COMM_LEN limit
+ * is a non-issue. We deliberately ignore steamwebhelper (15-char
+ * truncated to "steamwebhelper" — no match) and anything starting
+ * with "steam" that isn't exact.
+ */
+export function findSteamPid(): number | null {
+  let entries: string[];
+  try {
+    entries = readdirSync("/proc");
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const pid = Number(entry);
+    if (!Number.isFinite(pid) || pid <= 0) continue;
+    let comm: string;
+    try {
+      comm = readFileSync(`/proc/${pid}/comm`, "utf8").trim();
+    } catch {
+      // Process gone between readdir and readFile — normal, skip.
+      continue;
+    }
+    if (comm === "steam") return pid;
+  }
+  return null;
+}
+
+/**
+ * Send a signal to a pid via libc kill(2). Returns true on success.
+ * Non-throwing: on permission error or ESRCH we log and return false
+ * so the caller can continue (overlay should NOT become unusable just
+ * because we failed to freeze Steam — input grab is the backup).
+ */
+function sendSignal(pid: number, sig: number, label: string): boolean {
+  if (pid <= 0) return false;
+  const rc = libc.symbols.kill(pid, sig);
+  if (rc !== 0) {
+    console.warn(
+      `[process-control] kill(${pid}, ${label}) failed (rc=${rc})`,
+    );
+    return false;
+  }
+  return true;
+}
+
+/** SIGSTOP the given PID. Caller is responsible for remembering it
+ *  and calling resume() later — an unpaired suspend leaves Steam
+ *  frozen for the rest of the session. */
+export function suspendSteam(pid: number): boolean {
+  const ok = sendSignal(pid, SIGSTOP, "SIGSTOP");
+  if (ok) console.log(`[process-control] suspended Steam (PID ${pid})`);
+  return ok;
+}
+
+/** SIGCONT the given PID. Safe to call even when the process was
+ *  never suspended (kernel no-ops) — useful on overlay-service
+ *  shutdown to ensure we don't leave users with a frozen Steam. */
+export function resumeSteam(pid: number): boolean {
+  const ok = sendSignal(pid, SIGCONT, "SIGCONT");
+  if (ok) console.log(`[process-control] resumed Steam (PID ${pid})`);
+  return ok;
+}
+
+/** SIGTERM the given PID. Used by the "Restart Steam" maintenance
+ *  action when `steam -shutdown` doesn't clean up in time. */
+export function terminateSteam(pid: number): boolean {
+  const ok = sendSignal(pid, SIGTERM, "SIGTERM");
+  if (ok) console.log(`[process-control] terminated Steam (PID ${pid})`);
+  return ok;
+}
+
+/** SIGKILL the given PID. Last-resort path for a fully wedged Steam
+ *  that ignored both `steam -shutdown` and SIGTERM. */
+export function killSteam(pid: number): boolean {
+  const ok = sendSignal(pid, SIGKILL, "SIGKILL");
+  if (ok) console.log(`[process-control] killed Steam (PID ${pid})`);
+  return ok;
+}
+
+/** kill(pid, 0) probes whether a PID is still deliverable without
+ *  actually signaling it. Returns false on ESRCH / dead process. */
+export function isPidAlive(pid: number): boolean {
+  if (pid <= 0) return false;
+  return libc.symbols.kill(pid, 0) === 0;
+}

--- a/apps/overlay/src/bun/native/steam-quick-access.ts
+++ b/apps/overlay/src/bun/native/steam-quick-access.ts
@@ -1,0 +1,11 @@
+/**
+ * Stub for M1 — Steam BPM QAM dismissal is only useful when Loadout is
+ * integrating with Steam's Big Picture Mode (which it isn't yet). Returns
+ * false unconditionally so gamescope-atoms.ts's call site is a no-op.
+ *
+ * Re-port the CDP-based dismissal logic from the original repo when
+ * Steam BPM integration lands as its own milestone.
+ */
+export async function dismissSteamQuickAccessIfOpen(): Promise<boolean> {
+  return false;
+}

--- a/apps/overlay/src/bun/native/trace.ts
+++ b/apps/overlay/src/bun/native/trace.ts
@@ -1,0 +1,37 @@
+// Diagnostic logger for the overlay hot path.
+//
+// Under Electrobun's CEF-integrated event loop, Bun's stdout is block-
+// buffered against the systemd journal socket — `console.log` from the
+// toggle / reclaim / input-intercept hot path doesn't flush for minutes.
+// `process.stderr.write` had the same fate on-device. `fs.appendFileSync`
+// via `require("fs")` is the one path empirically verified to land
+// immediately, so we use that.
+//
+// Trace file lives in the repo root by default so the dev workflow
+// keeps a copy in the working tree for diagnosis. Also echoed to
+// stdout for the off chance someone's reading journalctl.
+//
+// `LOADOUT_TRACE_FILE` env var overrides the path; otherwise
+// fall back to `${tmpdir}/loadout-overlay.trace` so the appendSync
+// doesn't silently ENOENT on machines without the maintainer's repo
+// layout (audit B-021).
+//
+import { appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export const TRACE_FILE =
+  process.env.LOADOUT_TRACE_FILE ??
+  join(tmpdir(), "loadout-overlay.trace");
+
+export function trace(msg: string): void {
+  const line = `${new Date().toISOString()} ${msg}\n`;
+  // stdout for anyone watching journalctl. Buffered but harmless.
+  try {
+    console.log(msg);
+  } catch {}
+  // File sink — the reliable one.
+  try {
+    appendFileSync(TRACE_FILE, line);
+  } catch {}
+}

--- a/apps/overlay/src/bun/native/x11.ts
+++ b/apps/overlay/src/bun/native/x11.ts
@@ -1,0 +1,349 @@
+// libxcb wrapper for the gamescope atom hot path.
+//
+// The xprop-subprocess path in gamescope-atoms.ts spawns a process per
+// atom write (~10ms each). When show() chains 6+ writes, the elapsed
+// window during which Steam BPM and our overlay can both have
+// STEAM_OVERLAY=1 is ~60ms — long enough for gamescope to flicker
+// between compositing them while Steam BPM keeps re-asserting its
+// overlay claim from its own render loop.
+//
+// libxcb queues all property changes on a single connection and flushes
+// them in one round-trip to the X server. All PropertyNotify events
+// land in gamescope's queue back-to-back, so its DetermineAndApplyFocus
+// runs once on the final state — no intermediate "both at 1" window.
+//
+// This wrapper exposes a tight, gamescope-shaped surface:
+//   - intern atoms (cached)
+//   - change CARDINAL property (32-bit value) on a window
+//   - read a CARDINAL property with a synchronous reply
+//   - flush all pending writes in one round-trip
+//
+// We deliberately don't expose general xcb_send_event/configure paths
+// — gamescope-atoms.ts is the only consumer and it only needs property
+// manipulation.
+
+import { ptr, read, type Pointer } from "bun:ffi";
+import {
+  libc,
+  xcb,
+  XCB_EVENT_MASK_PROPERTY_CHANGE,
+  XCB_PROPERTY_NOTIFY,
+  XCB_PROPERTY_NOTIFY_WINDOW_OFF,
+  XCB_PROPERTY_NOTIFY_ATOM_OFF,
+} from "./ffi";
+
+/** PropMode constants (xproto.h: XCB_PROP_MODE_REPLACE = 0). */
+const PROP_MODE_REPLACE = 0;
+
+/** xcb_atom_t values for built-in atom types. From xproto.h. */
+const XA_CARDINAL = 6;
+const XA_STRING = 31;
+
+/** xcb_get_property_reply_t header layout (xproto.h):
+ *    uint8_t  response_type;   // 0
+ *    uint8_t  format;          // 1
+ *    uint16_t sequence;        // 2
+ *    uint32_t length;          // 4
+ *    xcb_atom_t type;          // 8  (uint32_t)
+ *    uint32_t bytes_after;     // 12
+ *    uint32_t value_len;       // 16  (count of `format`-bit elements)
+ *    uint8_t  pad0[12];        // 20
+ *  -> data starts at byte 32.
+ */
+const REPLY_HDR_FORMAT_OFF = 1;
+const REPLY_HDR_TYPE_OFF = 8;
+const REPLY_HDR_VALUE_LEN_OFF = 16;
+const REPLY_HDR_SIZE = 32;
+
+/**
+ * Persistent libxcb connection plus an atom cache and a single root
+ * lookup. One instance per process — the connection is opened lazily on
+ * first use and closed at shutdown.
+ */
+export class X11Connection {
+  private conn: Pointer | null = null;
+  private atomCache = new Map<string, number>();
+  private rootWindow: number = 0;
+
+  /** Open the X11 connection and intern any atoms passed up front. Safe
+   *  to call multiple times — idempotent. Returns false if the X server
+   *  is unreachable (no DISPLAY, gamescope down, etc.) so callers can
+   *  fall back to xprop or simply no-op. */
+  connect(display: string): boolean {
+    if (this.conn !== null) return true;
+    const displayBuf = Buffer.from(display + "\0");
+    const c = xcb.symbols.xcb_connect(displayBuf, null);
+    if (!c || xcb.symbols.xcb_connection_has_error(c) !== 0) {
+      // xcb_connect always returns a non-null connection even on error;
+      // the error must be checked separately. We treat both as fatal.
+      if (c) xcb.symbols.xcb_disconnect(c);
+      return false;
+    }
+    this.conn = c;
+    // We don't call xcb_get_setup / xcb_setup_roots_iterator here
+    // because we mostly write CARDINAL atoms onto specific windows whose
+    // IDs we already know via xprop/xdotool. Root-atom writes
+    // (STEAM_TOUCH_CLICK_MODE) need the root window id; we lift it from
+    // the X server reply header on first need rather than walking the
+    // setup struct (saves ~50 lines of FFI marshaling).
+    return true;
+  }
+
+  /** Forcibly close the connection. Idempotent. */
+  disconnect(): void {
+    if (this.conn === null) return;
+    xcb.symbols.xcb_disconnect(this.conn);
+    this.conn = null;
+    this.atomCache.clear();
+    this.rootWindow = 0;
+  }
+
+  /** True if the connection is open. */
+  isConnected(): boolean {
+    return this.conn !== null;
+  }
+
+  /** Set the root window id explicitly. xprop already knows it (via
+   *  xcb_get_setup, but we don't have that bound) — gamescope-atoms.ts
+   *  resolves it once via `xprop -root` and passes it in. */
+  setRoot(windowId: number): void {
+    this.rootWindow = windowId;
+  }
+
+  getRoot(): number {
+    return this.rootWindow;
+  }
+
+  /**
+   * Intern a property atom by name and cache it. Synchronous — issues
+   * the cookie and waits for the reply. Returns 0 on error (caller
+   * should treat as "atom unknown to server" and skip the operation).
+   */
+  internAtom(name: string): number {
+    if (this.conn === null) return 0;
+    const cached = this.atomCache.get(name);
+    if (cached !== undefined) return cached;
+
+    const nameBuf = Buffer.from(name + "\0");
+    // only_if_exists=0 → create the atom if it doesn't exist. All the
+    // atoms we deal with (STEAM_*, GAMESCOPE_*) are owned by the X server
+    // once gamescope or Steam has registered them, but this works for
+    // any case.
+    const cookie = xcb.symbols.xcb_intern_atom(
+      this.conn,
+      0, // only_if_exists
+      name.length,
+      nameBuf,
+    );
+    const replyPtr = xcb.symbols.xcb_intern_atom_reply(
+      this.conn,
+      cookie,
+      null,
+    );
+    if (!replyPtr) return 0;
+    // xcb_intern_atom_reply_t layout (xproto.h):
+    //   uint8_t response_type, pad0;  // 0,1
+    //   uint16_t sequence;            // 2
+    //   uint32_t length;              // 4
+    //   xcb_atom_t atom;              // 8 (uint32_t)
+    const atomId = read.u32(replyPtr, 8);
+    libc.symbols.free(replyPtr);
+    this.atomCache.set(name, atomId);
+    return atomId;
+  }
+
+  /**
+   * Queue a CARDINAL property write. Doesn't block — the write goes
+   * onto libxcb's outgoing queue and is dispatched by `flush()`. Pass a
+   * Uint32Array even for single values so the underlying FFI receives a
+   * stable pointer.
+   */
+  setCardinal(windowId: number, atomName: string, value: number): void {
+    if (this.conn === null) return;
+    const atomId = this.internAtom(atomName);
+    if (atomId === 0) return;
+    const buf = new Uint32Array([value]);
+    xcb.symbols.xcb_change_property(
+      this.conn,
+      PROP_MODE_REPLACE,
+      windowId,
+      atomId,
+      XA_CARDINAL,
+      32, // format
+      1, // data_len (count of 32-bit values)
+      ptr(buf),
+    );
+  }
+
+  /** Queue a string property write (UTF-8 / Latin-1). Used for WM_CLASS
+   *  and similar string-typed properties. */
+  setString(windowId: number, atomName: string, value: string): void {
+    if (this.conn === null) return;
+    const atomId = this.internAtom(atomName);
+    if (atomId === 0) return;
+    const buf = Buffer.from(value, "utf8");
+    xcb.symbols.xcb_change_property(
+      this.conn,
+      PROP_MODE_REPLACE,
+      windowId,
+      atomId,
+      XA_STRING,
+      8,
+      buf.length,
+      ptr(buf),
+    );
+  }
+
+  /**
+   * Read a single CARDINAL value off `windowId` synchronously. Returns
+   * null if the property isn't set, isn't a CARDINAL, or the request
+   * fails. Issues the cookie and immediately collects the reply — that
+   * makes it a round-trip; for the reclaim hot path we batch reads via
+   * `getCardinals` instead.
+   */
+  getCardinal(windowId: number, atomName: string): number | null {
+    if (this.conn === null) return null;
+    const atomId = this.internAtom(atomName);
+    if (atomId === 0) return null;
+    const cookie = xcb.symbols.xcb_get_property(
+      this.conn,
+      0, // delete
+      windowId,
+      atomId,
+      XA_CARDINAL,
+      0, // offset
+      1, // length (32-bit elements requested)
+    );
+    const replyPtr = xcb.symbols.xcb_get_property_reply(
+      this.conn,
+      cookie,
+      null,
+    );
+    if (!replyPtr) return null;
+    try {
+      const valueLen = read.u32(replyPtr, REPLY_HDR_VALUE_LEN_OFF);
+      const format = read.u8(replyPtr, REPLY_HDR_FORMAT_OFF);
+      const type = read.u32(replyPtr, REPLY_HDR_TYPE_OFF);
+      if (valueLen === 0 || format !== 32 || type !== XA_CARDINAL) {
+        return null;
+      }
+      // Value follows the 32-byte reply header. xcb_get_property_value()
+      // is the official accessor; without it bound we read offset 32.
+      return read.u32(replyPtr, REPLY_HDR_SIZE);
+    } finally {
+      libc.symbols.free(replyPtr);
+    }
+  }
+
+  /**
+   * Pipelined batch of CARDINAL reads on a single window. Issues all
+   * cookies first, then collects replies — saves N-1 round-trips
+   * compared to N sequential `getCardinal` calls. Returns a map keyed
+   * by atom name; missing atoms are absent from the map.
+   */
+  getCardinals(
+    windowId: number,
+    atomNames: readonly string[],
+  ): Map<string, number> {
+    const out = new Map<string, number>();
+    if (this.conn === null || atomNames.length === 0) return out;
+
+    type Pending = { name: string; cookie: number };
+    const pending: Pending[] = [];
+    for (const name of atomNames) {
+      const atomId = this.internAtom(name);
+      if (atomId === 0) continue;
+      const cookie = xcb.symbols.xcb_get_property(
+        this.conn,
+        0,
+        windowId,
+        atomId,
+        XA_CARDINAL,
+        0,
+        1,
+      );
+      pending.push({ name, cookie });
+    }
+    for (const { name, cookie } of pending) {
+      const replyPtr = xcb.symbols.xcb_get_property_reply(
+        this.conn,
+        cookie,
+        null,
+      );
+      if (!replyPtr) continue;
+      const valueLen = read.u32(replyPtr, REPLY_HDR_VALUE_LEN_OFF);
+      const format = read.u8(replyPtr, REPLY_HDR_FORMAT_OFF);
+      const type = read.u32(replyPtr, REPLY_HDR_TYPE_OFF);
+      if (valueLen > 0 && format === 32 && type === XA_CARDINAL) {
+        out.set(name, read.u32(replyPtr, REPLY_HDR_SIZE));
+      }
+      libc.symbols.free(replyPtr);
+    }
+    return out;
+  }
+
+  /** Dispatch all queued property writes to the X server in one
+   *  round-trip. Property changes from a single client are processed in
+   *  order, so gamescope sees all of them before the next focus
+   *  arbitration runs. */
+  flush(): void {
+    if (this.conn === null) return;
+    xcb.symbols.xcb_flush(this.conn);
+  }
+
+  /**
+   * Subscribe the given window to PropertyChangeMask, so subsequent
+   * property changes on it generate PropertyNotify events on this
+   * connection's event queue.
+   *
+   * Pairs with `pollPropertyChanges()` for event-driven monitoring —
+   * the same model HHD uses (`win.change_attributes(event_mask=
+   * Xlib.X.PropertyChangeMask)`). Replaces our old 100ms polling
+   * reclaim watcher: instead of reading Steam's atoms 10× per second
+   * regardless of whether anything changed, we only react when Steam
+   * actually changes state.
+   */
+  selectPropertyChanges(windowId: number): void {
+    if (this.conn === null) return;
+    // CW_EVENT_MASK = (1 << 11) — see /usr/include/xcb/xproto.h
+    const CW_EVENT_MASK = 1 << 11;
+    const valueList = new Uint32Array([XCB_EVENT_MASK_PROPERTY_CHANGE]);
+    xcb.symbols.xcb_change_window_attributes(
+      this.conn,
+      windowId,
+      CW_EVENT_MASK,
+      ptr(valueList),
+    );
+    this.flush();
+  }
+
+  /**
+   * Drain pending PropertyNotify events from the X server queue and
+   * return the (window, atom) pairs that changed. Non-blocking; safe
+   * to call from a fast tick loop. Other event types are silently
+   * dropped (we only subscribed to PropertyChangeMask anyway).
+   *
+   * The atom value is the gamescope-interned atom id, NOT the human
+   * name — callers compare against ids from `internAtom()`.
+   */
+  pollPropertyChanges(): Array<{ window: number; atom: number }> {
+    if (this.conn === null) return [];
+    const out: Array<{ window: number; atom: number }> = [];
+    while (true) {
+      const evtPtr = xcb.symbols.xcb_poll_for_event(this.conn);
+      if (!evtPtr) break;
+      // response_type's low 7 bits identify the event kind. Bit 7 is
+      // set when the event came from xcb_send_event (synthetic) — we
+      // ignore that bit by masking 0x7f.
+      const responseType = read.u8(evtPtr, 0) & 0x7f;
+      if (responseType === XCB_PROPERTY_NOTIFY) {
+        out.push({
+          window: read.u32(evtPtr, XCB_PROPERTY_NOTIFY_WINDOW_OFF),
+          atom: read.u32(evtPtr, XCB_PROPERTY_NOTIFY_ATOM_OFF),
+        });
+      }
+      libc.symbols.free(evtPtr);
+    }
+    return out;
+  }
+}

--- a/apps/overlay/src/bun/rpc-handlers.ts
+++ b/apps/overlay/src/bun/rpc-handlers.ts
@@ -1,0 +1,53 @@
+// RPC handler factory for the overlay's BrowserView.defineRPC surface.
+// M1 surface only:
+//   - show / hide / toggle (drive triple-flag overlay state)
+//   - isGamescopeMode
+//   - getControllerShortcuts / setControllerShortcuts
+//   - getOverlayVisibility
+//
+// Steam-restart / system-shutdown / sound-file reads are deferred to a
+// later milestone when their plugins land.
+
+import type { Ref } from "./lifecycle";
+import type { ControllerShortcuts } from "../webview/lib/electrobun";
+import { validateSetControllerShortcutsParams } from "./rpc-validation";
+import {
+  requestShow,
+  requestHide,
+  requestToggle,
+  type OverlayState,
+} from "./lib/overlay-state";
+
+export interface RpcHandlerDeps {
+  state: OverlayState;
+  shortcuts: Ref<ControllerShortcuts>;
+  gamescopeMode: boolean;
+}
+
+export function buildRpcHandlers(deps: RpcHandlerDeps) {
+  return {
+    requests: {
+      show: async () => {
+        requestShow(deps.state);
+      },
+      hide: async () => {
+        requestHide(deps.state);
+      },
+      toggle: async (): Promise<boolean> => requestToggle(deps.state),
+      isGamescopeMode: async () => deps.gamescopeMode,
+      getControllerShortcuts: async () => deps.shortcuts.current,
+      setControllerShortcuts: async (params?: unknown) => {
+        const next = validateSetControllerShortcutsParams(params);
+        if (next === null) {
+          console.warn("[overlay] setControllerShortcuts ignored — malformed payload", params);
+          return;
+        }
+        deps.shortcuts.current = next;
+      },
+      getOverlayVisibility: async (): Promise<{ isOpen: boolean }> => ({
+        isOpen: deps.state.isOpen,
+      }),
+    },
+    messages: {},
+  };
+}

--- a/apps/overlay/src/bun/rpc-validation.ts
+++ b/apps/overlay/src/bun/rpc-validation.ts
@@ -1,0 +1,70 @@
+// RPC payload validators. Extracted to a sibling module so the index.ts
+// handlers stay readable and the validation logic can be unit-tested
+// without booting the full overlay (window, atoms, evdev loop).
+//
+// Kept deliberately minimal — no zod, no schema framework. Just enough
+// structural checks to reject malformed CEF payloads with a logged
+// warning instead of an opaque TypeError or process crash.
+
+import type { ControllerShortcuts, ShortcutAction } from "../webview/lib/electrobun";
+
+const SHORTCUT_ACTION_TYPES = new Set([
+  "None",
+  "ToggleOverlay",
+  "OpenPlugin",
+  "OpenSettings",
+  "OpenHome",
+  "ToggleKeyboard",
+]);
+const SHORTCUT_KEYS = ["guide_a", "guide_b", "guide_x", "guide_y"] as const;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isValidShortcutAction(value: unknown): value is ShortcutAction {
+  if (!isPlainObject(value)) return false;
+  if (typeof value.type !== "string") return false;
+  if (!SHORTCUT_ACTION_TYPES.has(value.type)) return false;
+  if (value.value !== undefined && typeof value.value !== "string") return false;
+  return true;
+}
+
+function isValidControllerShortcuts(value: unknown): value is ControllerShortcuts {
+  if (!isPlainObject(value)) return false;
+  for (const key of SHORTCUT_KEYS) {
+    if (!isValidShortcutAction(value[key])) return false;
+  }
+  return true;
+}
+
+/**
+ * Validate the params passed to the `setControllerShortcuts` RPC handler.
+ * Returns the typed shortcuts on success, or null if the payload is
+ * malformed (caller logs + ignores). Fixes audit B-001 — previously the
+ * handler cast `params` directly to the expected shape, so a malformed
+ * payload either crashed (TypeError across IPC) or silently corrupted the
+ * module-global shortcuts state.
+ */
+export function validateSetControllerShortcutsParams(
+  params: unknown,
+): ControllerShortcuts | null {
+  if (!isPlainObject(params)) return null;
+  const next = params.shortcuts;
+  if (!isValidControllerShortcuts(next)) return null;
+  return next;
+}
+
+/**
+ * Validate the params passed to the `readSoundFile` RPC handler. Returns
+ * the filename string on success, or null if the payload is malformed.
+ * Fixes audit B-002 — `filename.includes("/")` threw a TypeError when
+ * `filename` was not a string. The path-traversal / extension checks in
+ * the handler still run after this returns; this only enforces the
+ * `typeof === "string"` precondition.
+ */
+export function validateReadSoundFileFilename(params: unknown): string | null {
+  if (!isPlainObject(params)) return null;
+  if (typeof params.filename !== "string") return null;
+  return params.filename;
+}

--- a/apps/overlay/src/webview/index.css
+++ b/apps/overlay/src/webview/index.css
@@ -1,0 +1,14 @@
+@import "tailwindcss";
+@plugin "daisyui";
+
+html, body, #root {
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: var(--color-base-100);
+  color: var(--color-base-content);
+}

--- a/apps/overlay/src/webview/index.html
+++ b/apps/overlay/src/webview/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Loadout Overlay</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!-- main.js is produced by electrobun build from main.tsx. -->
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/apps/overlay/src/webview/lib/electrobun.ts
+++ b/apps/overlay/src/webview/lib/electrobun.ts
@@ -1,0 +1,155 @@
+// Electrobun RPC shim — typed wrapper around the Bun↔webview message
+// channels declared in @loadout/types/webview-messages.
+//
+// For M1 controller-shortcuts persistence is in-memory only on the Bun side
+// (no user config layer yet). Gains disk persistence when @loadout/user-config
+// lands in M2.
+
+import { getElectroRpc } from "./get-electro-rpc";
+
+const isElectrobun = typeof globalThis.__electrobun !== "undefined";
+
+type OverlayRpc = {
+  show(): Promise<void>;
+  hide(): Promise<void>;
+  toggle(): Promise<boolean>;
+  isGamescopeMode(): Promise<boolean>;
+  getControllerShortcuts(): Promise<ControllerShortcuts>;
+  setControllerShortcuts(args: { shortcuts: ControllerShortcuts }): Promise<void>;
+  getOverlayVisibility(): Promise<{ isOpen: boolean }>;
+};
+
+async function rpc(): Promise<OverlayRpc | undefined> {
+  if (!isElectrobun) return undefined;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore — resolved at runtime inside the Electrobun webview process.
+  const mod = await import("electrobun/view");
+  return (mod.Electroview as unknown as { rpc: OverlayRpc }).rpc;
+}
+
+export async function showOverlay() {
+  return (await rpc())?.show();
+}
+export async function hideOverlay() {
+  return (await rpc())?.hide();
+}
+export async function toggleOverlay() {
+  return (await rpc())?.toggle();
+}
+export async function isGamescopeMode(): Promise<boolean> {
+  const r = await rpc();
+  if (!r) return false;
+  return r.isGamescopeMode();
+}
+
+export interface ShortcutAction {
+  type: "None" | "ToggleOverlay" | "OpenPlugin" | "OpenSettings" | "OpenHome" | "ToggleKeyboard";
+  value?: string;
+}
+export interface ControllerShortcuts {
+  guide_a: ShortcutAction;
+  guide_b: ShortcutAction;
+  guide_x: ShortcutAction;
+  guide_y: ShortcutAction;
+}
+
+const DEFAULT_SHORTCUTS: ControllerShortcuts = {
+  guide_a: { type: "None" },
+  guide_b: { type: "None" },
+  guide_x: { type: "ToggleOverlay" },
+  guide_y: { type: "None" },
+};
+
+export async function getControllerShortcuts(): Promise<ControllerShortcuts> {
+  const r = await rpc();
+  if (!r) return DEFAULT_SHORTCUTS;
+  return r.getControllerShortcuts();
+}
+
+export async function setControllerShortcuts(shortcuts: ControllerShortcuts): Promise<void> {
+  const r = await rpc();
+  if (!r) return;
+  return r.setControllerShortcuts({ shortcuts });
+}
+
+export type OverlayAction =
+  | "up" | "down" | "left" | "right" | "a" | "b" | "x" | "x_up" | "y" | "lb" | "rb";
+
+export async function onOverlayAction(
+  handler: (action: OverlayAction) => void,
+): Promise<() => void> {
+  if (!isElectrobun) return () => {};
+  const r = getElectroRpc();
+  if (!r) return () => {};
+  const wrapped = (payload: { action: string }) => handler(payload.action as OverlayAction);
+  r.addMessageListener("overlay-action", wrapped);
+  return () => r.removeMessageListener?.("overlay-action", wrapped);
+}
+
+export interface OverlayScrollPayload {
+  axis: "RightStickX" | "RightStickY";
+  value: number;
+}
+
+export async function onOverlayScroll(
+  handler: (payload: OverlayScrollPayload) => void,
+): Promise<() => void> {
+  if (!isElectrobun) return () => {};
+  const r = getElectroRpc();
+  if (!r) return () => {};
+  r.addMessageListener("overlay-scroll", handler);
+  return () => r.removeMessageListener?.("overlay-scroll", handler);
+}
+
+export async function getOverlayVisibility(): Promise<boolean> {
+  const r = await rpc();
+  if (!r) return true;
+  const { isOpen } = await r.getOverlayVisibility();
+  return isOpen;
+}
+
+export async function onOverlayOpenPlugin(
+  handler: (pluginId: string) => void,
+): Promise<() => void> {
+  if (!isElectrobun) return () => {};
+  const r = getElectroRpc();
+  if (!r) return () => {};
+  const wrapped = (p: { pluginId: string }) => handler(p.pluginId);
+  r.addMessageListener("overlay-open-plugin", wrapped);
+  return () => r.removeMessageListener?.("overlay-open-plugin", wrapped);
+}
+
+export async function onOverlayOpenSettings(handler: () => void): Promise<() => void> {
+  if (!isElectrobun) return () => {};
+  const r = getElectroRpc();
+  if (!r) return () => {};
+  r.addMessageListener("overlay-open-settings", handler);
+  return () => r.removeMessageListener?.("overlay-open-settings", handler);
+}
+
+export async function onOverlayOpenHome(handler: () => void): Promise<() => void> {
+  if (!isElectrobun) return () => {};
+  const r = getElectroRpc();
+  if (!r) return () => {};
+  r.addMessageListener("overlay-open-home", handler);
+  return () => r.removeMessageListener?.("overlay-open-home", handler);
+}
+
+export async function onOverlayToggleKeyboard(handler: () => void): Promise<() => void> {
+  if (!isElectrobun) return () => {};
+  const r = getElectroRpc();
+  if (!r) return () => {};
+  r.addMessageListener("overlay-toggle-keyboard", handler);
+  return () => r.removeMessageListener?.("overlay-toggle-keyboard", handler);
+}
+
+export async function onOverlayVisibility(
+  handler: (isOpen: boolean) => void,
+): Promise<() => void> {
+  if (!isElectrobun) return () => {};
+  const r = getElectroRpc();
+  if (!r) return () => {};
+  const wrapped = (p: { isOpen: boolean }) => handler(p.isOpen);
+  r.addMessageListener("overlay-visibility", wrapped);
+  return () => r.removeMessageListener?.("overlay-visibility", wrapped);
+}

--- a/apps/overlay/src/webview/lib/get-electro-rpc.ts
+++ b/apps/overlay/src/webview/lib/get-electro-rpc.ts
@@ -1,0 +1,44 @@
+// Typed accessor for the Electroview instance stashed on `window` by
+// main.tsx. Centralizes the runtime null-check + cast so subscriber call
+// sites can drop their `(window as any).__electroview` boilerplate and
+// get a narrow type back instead.
+//
+// Returns `null` outside Electrobun (vite dev, vitest, etc.) so callers
+// can early-return without crashing. The `WebviewMessages` schema lives
+// in `@loadout/types` so the channel surface is import-free for
+// plugins.
+
+import type { WebviewMessages } from "@loadout/types";
+
+/** Narrow surface of `Electroview.rpc` that the webview subscribers
+ *  actually use. `request` is a runtime-built record from defineRPC()'s
+ *  schema; we type it loosely here because individual call sites narrow
+ *  per-method (see `webview/lib/electrobun.ts`). */
+export interface ElectroRpc {
+  request?: Record<string, (args?: unknown) => Promise<unknown>>;
+  addMessageListener<K extends keyof WebviewMessages>(
+    name: K,
+    handler: (payload: WebviewMessages[K]) => void,
+  ): void;
+  removeMessageListener?<K extends keyof WebviewMessages>(
+    name: K,
+    handler: (payload: WebviewMessages[K]) => void,
+  ): void;
+}
+
+/**
+ * Look up the Electroview instance + RPC on `window`. Returns the typed
+ * `ElectroRpc` when both are present; `null` otherwise (standalone vite
+ * dev, vitest, or before main.tsx has finished bootstrapping). `Window`
+ * is augmented in root `types/window-augmentations.d.ts` with a looser
+ * shape (payload typed as `unknown`); the cast below narrows it to the
+ * `WebviewMessages`-keyed surface this helper exposes. Centralising the
+ * cast here means subscriber call sites stay assertion-free.
+ */
+export function getElectroRpc(): ElectroRpc | null {
+  const rpc = (window.__electroview as { rpc?: unknown } | undefined)?.rpc as
+    | Partial<ElectroRpc>
+    | undefined;
+  if (!rpc || typeof rpc.addMessageListener !== "function") return null;
+  return rpc as ElectroRpc;
+}

--- a/apps/overlay/src/webview/main.tsx
+++ b/apps/overlay/src/webview/main.tsx
@@ -1,7 +1,8 @@
 // Electrobun webview entry. Wires:
 //   - Electroview instance (so window.__electroview exists for the RPC shim)
-//   - Session token fetch → window.__LOADOUT_TOKEN__ → WS connect
-//   - Spatial-nav singleton install (shell + plugins share the same focus tree)
+//   - Session token from the URL (passed by the Bun side at window create)
+//   - Spatial-nav singleton init (one focus tree across every React root)
+//   - Vendor globals (React + @loadout/ui shared with plugin bundles)
 //   - Bun→webview channel bridges: visibility, action, scroll, open-plugin, etc.
 //   - React root rendering @loadout/overlay-shell's <App/>
 
@@ -34,26 +35,33 @@ import {
   type OverlayAction,
 } from "./lib/electrobun";
 
-// Expose React + @loadout/ui as globals so plugin bundles compiled with
-// `vendorGlobalsPlugin` resolve to the SAME React instance — sharing hooks
-// across plugin React roots requires one canonical React.
-window.__LOADOUT_REACT = React;
-window.__LOADOUT_REACT_JSX_RUNTIME = ReactJsxRuntime;
-window.__LOADOUT_REACT_JSX_DEV_RUNTIME = ReactJsxDevRuntime;
-window.__LOADOUT_REACT_DOM = ReactDOM;
-window.__LOADOUT_REACT_DOM_CLIENT = ReactDOMClient;
-window.__LOADOUT_UI = LoadoutUi;
+// Expose the shell's React + @loadout/ui instances as window globals so
+// plugin bundles (compiled by the server with `vendorGlobalsPlugin`) resolve
+// imports to the same instances. Without this, plugins bundle their own
+// React copy and hooks break across roots.
+type GlobalRefs = {
+  __LOADOUT_REACT: typeof React;
+  __LOADOUT_REACT_JSX_RUNTIME: typeof ReactJsxRuntime;
+  __LOADOUT_REACT_JSX_DEV_RUNTIME: typeof ReactJsxDevRuntime;
+  __LOADOUT_REACT_DOM: typeof ReactDOM;
+  __LOADOUT_REACT_DOM_CLIENT: typeof ReactDOMClient;
+  __LOADOUT_UI: typeof LoadoutUi;
+};
+const w = window as unknown as Window & GlobalRefs;
+w.__LOADOUT_REACT = React;
+w.__LOADOUT_REACT_JSX_RUNTIME = ReactJsxRuntime;
+w.__LOADOUT_REACT_JSX_DEV_RUNTIME = ReactJsxDevRuntime;
+w.__LOADOUT_REACT_DOM = ReactDOM;
+w.__LOADOUT_REACT_DOM_CLIENT = ReactDOMClient;
+w.__LOADOUT_UI = LoadoutUi;
 
-// Install the shared spatial-navigation singleton on window.__LOADOUT_SPATIAL_NAV.
 installSpatialNav();
 
-// Electroview MUST exist so window.__electroview is non-null for the RPC shim.
 const electro = new Electroview({
   rpc: Electroview.defineRPC({ handlers: { requests: {}, messages: {} } }),
 });
 window.__electroview = electro;
 
-// Catch-all error logging so screen-captures + log greps land on a known prefix.
 window.addEventListener("error", (e) => {
   console.error(`[window.error] ${e.message} @ ${e.filename}:${e.lineno}:${e.colno}`, e.error);
 });
@@ -61,21 +69,23 @@ window.addEventListener("unhandledrejection", (e) => {
   console.error(`[unhandledrejection]`, e.reason);
 });
 
-async function fetchToken(): Promise<string> {
-  const res = await fetch("http://127.0.0.1:33820/api/token");
-  if (!res.ok) throw new Error(`token fetch failed: ${res.status}`);
-  const data = (await res.json()) as { token: string };
-  return data.token;
+function readToken(): string {
+  // Token is passed via URL search params by the Bun side at window construction.
+  // Throws when empty so we fail loud in dev rather than 401-loop the WS reconnect.
+  const fromUrl = new URLSearchParams(window.location.search).get("token");
+  if (fromUrl) return fromUrl;
+  throw new Error(
+    "Missing ?token= in webview URL. The Bun host must pass the session token via the BrowserWindow URL.",
+  );
 }
 
-async function navigate(hash: string) {
+function navigate(hash: string) {
   if (window.location.hash !== hash) window.location.hash = hash;
 }
 
 async function boot() {
   console.log("[overlay] boot");
-  const token = await fetchToken();
-  window.__LOADOUT_TOKEN__ = token;
+  window.__LOADOUT_TOKEN__ = readToken();
 
   const root = createRoot(document.getElementById("root")!);
   root.render(<App />);
@@ -86,6 +96,8 @@ async function boot() {
     event: "reload",
     handler: () => {
       // Plugin source changed on disk — reload to pick up the new bundle.
+      // Plugin React state is not preserved; saved config is plugin-owned
+      // and reloaded on next mount, so this is fine for dev iteration.
       location.reload();
     },
   });

--- a/apps/overlay/src/webview/main.tsx
+++ b/apps/overlay/src/webview/main.tsx
@@ -1,0 +1,220 @@
+// Electrobun webview entry. Wires:
+//   - Electroview instance (so window.__electroview exists for the RPC shim)
+//   - Session token fetch → window.__LOADOUT_TOKEN__ → WS connect
+//   - Spatial-nav singleton install (shell + plugins share the same focus tree)
+//   - Bun→webview channel bridges: visibility, action, scroll, open-plugin, etc.
+//   - React root rendering @loadout/overlay-shell's <App/>
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — electrobun/view resolves at runtime.
+import { Electroview } from "electrobun/view";
+
+import "@loadout/ui/styles.css";
+import "./index.css";
+
+import { createRoot } from "react-dom/client";
+import * as React from "react";
+import * as ReactJsxRuntime from "react/jsx-runtime";
+import * as ReactJsxDevRuntime from "react/jsx-dev-runtime";
+import * as ReactDOM from "react-dom";
+import * as ReactDOMClient from "react-dom/client";
+import * as LoadoutUi from "@loadout/ui";
+
+import { App, installSpatialNav } from "@loadout/overlay-shell";
+import { ensureConnected, subscribe } from "@loadout/ui";
+import {
+  onOverlayAction,
+  onOverlayOpenPlugin,
+  onOverlayOpenSettings,
+  onOverlayOpenHome,
+  onOverlayToggleKeyboard,
+  onOverlayScroll,
+  onOverlayVisibility,
+  getOverlayVisibility,
+  type OverlayAction,
+} from "./lib/electrobun";
+
+// Expose React + @loadout/ui as globals so plugin bundles compiled with
+// `vendorGlobalsPlugin` resolve to the SAME React instance — sharing hooks
+// across plugin React roots requires one canonical React.
+window.__LOADOUT_REACT = React;
+window.__LOADOUT_REACT_JSX_RUNTIME = ReactJsxRuntime;
+window.__LOADOUT_REACT_JSX_DEV_RUNTIME = ReactJsxDevRuntime;
+window.__LOADOUT_REACT_DOM = ReactDOM;
+window.__LOADOUT_REACT_DOM_CLIENT = ReactDOMClient;
+window.__LOADOUT_UI = LoadoutUi;
+
+// Install the shared spatial-navigation singleton on window.__LOADOUT_SPATIAL_NAV.
+installSpatialNav();
+
+// Electroview MUST exist so window.__electroview is non-null for the RPC shim.
+const electro = new Electroview({
+  rpc: Electroview.defineRPC({ handlers: { requests: {}, messages: {} } }),
+});
+window.__electroview = electro;
+
+// Catch-all error logging so screen-captures + log greps land on a known prefix.
+window.addEventListener("error", (e) => {
+  console.error(`[window.error] ${e.message} @ ${e.filename}:${e.lineno}:${e.colno}`, e.error);
+});
+window.addEventListener("unhandledrejection", (e) => {
+  console.error(`[unhandledrejection]`, e.reason);
+});
+
+async function fetchToken(): Promise<string> {
+  const res = await fetch("http://127.0.0.1:33820/api/token");
+  if (!res.ok) throw new Error(`token fetch failed: ${res.status}`);
+  const data = (await res.json()) as { token: string };
+  return data.token;
+}
+
+async function navigate(hash: string) {
+  if (window.location.hash !== hash) window.location.hash = hash;
+}
+
+async function boot() {
+  console.log("[overlay] boot");
+  const token = await fetchToken();
+  window.__LOADOUT_TOKEN__ = token;
+
+  const root = createRoot(document.getElementById("root")!);
+  root.render(<App />);
+
+  ensureConnected();
+  subscribe({
+    plugin: "__system",
+    event: "reload",
+    handler: () => {
+      // Plugin source changed on disk — reload to pick up the new bundle.
+      location.reload();
+    },
+  });
+
+  // Bridge Bun→webview channels.
+  const actionKeyMap: Record<OverlayAction, { key: string; keyCode: number } | undefined> = {
+    up: { key: "ArrowUp", keyCode: 38 },
+    down: { key: "ArrowDown", keyCode: 40 },
+    left: { key: "ArrowLeft", keyCode: 37 },
+    right: { key: "ArrowRight", keyCode: 39 },
+    a: { key: "Enter", keyCode: 13 },
+    b: { key: "Escape", keyCode: 27 },
+    lb: { key: "PageUp", keyCode: 33 },
+    rb: { key: "PageDown", keyCode: 34 },
+    x: undefined,
+    x_up: undefined,
+    y: undefined,
+  };
+
+  function dispatchVisibility(isOpen: boolean): void {
+    window.dispatchEvent(new CustomEvent("loadout:overlay-visibility", { detail: { isOpen } }));
+  }
+  getOverlayVisibility().then(dispatchVisibility).catch(() => {});
+  onOverlayVisibility(dispatchVisibility);
+
+  onOverlayOpenPlugin((pluginId) => navigate(`#/plugin/${pluginId}`));
+  onOverlayOpenSettings(() => navigate("#/settings"));
+  onOverlayOpenHome(() => navigate("#/"));
+  onOverlayToggleKeyboard(() => {
+    // M1: no OSK yet. Wire to @loadout/ui keyboard module when it lands.
+  });
+
+  await onOverlayAction((action) => {
+    window.dispatchEvent(new CustomEvent("loadout:overlay-action", { detail: { action } }));
+    const mapping = actionKeyMap[action];
+    if (!mapping) return;
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: mapping.key, keyCode: mapping.keyCode, bubbles: true }),
+    );
+  });
+
+  await startRightStickScroll();
+}
+
+// ---- Right-stick scroll engine -------------------------------------------------
+
+const RIGHT_STICK_DEADZONE = 0.15;
+const RIGHT_STICK_SPEED = 14;
+const SCROLL_FRICTION = 0.85;
+const SCROLL_MIN_VELOCITY = 0.5;
+const SCROLL_TARGET_TTL_MS = 500;
+
+function isScrollable(node: HTMLElement): boolean {
+  const s = getComputedStyle(node);
+  return (
+    (s.overflowY === "auto" || s.overflowY === "scroll") &&
+    node.scrollHeight > node.clientHeight
+  );
+}
+
+function findMainScrollTarget(): Element | null {
+  const main = document.querySelector("main");
+  if (!main) return null;
+  const candidates = main.querySelectorAll<HTMLElement>("*");
+  for (const node of candidates) {
+    if (isScrollable(node)) return node;
+  }
+  return null;
+}
+
+async function startRightStickScroll(): Promise<() => void> {
+  let stickY = 0;
+  let velocity = 0;
+  let target: Element | null = null;
+  let targetResolvedAt = 0;
+  let overlayOpen = true;
+  let cancelled = false;
+  let rafId = 0;
+
+  function invalidateTarget(): void {
+    target = null;
+  }
+
+  function onVisibility(e: Event): void {
+    const detail = (e as CustomEvent<{ isOpen: boolean }>).detail;
+    overlayOpen = detail?.isOpen ?? true;
+    if (!overlayOpen) {
+      stickY = 0;
+      velocity = 0;
+      invalidateTarget();
+    }
+  }
+
+  window.addEventListener("loadout:overlay-visibility", onVisibility as EventListener);
+  window.addEventListener("hashchange", invalidateTarget);
+
+  const offScroll = await onOverlayScroll(({ axis, value }) => {
+    if (axis === "RightStickY") stickY = value;
+  });
+
+  function tick(): void {
+    if (cancelled) return;
+    if (overlayOpen) {
+      if (Math.abs(stickY) > RIGHT_STICK_DEADZONE) {
+        velocity = stickY * RIGHT_STICK_SPEED;
+      } else {
+        velocity *= SCROLL_FRICTION;
+        if (Math.abs(velocity) < SCROLL_MIN_VELOCITY) velocity = 0;
+      }
+      if (velocity !== 0) {
+        const now = performance.now();
+        if (!target || now - targetResolvedAt > SCROLL_TARGET_TTL_MS) {
+          target = findMainScrollTarget();
+          targetResolvedAt = now;
+        }
+        if (target) target.scrollBy({ top: velocity });
+      }
+    }
+    rafId = requestAnimationFrame(tick);
+  }
+  rafId = requestAnimationFrame(tick);
+
+  return () => {
+    cancelled = true;
+    cancelAnimationFrame(rafId);
+    window.removeEventListener("loadout:overlay-visibility", onVisibility as EventListener);
+    window.removeEventListener("hashchange", invalidateTarget);
+    offScroll();
+  };
+}
+
+boot().catch((e) => console.error("[overlay] boot crashed:", e));

--- a/apps/overlay/tsconfig.json
+++ b/apps/overlay/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["bun"],
+    "paths": {
+      "@loadout/ui": ["../../packages/ui/src"],
+      "@loadout/ui/*": ["../../packages/ui/src/*"],
+      "@loadout/types": ["../../packages/types/src"],
+      "@loadout/types/*": ["../../packages/types/src/*"],
+      "@loadout/server": ["../../packages/server/src"],
+      "@loadout/overlay-shell": ["../../packages/overlay-shell/src"],
+      "@loadout/device": ["../../packages/device/src"],
+      "@loadout/exec": ["../../packages/exec/src"]
+    }
+  },
+  "include": ["src/**/*", "electrobun.config.ts", "vite.config.ts"]
+}

--- a/apps/overlay/vite.config.ts
+++ b/apps/overlay/vite.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, type Plugin } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import path from "node:path";
+
+const BACKEND_URL = "http://127.0.0.1:33820";
+
+// Strip `crossorigin` from HTML <script>/<link> tags — CEF rejects
+// crossorigin-tagged assets loaded from the views:// custom scheme.
+function stripCrossorigin(): Plugin {
+  return {
+    name: "strip-crossorigin",
+    transformIndexHtml(html) {
+      return html.replace(/ crossorigin/g, "");
+    },
+  };
+}
+
+export default defineConfig({
+  plugins: [react(), tailwindcss(), stripCrossorigin()],
+  root: "src/webview",
+  resolve: {
+    alias: {
+      "@loadout/ui": path.resolve(__dirname, "../../packages/ui/src"),
+      "@loadout/types": path.resolve(__dirname, "../../packages/types/src"),
+      "@loadout/overlay-shell": path.resolve(
+        __dirname,
+        "../../packages/overlay-shell/src",
+      ),
+    },
+  },
+  server: {
+    port: 1420,
+    strictPort: true,
+    proxy: {
+      "/api": BACKEND_URL,
+      "/ws": { target: BACKEND_URL, ws: true },
+      "/plugins": BACKEND_URL,
+    },
+  },
+  build: {
+    outDir: "../../webview-dist",
+    emptyOutDir: true,
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@loadout/types": "*",
+        "@noriginmedia/norigin-spatial-navigation": "^3.0.0",
       },
       "peerDependencies": {
         "react": "^18.3.0",

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,806 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "loadout",
+      "dependencies": {
+        "@tailwindcss/browser": "^4.2.2",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.0.0",
+        "@happy-dom/global-registrator": "^20.9.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/bun": "^1.3.10",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "eslint": "^9.0.0",
+        "eslint-config-prettier": "^10.0.0",
+        "eslint-plugin-react-hooks": "^5.0.0",
+        "prettier": "^3.4.0",
+        "typescript": "^5.7.0",
+        "typescript-eslint": "^8.0.0",
+      },
+    },
+    "apps/overlay": {
+      "name": "@loadout/app-overlay",
+      "version": "0.0.1",
+      "dependencies": {
+        "@loadout/device": "*",
+        "@loadout/exec": "*",
+        "@loadout/overlay-shell": "*",
+        "@loadout/server": "*",
+        "@loadout/types": "*",
+        "@loadout/ui": "*",
+        "@noriginmedia/norigin-spatial-navigation": "^3.0.0",
+        "daisyui": "^5.5.19",
+        "electrobun": "^1.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.0.0",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.0",
+        "tailwindcss": "^4.0.0",
+        "vite": "^6.0.0",
+      },
+    },
+    "packages/device": {
+      "name": "@loadout/device",
+      "version": "0.0.1",
+    },
+    "packages/exec": {
+      "name": "@loadout/exec",
+      "version": "0.0.1",
+    },
+    "packages/overlay-shell": {
+      "name": "@loadout/overlay-shell",
+      "version": "0.0.1",
+      "dependencies": {
+        "@loadout/types": "*",
+        "@loadout/ui": "*",
+        "@noriginmedia/norigin-spatial-navigation": "^3.0.0",
+      },
+      "peerDependencies": {
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+      },
+    },
+    "packages/server": {
+      "name": "@loadout/server",
+      "version": "0.0.1",
+      "dependencies": {
+        "@loadout/types": "*",
+      },
+    },
+    "packages/types": {
+      "name": "@loadout/types",
+      "version": "0.0.1",
+    },
+    "packages/ui": {
+      "name": "@loadout/ui",
+      "version": "0.0.1",
+      "dependencies": {
+        "@loadout/types": "*",
+      },
+      "peerDependencies": {
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+      },
+    },
+    "plugins/hello-world": {
+      "name": "@loadout/plugin-hello-world",
+      "version": "0.0.1",
+      "dependencies": {
+        "@loadout/device": "*",
+        "@loadout/types": "*",
+      },
+      "peerDependencies": {
+        "@loadout/ui": "*",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+      },
+    },
+  },
+  "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
+
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@babylonjs/core": ["@babylonjs/core@7.54.3", "", {}, "sha512-P5ncXVd8GEUJLhwloP9V0oVwQYIrvZztguVeLlvd5Rx+9aQnenKjpV8auJ6SRsUlAmNZU4pFTKzwF6o2EUfhAw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@loadout/app-overlay": ["@loadout/app-overlay@workspace:apps/overlay"],
+
+    "@loadout/device": ["@loadout/device@workspace:packages/device"],
+
+    "@loadout/exec": ["@loadout/exec@workspace:packages/exec"],
+
+    "@loadout/overlay-shell": ["@loadout/overlay-shell@workspace:packages/overlay-shell"],
+
+    "@loadout/plugin-hello-world": ["@loadout/plugin-hello-world@workspace:plugins/hello-world"],
+
+    "@loadout/server": ["@loadout/server@workspace:packages/server"],
+
+    "@loadout/types": ["@loadout/types@workspace:packages/types"],
+
+    "@loadout/ui": ["@loadout/ui@workspace:packages/ui"],
+
+    "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@1.1.1", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ=="],
+
+    "@noriginmedia/norigin-spatial-navigation": ["@noriginmedia/norigin-spatial-navigation@3.1.0", "", { "dependencies": { "@noriginmedia/norigin-spatial-navigation-core": "^3.1.0", "@noriginmedia/norigin-spatial-navigation-react": "^3.1.0" } }, "sha512-KPge4ocpDFde7cpZ2aqrPrKmxOxkue983NsfpmE/vX4k2l+Ik8UkucCWGqkcy81TXkEyRhdsYwFTRePNB5qUCg=="],
+
+    "@noriginmedia/norigin-spatial-navigation-core": ["@noriginmedia/norigin-spatial-navigation-core@3.1.0", "", { "dependencies": { "lodash-es": "^4.17.21" } }, "sha512-AFxJHurTqy+I3NLnaXsLUBa9FZjUryMNFEdLpPrITSqDjk525aINeLMOK1PN7WTiK5xpHL0pbpw0+uVOfWgp4w=="],
+
+    "@noriginmedia/norigin-spatial-navigation-react": ["@noriginmedia/norigin-spatial-navigation-react@3.1.0", "", { "dependencies": { "@noriginmedia/norigin-spatial-navigation-core": "^3.1.0", "lodash-es": "^4.17.21" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-F2PIqzTnlYbbc+oRdIQfBf7e1VcA1uhyjze4uOal8FHI8tZs1U8nomH84+2KcM6G3EM/XGexgQsPy5f5dtrmUA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.4", "", { "os": "android", "cpu": "arm" }, "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.4", "", { "os": "android", "cpu": "arm64" }, "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.4", "", { "os": "none", "cpu": "arm64" }, "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
+
+    "@tailwindcss/browser": ["@tailwindcss/browser@4.3.0", "", {}, "sha512-izCuCS1V4c18DH47BbJuAPoCi7LP9gSSanr4k42cL+GN3Km/H3QO3fpMVVPXUBpAatHYgfmQWOmrNJqq+bzAAQ=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.0", "@tailwindcss/oxide-darwin-arm64": "4.3.0", "@tailwindcss/oxide-darwin-x64": "4.3.0", "@tailwindcss/oxide-freebsd-x64": "4.3.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0", "@tailwindcss/oxide-linux-arm64-musl": "4.3.0", "@tailwindcss/oxide-linux-x64-gnu": "4.3.0", "@tailwindcss/oxide-linux-x64-musl": "4.3.0", "@tailwindcss/oxide-wasm32-wasi": "4.3.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0", "@tailwindcss/oxide-win32-x64-msvc": "4.3.0" } }, "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.0", "", { "os": "android", "cpu": "arm64" }, "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.0", "", { "dependencies": { "@emnapi/core": "^1.10.0", "@emnapi/runtime": "^1.10.0", "@emnapi/wasi-threads": "^1.2.1", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA=="],
+
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
+
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
+
+    "@types/react": ["@types/react@18.3.29", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg=="],
+
+    "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.60.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.60.0", "@typescript-eslint/type-utils": "8.60.0", "@typescript-eslint/utils": "8.60.0", "@typescript-eslint/visitor-keys": "8.60.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.60.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.60.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.60.0", "@typescript-eslint/types": "8.60.0", "@typescript-eslint/typescript-estree": "8.60.0", "@typescript-eslint/visitor-keys": "8.60.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.60.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.60.0", "@typescript-eslint/types": "^8.60.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.60.0", "", { "dependencies": { "@typescript-eslint/types": "8.60.0", "@typescript-eslint/visitor-keys": "8.60.0" } }, "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.60.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.60.0", "", { "dependencies": { "@typescript-eslint/types": "8.60.0", "@typescript-eslint/typescript-estree": "8.60.0", "@typescript-eslint/utils": "8.60.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.60.0", "", {}, "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.60.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.60.0", "@typescript-eslint/tsconfig-utils": "8.60.0", "@typescript-eslint/types": "8.60.0", "@typescript-eslint/visitor-keys": "8.60.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.60.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.60.0", "@typescript-eslint/types": "8.60.0", "@typescript-eslint/typescript-estree": "8.60.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.60.0", "", { "dependencies": { "@typescript-eslint/types": "8.60.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.32", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg=="],
+
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cross-spawn-windows-exe": ["cross-spawn-windows-exe@1.2.0", "", { "dependencies": { "@malept/cross-spawn-promise": "^1.1.0", "is-wsl": "^2.2.0", "which": "^2.0.2" } }, "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "daisyui": ["daisyui@5.5.20", "", {}, "sha512-HemJcjl0Gk9rQ8BcgofN6p+EURrqftQG9wK1Hkxs98i49xe68+QxpNvry+PyxwkIUgrbMpNmZ5ZWjmtffAjfhQ=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "electrobun": ["electrobun@1.18.1", "", { "dependencies": { "@babylonjs/core": "^7.45.0", "@types/bun": "^1.3.8", "png-to-ico": "^2.1.8", "proxy-agent": "^6.5.0", "rcedit": "^4.0.1", "three": "^0.165.0" }, "bin": { "electrobun": "bin/electrobun.cjs" } }, "sha512-tgZ+WKGskn/1/Y5i1mpVCCkgRa1O31Tz7MIArBTK44GfPzT43uOq9c/HvxdQGrLeZV8ZvjK1lQrwqSXCgh6tvA=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.361", "", {}, "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.22.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
+
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@5.2.0", "", { "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
+    "node-releases": ["node-releases@2.0.46", "", {}, "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "png-to-ico": ["png-to-ico@2.1.8", "", { "dependencies": { "@types/node": "^17.0.36", "minimist": "^1.2.6", "pngjs": "^6.0.0" }, "bin": { "png-to-ico": "bin/cli.js" } }, "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w=="],
+
+    "pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "rcedit": ["rcedit@4.0.1", "", { "dependencies": { "cross-spawn-windows-exe": "^1.1.0" } }, "sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg=="],
+
+    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
+
+    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "three": ["three@0.165.0", "", {}, "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.60.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.60.0", "@typescript-eslint/parser": "8.60.0", "@typescript-eslint/typescript-estree": "8.60.0", "@typescript-eslint/utils": "8.60.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "png-to-ico/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+
+    "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+  }
+}

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,5 @@
+[install]
+peer = false
+
+[test]
+preload = ["./test/setup.ts"]

--- a/docs/steam-deck-overlay-trigger.md
+++ b/docs/steam-deck-overlay-trigger.md
@@ -1,0 +1,184 @@
+# Toggling the overlay from a controller button on the Steam Deck (SteamOS)
+
+This documents how to open/toggle the Electrobun overlay from a **controller
+button on a Steam Deck running SteamOS**, why the obvious approaches don't work
+there, and the validated recipe (proven working: **bottom-right back paddle →
+overlay toggles**).
+
+> TL;DR — On SteamOS the only signal that can reach the overlay in-game is a
+> **real evdev key event**. We get one by having **InputPlumber** map a back
+> paddle → **F16** (the overlay's QAM wake key), loaded **at boot**, plus a
+> **permission fix** so the overlay can actually open InputPlumber's virtual
+> keyboard. This is the same mechanism the OneXPlayer APEX uses (the apex-fixes
+> plugin, not yet ported into Loadout — see the original `linux-gaming-plugin-manager`
+> repo for the reference shape), adapted to the Deck.
+
+## Background: how the overlay receives a "wake"
+
+The overlay (`packages/overlay-electrobun`) opens on:
+
+- **`KEY_F16`** read from any evdev device that advertises it ("QAM" wake) —
+  `input-intercept.ts` (`QAM_KEY_CODES = [KEY_F16]`), and
+- **`Ctrl+3` / `Ctrl+4`** on keyboard-class devices, and
+- **`Ctrl+Shift+O`** via an Electrobun X11 GlobalShortcut.
+
+The key constraint: the overlay reads **evdev** (`/dev/input/event*`). It only
+reacts to **real** kernel input events.
+
+## What does NOT work on SteamOS (and why)
+
+| Approach | Result | Why |
+|----------|--------|-----|
+| Steam Input **chord** → inject a key (e.g. `chord_neptune.vdf` `key_press`) | ❌ | Steam injects chord keystrokes as **synthetic X events to the focused window** (XTEST-style), *not* evdev. Confirmed by monitoring all 21 evdev nodes (0 events) while a chord typed into the focused terminal. Also: Steam **rewrites `chord_neptune.vdf` on shutdown**, reverting edits. |
+| Steam **frontend** via CDP (`SteamClient.Input`) | ❌ | `RegisterForControllerInputMessages` delivers nothing passively; only `RegisterForControllerCommandMessages` fires, and **only for the Steam button** (`eAction 65`). Regular buttons/paddles/combos are invisible to the frontend in-game. |
+| `xdotool`/synthetic `Ctrl+Shift+O` | ❌ in-game | Goes to the focused window, not the overlay's grab, under gamescope. |
+| **`Guide+X` / `Guide+B`** controller combo (the overlay's `ControllerShortcuts`) | ❌ on Deck | Works on **Bazzite** because the overlay reads the controller's evdev directly and there's no competing chord layer. On the Deck the Steam button is owned by Steam and its chords are live (`Guide+X`=keyboard, `Guide+A`=record…), so they collide / never reach the overlay. |
+
+The throughline: **anything injected at the X layer, or read from the Steam
+frontend, can't reach the overlay's evdev watch in-game.** Only a real evdev
+event works — which is exactly what InputPlumber produces.
+
+## What works: InputPlumber → F16 (the APEX recipe, adapted)
+
+InputPlumber **is installed on SteamOS** (`/usr/bin/inputplumber`,
+`inputplumber.service`) but **disabled by default** on the Deck (Steam Input
+drives the built-in controller via `hid-steam`). We enable it, have it manage
+the Deck controller, and map a back paddle to F16.
+
+Five parts — **all five are required**:
+
+### 1. Device config — let IP manage the Deck at boot
+`/etc/inputplumber/devices.d/50-steam_deck.yaml` (writable override of the
+shipped `/usr/share/...` config) with **`auto_manage: true`** so IP claims the
+Deck controller at boot. The Deck's source config uses
+`hidraw 0x28de:0x1205 interface_num 2`.
+
+### 2. Profile — map paddles → F16, and FORCE a keyboard target
+IP's Deck handling switches the gamepad target to **`deck-uhid`** (a faithful
+Valve Steam Deck Controller emulation — good, it avoids a double controller),
+but **that drops the keyboard target**. The profile must re-add it:
+
+```yaml
+target_devices: [ deck-uhid, keyboard, mouse, touchpad ]   # keyboard is essential
+mapping:
+  - { name: RightPaddle1 -> F16, source_event: { gamepad: { button: RightPaddle1 } }, target_events: [ { keyboard: KeyF16 } ] }
+  # ...LeftPaddle1/2, RightPaddle2 likewise
+```
+
+**Deck paddle source names are `LeftPaddle1`/`LeftPaddle2`/`RightPaddle1`/
+`RightPaddle2`** — *not* `LeftTop`/`RightTop` (that's the APEX naming, and was
+the cause of an hour of "nothing happens"). Confirm names via the composite
+device's `Capabilities` D-Bus property.
+
+### 3. Boot timing — load the profile BEFORE the overlay starts
+IP loads its **default** profile at boot (no keyboard target). Our profile must
+be loaded *before the overlay enumerates input devices*, or the overlay never
+sees IP's keyboard. A **systemd one-shot** ordered `After=inputplumber.service`,
+`Before=graphical.target` calls `CompositeDevice.LoadProfilePath`. (Loading it
+manually after the session starts is too late — that wasted a lot of time.)
+
+### 4. ⚠️ Permission — let the overlay OPEN IP's virtual keyboard
+**This is the non-obvious gotcha that blocked everything.** The overlay logged:
+
+```
+[input-intercept] open failed for /dev/input/event18 (InputPlumber Keyboard)
+[overlay] input intercept ready — 0 controller(s), 3 keyboard(s), 2 qam device(s)
+```
+
+The overlay finds IP's keyboard but **can't open it**. The `deck` user is **not
+in the `input` group**; physical keyboards work via a logind **`uaccess`** ACL,
+but IP's virtual keyboard doesn't get that ACL — SteamOS's
+`90-steam-inputplumber.rules` gates the `uaccess` tag on `USE_INPUTPLUMBER==1`,
+which **isn't set on the Deck**. Compare ACLs:
+
+```
+event14 (Apple kbd, opens): user:deck:rw-     ← uaccess ACL present
+event18 (InputPlumber kbd): (no deck ACL)      ← open() → EACCES
+```
+
+**Fix (pick one):**
+- **udev `uaccess` rule** for IP's virtual devices (recommended for shipping —
+  grants the active session user, no group change):
+  ```
+  # /etc/udev/rules.d/71-loadout-inputplumber-uaccess.rules
+  SUBSYSTEM=="input", ATTRS{name}=="InputPlumber*", TAG+="uaccess"
+  ```
+- **or** add the user to the `input` group: `usermod -aG input deck` (this is
+  the overlay's documented requirement; **the validated working setup used
+  this**). Requires re-login/reboot.
+
+### 5. Enable the services
+`systemctl enable inputplumber.service loadout-ip-profile.service`, reboot.
+
+## Result
+
+Boot order becomes: InputPlumber starts → one-shot loads the paddle→F16 profile
+(IP keyboard now exists) → session + overlay start and enumerate that keyboard →
+**press a back paddle → F16 → overlay toggles.** No double controller
+(`deck-uhid` keeps it single), renders normally on a clean boot.
+
+## Why this is the right answer for the broader fleet
+
+- **Steam Deck**: this recipe (IP off by default → we enable + manage + uaccess).
+- **OneXPlayer APEX / ROG Ally / Legion Go (Bazzite/SteamOS-other)**: InputPlumber
+  is already the active input layer, so just the profile mapping is needed
+  (button source names differ per device — handled by per-device handheld plugins
+  that will land in later milestones).
+- The **overlay side is universal**: watch F16. No per-device overlay code.
+
+So per-device InputPlumber profiles aren't ideal, but they're the only thing
+that works on SteamOS, and they match the pattern already established for APEX.
+
+## The installer: vendored assets + a thin wrapper
+
+The five pieces above are all **vendored as real files** under
+`scripts/deck-overlay-trigger/`, and `scripts/setup-deck.sh`
+is a thin wrapper that copies them into place. Only one piece is rendered
+per-install: the profile's `mapping:` list, which is generated from the
+user-selected button names by `inputplumber/render-profile.sh`.
+
+```
+scripts/
+├── setup-deck.sh        ← entry-point (~90 lines, no heredocs)
+└── deck-overlay-trigger/
+    ├── inputplumber/
+    │   ├── devices/50-steam_deck.yaml          ← device override (static)
+    │   ├── profiles/overlay-trigger.header.yaml← profile header (static)
+    │   └── render-profile.sh                   ← appends mapping entries
+    ├── systemd/loadout-ip-profile.service ← boot one-shot (static)
+    ├── udev/71-inputplumber-uaccess.rules      ← permission rule (static)
+    └── bin/ip-load-profile.sh                  ← deployed to /etc (static)
+```
+
+Real YAMLs with `yaml-language-server` schema headers, reviewable in diffs,
+editable in any LSP-aware editor. The installer is a thin wrapper around them.
+
+### Future: user-configurable button via the overlay UI
+
+1. **DMI-guarded setup**: on a Deck (`product_name` Galileo/Jupiter,
+   `sys_vendor` Valve, exposed by `@loadout/device`), a future onboarding
+   step or settings panel can shell out to `setup-deck.sh`.
+2. **Button picker in a settings panel**: L4 / L5 / R4 / R5 / Off — *not* a
+   `Guide+` chord (those can't work on the Deck, see above). Changing the
+   selection **re-runs `render-profile.sh`** with the new button list and
+   reloads via `CompositeDevice.LoadProfilePath` — no reboot.
+3. **F16 is the wake key**: single key, no terminal/SIGQUIT side effects,
+   and matches the overlay's existing QAM evdev watch.
+
+### Validated configuration reference (install destinations)
+
+| Piece | Source (in repo) | Destination |
+|-------|------------------|-------------|
+| Device override | `inputplumber/devices/50-steam_deck.yaml` | `/etc/inputplumber/devices.d/50-steam_deck.yaml` |
+| Profile (rendered) | `inputplumber/profiles/overlay-trigger.header.yaml` + `render-profile.sh` | `/etc/loadout/inputplumber/overlay-profile.yaml` |
+| Boot loader script | `bin/ip-load-profile.sh` | `/etc/loadout/inputplumber/ip-load-profile.sh` |
+| Boot one-shot unit | `systemd/loadout-ip-profile.service` | `/etc/systemd/system/loadout-ip-profile.service` |
+| Permission (uaccess) rule | `udev/71-inputplumber-uaccess.rules` | `/etc/udev/rules.d/71-loadout-inputplumber-uaccess.rules` |
+
+All destinations are under `/etc` so they survive ostree deployment switches
+on SteamOS (`/usr` is read-only and overlay-scoped to the current deployment).
+
+> History note: the long debugging path that produced this (chord injection,
+> CDP frontend probing, the `deck-uhid`/keyboard-target discovery, paddle source
+> names, and the `uaccess` permission gotcha) is summarised in the table above —
+> each row was a dead end or a required piece discovered the hard way.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,58 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import prettier from "eslint-config-prettier";
+
+export default tseslint.config(
+  {
+    ignores: [
+      "node_modules",
+      "dist",
+      "**/dist/**",
+      ".cache/**",
+      "**/build/**",
+      "**/webview-dist/**",
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["**/*.tsx", "**/*.ts"],
+    plugins: {
+      "react-hooks": reactHooks,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "react-hooks/exhaustive-deps": "error",
+    },
+  },
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/consistent-type-imports": "error",
+      "no-empty": ["warn", { allowEmptyCatch: true }],
+    },
+  },
+  {
+    files: ["plugins/*/*.ts", "plugins/*/*.tsx", "plugins/*/**/*.ts", "plugins/*/**/*.tsx"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["plugins/**", "@/plugins/**"],
+              message:
+                "Plugins are sealed: don't import from another plugin. Lift shared code into a @loadout/* workspace package instead.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  prettier,
+);

--- a/loadout.service
+++ b/loadout.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Loadout overlay
+# Loopback-only; no After=network.target so boot isn't gated on DNS/network.
+
+[Service]
+Type=simple
+ExecStart=%h/.local/share/loadout/bin/launcher
+WorkingDirectory=%h/.local/share/loadout
+Restart=on-failure
+RestartSec=5
+Environment=LOADOUT_PROJECT_ROOT=%h/.local/share/loadout
+Environment=LOADOUT_PLUGINS_DIR=%h/.local/share/loadout/plugins
+
+[Install]
+WantedBy=default.target

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "loadout",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "workspaces": [
+    "apps/*",
+    "packages/*",
+    "plugins/*"
+  ],
+  "scripts": {
+    "build": "bash scripts/build.sh",
+    "install-local": "bash scripts/install-local.sh",
+    "dev:server": "bun --watch run packages/server/src/cli.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "@tailwindcss/browser": "^4.2.2",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "@happy-dom/global-registrator": "^20.9.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/bun": "^1.3.10",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^9.0.0",
+    "eslint-config-prettier": "^10.0.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
+    "prettier": "^3.4.0",
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.0.0"
+  }
+}

--- a/packages/device/package.json
+++ b/packages/device/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@loadout/device",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/device/src/dmi.ts
+++ b/packages/device/src/dmi.ts
@@ -1,0 +1,29 @@
+import { readFile } from "node:fs/promises";
+
+export interface DmiInfo {
+  sysVendor: string;
+  productName: string;
+  productFamily: string;
+  boardName: string;
+}
+
+const DMI_BASE = "/sys/class/dmi/id";
+
+async function readField(field: string): Promise<string> {
+  try {
+    const raw = await readFile(`${DMI_BASE}/${field}`, "utf-8");
+    return raw.trim();
+  } catch {
+    return "";
+  }
+}
+
+export async function readDmi(): Promise<DmiInfo> {
+  const [sysVendor, productName, productFamily, boardName] = await Promise.all([
+    readField("sys_vendor"),
+    readField("product_name"),
+    readField("product_family"),
+    readField("board_name"),
+  ]);
+  return { sysVendor, productName, productFamily, boardName };
+}

--- a/packages/device/src/fingerprints.spec.ts
+++ b/packages/device/src/fingerprints.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "bun:test";
+import { matchFingerprint } from "./fingerprints";
+
+const baseDmi = { sysVendor: "", productName: "", productFamily: "", boardName: "" };
+
+describe("matchFingerprint", () => {
+  it("matches Apex", () => {
+    const fp = matchFingerprint({
+      ...baseDmi,
+      sysVendor: "ONE-NETBOOK",
+      productName: "ONEXPLAYER APEX 1",
+    });
+    expect(fp?.id).toBe("apex");
+    expect(fp?.capabilities.hasRGB).toBe(true);
+  });
+
+  it("matches OneXFly F1 Pro", () => {
+    const fp = matchFingerprint({
+      ...baseDmi,
+      sysVendor: "ONE-NETBOOK",
+      productName: "ONEXPLAYER F1 Pro",
+    });
+    expect(fp?.id).toBe("onexfly-f1-pro");
+  });
+
+  it("matches Steam Deck OLED (Galileo)", () => {
+    const fp = matchFingerprint({
+      ...baseDmi,
+      sysVendor: "Valve",
+      productName: "Galileo",
+    });
+    expect(fp?.id).toBe("steamdeck-oled");
+    expect(fp?.capabilities.hasRGB).toBe(false);
+  });
+
+  it("matches Steam Deck LCD (Jupiter)", () => {
+    const fp = matchFingerprint({
+      ...baseDmi,
+      sysVendor: "Valve",
+      productName: "Jupiter",
+    });
+    expect(fp?.id).toBe("steamdeck-lcd");
+  });
+
+  it("returns undefined for unknown hardware", () => {
+    const fp = matchFingerprint({
+      ...baseDmi,
+      sysVendor: "Acme",
+      productName: "GenericLaptop 9000",
+    });
+    expect(fp).toBeUndefined();
+  });
+});

--- a/packages/device/src/fingerprints.ts
+++ b/packages/device/src/fingerprints.ts
@@ -1,0 +1,77 @@
+import type { DmiInfo } from "./dmi";
+
+export type DeviceId =
+  | "apex"
+  | "steamdeck-oled"
+  | "steamdeck-lcd"
+  | "onexfly-f1-pro"
+  | "generic";
+
+export interface DeviceCapabilities {
+  hasRGB: boolean;
+  hasFanControl: boolean;
+  hasTDP: boolean;
+  hasBatteryControl: boolean;
+}
+
+export interface Fingerprint {
+  id: DeviceId;
+  match: (dmi: DmiInfo) => boolean;
+  capabilities: DeviceCapabilities;
+}
+
+export const FINGERPRINTS: Fingerprint[] = [
+  {
+    id: "apex",
+    match: (d) =>
+      d.sysVendor === "ONE-NETBOOK" && d.productName.startsWith("ONEXPLAYER APEX"),
+    capabilities: {
+      hasRGB: true,
+      hasFanControl: true,
+      hasTDP: true,
+      hasBatteryControl: true,
+    },
+  },
+  {
+    id: "onexfly-f1-pro",
+    match: (d) =>
+      d.sysVendor === "ONE-NETBOOK" && /ONEXPLAYER\s+F1\s*PRO/i.test(d.productName),
+    capabilities: {
+      hasRGB: true,
+      hasFanControl: true,
+      hasTDP: true,
+      hasBatteryControl: true,
+    },
+  },
+  {
+    id: "steamdeck-oled",
+    match: (d) => d.sysVendor === "Valve" && d.productName === "Galileo",
+    capabilities: {
+      hasRGB: false,
+      hasFanControl: true,
+      hasTDP: true,
+      hasBatteryControl: true,
+    },
+  },
+  {
+    id: "steamdeck-lcd",
+    match: (d) => d.sysVendor === "Valve" && d.productName === "Jupiter",
+    capabilities: {
+      hasRGB: false,
+      hasFanControl: true,
+      hasTDP: true,
+      hasBatteryControl: true,
+    },
+  },
+];
+
+export const GENERIC_CAPABILITIES: DeviceCapabilities = {
+  hasRGB: false,
+  hasFanControl: false,
+  hasTDP: false,
+  hasBatteryControl: false,
+};
+
+export function matchFingerprint(dmi: DmiInfo): Fingerprint | undefined {
+  return FINGERPRINTS.find((f) => f.match(dmi));
+}

--- a/packages/device/src/index.ts
+++ b/packages/device/src/index.ts
@@ -1,0 +1,39 @@
+import { readDmi, type DmiInfo } from "./dmi";
+import {
+  matchFingerprint,
+  GENERIC_CAPABILITIES,
+  type DeviceCapabilities,
+  type DeviceId,
+} from "./fingerprints";
+
+export type { DmiInfo } from "./dmi";
+export type { DeviceCapabilities, DeviceId } from "./fingerprints";
+
+export interface Device {
+  id: DeviceId;
+  dmi: DmiInfo;
+  gamescope: boolean;
+  capabilities: DeviceCapabilities;
+}
+
+let cached: Device | undefined;
+
+export async function detectDevice(): Promise<Device> {
+  if (cached) return cached;
+  const dmi = await readDmi();
+  const fp = matchFingerprint(dmi);
+  const gamescope =
+    !!process.env.GAMESCOPE_DISPLAY || !!process.env.GAMESCOPE_WAYLAND_DISPLAY;
+  cached = {
+    id: fp?.id ?? "generic",
+    dmi,
+    gamescope,
+    capabilities: fp?.capabilities ?? GENERIC_CAPABILITIES,
+  };
+  return cached;
+}
+
+/** Test-only: reset the detection cache. */
+export function _resetDeviceCache(): void {
+  cached = undefined;
+}

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@loadout/exec",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/exec/src/exec.spec.ts
+++ b/packages/exec/src/exec.spec.ts
@@ -1,0 +1,115 @@
+// Use Bun.spawn() directly instead of importing from ./index to avoid
+// contamination from mock.module("@loadout/exec", ...) in other test files.
+import { describe, it, expect } from "bun:test";
+
+/** Re-implement run() inline using Bun.spawn to bypass mock contamination. */
+async function run(
+  cmd: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  return { stdout: stdout.trim(), exitCode };
+}
+
+/** Re-implement runCode() inline using Bun.spawn to bypass mock contamination. */
+async function runCode(cmd: string[]): Promise<number> {
+  const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
+  return proc.exited;
+}
+
+/** Re-implement commandExists() inline using Bun.spawn to bypass mock contamination. */
+async function commandExists(name: string): Promise<boolean> {
+  try {
+    const { exitCode } = await run(["which", name]);
+    return exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+describe("run", () => {
+  it("returns stdout and exitCode 0 for a successful command", async () => {
+    const result = await run(["echo", "hello"]);
+    expect(result.stdout).toBe("hello");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("returns non-zero exitCode for a failing command", async () => {
+    const result = await run(["false"]);
+    expect(result.exitCode).not.toBe(0);
+  });
+});
+
+describe("runCode", () => {
+  it("returns 0 for a successful command", async () => {
+    const code = await runCode(["true"]);
+    expect(code).toBe(0);
+  });
+
+  it("returns non-zero for a failing command", async () => {
+    const code = await runCode(["false"]);
+    expect(code).not.toBe(0);
+  });
+});
+
+describe("commandExists", () => {
+  it("returns true for a known command", async () => {
+    const exists = await commandExists("echo");
+    expect(exists).toBe(true);
+  });
+
+  it("returns false for a nonexistent command", async () => {
+    const exists = await commandExists("definitely-not-a-command-xyz");
+    expect(exists).toBe(false);
+  });
+});
+
+// `runStreaming` is new and not mocked anywhere, so it's safe to
+// import directly from ./index — mock-contamination won't bite.
+import { runStreaming } from "./index";
+
+describe("runStreaming", () => {
+  it("calls onLine once per stdout line, in order, without trailing partials", async () => {
+    const lines: string[] = [];
+    const result = await runStreaming(
+      ["sh", "-c", "printf 'one\\ntwo\\nthree\\n'"],
+      { onLine: (l) => lines.push(l) },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(lines).toEqual(["one", "two", "three"]);
+  });
+
+  it("flushes the trailing line when stdout doesn't end with newline", async () => {
+    const lines: string[] = [];
+    await runStreaming(["sh", "-c", "printf 'no-newline'"], {
+      onLine: (l) => lines.push(l),
+    });
+    expect(lines).toEqual(["no-newline"]);
+  });
+
+  it("merges stderr into the same stream so build progress (which most tools write to stderr) isn't lost", async () => {
+    const lines: string[] = [];
+    await runStreaming(
+      ["sh", "-c", "printf 'a\\n' >&2; printf 'b\\n'; printf 'c\\n' >&2"],
+      { onLine: (l) => lines.push(l) },
+    );
+    expect(lines.sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("propagates non-zero exit codes without throwing", async () => {
+    const result = await runStreaming(["false"], { onLine: () => {} });
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("kills the process after timeoutMs", async () => {
+    const start = Date.now();
+    const result = await runStreaming(["sleep", "30"], {
+      onLine: () => {},
+      timeoutMs: 100,
+    });
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(2000);
+    expect(result.exitCode).not.toBe(0);
+  });
+});

--- a/packages/exec/src/index.ts
+++ b/packages/exec/src/index.ts
@@ -1,0 +1,221 @@
+export interface RunOptions {
+  /** Kill the subprocess if it hasn't exited within this many ms.
+   *  `run()` / `runFull()` return `{ stdout: "", stderr: "", exitCode: -1 }`
+   *  on timeout. Useful when shelling out to X11 tools (xprop / xdotool)
+   *  that can hang indefinitely on a stuck X server — without a timeout
+   *  the await blocks Bun's event loop for the whole process. */
+  timeoutMs?: number;
+  /** Bytes (or a string, UTF-8 encoded) to pipe to the subprocess stdin
+   *  before closing it. Use when you want to feed a value to `tee` /
+   *  `sudo -S` / a tool that reads from stdin. For interactive stdin
+   *  streams, use `spawn()` directly. */
+  stdin?: Uint8Array | string;
+  /** Extra env vars merged on top of `process.env`. Set a key to
+   *  `undefined` to unset it. */
+  env?: Record<string, string | undefined>;
+  /** Working directory. Defaults to the process cwd. */
+  cwd?: string;
+}
+
+export interface RunResult {
+  /** Raw stdout. NOT trimmed — `runFull` preserves whitespace; `run`
+   *  trims for ergonomic single-line outputs. */
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+interface SpawnOpts {
+  stdout: "pipe";
+  stderr: "pipe";
+  stdin?: ReadableStream<Uint8Array>;
+  env?: Record<string, string>;
+  cwd?: string;
+}
+
+/** Build the Bun.spawn options bag from our `RunOptions`. */
+function buildOpts(opts: RunOptions): SpawnOpts {
+  const out: SpawnOpts = { stdout: "pipe", stderr: "pipe" };
+  if (opts.stdin !== undefined) {
+    const bytes =
+      typeof opts.stdin === "string" ? new TextEncoder().encode(opts.stdin) : opts.stdin;
+    out.stdin = new ReadableStream({
+      start(c) {
+        c.enqueue(bytes);
+        c.close();
+      },
+    });
+  }
+  if (opts.env) {
+    const merged: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (typeof v === "string") merged[k] = v;
+    }
+    for (const [k, v] of Object.entries(opts.env)) {
+      if (v === undefined) delete merged[k];
+      else merged[k] = v;
+    }
+    out.env = merged;
+  }
+  if (opts.cwd) out.cwd = opts.cwd;
+  return out;
+}
+
+/**
+ * Run a one-shot command and return trimmed stdout + exit code.
+ * Drops stderr — use `runFull()` if you need it.
+ */
+export async function run(
+  cmd: string[],
+  opts: RunOptions = {},
+): Promise<{ stdout: string; exitCode: number }> {
+  const result = await runFull(cmd, opts);
+  return { stdout: result.stdout.trim(), exitCode: result.exitCode };
+}
+
+/**
+ * Run a one-shot command and return raw stdout, stderr, and exit code.
+ * Use when you need to surface stderr (most subprocess errors live there).
+ */
+export async function runFull(
+  cmd: string[],
+  opts: RunOptions = {},
+): Promise<RunResult> {
+  const proc = Bun.spawn(cmd, buildOpts(opts));
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let timedOut = false;
+  if (opts.timeoutMs && opts.timeoutMs > 0) {
+    timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+    }, opts.timeoutMs);
+  }
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (timedOut) return { stdout: "", stderr: "", exitCode: -1 };
+    return { stdout, stderr, exitCode };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Run a command and return only the exit code. Stdout + stderr are
+ * silenced (Bun.spawn with `"ignore"` on both).
+ */
+export async function runCode(cmd: string[]): Promise<number> {
+  const proc = Bun.spawn(cmd, { stdout: "ignore", stderr: "ignore" });
+  return proc.exited;
+}
+
+/**
+ * Run a command and stream every output line to a callback while it
+ * executes. Use for long-running processes whose progress matters
+ * to the UI — `make`, `cmake`, `git clone --progress`, etc. — where
+ * waiting for `runFull()` to return at the end leaves the user
+ * staring at a frozen progress bar for minutes.
+ *
+ * Both stdout AND stderr are merged into the same stream; most
+ * build tools spew their actual progress info to stderr (e.g.
+ * `make -j` runs and `gcc` compile lines), so anything else would
+ * miss it. Lines are buffered until each `\n` so `onLine` always
+ * receives a complete line (no partial fragments). The trailing
+ * unterminated buffer is flushed on exit.
+ *
+ * Honours `timeoutMs` (kills the process), `env` (merged on top of
+ * `process.env`), `cwd`. `stdin` is intentionally NOT supported —
+ * if you need to pipe input AND stream output, use `spawn()`
+ * directly.
+ *
+ * Returns the exit code; doesn't throw on non-zero. Caller decides
+ * what's an error.
+ */
+export async function runStreaming(
+  cmd: string[],
+  opts: Omit<RunOptions, "stdin"> & {
+    onLine: (line: string) => void;
+    /**
+     * Fired once with the spawned subprocess so the caller can stash
+     * the handle and signal it later (e.g. SIGTERM on user-initiated
+     * cancel). Optional — callers that don't need to cancel skip it
+     * and behaviour is unchanged.
+     */
+    onSpawn?: (proc: ReturnType<typeof Bun.spawn>) => void;
+  },
+): Promise<{ exitCode: number }> {
+  const proc = Bun.spawn(cmd, buildOpts({ env: opts.env, cwd: opts.cwd }));
+  opts.onSpawn?.(proc);
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  if (opts.timeoutMs && opts.timeoutMs > 0) {
+    timer = setTimeout(() => proc.kill(), opts.timeoutMs);
+  }
+  // Drain a ReadableStream<Uint8Array> line-by-line, calling onLine
+  // for each `\n`-terminated chunk and flushing whatever's left in
+  // the buffer when the stream closes.
+  const drain = async (stream: ReadableStream<Uint8Array> | null) => {
+    if (!stream) return;
+    const reader = stream.getReader();
+    const decoder = new TextDecoder("utf-8");
+    let buf = "";
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let nl: number;
+        while ((nl = buf.indexOf("\n")) !== -1) {
+          opts.onLine(buf.slice(0, nl));
+          buf = buf.slice(nl + 1);
+        }
+      }
+    } finally {
+      buf += decoder.decode();
+      if (buf.length > 0) opts.onLine(buf);
+    }
+  };
+  try {
+    const [, , exitCode] = await Promise.all([
+      drain(proc.stdout as ReadableStream<Uint8Array> | null),
+      drain(proc.stderr as ReadableStream<Uint8Array> | null),
+      proc.exited,
+    ]);
+    return { exitCode };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Check if a command exists on the system PATH.
+ */
+export async function commandExists(name: string): Promise<boolean> {
+  try {
+    const { exitCode } = await run(["which", name]);
+    return exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Wrapper around `Bun.spawn` for long-lived or streaming subprocesses
+ * (e.g. mpv with an IPC socket, `flatpak update` with line-streamed
+ * progress). For one-shot commands prefer `run()` / `runFull()` —
+ * they handle stdin / env / cwd / timeout cleanly.
+ *
+ * The reason this wrapper exists at all: a lint rule (Q-006 in the
+ * 2026-05 audit) forbids `Bun.spawn` outside `packages/exec`. Routing
+ * the long-lived cases through this single export keeps "all subprocess
+ * work goes through @loadout/exec" as one teachable rule.
+ *
+ * Implemented as a function (not `export const spawn = Bun.spawn`) so
+ * test specs that re-assign `Bun.spawn` at test time still get
+ * intercepted — the const form would capture the real `Bun.spawn` at
+ * module-load and ignore later mocks.
+ */
+export const spawn: typeof Bun.spawn = ((...args: Parameters<typeof Bun.spawn>) =>
+  Bun.spawn(...args)) as typeof Bun.spawn;

--- a/packages/overlay-shell/package.json
+++ b/packages/overlay-shell/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@loadout/overlay-shell",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@loadout/types": "*",
+    "@loadout/ui": "*",
+    "@noriginmedia/norigin-spatial-navigation": "^3.0.0"
+  },
+  "peerDependencies": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  }
+}

--- a/packages/overlay-shell/src/App.tsx
+++ b/packages/overlay-shell/src/App.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useMemo, useState } from "react";
+import { BackendProvider } from "@loadout/ui";
+import { GamepadNavProvider } from "./GamepadNav";
+import { usePlugins, type PluginInfo } from "./usePlugins";
+import { PluginHost } from "./PluginHost";
+
+interface Route {
+  view: "home" | "plugin";
+  pluginId?: string;
+}
+
+function parseHash(hash: string): Route {
+  const h = hash.replace(/^#\/?/, "");
+  if (h.startsWith("plugin/")) {
+    const id = h.slice("plugin/".length);
+    if (id) return { view: "plugin", pluginId: id };
+  }
+  return { view: "home" };
+}
+
+function useHashRoute(): Route {
+  const [route, setRoute] = useState<Route>(() => parseHash(window.location.hash));
+  useEffect(() => {
+    const onChange = () => setRoute(parseHash(window.location.hash));
+    window.addEventListener("hashchange", onChange);
+    return () => window.removeEventListener("hashchange", onChange);
+  }, []);
+  return route;
+}
+
+function Home({ plugins }: { plugins: PluginInfo[] }) {
+  // M1: jump straight into the first available plugin if there's exactly one.
+  // Later milestones will replace this with a real launcher / plugin list.
+  useEffect(() => {
+    const first = plugins.find((p) => p.hasApp);
+    if (first) {
+      window.location.hash = `#/plugin/${first.id}`;
+    }
+  }, [plugins]);
+
+  return (
+    <div className="p-6">
+      <h2 className="text-lg font-semibold mb-2">Loadout</h2>
+      <p className="text-sm text-base-content/60">
+        {plugins.length === 0
+          ? "No plugins loaded."
+          : `Loaded: ${plugins.map((p) => p.name).join(", ")}`}
+      </p>
+    </div>
+  );
+}
+
+export function App() {
+  const route = useHashRoute();
+  const { plugins, loading, error } = usePlugins();
+
+  const activePlugin = useMemo(() => {
+    if (route.view !== "plugin" || !route.pluginId) return undefined;
+    return plugins.find((p) => p.id === route.pluginId);
+  }, [route, plugins]);
+
+  return (
+    <BackendProvider>
+      <GamepadNavProvider onBack={() => (window.location.hash = "#/")}>
+        <main className="h-screen w-screen bg-base-100 text-base-content">
+          {loading && <div className="p-6 text-base-content/60">Loading plugins…</div>}
+          {error && <div className="p-6 text-error">{error}</div>}
+          {!loading && !error && route.view === "home" && <Home plugins={plugins} />}
+          {!loading && !error && route.view === "plugin" && activePlugin && (
+            <PluginHost plugin={activePlugin} />
+          )}
+          {!loading && !error && route.view === "plugin" && !activePlugin && (
+            <div className="p-6 text-error">
+              Plugin not found: {route.pluginId}
+            </div>
+          )}
+        </main>
+      </GamepadNavProvider>
+    </BackendProvider>
+  );
+}

--- a/packages/overlay-shell/src/GamepadNav.tsx
+++ b/packages/overlay-shell/src/GamepadNav.tsx
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, type ReactNode } from "react";
+import {
+  useFocusable,
+  FocusContext,
+} from "@noriginmedia/norigin-spatial-navigation";
+import { tryRunBackInterceptor } from "@loadout/ui";
+
+/**
+ * Wraps the shell tree with the root focus boundary. Listens for Escape
+ * (Bun-side evdev relays the B button as Escape) and runs the back chain.
+ */
+export function GamepadNavProvider({
+  children,
+  onBack,
+}: {
+  children: ReactNode;
+  onBack?: () => void;
+}) {
+  const { ref, focusKey, focusSelf } = useFocusable({
+    isFocusBoundary: false,
+    trackChildren: true,
+    saveLastFocusedChild: true,
+  });
+
+  const handleBack = useCallback(() => {
+    if (tryRunBackInterceptor()) return;
+    onBack?.();
+  }, [onBack]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        handleBack();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [handleBack]);
+
+  useEffect(() => {
+    focusSelf();
+  }, [focusSelf]);
+
+  return (
+    <FocusContext.Provider value={focusKey}>
+      <div ref={ref as unknown as React.RefObject<HTMLDivElement>} className="contents">
+        {children}
+      </div>
+    </FocusContext.Provider>
+  );
+}

--- a/packages/overlay-shell/src/PluginHost.tsx
+++ b/packages/overlay-shell/src/PluginHost.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from "react";
+import { Spinner } from "@loadout/ui";
+import type { PluginInfo } from "./usePlugins";
+
+const DEFAULT_PORT = 33820;
+
+interface PluginModule {
+  default?: PluginMountFn | React.ComponentType;
+  mount?: PluginMountFn;
+}
+
+type PluginMountFn = (
+  container: HTMLElement,
+  opts: { parentFocusKey?: string },
+) => (() => void) | void;
+
+async function importPluginBundle(pluginId: string, port = DEFAULT_PORT): Promise<PluginModule> {
+  const token = window.__LOADOUT_TOKEN__ ?? "";
+  const url = `http://127.0.0.1:${port}/plugins/${pluginId}/app-bundle.js?token=${encodeURIComponent(token)}`;
+  return (await import(/* @vite-ignore */ url)) as PluginModule;
+}
+
+/**
+ * Mounts a plugin's app bundle inside its own React root. The plugin owns
+ * its mount/unmount lifecycle; the shell only provides the container and
+ * a parentFocusKey hint for spatial nav.
+ */
+export function PluginHost({ plugin }: { plugin: PluginInfo }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const unmountRef = useRef<(() => void) | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const mod = await importPluginBundle(plugin.id);
+        if (cancelled) return;
+        const mount = mod.mount ?? (mod.default as PluginMountFn | undefined);
+        if (typeof mount !== "function") {
+          throw new Error(`Plugin "${plugin.id}" does not export a mount function`);
+        }
+        const result = mount(container, { parentFocusKey: "content" });
+        unmountRef.current = typeof result === "function" ? result : null;
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (unmountRef.current) {
+        try {
+          unmountRef.current();
+        } catch {}
+        unmountRef.current = null;
+      }
+    };
+  }, [plugin.id]);
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <h3 className="text-error font-semibold mb-2">Plugin failed to load</h3>
+        <p className="text-sm text-base-content/70 break-words">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full">
+      {loading && (
+        <div className="flex flex-col items-center justify-center h-full gap-3">
+          <Spinner />
+          <p className="text-sm text-base-content/60">Loading {plugin.name}…</p>
+        </div>
+      )}
+      <div ref={containerRef} className={loading ? "h-0 overflow-hidden" : "h-full"} />
+    </div>
+  );
+}

--- a/packages/overlay-shell/src/PluginHost.tsx
+++ b/packages/overlay-shell/src/PluginHost.tsx
@@ -45,6 +45,17 @@ export function PluginHost({ plugin }: { plugin: PluginInfo }) {
           throw new Error(`Plugin "${plugin.id}" does not export a mount function`);
         }
         const result = mount(container, { parentFocusKey: "content" });
+        // If the effect cleanup already ran (cancelled between await and now),
+        // the React root we just mounted has no other reference. Tear it down
+        // immediately so we don't leak.
+        if (cancelled) {
+          if (typeof result === "function") {
+            try {
+              result();
+            } catch {}
+          }
+          return;
+        }
         unmountRef.current = typeof result === "function" ? result : null;
         setLoading(false);
       } catch (err) {

--- a/packages/overlay-shell/src/index.ts
+++ b/packages/overlay-shell/src/index.ts
@@ -1,0 +1,6 @@
+export { App } from "./App";
+export { GamepadNavProvider } from "./GamepadNav";
+export { PluginHost } from "./PluginHost";
+export { usePlugins } from "./usePlugins";
+export type { PluginInfo } from "./usePlugins";
+export { installSpatialNav } from "./spatial-nav-init";

--- a/packages/overlay-shell/src/spatial-nav-init.ts
+++ b/packages/overlay-shell/src/spatial-nav-init.ts
@@ -1,0 +1,55 @@
+/**
+ * One-time bootstrap of the shared spatial-navigation singleton.
+ *
+ * The shell uses `@noriginmedia/norigin-spatial-navigation` directly; plugin
+ * bundles reach the same singleton via `window.__LOADOUT_SPATIAL_NAV`. The
+ * singleton internally is the library's module-level state, so all we need to
+ * do is expose its imperative API on a window key for plugin proxies to call.
+ */
+import {
+  init,
+  setFocus,
+  getCurrentFocusKey,
+  navigateByDirection,
+  pause,
+  resume,
+  updateAllLayouts,
+  destroy,
+} from "@noriginmedia/norigin-spatial-navigation";
+
+let installed = false;
+
+interface NavInternals {
+  addFocusable(opts: unknown): void;
+  removeFocusable(opts: { focusKey: string }): void;
+  updateFocusable(focusKey: string, opts: unknown): void;
+}
+
+declare const globalThis: {
+  SpatialNavigation?: NavInternals;
+} & typeof window;
+
+export function installSpatialNav(): void {
+  if (installed) return;
+  installed = true;
+  init({ debug: false, visualDebug: false, shouldFocusDOMNode: true, throttle: 100 });
+
+  // Norigin v3 exposes its singleton on globalThis.SpatialNavigation. The
+  // imperative API exported above (setFocus, navigateByDirection...) goes
+  // through that same singleton, so wrapping them here makes the plugin
+  // proxy in @loadout/ui call the exact same backing functions.
+  const internals = (globalThis.SpatialNavigation ?? {}) as NavInternals;
+
+  window.__LOADOUT_SPATIAL_NAV = {
+    addFocusable: (opts) => internals.addFocusable?.(opts),
+    removeFocusable: (opts) => internals.removeFocusable?.(opts),
+    updateFocusable: (key, opts) => internals.updateFocusable?.(key, opts),
+    setFocus,
+    getCurrentFocusKey,
+    navigateByDirection,
+    pause,
+    resume,
+    updateAllLayouts,
+    destroy,
+  };
+}

--- a/packages/overlay-shell/src/spatial-nav-init.ts
+++ b/packages/overlay-shell/src/spatial-nav-init.ts
@@ -1,55 +1,20 @@
 /**
- * One-time bootstrap of the shared spatial-navigation singleton.
+ * One-time bootstrap of the spatial-navigation singleton.
  *
- * The shell uses `@noriginmedia/norigin-spatial-navigation` directly; plugin
- * bundles reach the same singleton via `window.__LOADOUT_SPATIAL_NAV`. The
- * singleton internally is the library's module-level state, so all we need to
- * do is expose its imperative API on a window key for plugin proxies to call.
+ * `@loadout/ui` re-exports norigin's hooks directly. The shell bundles
+ * `@loadout/ui` once (via Vite) and exposes it on `window.__LOADOUT_UI` so
+ * plugin bundles get the same module. That makes the library's internal
+ * `SpatialNavigation` instance a process-wide singleton — every focusable
+ * component, in every React root, registers with the same focus tree.
+ *
+ * All this function does is call `init()` once.
  */
-import {
-  init,
-  setFocus,
-  getCurrentFocusKey,
-  navigateByDirection,
-  pause,
-  resume,
-  updateAllLayouts,
-  destroy,
-} from "@noriginmedia/norigin-spatial-navigation";
+import { init } from "@noriginmedia/norigin-spatial-navigation";
 
 let installed = false;
-
-interface NavInternals {
-  addFocusable(opts: unknown): void;
-  removeFocusable(opts: { focusKey: string }): void;
-  updateFocusable(focusKey: string, opts: unknown): void;
-}
-
-declare const globalThis: {
-  SpatialNavigation?: NavInternals;
-} & typeof window;
 
 export function installSpatialNav(): void {
   if (installed) return;
   installed = true;
   init({ debug: false, visualDebug: false, shouldFocusDOMNode: true, throttle: 100 });
-
-  // Norigin v3 exposes its singleton on globalThis.SpatialNavigation. The
-  // imperative API exported above (setFocus, navigateByDirection...) goes
-  // through that same singleton, so wrapping them here makes the plugin
-  // proxy in @loadout/ui call the exact same backing functions.
-  const internals = (globalThis.SpatialNavigation ?? {}) as NavInternals;
-
-  window.__LOADOUT_SPATIAL_NAV = {
-    addFocusable: (opts) => internals.addFocusable?.(opts),
-    removeFocusable: (opts) => internals.removeFocusable?.(opts),
-    updateFocusable: (key, opts) => internals.updateFocusable?.(key, opts),
-    setFocus,
-    getCurrentFocusKey,
-    navigateByDirection,
-    pause,
-    resume,
-    updateAllLayouts,
-    destroy,
-  };
 }

--- a/packages/overlay-shell/src/usePlugins.ts
+++ b/packages/overlay-shell/src/usePlugins.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import type { PluginManifest } from "@loadout/types";
+
+export interface PluginInfo extends PluginManifest {
+  hasApp: boolean;
+}
+
+const DEFAULT_PORT = 33820;
+
+export interface UsePluginsOptions {
+  port?: number;
+}
+
+export function usePlugins(opts: UsePluginsOptions = {}): {
+  plugins: PluginInfo[];
+  loading: boolean;
+  error: string | null;
+} {
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const port = opts.port ?? DEFAULT_PORT;
+    const token = window.__LOADOUT_TOKEN__ ?? "";
+    const url = `http://127.0.0.1:${port}/api/plugins`;
+    fetch(url, { headers: { authorization: `Bearer ${token}` } })
+      .then((r) => r.json())
+      .then((data) => {
+        if (!alive) return;
+        setPlugins(data.plugins ?? []);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (!alive) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [opts.port]);
+
+  return { plugins, loading, error };
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@loadout/server",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@loadout/types": "*"
+  }
+}

--- a/packages/server/src/auth.spec.ts
+++ b/packages/server/src/auth.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "bun:test";
+import { createSessionAuth } from "./auth";
+
+describe("createSessionAuth", () => {
+  it("generates a 64-char hex token", () => {
+    const { token } = createSessionAuth();
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("validates ?token= query parameter", () => {
+    const auth = createSessionAuth();
+    const req = new Request(`http://x/ws?token=${auth.token}`);
+    expect(auth.validateRequest(req)).toBe(true);
+  });
+
+  it("validates Authorization: Bearer header", () => {
+    const auth = createSessionAuth();
+    const req = new Request("http://x/api/plugins", {
+      headers: { authorization: `Bearer ${auth.token}` },
+    });
+    expect(auth.validateRequest(req)).toBe(true);
+  });
+
+  it("rejects mismatched tokens", () => {
+    const auth = createSessionAuth();
+    expect(auth.validateRequest(new Request("http://x/?token=wrong"))).toBe(false);
+    expect(auth.validateRequest(new Request("http://x/"))).toBe(false);
+  });
+});

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,0 +1,21 @@
+import { randomBytes } from "node:crypto";
+
+export interface SessionAuth {
+  token: string;
+  validateRequest(req: Request): boolean;
+}
+
+export function createSessionAuth(): SessionAuth {
+  const token = randomBytes(32).toString("hex");
+  return {
+    token,
+    validateRequest(req) {
+      const url = new URL(req.url);
+      const queryToken = url.searchParams.get("token");
+      if (queryToken === token) return true;
+      const header = req.headers.get("authorization");
+      if (header === `Bearer ${token}`) return true;
+      return false;
+    },
+  };
+}

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,8 +1,13 @@
-import { randomBytes } from "node:crypto";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 
 export interface SessionAuth {
   token: string;
   validateRequest(req: Request): boolean;
+}
+
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
 }
 
 export function createSessionAuth(): SessionAuth {
@@ -12,9 +17,12 @@ export function createSessionAuth(): SessionAuth {
     validateRequest(req) {
       const url = new URL(req.url);
       const queryToken = url.searchParams.get("token");
-      if (queryToken === token) return true;
+      if (queryToken && safeEqual(queryToken, token)) return true;
       const header = req.headers.get("authorization");
-      if (header === `Bearer ${token}`) return true;
+      if (header && header.startsWith("Bearer ")) {
+        const provided = header.slice("Bearer ".length);
+        if (safeEqual(provided, token)) return true;
+      }
       return false;
     },
   };

--- a/packages/server/src/bundler.ts
+++ b/packages/server/src/bundler.ts
@@ -1,5 +1,6 @@
 import { mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
+import type { BunPlugin } from "bun";
 import { vendorGlobalsPlugin } from "./vendor-globals";
 import { log } from "./logger";
 
@@ -9,14 +10,50 @@ export interface CompileResult {
 }
 
 /**
- * Compile a plugin's `app.tsx` (or other browser entrypoint) to ESM with
- * vendor globals injected. Result is cached in-memory by the caller.
+ * Bun plugin that blocks any local file import outside `pluginRoot`. Bun.build
+ * will follow `import "/etc/passwd"` or `import "../../secrets.ts"` from a
+ * plugin's app.tsx and read the contents into the bundle (or, on failure, into
+ * the error logs). Constraining the resolve namespace here keeps plugins from
+ * exfiltrating arbitrary files via the build pipeline.
+ *
+ * node_modules imports are allowed through unchanged (resolver default).
  */
-export async function compileBrowserBundle(entrypoint: string): Promise<CompileResult> {
+function sandboxPluginPathsPlugin(pluginRoot: string): BunPlugin {
+  const rootResolved = resolve(pluginRoot);
+  return {
+    name: "loadout-sandbox-plugin-paths",
+    setup(build) {
+      build.onResolve({ filter: /^[./]/ }, (args) => {
+        // Relative imports are resolved relative to the importer. Absolute
+        // imports start with `/`. Reject anything that escapes the plugin
+        // directory by failing the resolve.
+        const importerDir = args.importer ? resolve(args.importer, "..") : rootResolved;
+        const resolved = resolve(importerDir, args.path);
+        const rootWithSep = rootResolved.endsWith(sep) ? rootResolved : rootResolved + sep;
+        if (resolved !== rootResolved && !resolved.startsWith(rootWithSep)) {
+          throw new Error(
+            `Plugin import escapes plugin root: ${args.path} (resolved to ${resolved})`,
+          );
+        }
+        return undefined;
+      });
+    },
+  };
+}
+
+/**
+ * Compile a plugin's `app.tsx` (or other browser entrypoint) to ESM with
+ * vendor globals injected. `pluginRoot` constrains the import graph so a
+ * malicious plugin can't reference files outside its own directory.
+ */
+export async function compileBrowserBundle(
+  entrypoint: string,
+  pluginRoot: string,
+): Promise<CompileResult> {
   try {
     const result = await Bun.build({
       entrypoints: [entrypoint],
-      plugins: [vendorGlobalsPlugin()],
+      plugins: [sandboxPluginPathsPlugin(pluginRoot), vendorGlobalsPlugin()],
       target: "browser",
       format: "esm",
       minify: false,
@@ -25,19 +62,29 @@ export async function compileBrowserBundle(entrypoint: string): Promise<CompileR
     if (result.success && result.outputs.length > 0) {
       return { ok: true, code: await result.outputs[0].text() };
     }
+    // Errors might contain absolute file paths from the resolver. Surface a
+    // generic message in the webview-bound response; full details go to logs.
     const logs = result.logs.map(String).join("\n");
     log.error(`Browser build failed: ${entrypoint}\n${logs}`);
-    return { ok: false, code: `// Build failed:\n// ${logs.replace(/\*\//g, "*\\/")}` };
+    return { ok: false, code: `// Build failed (see server logs)` };
   } catch (err) {
     log.error(`Browser build error: ${entrypoint} — ${err}`);
-    return { ok: false, code: `// Build error: ${err}` };
+    return { ok: false, code: `// Build error (see server logs)` };
   }
 }
 
 /**
  * Bundle a plugin's `backend.ts` into a self-contained ESM file the loader
- * can dynamic-import. Required because compiled Bun binaries can't resolve
- * node_modules from arbitrary directories.
+ * can dynamic-import. The bundle inlines workspace deps (e.g. `@loadout/device`)
+ * so it can run from an install path that doesn't have a `node_modules` tree.
+ *
+ * Build flow:
+ *   - If `.cache/backend.bundle.js` exists and is mtime-newer than the source,
+ *     reuse it. This is the only path that works under the installed layout
+ *     (no workspace, no node_modules at the plugin dir).
+ *   - Otherwise rebuild from source. This path requires the workspace to be
+ *     reachable — only used during local dev or via `scripts/build.sh`'s
+ *     pre-bundle step.
  */
 export async function bundleBackend(
   pluginDir: string,
@@ -66,7 +113,9 @@ export async function bundleBackend(
   });
   if (!result.success) {
     throw new Error(
-      `Backend bundle failed for ${pluginId}:\n${result.logs.map(String).join("\n")}`,
+      `Backend bundle failed for ${pluginId}:\n${result.logs.map(String).join("\n")}\n` +
+        `If you are running an installed build, ensure scripts/build.sh has been run so ` +
+        `.cache/backend.bundle.js is present alongside backend.ts.`,
     );
   }
   return bundlePath;

--- a/packages/server/src/bundler.ts
+++ b/packages/server/src/bundler.ts
@@ -1,0 +1,73 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { vendorGlobalsPlugin } from "./vendor-globals";
+import { log } from "./logger";
+
+export interface CompileResult {
+  ok: boolean;
+  code: string;
+}
+
+/**
+ * Compile a plugin's `app.tsx` (or other browser entrypoint) to ESM with
+ * vendor globals injected. Result is cached in-memory by the caller.
+ */
+export async function compileBrowserBundle(entrypoint: string): Promise<CompileResult> {
+  try {
+    const result = await Bun.build({
+      entrypoints: [entrypoint],
+      plugins: [vendorGlobalsPlugin()],
+      target: "browser",
+      format: "esm",
+      minify: false,
+      define: { "process.env.NODE_ENV": '"production"' },
+    });
+    if (result.success && result.outputs.length > 0) {
+      return { ok: true, code: await result.outputs[0].text() };
+    }
+    const logs = result.logs.map(String).join("\n");
+    log.error(`Browser build failed: ${entrypoint}\n${logs}`);
+    return { ok: false, code: `// Build failed:\n// ${logs.replace(/\*\//g, "*\\/")}` };
+  } catch (err) {
+    log.error(`Browser build error: ${entrypoint} — ${err}`);
+    return { ok: false, code: `// Build error: ${err}` };
+  }
+}
+
+/**
+ * Bundle a plugin's `backend.ts` into a self-contained ESM file the loader
+ * can dynamic-import. Required because compiled Bun binaries can't resolve
+ * node_modules from arbitrary directories.
+ */
+export async function bundleBackend(
+  pluginDir: string,
+  backendPath: string,
+  pluginId: string,
+): Promise<string> {
+  const cacheDir = join(pluginDir, ".cache");
+  const bundlePath = join(cacheDir, "backend.bundle.js");
+
+  const srcFile = Bun.file(backendPath);
+  const cached = Bun.file(bundlePath);
+  if (await cached.exists()) {
+    const cachedMtime = cached.lastModified;
+    const srcMtime = (await srcFile.exists()) ? srcFile.lastModified : 0;
+    if (cachedMtime >= srcMtime) return bundlePath;
+  }
+
+  await mkdir(cacheDir, { recursive: true });
+  const result = await Bun.build({
+    entrypoints: [backendPath],
+    target: "bun",
+    format: "esm",
+    minify: false,
+    outdir: cacheDir,
+    naming: "backend.bundle.js",
+  });
+  if (!result.success) {
+    throw new Error(
+      `Backend bundle failed for ${pluginId}:\n${result.logs.map(String).join("\n")}`,
+    );
+  }
+  return bundlePath;
+}

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,0 +1,3 @@
+import { startServer } from "./server";
+
+await startServer();

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,0 +1,5 @@
+export { startServer } from "./server";
+export type { ServerOptions, LoadedPlugin } from "./server";
+export { log, createPluginLogger } from "./logger";
+export type { Logger } from "./logger";
+export { vendorGlobalsPlugin } from "./vendor-globals";

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,0 +1,31 @@
+import type { PluginLogger } from "@loadout/types";
+
+export interface Logger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+  debug(message: string): void;
+}
+
+function ts(): string {
+  return new Date().toISOString();
+}
+
+export const log: Logger = {
+  info: (m) => console.log(`[${ts()}] INFO  ${m}`),
+  warn: (m) => console.warn(`[${ts()}] WARN  ${m}`),
+  error: (m) => console.error(`[${ts()}] ERROR ${m}`),
+  debug: (m) => {
+    if (process.env.LOADOUT_DEBUG === "1") console.debug(`[${ts()}] DEBUG ${m}`);
+  },
+};
+
+export function createPluginLogger(pluginId: string): PluginLogger {
+  const prefix = `[${pluginId}]`;
+  return {
+    info: (m) => log.info(`${prefix} ${m}`),
+    warn: (m) => log.warn(`${prefix} ${m}`),
+    error: (m) => log.error(`${prefix} ${m}`),
+    debug: (m) => log.debug(`${prefix} ${m}`),
+  };
+}

--- a/packages/server/src/plugin-manager.ts
+++ b/packages/server/src/plugin-manager.ts
@@ -1,0 +1,102 @@
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { PluginManifest, PluginBackend, RpcEvent } from "@loadout/types";
+import { bundleBackend } from "./bundler";
+import { createPluginLogger, log } from "./logger";
+
+export interface LoadedPlugin {
+  manifest: PluginManifest;
+  instance: PluginBackend;
+  hasApp: boolean;
+  dir: string;
+}
+
+export interface LoadPluginsArgs {
+  pluginsDir: string;
+  broadcast: (msg: RpcEvent) => void;
+}
+
+async function readManifest(pluginDir: string): Promise<PluginManifest | undefined> {
+  const pluginJson = Bun.file(join(pluginDir, "plugin.json"));
+  if (await pluginJson.exists()) {
+    return (await pluginJson.json()) as PluginManifest;
+  }
+  const pkgJson = Bun.file(join(pluginDir, "package.json"));
+  if (await pkgJson.exists()) {
+    const pkg = await pkgJson.json();
+    if (!pkg.plugin) return undefined;
+    return {
+      id: pkg.plugin.id ?? pkg.name,
+      name: pkg.plugin.name ?? pkg.name,
+      version: pkg.version ?? "0.0.0",
+      description: pkg.plugin.description ?? pkg.description,
+      author: pkg.plugin.author ?? pkg.author,
+      ...pkg.plugin,
+    } as PluginManifest;
+  }
+  return undefined;
+}
+
+export async function loadPlugins({
+  pluginsDir,
+  broadcast,
+}: LoadPluginsArgs): Promise<Map<string, LoadedPlugin>> {
+  const loaded = new Map<string, LoadedPlugin>();
+
+  let entries: string[];
+  try {
+    entries = await readdir(pluginsDir);
+  } catch {
+    log.warn(`Plugins directory not found: ${pluginsDir}`);
+    return loaded;
+  }
+
+  for (const entry of entries) {
+    const pluginDir = join(pluginsDir, entry);
+    let manifest: PluginManifest | undefined;
+    try {
+      manifest = await readManifest(pluginDir);
+    } catch (err) {
+      log.warn(`Skipping ${entry}: failed to read manifest (${err})`);
+      continue;
+    }
+    if (!manifest) {
+      log.debug(`Skipping ${entry}: no plugin.json or package.json with plugin field`);
+      continue;
+    }
+
+    const backendPath = join(pluginDir, "backend.ts");
+    const hasBackend = await Bun.file(backendPath).exists();
+    let instance: PluginBackend = {};
+
+    if (hasBackend) {
+      try {
+        const bundlePath = await bundleBackend(pluginDir, backendPath, manifest.id);
+        const mod = await import(bundlePath);
+        const BackendClass = mod.default;
+        instance = new BackendClass();
+      } catch (err) {
+        log.error(`Failed to load backend for ${manifest.id}: ${err}`);
+        continue;
+      }
+      instance.emit = ({ event, data }) =>
+        broadcast({ type: "event", plugin: manifest!.id, event, data });
+      instance.log = createPluginLogger(manifest.id);
+      try {
+        await instance.onLoad?.();
+      } catch (err) {
+        log.error(`onLoad failed for ${manifest.id}: ${err}`);
+      }
+    }
+
+    const appPath = join(pluginDir, "app.tsx");
+    const hasApp = await Bun.file(appPath).exists();
+
+    loaded.set(manifest.id, { manifest, instance, hasApp, dir: pluginDir });
+    log.info(
+      `Loaded plugin: ${manifest.name} (${manifest.id}) [backend=${hasBackend}, app=${hasApp}]`,
+    );
+  }
+
+  return loaded;
+}

--- a/packages/server/src/plugin-manager.ts
+++ b/packages/server/src/plugin-manager.ts
@@ -16,6 +16,13 @@ export interface LoadPluginsArgs {
   broadcast: (msg: RpcEvent) => void;
 }
 
+/**
+ * Plugin id charset. Constrained so the id is safe in URL paths, log lines,
+ * filesystem cache dirs, and JSON keys — no traversal, no shell-interesting
+ * chars. Reject leading dash so `--foo`-style switches can't be smuggled.
+ */
+const PLUGIN_ID_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
 async function readManifest(pluginDir: string): Promise<PluginManifest | undefined> {
   const pluginJson = Bun.file(join(pluginDir, "plugin.json"));
   if (await pluginJson.exists()) {
@@ -62,6 +69,12 @@ export async function loadPlugins({
     }
     if (!manifest) {
       log.debug(`Skipping ${entry}: no plugin.json or package.json with plugin field`);
+      continue;
+    }
+    if (!PLUGIN_ID_RE.test(manifest.id)) {
+      log.warn(
+        `Skipping ${entry}: plugin id ${JSON.stringify(manifest.id)} does not match ${PLUGIN_ID_RE}`,
+      );
       continue;
     }
 

--- a/packages/server/src/rpc.spec.ts
+++ b/packages/server/src/rpc.spec.ts
@@ -12,9 +12,26 @@ describe("createRpcHandler", () => {
     expect(await h("not json")).toBeNull();
   });
 
-  it("returns null when required fields are missing", async () => {
+  it("returns null when id is missing too", async () => {
     const h = createRpcHandler(new Map());
-    expect(await h(JSON.stringify({ id: "1" }))).toBeNull();
+    expect(await h(JSON.stringify({ plugin: "x", method: "y" }))).toBeNull();
+  });
+
+  it("returns error envelope when required fields are missing but id is present", async () => {
+    const h = createRpcHandler(new Map());
+    const raw = await h(JSON.stringify({ id: "1" }));
+    expect(raw).not.toBeNull();
+    const res = JSON.parse(raw!);
+    expect(res).toEqual({ id: "1", error: "Malformed RPC request" });
+  });
+
+  it("rejects oversized args arrays", async () => {
+    const h = createRpcHandler(new Map());
+    const raw = await h(
+      JSON.stringify({ id: "1", plugin: "x", method: "y", args: new Array(100).fill(0) }),
+    );
+    const res = JSON.parse(raw!);
+    expect(res.error).toMatch(/Too many args/);
   });
 
   it("returns plugin-not-found error", async () => {

--- a/packages/server/src/rpc.spec.ts
+++ b/packages/server/src/rpc.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "bun:test";
+import { createRpcHandler } from "./rpc";
+import type { PluginBackend } from "@loadout/types";
+
+function entry(instance: PluginBackend) {
+  return { instance };
+}
+
+describe("createRpcHandler", () => {
+  it("returns null for invalid JSON", async () => {
+    const h = createRpcHandler(new Map());
+    expect(await h("not json")).toBeNull();
+  });
+
+  it("returns null when required fields are missing", async () => {
+    const h = createRpcHandler(new Map());
+    expect(await h(JSON.stringify({ id: "1" }))).toBeNull();
+  });
+
+  it("returns plugin-not-found error", async () => {
+    const h = createRpcHandler(new Map());
+    const raw = await h(JSON.stringify({ id: "1", plugin: "x", method: "y", args: [] }));
+    const res = JSON.parse(raw!);
+    expect(res.error).toMatch(/not found/);
+  });
+
+  it("returns method-not-found error", async () => {
+    const h = createRpcHandler(new Map([["p", entry({})]]));
+    const raw = await h(JSON.stringify({ id: "1", plugin: "p", method: "missing", args: [] }));
+    const res = JSON.parse(raw!);
+    expect(res.error).toMatch(/Method "missing"/);
+  });
+
+  it("dispatches and returns method result", async () => {
+    const plugin: PluginBackend & { add: (a: number, b: number) => number } = {
+      add: (a, b) => a + b,
+    };
+    const h = createRpcHandler(new Map([["math", entry(plugin)]]));
+    const raw = await h(JSON.stringify({ id: "7", plugin: "math", method: "add", args: [2, 3] }));
+    const res = JSON.parse(raw!);
+    expect(res).toEqual({ id: "7", result: 5 });
+  });
+
+  it("captures thrown errors as error strings", async () => {
+    const plugin: PluginBackend & { boom: () => never } = {
+      boom: () => {
+        throw new Error("kaboom");
+      },
+    };
+    const h = createRpcHandler(new Map([["p", entry(plugin)]]));
+    const raw = await h(JSON.stringify({ id: "1", plugin: "p", method: "boom", args: [] }));
+    const res = JSON.parse(raw!);
+    expect(res.error).toBe("kaboom");
+  });
+
+  it("awaits async methods", async () => {
+    const plugin: PluginBackend & { ping: () => Promise<string> } = {
+      ping: async () => "pong",
+    };
+    const h = createRpcHandler(new Map([["p", entry(plugin)]]));
+    const raw = await h(JSON.stringify({ id: "1", plugin: "p", method: "ping", args: [] }));
+    const res = JSON.parse(raw!);
+    expect(res.result).toBe("pong");
+  });
+});

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -1,0 +1,45 @@
+import type { RpcRequest, RpcResponse, PluginBackend } from "@loadout/types";
+import { resolveMethod } from "@loadout/types";
+
+export interface RpcEntry {
+  instance: PluginBackend;
+}
+
+export type RpcHandler = (message: string) => Promise<string | null>;
+
+function reply(res: RpcResponse): string {
+  return JSON.stringify(res);
+}
+
+export function createRpcHandler(plugins: Map<string, RpcEntry>): RpcHandler {
+  return async (message: string): Promise<string | null> => {
+    let req: RpcRequest;
+    try {
+      req = JSON.parse(message);
+    } catch {
+      return null;
+    }
+    if (!req.id || !req.plugin || !req.method) return null;
+
+    const entry = plugins.get(req.plugin);
+    if (!entry) {
+      return reply({ id: req.id, error: `Plugin "${req.plugin}" not found` });
+    }
+    const method = resolveMethod(entry.instance, req.method);
+    if (!method) {
+      return reply({
+        id: req.id,
+        error: `Method "${req.method}" not found on plugin "${req.plugin}"`,
+      });
+    }
+    try {
+      const result = await method(...req.args);
+      return reply({ id: req.id, result });
+    } catch (err) {
+      return reply({
+        id: req.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+}

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -7,19 +7,45 @@ export interface RpcEntry {
 
 export type RpcHandler = (message: string) => Promise<string | null>;
 
+/** Hard cap on RPC args to bound JSON-parsed memory cost. */
+const MAX_ARGS = 64;
+
 function reply(res: RpcResponse): string {
   return JSON.stringify(res);
 }
 
+function isValidRequest(req: unknown): req is RpcRequest {
+  if (typeof req !== "object" || req === null) return false;
+  const r = req as Record<string, unknown>;
+  return (
+    typeof r.id === "string" &&
+    typeof r.plugin === "string" &&
+    typeof r.method === "string" &&
+    Array.isArray(r.args)
+  );
+}
+
 export function createRpcHandler(plugins: Map<string, RpcEntry>): RpcHandler {
   return async (message: string): Promise<string | null> => {
-    let req: RpcRequest;
+    let parsed: unknown;
     try {
-      req = JSON.parse(message);
+      parsed = JSON.parse(message);
     } catch {
       return null;
     }
-    if (!req.id || !req.plugin || !req.method) return null;
+    if (!isValidRequest(parsed)) {
+      // Reply with an error envelope when an id is at least present so the
+      // caller's pending-promise resolves instead of hanging forever.
+      const id =
+        parsed && typeof (parsed as { id?: unknown }).id === "string"
+          ? (parsed as { id: string }).id
+          : undefined;
+      return id ? reply({ id, error: "Malformed RPC request" }) : null;
+    }
+    const req = parsed;
+    if (req.args.length > MAX_ARGS) {
+      return reply({ id: req.id, error: `Too many args (max ${MAX_ARGS})` });
+    }
 
     const entry = plugins.get(req.plugin);
     if (!entry) {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,0 +1,159 @@
+import { join } from "node:path";
+import type { RpcEvent } from "@loadout/types";
+import { createSessionAuth } from "./auth";
+import { loadPlugins, type LoadedPlugin } from "./plugin-manager";
+import { createRpcHandler } from "./rpc";
+import { compileBrowserBundle } from "./bundler";
+import { watchDir } from "./watcher";
+import { log } from "./logger";
+
+export interface ServerOptions {
+  port?: number;
+  pluginsDir?: string;
+  projectRoot?: string;
+}
+
+interface WsClient {
+  send(data: string): void;
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json;charset=utf-8" },
+  });
+}
+
+function jsResponse(code: string, ok = true): Response {
+  return new Response(code, {
+    status: ok ? 200 : 500,
+    headers: { "Content-Type": "application/javascript;charset=utf-8" },
+  });
+}
+
+export async function startServer(options: ServerOptions = {}) {
+  const port = options.port ?? 33820;
+  const projectRoot = options.projectRoot ?? process.cwd();
+  const pluginsDir = options.pluginsDir ?? join(projectRoot, "plugins");
+
+  const auth = createSessionAuth();
+  log.info(`Session token: ${auth.token}`);
+
+  const wsClients = new Set<WsClient>();
+  function broadcast(msg: RpcEvent) {
+    const data = JSON.stringify(msg);
+    for (const ws of wsClients) {
+      try {
+        ws.send(data);
+      } catch {}
+    }
+  }
+
+  log.info(`Loading plugins from ${pluginsDir}`);
+  const plugins = await loadPlugins({ pluginsDir, broadcast });
+  log.info(`Loaded ${plugins.size} plugin(s)`);
+
+  const rpcHandler = createRpcHandler(
+    new Map([...plugins].map(([id, p]) => [id, { instance: p.instance }])),
+  );
+
+  const bundleCache = new Map<string, string>();
+
+  async function getPluginBundle(pluginId: string): Promise<Response> {
+    const plugin = plugins.get(pluginId);
+    if (!plugin || !plugin.hasApp) {
+      return new Response("Plugin or app.tsx not found", { status: 404 });
+    }
+    const cached = bundleCache.get(pluginId);
+    if (cached) return jsResponse(cached);
+    const result = await compileBrowserBundle(join(plugin.dir, "app.tsx"));
+    if (result.ok) bundleCache.set(pluginId, result.code);
+    return jsResponse(result.code, result.ok);
+  }
+
+  function listManifests() {
+    return [...plugins.values()].map((p) => ({
+      ...p.manifest,
+      hasApp: p.hasApp,
+    }));
+  }
+
+  const server = Bun.serve<{ type: "rpc" }>({
+    port,
+    hostname: "127.0.0.1",
+
+    async fetch(req, srv) {
+      const url = new URL(req.url);
+
+      if (url.pathname === "/up") return new Response("ok");
+
+      if (url.pathname === "/api/token") {
+        // Returns the token to in-process callers only. Bound to 127.0.0.1 so
+        // anything off-host can't reach this surface.
+        return jsonResponse({ token: auth.token });
+      }
+
+      if (url.pathname === "/ws") {
+        if (!auth.validateRequest(req)) return new Response("Unauthorized", { status: 401 });
+        const ok = srv.upgrade(req, { data: { type: "rpc" } });
+        return ok ? (undefined as unknown as Response) : new Response("upgrade failed", { status: 400 });
+      }
+
+      if (url.pathname.startsWith("/api/") && !auth.validateRequest(req)) {
+        return jsonResponse({ error: "Unauthorized" }, 401);
+      }
+
+      if (url.pathname === "/api/plugins") {
+        return jsonResponse({ plugins: listManifests() });
+      }
+
+      const bundleMatch = url.pathname.match(/^\/plugins\/([^/]+)\/app-bundle\.js$/);
+      if (bundleMatch) {
+        if (!auth.validateRequest(req)) return new Response("Unauthorized", { status: 401 });
+        return getPluginBundle(bundleMatch[1]);
+      }
+
+      return new Response("Not Found", { status: 404 });
+    },
+
+    websocket: {
+      open(ws: WsClient) {
+        wsClients.add(ws);
+      },
+      async message(ws: WsClient, raw: string | Buffer) {
+        const msg = typeof raw === "string" ? raw : raw.toString();
+        const response = await rpcHandler(msg);
+        if (response) ws.send(response);
+      },
+      close(ws: WsClient) {
+        wsClients.delete(ws);
+      },
+    },
+  });
+
+  log.info(`Loadout server running at http://127.0.0.1:${port}`);
+
+  // Hot reload: any change inside a plugin dir invalidates its bundle and
+  // broadcasts a reload event so the overlay can re-import.
+  const watchers: ReturnType<typeof watchDir>[] = [];
+  for (const [id, plugin] of plugins) {
+    const w = watchDir(plugin.dir, (filename) => {
+      log.debug(`[hot-reload] ${id}: ${filename}`);
+      bundleCache.delete(id);
+      broadcast({ type: "event", plugin: "__system", event: "reload", data: { plugin: id } });
+    });
+    watchers.push(w);
+  }
+
+  return {
+    server,
+    token: auth.token,
+    plugins,
+    close() {
+      for (const w of watchers) w.close();
+      server.stop();
+    },
+  };
+}
+
+export type { LoadedPlugin };

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -11,10 +11,13 @@ export interface ServerOptions {
   port?: number;
   pluginsDir?: string;
   projectRoot?: string;
+  /** Hard cap on concurrent WS connections. Defaults to 16 — overlay needs one. */
+  maxWsClients?: number;
 }
 
 interface WsClient {
   send(data: string): void;
+  close?(): void;
 }
 
 function jsonResponse(data: unknown, status = 200): Response {
@@ -35,9 +38,13 @@ export async function startServer(options: ServerOptions = {}) {
   const port = options.port ?? 33820;
   const projectRoot = options.projectRoot ?? process.cwd();
   const pluginsDir = options.pluginsDir ?? join(projectRoot, "plugins");
+  const maxWsClients = options.maxWsClients ?? 16;
 
   const auth = createSessionAuth();
-  log.info(`Session token: ${auth.token}`);
+  // Token is no longer exposed via HTTP — the Bun host hands it to the webview
+  // through the BrowserWindow URL at construction time. Log a redacted form so
+  // local-debug callers can still tell things are wired.
+  log.info(`Session token issued (${auth.token.slice(0, 6)}…)`);
 
   const wsClients = new Set<WsClient>();
   function broadcast(msg: RpcEvent) {
@@ -66,7 +73,7 @@ export async function startServer(options: ServerOptions = {}) {
     }
     const cached = bundleCache.get(pluginId);
     if (cached) return jsResponse(cached);
-    const result = await compileBrowserBundle(join(plugin.dir, "app.tsx"));
+    const result = await compileBrowserBundle(join(plugin.dir, "app.tsx"), plugin.dir);
     if (result.ok) bundleCache.set(pluginId, result.code);
     return jsResponse(result.code, result.ok);
   }
@@ -87,14 +94,16 @@ export async function startServer(options: ServerOptions = {}) {
 
       if (url.pathname === "/up") return new Response("ok");
 
-      if (url.pathname === "/api/token") {
-        // Returns the token to in-process callers only. Bound to 127.0.0.1 so
-        // anything off-host can't reach this surface.
-        return jsonResponse({ token: auth.token });
-      }
+      // `/ws` and `/api/*` are token-gated. There is intentionally no
+      // unauthenticated `/api/token` route — the token is delivered to the
+      // webview via the BrowserWindow URL at construction time, so no other
+      // local process can fetch it from this server.
 
       if (url.pathname === "/ws") {
         if (!auth.validateRequest(req)) return new Response("Unauthorized", { status: 401 });
+        if (wsClients.size >= maxWsClients) {
+          return new Response("Too many WS clients", { status: 503 });
+        }
         const ok = srv.upgrade(req, { data: { type: "rpc" } });
         return ok ? (undefined as unknown as Response) : new Response("upgrade failed", { status: 400 });
       }
@@ -134,7 +143,8 @@ export async function startServer(options: ServerOptions = {}) {
   log.info(`Loadout server running at http://127.0.0.1:${port}`);
 
   // Hot reload: any change inside a plugin dir invalidates its bundle and
-  // broadcasts a reload event so the overlay can re-import.
+  // broadcasts a reload event so the overlay can re-import. Watcher already
+  // ignores .cache/ + .build/ + node_modules.
   const watchers: ReturnType<typeof watchDir>[] = [];
   for (const [id, plugin] of plugins) {
     const w = watchDir(plugin.dir, (filename) => {
@@ -151,7 +161,7 @@ export async function startServer(options: ServerOptions = {}) {
     plugins,
     close() {
       for (const w of watchers) w.close();
-      server.stop();
+      server.stop(true);
     },
   };
 }

--- a/packages/server/src/vendor-globals.ts
+++ b/packages/server/src/vendor-globals.ts
@@ -3,28 +3,107 @@ import type { BunPlugin } from "bun";
 /**
  * Resolves `react`, `react/jsx-runtime`, `react-dom`, `react-dom/client`,
  * and `@loadout/ui` to globals set up by the overlay shell. Plugins bundled
- * with these plugins share React with the shell — without this, each plugin
- * gets its own React copy and hooks break.
+ * with this plugin share React with the shell — without this, each plugin
+ * gets its own React copy and hooks break across roots.
+ *
+ * The injected module is emitted as ESM (`export { ... }`) so plugin bundles
+ * resolve named imports (`import { useState } from "react"`) through the
+ * bundler's static analysis path rather than tripping over a CJS `module.exports`
+ * shim. We enumerate the named exports per module so the bundler can tree-shake
+ * + lint missing names properly.
  */
-const MAPPINGS: Record<string, string> = {
-  react: "globalThis.__LOADOUT_REACT",
-  "react/jsx-runtime": "globalThis.__LOADOUT_REACT_JSX_RUNTIME",
-  "react/jsx-dev-runtime": "globalThis.__LOADOUT_REACT_JSX_DEV_RUNTIME",
-  "react-dom": "globalThis.__LOADOUT_REACT_DOM",
-  "react-dom/client": "globalThis.__LOADOUT_REACT_DOM_CLIENT",
-  "@loadout/ui": "globalThis.__LOADOUT_UI",
+
+interface Mapping {
+  global: string;
+  /** Named exports the bundler will see on this module. */
+  names: string[];
+  /** True when the module also has a default export. */
+  hasDefault: boolean;
+}
+
+const MAPPINGS: Record<string, Mapping> = {
+  react: {
+    global: "globalThis.__LOADOUT_REACT",
+    hasDefault: true,
+    names: [
+      "Children", "Component", "Fragment", "Profiler", "PureComponent",
+      "StrictMode", "Suspense", "cloneElement", "createContext",
+      "createElement", "createFactory", "createRef", "forwardRef",
+      "isValidElement", "lazy", "memo", "startTransition", "useCallback",
+      "useContext", "useDebugValue", "useDeferredValue", "useEffect",
+      "useId", "useImperativeHandle", "useInsertionEffect", "useLayoutEffect",
+      "useMemo", "useReducer", "useRef", "useState", "useSyncExternalStore",
+      "useTransition", "version",
+    ],
+  },
+  "react/jsx-runtime": {
+    global: "globalThis.__LOADOUT_REACT_JSX_RUNTIME",
+    hasDefault: false,
+    names: ["jsx", "jsxs", "Fragment"],
+  },
+  "react/jsx-dev-runtime": {
+    global: "globalThis.__LOADOUT_REACT_JSX_DEV_RUNTIME",
+    hasDefault: false,
+    names: ["jsxDEV", "Fragment"],
+  },
+  "react-dom": {
+    global: "globalThis.__LOADOUT_REACT_DOM",
+    hasDefault: true,
+    names: [
+      "createPortal", "findDOMNode", "flushSync", "hydrate", "render",
+      "unmountComponentAtNode", "unstable_batchedUpdates", "version",
+    ],
+  },
+  "react-dom/client": {
+    global: "globalThis.__LOADOUT_REACT_DOM_CLIENT",
+    hasDefault: false,
+    names: ["createRoot", "hydrateRoot"],
+  },
+  "@loadout/ui": {
+    global: "globalThis.__LOADOUT_UI",
+    hasDefault: false,
+    // Plugins can import any export from @loadout/ui — too many to enumerate.
+    // For this module only, we fall back to a star re-export via a Proxy on the
+    // global; see `buildUiContents` below.
+    names: [],
+  },
 };
+
+function buildContents(m: Mapping): string {
+  if (m.global === "globalThis.__LOADOUT_UI") {
+    // @loadout/ui has a large + evolving surface — emit a star-style re-export
+    // through a Proxy-backed module object so any named import resolves at
+    // runtime against the global. The bundler is permissive about names it
+    // can't statically resolve on this namespace.
+    return `
+const __ns = ${m.global};
+const __keys = __ns ? Object.keys(__ns) : [];
+${[...new Set(["Button","Panel","Text","Toggle","Field","Slider","TextInput","TabBar","IconButton","Spinner","colors","useFocusable","useFocusContext","FocusContext","setFocus","getCurrentFocusKey","navigateByDirection","pauseNav","resumeNav","pushBackInterceptor","tryRunBackInterceptor","applyFocusPulse","focusScaleClass","BackendProvider","PluginProvider","useBackend","ensureConnected","subscribe","wsCall","initSpatialNav","SpatialNavigation","ROOT_FOCUS_KEY"])]
+  .map((n) => `export const ${n} = __ns?.${n};`)
+  .join("\n")}
+`;
+  }
+  const lines: string[] = [`const __ns = ${m.global};`];
+  for (const name of m.names) {
+    // Wrap each export in a fresh identifier so plugins doing
+    // `import { useState as us } from "react"` work as expected.
+    lines.push(`export const ${name} = __ns?.${name};`);
+  }
+  if (m.hasDefault) lines.push(`export default __ns;`);
+  return lines.join("\n");
+}
 
 export function vendorGlobalsPlugin(): BunPlugin {
   return {
     name: "loadout-vendor-globals",
     setup(build) {
-      for (const [pkg, globalVar] of Object.entries(MAPPINGS)) {
+      for (const [pkg, mapping] of Object.entries(MAPPINGS)) {
         const escaped = pkg.replace(/\//g, "\\/");
         const filter = new RegExp(`^${escaped}$`);
+        const contents = buildContents(mapping);
         build.onResolve({ filter }, () => ({ path: pkg, namespace: "loadout-global" }));
         build.onLoad({ filter, namespace: "loadout-global" }, () => ({
-          contents: `module.exports = ${globalVar};`,
+          contents,
           loader: "js",
         }));
       }
@@ -32,4 +111,4 @@ export function vendorGlobalsPlugin(): BunPlugin {
   };
 }
 
-export const VENDOR_GLOBAL_KEYS = Object.values(MAPPINGS);
+export const VENDOR_GLOBAL_KEYS = Object.values(MAPPINGS).map((m) => m.global);

--- a/packages/server/src/vendor-globals.ts
+++ b/packages/server/src/vendor-globals.ts
@@ -1,0 +1,35 @@
+import type { BunPlugin } from "bun";
+
+/**
+ * Resolves `react`, `react/jsx-runtime`, `react-dom`, `react-dom/client`,
+ * and `@loadout/ui` to globals set up by the overlay shell. Plugins bundled
+ * with these plugins share React with the shell — without this, each plugin
+ * gets its own React copy and hooks break.
+ */
+const MAPPINGS: Record<string, string> = {
+  react: "globalThis.__LOADOUT_REACT",
+  "react/jsx-runtime": "globalThis.__LOADOUT_REACT_JSX_RUNTIME",
+  "react/jsx-dev-runtime": "globalThis.__LOADOUT_REACT_JSX_DEV_RUNTIME",
+  "react-dom": "globalThis.__LOADOUT_REACT_DOM",
+  "react-dom/client": "globalThis.__LOADOUT_REACT_DOM_CLIENT",
+  "@loadout/ui": "globalThis.__LOADOUT_UI",
+};
+
+export function vendorGlobalsPlugin(): BunPlugin {
+  return {
+    name: "loadout-vendor-globals",
+    setup(build) {
+      for (const [pkg, globalVar] of Object.entries(MAPPINGS)) {
+        const escaped = pkg.replace(/\//g, "\\/");
+        const filter = new RegExp(`^${escaped}$`);
+        build.onResolve({ filter }, () => ({ path: pkg, namespace: "loadout-global" }));
+        build.onLoad({ filter, namespace: "loadout-global" }, () => ({
+          contents: `module.exports = ${globalVar};`,
+          loader: "js",
+        }));
+      }
+    },
+  };
+}
+
+export const VENDOR_GLOBAL_KEYS = Object.values(MAPPINGS);

--- a/packages/server/src/watcher.spec.ts
+++ b/packages/server/src/watcher.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "bun:test";
+import { sep } from "node:path";
+import { shouldIgnore } from "./watcher";
+
+describe("shouldIgnore", () => {
+  it("ignores null filenames", () => {
+    expect(shouldIgnore(null)).toBe(true);
+  });
+
+  it("ignores .cache, .build, node_modules at top level", () => {
+    expect(shouldIgnore(".cache")).toBe(true);
+    expect(shouldIgnore(".build")).toBe(true);
+    expect(shouldIgnore("node_modules")).toBe(true);
+  });
+
+  it("ignores nested .cache / .build / node_modules", () => {
+    expect(shouldIgnore(`sub${sep}.cache${sep}foo`)).toBe(true);
+    expect(shouldIgnore(`sub${sep}.build${sep}out.js`)).toBe(true);
+    expect(shouldIgnore(`sub${sep}node_modules${sep}pkg`)).toBe(true);
+  });
+
+  it("passes through source file changes", () => {
+    expect(shouldIgnore("app.tsx")).toBe(false);
+    expect(shouldIgnore("backend.ts")).toBe(false);
+    expect(shouldIgnore(`src${sep}index.ts`)).toBe(false);
+  });
+});

--- a/packages/server/src/watcher.ts
+++ b/packages/server/src/watcher.ts
@@ -1,0 +1,38 @@
+import { sep } from "node:path";
+import { watch, type FSWatcher } from "node:fs";
+
+/** Returns true for filenames the plugin watcher should ignore. */
+export function shouldIgnore(filename: string | null): boolean {
+  if (!filename) return true;
+  for (const dir of [".cache", ".build", "node_modules"]) {
+    if (filename.startsWith(dir)) return true;
+    if (filename.includes(`${sep}${dir}${sep}`)) return true;
+    if (filename.endsWith(`${sep}${dir}`)) return true;
+  }
+  return false;
+}
+
+export interface WatchHandle {
+  close(): void;
+}
+
+export function watchDir(
+  dir: string,
+  onChange: (filename: string) => void,
+  debounceMs = 300,
+): WatchHandle {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let lastFilename = "";
+  const watcher: FSWatcher = watch(dir, { recursive: true }, (_eventType, filename) => {
+    if (shouldIgnore(filename)) return;
+    lastFilename = filename ?? "";
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => onChange(lastFilename), debounceMs);
+  });
+  return {
+    close() {
+      if (timer) clearTimeout(timer);
+      watcher.close();
+    },
+  };
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@loadout/types",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,10 @@
+export type { RpcRequest, RpcResponse, RpcEvent, WsMessage } from "./ipc";
+export type {
+  PluginTarget,
+  PluginManifest,
+  PluginLogger,
+  PluginBackend,
+  EmitPayload,
+} from "./plugin";
+export { resolveMethod } from "./plugin";
+export type { WebviewMessages, WebviewAnalogAxis } from "./webview-messages";

--- a/packages/types/src/ipc.ts
+++ b/packages/types/src/ipc.ts
@@ -1,0 +1,21 @@
+export interface RpcRequest {
+  id: string;
+  plugin: string;
+  method: string;
+  args: unknown[];
+}
+
+export interface RpcResponse {
+  id: string;
+  result?: unknown;
+  error?: string;
+}
+
+export interface RpcEvent {
+  type: "event";
+  plugin: string;
+  event: string;
+  data: unknown;
+}
+
+export type WsMessage = RpcResponse | RpcEvent;

--- a/packages/types/src/plugin.spec.ts
+++ b/packages/types/src/plugin.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "bun:test";
+import { resolveMethod, type PluginBackend } from "./plugin";
+
+describe("resolveMethod", () => {
+  it("returns a bound function for a public method", () => {
+    const instance: PluginBackend & { ping: () => string } = {
+      ping() {
+        return "pong";
+      },
+    };
+    const fn = resolveMethod(instance, "ping");
+    expect(fn).toBeDefined();
+    expect(fn?.()).toBe("pong");
+  });
+
+  it("blocks lifecycle methods", () => {
+    const instance: PluginBackend = {
+      onLoad: () => {},
+      onUnload: () => {},
+      emit: () => {},
+    };
+    expect(resolveMethod(instance, "onLoad")).toBeUndefined();
+    expect(resolveMethod(instance, "onUnload")).toBeUndefined();
+    expect(resolveMethod(instance, "emit")).toBeUndefined();
+  });
+
+  it("blocks underscore-prefixed methods", () => {
+    const instance = { _secret: () => "no" } as unknown as PluginBackend;
+    expect(resolveMethod(instance, "_secret")).toBeUndefined();
+  });
+
+  it("blocks Object.prototype methods", () => {
+    const instance: PluginBackend = {};
+    expect(resolveMethod(instance, "toString")).toBeUndefined();
+    expect(resolveMethod(instance, "hasOwnProperty")).toBeUndefined();
+  });
+
+  it("returns undefined for non-functions and missing keys", () => {
+    const instance = { value: 42 } as unknown as PluginBackend;
+    expect(resolveMethod(instance, "value")).toBeUndefined();
+    expect(resolveMethod(instance, "missing")).toBeUndefined();
+  });
+
+  it("binds `this` to the instance", () => {
+    const instance: PluginBackend & { state: number; get: () => number } = {
+      state: 7,
+      get() {
+        return this.state;
+      },
+    };
+    const fn = resolveMethod(instance, "get");
+    expect(fn?.()).toBe(7);
+  });
+});

--- a/packages/types/src/plugin.ts
+++ b/packages/types/src/plugin.ts
@@ -1,0 +1,68 @@
+export interface PluginTarget {
+  type: "panel" | "overlay";
+  /** Named export from app.tsx to render. Defaults to "default". */
+  export?: string;
+  /** Display name in the overlay nav. */
+  title?: string;
+}
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  target?: PluginTarget;
+  /** Capability gates from @loadout/device. Plugin is hidden when any required cap is false. */
+  requires?: Array<"hasRGB" | "hasFanControl" | "hasTDP" | "hasBatteryControl">;
+  /** If true, the overlay imports this plugin's bundle at startup and calls its `init(api)` export. */
+  loadOnStartup?: boolean;
+}
+
+export interface PluginLogger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+  debug(message: string): void;
+}
+
+export interface EmitPayload {
+  event: string;
+  data: unknown;
+}
+
+export interface PluginBackend {
+  onLoad?(): Promise<void> | void;
+  onUnload?(): Promise<void> | void;
+  emit?(payload: EmitPayload): void;
+  log?: PluginLogger;
+}
+
+const BLOCKED_METHODS = new Set([
+  "onLoad",
+  "onUnload",
+  "emit",
+  "constructor",
+  "toString",
+  "valueOf",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__",
+  "__proto__",
+]);
+
+export function resolveMethod(
+  instance: PluginBackend,
+  name: string,
+): ((...args: unknown[]) => unknown) | undefined {
+  if (BLOCKED_METHODS.has(name)) return undefined;
+  if (name.startsWith("_")) return undefined;
+  const fn = (instance as Record<string, unknown>)[name];
+  if (typeof fn !== "function") return undefined;
+  return fn.bind(instance) as (...args: unknown[]) => unknown;
+}

--- a/packages/types/src/webview-messages.ts
+++ b/packages/types/src/webview-messages.ts
@@ -1,0 +1,19 @@
+/**
+ * Bun → webview channel schema for the overlay app.
+ *
+ * One entry per `rpc.send(name, payload)` channel. The Bun side is the
+ * only producer, the webview is the only consumer. Adding a new channel
+ * = one entry here + one handler each side.
+ */
+
+export type WebviewAnalogAxis = "RightStickX" | "RightStickY";
+
+export type WebviewMessages = {
+  "overlay-visibility": { isOpen: boolean };
+  "overlay-open-plugin": { pluginId: string };
+  "overlay-open-settings": Record<string, never>;
+  "overlay-open-home": Record<string, never>;
+  "overlay-toggle-keyboard": Record<string, never>;
+  "overlay-action": { action: string };
+  "overlay-scroll": { axis: WebviewAnalogAxis; value: number };
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@loadout/ui",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./styles.css": "./src/styles.css"
+  },
+  "dependencies": {
+    "@loadout/types": "*"
+  },
+  "peerDependencies": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,7 +10,8 @@
     "./styles.css": "./src/styles.css"
   },
   "dependencies": {
-    "@loadout/types": "*"
+    "@loadout/types": "*",
+    "@noriginmedia/norigin-spatial-navigation": "^3.0.0"
   },
   "peerDependencies": {
     "react": "^18.3.0",

--- a/packages/ui/src/backend.tsx
+++ b/packages/ui/src/backend.tsx
@@ -1,0 +1,83 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { ensureConnected, onConnect, call as wsCall, subscribe } from "./ws-client";
+import { FocusContext } from "./spatial-nav";
+
+interface BackendContextValue {
+  ready: boolean;
+}
+
+const BackendContext = createContext<BackendContextValue>({ ready: false });
+
+export function BackendProvider({ children }: { children: ReactNode }) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    ensureConnected();
+    const off = onConnect(() => setReady(true));
+    return off;
+  }, []);
+
+  const value = useMemo(() => ({ ready }), [ready]);
+  return <BackendContext.Provider value={value}>{children}</BackendContext.Provider>;
+}
+
+/**
+ * Wraps a plugin's tree with the backend connection + its slot in the
+ * shell's focus tree. Called by PluginHost.
+ */
+export function PluginProvider({
+  children,
+  parentFocusKey,
+}: {
+  children: ReactNode;
+  parentFocusKey?: string;
+}) {
+  return (
+    <BackendProvider>
+      <FocusContext.Provider value={parentFocusKey ?? "content"}>{children}</FocusContext.Provider>
+    </BackendProvider>
+  );
+}
+
+export interface BackendApi {
+  call(method: string, ...args: unknown[]): Promise<unknown>;
+  useEvent(args: { event: string; handler: (data: unknown) => void }): void;
+  ready: boolean;
+}
+
+export function useBackend(pluginId: string): BackendApi {
+  const ctx = useContext(BackendContext);
+
+  const call = useCallback(
+    (method: string, ...args: unknown[]): Promise<unknown> =>
+      wsCall({ plugin: pluginId, method, args }),
+    [pluginId],
+  );
+
+  const useEvent = ({ event, handler }: { event: string; handler: (data: unknown) => void }) => {
+    const handlerRef = useRef(handler);
+    handlerRef.current = handler;
+    useEffect(() => {
+      return subscribe({
+        plugin: pluginId,
+        event,
+        handler: (data) => handlerRef.current(data),
+      });
+    }, [event]);
+  };
+
+  return useMemo(
+    () => ({ call, useEvent, ready: ctx.ready }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [call, ctx.ready],
+  );
+}

--- a/packages/ui/src/colors.ts
+++ b/packages/ui/src/colors.ts
@@ -1,0 +1,18 @@
+/**
+ * Semantic palette. Maps a role to the DaisyUI v5 token currently filling it.
+ * Components reach for `colors.surface` instead of hardcoding
+ * `var(--color-base-200)` — swapping the theme system becomes a single edit.
+ */
+export const colors = {
+  background: "var(--color-base-100)",
+  surface: "var(--color-base-200)",
+  surfaceHover: "var(--color-base-300)",
+  border: "var(--color-base-300)",
+  text: "var(--color-base-content)",
+  textSecondary: "color-mix(in oklch, var(--color-base-content) 60%, transparent)",
+  accent: "var(--color-primary)",
+  accentHover: "color-mix(in oklch, var(--color-primary) 80%, transparent)",
+  error: "var(--color-error)",
+  success: "var(--color-success)",
+  warning: "var(--color-warning)",
+} as const;

--- a/packages/ui/src/components/Button.spec.tsx
+++ b/packages/ui/src/components/Button.spec.tsx
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Button } from "./Button";
+
+describe("Button", () => {
+  afterEach(() => cleanup());
+
+  it("renders children", () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole("button").textContent).toBe("Click me");
+  });
+
+  it("invokes onClick on click", () => {
+    let count = 0;
+    render(<Button onClick={() => count++}>Tap</Button>);
+    fireEvent.click(screen.getByRole("button"));
+    expect(count).toBe(1);
+  });
+
+  it("does not invoke onClick when disabled", () => {
+    let count = 0;
+    render(
+      <Button onClick={() => count++} disabled>
+        Tap
+      </Button>,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(count).toBe(0);
+  });
+
+  it("applies primary variant class", () => {
+    render(<Button variant="primary">Go</Button>);
+    expect(screen.getByRole("button").className).toContain("btn-primary");
+  });
+
+  it("applies sm size class", () => {
+    render(<Button size="sm">Go</Button>);
+    expect(screen.getByRole("button").className).toContain("btn-sm");
+  });
+});

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -62,7 +62,7 @@ export function Button({
     if (pressTimer.current) clearTimeout(pressTimer.current);
   }, []);
 
-  const { ref, focused } = useFocusable<HTMLButtonElement>({
+  const { ref, focused } = useFocusable({
     focusable: !disabled,
     onEnterPress: () => {
       if (disabled || !onClick) return;

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,0 +1,89 @@
+import { type CSSProperties, type ReactNode, useEffect, useRef, useState } from "react";
+import { useFocusable } from "../spatial-nav";
+import { applyFocusPulse } from "../focus-style";
+
+export type ButtonVariant =
+  | "default"
+  | "neutral"
+  | "primary"
+  | "secondary"
+  | "accent"
+  | "info"
+  | "success"
+  | "warning"
+  | "error"
+  | "danger";
+
+export type ButtonSize = "sm" | "md";
+
+function variantClass(variant: ButtonVariant): string {
+  switch (variant) {
+    case "primary":
+      return "btn-primary";
+    case "secondary":
+      return "btn-secondary";
+    case "accent":
+      return "btn-accent";
+    case "info":
+      return "btn-info";
+    case "success":
+      return "btn-success";
+    case "warning":
+      return "btn-warning";
+    case "error":
+    case "danger":
+      return "btn-error";
+    case "neutral":
+    case "default":
+    default:
+      return "btn-soft";
+  }
+}
+
+export function Button({
+  children,
+  variant = "default",
+  size = "md",
+  onClick,
+  disabled,
+  style,
+}: {
+  children: ReactNode;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  onClick?: () => void;
+  disabled?: boolean;
+  style?: CSSProperties;
+}) {
+  const [pressed, setPressed] = useState(false);
+  const pressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (pressTimer.current) clearTimeout(pressTimer.current);
+  }, []);
+
+  const { ref, focused } = useFocusable<HTMLButtonElement>({
+    focusable: !disabled,
+    onEnterPress: () => {
+      if (disabled || !onClick) return;
+      setPressed(true);
+      onClick();
+      pressTimer.current = setTimeout(() => setPressed(false), 120);
+    },
+  });
+
+  const scaleClass = pressed ? "scale-[0.97]" : focused ? "scale-[1.02]" : "";
+  const sizeClass = size === "sm" ? "btn-sm text-xs" : "min-h-[44px] text-sm";
+
+  return (
+    <button
+      ref={ref}
+      className={`btn ${variantClass(variant)} ${sizeClass} transition-transform duration-100 ${scaleClass}`}
+      style={applyFocusPulse(focused, style)}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/ui/src/components/Field.tsx
+++ b/packages/ui/src/components/Field.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+
+export function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex justify-between items-center py-3 border-b border-base-300/50 last:border-b-0 min-h-[48px]">
+      <span className="text-sm text-base-content/60">{label}</span>
+      <span className="text-sm text-base-content font-medium">{children}</span>
+    </div>
+  );
+}

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -1,0 +1,58 @@
+import { type CSSProperties, type ReactNode } from "react";
+import { useFocusable } from "../spatial-nav";
+import { applyFocusPulse, focusScaleClass } from "../focus-style";
+
+export type IconButtonVariant = "neutral" | "accent" | "danger";
+
+export function IconButton({
+  children,
+  onClick,
+  disabled,
+  title,
+  ariaLabel,
+  variant = "neutral",
+  size = 28,
+  className,
+  style,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  title?: string;
+  ariaLabel?: string;
+  variant?: IconButtonVariant;
+  size?: number;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  const { ref, focused } = useFocusable<HTMLButtonElement>({
+    focusable: !disabled,
+    onEnterPress: () => !disabled && onClick(),
+  });
+
+  const variantClass = (() => {
+    switch (variant) {
+      case "accent":
+        return "border-primary text-primary";
+      case "danger":
+        return "border-base-300 text-error";
+      default:
+        return "border-base-300 text-base-content/60 hover:text-base-content";
+    }
+  })();
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-label={ariaLabel}
+      className={`rounded-md grid place-items-center bg-base-100 border shrink-0 transition-transform duration-100 disabled:opacity-50 ${variantClass} ${focusScaleClass(focused, "1.04")} ${className ?? ""}`}
+      style={applyFocusPulse(focused, { width: size, height: size, ...style })}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -25,7 +25,7 @@ export function IconButton({
   className?: string;
   style?: CSSProperties;
 }) {
-  const { ref, focused } = useFocusable<HTMLButtonElement>({
+  const { ref, focused } = useFocusable({
     focusable: !disabled,
     onEnterPress: () => !disabled && onClick(),
   });

--- a/packages/ui/src/components/Panel.tsx
+++ b/packages/ui/src/components/Panel.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+export function Panel({ title, children }: { title?: string; children: ReactNode }) {
+  return (
+    <div className="bg-base-200 border border-base-300 rounded-2xl p-5 mb-5">
+      {title && (
+        <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">
+          {title}
+        </h3>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/components/Slider.tsx
+++ b/packages/ui/src/components/Slider.tsx
@@ -31,7 +31,7 @@ export function Slider({
   accentColor?: string;
   style?: CSSProperties;
 }) {
-  const { ref, focused } = useFocusable<HTMLInputElement>({
+  const { ref, focused } = useFocusable({
     focusable: !disabled,
     onArrowPress: (direction) => {
       if (direction !== "left" && direction !== "right") return true;

--- a/packages/ui/src/components/Slider.tsx
+++ b/packages/ui/src/components/Slider.tsx
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, type CSSProperties, type ChangeEvent } from "react";
+import { useFocusable } from "../spatial-nav";
+import { applyFocusPulse, focusScaleClass } from "../focus-style";
+
+/**
+ * Range slider with optional onCommit semantics.
+ *
+ * `onChange` fires every input event. `onCommit` fires on pointerup,
+ * touchend, keyup, blur, or 600 ms idle after the last change. Use
+ * `onCommit` for callsites that write to backend / IPC so dragging
+ * doesn't thrash with every tick.
+ */
+export function Slider({
+  value,
+  onChange,
+  onCommit,
+  min = 0,
+  max = 100,
+  step = 1,
+  disabled,
+  accentColor,
+  style,
+}: {
+  value: number;
+  onChange: (value: number) => void;
+  onCommit?: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+  accentColor?: string;
+  style?: CSSProperties;
+}) {
+  const { ref, focused } = useFocusable<HTMLInputElement>({
+    focusable: !disabled,
+    onArrowPress: (direction) => {
+      if (direction !== "left" && direction !== "right") return true;
+      const delta = direction === "right" ? step : -step;
+      const next = Math.max(min, Math.min(max, value + delta));
+      if (next !== value) onChange(next);
+      return false;
+    },
+  });
+
+  const latest = useRef(value);
+  useEffect(() => {
+    latest.current = value;
+  }, [value]);
+
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const armIdleCommit = useCallback(() => {
+    if (!onCommit) return;
+    if (idleTimer.current) clearTimeout(idleTimer.current);
+    idleTimer.current = setTimeout(() => onCommit(latest.current), 600);
+  }, [onCommit]);
+  const flushNow = useCallback(() => {
+    if (!onCommit) return;
+    if (idleTimer.current) clearTimeout(idleTimer.current);
+    idleTimer.current = null;
+    onCommit(latest.current);
+  }, [onCommit]);
+  useEffect(
+    () => () => {
+      if (idleTimer.current) clearTimeout(idleTimer.current);
+    },
+    [],
+  );
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      onChange(Number(e.target.value));
+      armIdleCommit();
+    },
+    [onChange, armIdleCommit],
+  );
+
+  const baseStyle: CSSProperties | undefined = accentColor
+    ? { ...(style ?? {}), accentColor }
+    : style;
+
+  return (
+    <input
+      ref={ref}
+      type="range"
+      min={min}
+      max={max}
+      step={step}
+      value={value}
+      onChange={handleChange}
+      onPointerUp={flushNow}
+      onTouchEnd={flushNow}
+      onKeyUp={flushNow}
+      onBlur={flushNow}
+      disabled={disabled}
+      className={`range range-primary range-xs w-full transition-transform duration-150 ${focusScaleClass(focused)} ${focused ? "rounded-lg" : ""}`}
+      style={applyFocusPulse(focused, baseStyle)}
+    />
+  );
+}

--- a/packages/ui/src/components/Spinner.tsx
+++ b/packages/ui/src/components/Spinner.tsx
@@ -1,0 +1,15 @@
+type SpinnerVariant = "spinner" | "dots";
+type SpinnerNamedSize = "xs" | "sm" | "md" | "lg";
+
+export function Spinner({
+  variant = "spinner",
+  size = variant === "spinner" ? 20 : "md",
+}: {
+  variant?: SpinnerVariant;
+  size?: number | SpinnerNamedSize;
+} = {}) {
+  const variantClass = variant === "dots" ? "loading-dots" : "loading-spinner";
+  const sizeClass = typeof size === "string" ? ` loading-${size}` : "";
+  const style = typeof size === "number" ? { width: size, height: size } : undefined;
+  return <span className={`loading ${variantClass}${sizeClass} text-primary`} style={style} />;
+}

--- a/packages/ui/src/components/TabBar.tsx
+++ b/packages/ui/src/components/TabBar.tsx
@@ -1,0 +1,58 @@
+import { useFocusable } from "../spatial-nav";
+import { colors } from "../colors";
+
+const containerClass = "flex border-b border-base-300";
+
+function Tab({
+  id,
+  label,
+  active,
+  onSelect,
+}: {
+  id: string;
+  label: string;
+  active: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const { ref, focused } = useFocusable<HTMLButtonElement>({
+    onEnterPress: () => onSelect(id),
+  });
+
+  return (
+    <button
+      ref={ref}
+      onClick={() => onSelect(id)}
+      className={`px-4 min-h-[44px] text-sm font-medium border-b-2 transition-colors ${focused ? "ring-2 ring-primary/40 rounded-t" : ""}`}
+      style={{
+        color: active || focused ? colors.accent : colors.textSecondary,
+        borderBottomColor: active ? colors.accent : "transparent",
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+export function TabBar({
+  tabs,
+  activeTab,
+  onTabChange,
+}: {
+  tabs: { id: string; label: string }[];
+  activeTab: string;
+  onTabChange: (id: string) => void;
+}) {
+  return (
+    <div className={containerClass}>
+      {tabs.map((tab) => (
+        <Tab
+          key={tab.id}
+          id={tab.id}
+          label={tab.label}
+          active={tab.id === activeTab}
+          onSelect={onTabChange}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/TabBar.tsx
+++ b/packages/ui/src/components/TabBar.tsx
@@ -14,7 +14,7 @@ function Tab({
   active: boolean;
   onSelect: (id: string) => void;
 }) {
-  const { ref, focused } = useFocusable<HTMLButtonElement>({
+  const { ref, focused } = useFocusable({
     onEnterPress: () => onSelect(id),
   });
 

--- a/packages/ui/src/components/Text.tsx
+++ b/packages/ui/src/components/Text.tsx
@@ -1,0 +1,25 @@
+import type { CSSProperties, ReactNode } from "react";
+
+const VARIANTS = {
+  body: "text-sm text-base-content leading-relaxed m-0",
+  secondary: "text-sm text-base-content/50 leading-relaxed m-0",
+  heading: "text-lg font-semibold text-base-content mb-2 leading-snug",
+} as const;
+
+export type TextVariant = keyof typeof VARIANTS;
+
+export function Text({
+  variant = "body",
+  children,
+  style,
+}: {
+  variant?: TextVariant;
+  children: ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <p className={VARIANTS[variant]} style={style}>
+      {children}
+    </p>
+  );
+}

--- a/packages/ui/src/components/TextInput.tsx
+++ b/packages/ui/src/components/TextInput.tsx
@@ -26,7 +26,7 @@ export function TextInput({
   className?: string;
   style?: CSSProperties;
 }) {
-  const { ref, focused } = useFocusable<HTMLInputElement>({
+  const { ref, focused } = useFocusable({
     focusable: !disabled,
     onEnterPress: () => {
       if (disabled) return;

--- a/packages/ui/src/components/TextInput.tsx
+++ b/packages/ui/src/components/TextInput.tsx
@@ -1,0 +1,57 @@
+import { useEffect, type CSSProperties, type FocusEvent, type KeyboardEvent } from "react";
+import { useFocusable } from "../spatial-nav";
+
+export function TextInput({
+  value,
+  onChange,
+  placeholder,
+  type,
+  inputMode,
+  autoFocus,
+  disabled,
+  onKeyDown,
+  onBlur,
+  className,
+  style,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  type?: string;
+  inputMode?: "text" | "numeric" | "decimal" | "tel" | "email" | "url" | "search";
+  autoFocus?: boolean;
+  disabled?: boolean;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  const { ref, focused } = useFocusable<HTMLInputElement>({
+    focusable: !disabled,
+    onEnterPress: () => {
+      if (disabled) return;
+      ref.current?.focus();
+      ref.current?.select();
+    },
+  });
+
+  useEffect(() => {
+    if (autoFocus) ref.current?.focus();
+  }, [autoFocus, ref]);
+
+  return (
+    <input
+      ref={ref}
+      type={type ?? "text"}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={onKeyDown}
+      onBlur={onBlur}
+      placeholder={placeholder}
+      inputMode={inputMode}
+      disabled={disabled}
+      className={className ?? `input input-sm input-bordered w-full ${focused ? "ring-2 ring-primary/40" : ""}`}
+      style={style}
+    />
+  );
+}

--- a/packages/ui/src/components/Toggle.spec.tsx
+++ b/packages/ui/src/components/Toggle.spec.tsx
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Toggle } from "./Toggle";
+
+describe("Toggle", () => {
+  afterEach(() => cleanup());
+
+  it("reflects checked state", () => {
+    render(<Toggle checked={true} onChange={() => {}} />);
+    expect((screen.getByRole("checkbox") as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("calls onChange with the inverse value", () => {
+    const observed: boolean[] = [];
+    render(<Toggle checked={false} onChange={(v) => observed.push(v)} />);
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(observed).toEqual([true]);
+  });
+
+  it("doesn't fire onChange when disabled", () => {
+    let value: boolean | null = null;
+    render(<Toggle checked={false} disabled onChange={(v) => (value = v)} />);
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(value).toBeNull();
+  });
+});

--- a/packages/ui/src/components/Toggle.tsx
+++ b/packages/ui/src/components/Toggle.tsx
@@ -12,7 +12,7 @@ export function Toggle({
   disabled?: boolean;
   size?: "small" | "default";
 }) {
-  const { ref, focused } = useFocusable<HTMLInputElement>({
+  const { ref, focused } = useFocusable({
     focusable: !disabled,
     onEnterPress: () => {
       if (!disabled) onChange(!checked);

--- a/packages/ui/src/components/Toggle.tsx
+++ b/packages/ui/src/components/Toggle.tsx
@@ -1,0 +1,33 @@
+import { useFocusable } from "../spatial-nav";
+import { applyFocusPulse, focusScaleClass } from "../focus-style";
+
+export function Toggle({
+  checked,
+  onChange,
+  disabled,
+  size = "default",
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+  size?: "small" | "default";
+}) {
+  const { ref, focused } = useFocusable<HTMLInputElement>({
+    focusable: !disabled,
+    onEnterPress: () => {
+      if (!disabled) onChange(!checked);
+    },
+  });
+
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      className={`toggle toggle-primary ${size === "small" ? "toggle-xs" : "toggle-sm"} transition-transform duration-150 ${focusScaleClass(focused)}`}
+      style={applyFocusPulse(focused)}
+      checked={checked}
+      onChange={() => !disabled && onChange(!checked)}
+      disabled={disabled}
+    />
+  );
+}

--- a/packages/ui/src/focus-style.spec.ts
+++ b/packages/ui/src/focus-style.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "bun:test";
+import { applyFocusPulse, focusScaleClass } from "./focus-style";
+
+describe("focusScaleClass", () => {
+  it("returns scale class when focused", () => {
+    expect(focusScaleClass(true)).toBe("scale-[1.02]");
+  });
+  it("returns empty when not focused", () => {
+    expect(focusScaleClass(false)).toBe("");
+  });
+  it("honors custom scale amount", () => {
+    expect(focusScaleClass(true, "1.05")).toBe("scale-[1.05]");
+  });
+});
+
+describe("applyFocusPulse", () => {
+  it("returns base when not focused", () => {
+    expect(applyFocusPulse(false, { color: "red" })).toEqual({ color: "red" });
+    expect(applyFocusPulse(false)).toBeUndefined();
+  });
+  it("merges pulse animation with base when focused", () => {
+    expect(applyFocusPulse(true, { color: "red" })).toEqual({
+      color: "red",
+      animation: "focusPulse 2s ease-in-out infinite",
+    });
+  });
+  it("returns animation alone when focused with no base", () => {
+    expect(applyFocusPulse(true)).toEqual({
+      animation: "focusPulse 2s ease-in-out infinite",
+    });
+  });
+});

--- a/packages/ui/src/focus-style.ts
+++ b/packages/ui/src/focus-style.ts
@@ -1,0 +1,21 @@
+import type { CSSProperties } from "react";
+
+/**
+ * Shared focus-ring styling for interactive components. Centralises what
+ * used to be a copy-pasted "focusPulse animation + scale-[1.02]" pair on
+ * every focusable component.
+ */
+
+const PULSE_ANIMATION = "focusPulse 2s ease-in-out infinite";
+
+export function focusScaleClass(focused: boolean, amount = "1.02"): string {
+  return focused ? `scale-[${amount}]` : "";
+}
+
+export function applyFocusPulse(
+  focused: boolean,
+  base: CSSProperties | undefined = undefined,
+): CSSProperties | undefined {
+  if (!focused) return base;
+  return { ...(base ?? {}), animation: PULSE_ANIMATION };
+}

--- a/packages/ui/src/globals.d.ts
+++ b/packages/ui/src/globals.d.ts
@@ -1,0 +1,21 @@
+declare global {
+  interface Window {
+    __LOADOUT_TOKEN__?: string;
+    __LOADOUT_SPATIAL_NAV?: {
+      addFocusable(opts: unknown): void;
+      removeFocusable(opts: { focusKey: string }): void;
+      updateFocusable(focusKey: string, opts: unknown): void;
+      setFocus(focusKey: string, details?: unknown): void;
+      getCurrentFocusKey(): string;
+      navigateByDirection(direction: string, details?: unknown): void;
+      pause(): void;
+      resume(): void;
+      updateAllLayouts(): void;
+      destroy(): void;
+    };
+    __LOADOUT_FOCUS_ID__?: number;
+    __LOADOUT_BACK_INTERCEPTORS__?: Array<() => boolean>;
+  }
+}
+
+export {};

--- a/packages/ui/src/globals.d.ts
+++ b/packages/ui/src/globals.d.ts
@@ -1,19 +1,6 @@
 declare global {
   interface Window {
     __LOADOUT_TOKEN__?: string;
-    __LOADOUT_SPATIAL_NAV?: {
-      addFocusable(opts: unknown): void;
-      removeFocusable(opts: { focusKey: string }): void;
-      updateFocusable(focusKey: string, opts: unknown): void;
-      setFocus(focusKey: string, details?: unknown): void;
-      getCurrentFocusKey(): string;
-      navigateByDirection(direction: string, details?: unknown): void;
-      pause(): void;
-      resume(): void;
-      updateAllLayouts(): void;
-      destroy(): void;
-    };
-    __LOADOUT_FOCUS_ID__?: number;
     __LOADOUT_BACK_INTERCEPTORS__?: Array<() => boolean>;
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,21 +19,32 @@ export { Spinner } from "./components/Spinner";
 export {
   useFocusable,
   FocusContext,
+  init as initSpatialNav,
   setFocus,
   getCurrentFocusKey,
   navigateByDirection,
   pauseNav,
   resumeNav,
+  updateAllLayouts,
+  destroyNav,
+  doesFocusableExist,
+  setKeyMap,
+  setThrottle,
+  updateRtl,
+  ROOT_FOCUS_KEY,
+  SpatialNavigation,
   pushBackInterceptor,
   tryRunBackInterceptor,
 } from "./spatial-nav";
+export type { BackInterceptor } from "./spatial-nav";
 export type {
-  FocusableLayout,
-  FocusDetails,
   UseFocusableConfig,
   UseFocusableResult,
-  BackInterceptor,
-} from "./spatial-nav";
+  FocusableComponentLayout,
+  FocusDetails,
+  KeyPressDetails,
+  Direction,
+} from "@noriginmedia/norigin-spatial-navigation";
 
 export { applyFocusPulse, focusScaleClass } from "./focus-style";
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,50 @@
+import "./globals";
+
+export { colors } from "./colors";
+
+export { Button } from "./components/Button";
+export type { ButtonVariant, ButtonSize } from "./components/Button";
+export { IconButton } from "./components/IconButton";
+export type { IconButtonVariant } from "./components/IconButton";
+export { Panel } from "./components/Panel";
+export { Text } from "./components/Text";
+export type { TextVariant } from "./components/Text";
+export { Field } from "./components/Field";
+export { Toggle } from "./components/Toggle";
+export { Slider } from "./components/Slider";
+export { TextInput } from "./components/TextInput";
+export { TabBar } from "./components/TabBar";
+export { Spinner } from "./components/Spinner";
+
+export {
+  useFocusable,
+  FocusContext,
+  setFocus,
+  getCurrentFocusKey,
+  navigateByDirection,
+  pauseNav,
+  resumeNav,
+  pushBackInterceptor,
+  tryRunBackInterceptor,
+} from "./spatial-nav";
+export type {
+  FocusableLayout,
+  FocusDetails,
+  UseFocusableConfig,
+  UseFocusableResult,
+  BackInterceptor,
+} from "./spatial-nav";
+
+export { applyFocusPulse, focusScaleClass } from "./focus-style";
+
+export {
+  ensureConnected,
+  onConnect,
+  call as wsCall,
+  subscribe,
+  getUrl as getWsUrl,
+} from "./ws-client";
+export type { CallArgs, SubscribeArgs } from "./ws-client";
+
+export { BackendProvider, PluginProvider, useBackend } from "./backend";
+export type { BackendApi } from "./backend";

--- a/packages/ui/src/spatial-nav.ts
+++ b/packages/ui/src/spatial-nav.ts
@@ -1,229 +1,43 @@
 /**
- * Spatial navigation hook. Consumer-React hooks register with a SHARED
- * SpatialNavigation singleton on `window.__LOADOUT_SPATIAL_NAV` so plugins
- * loaded as separate React roots still navigate together via the shell.
+ * Spatial navigation re-export.
+ *
+ * `@loadout/ui` is bundled once by the shell (via Vite) and exposed on
+ * `window.__LOADOUT_UI`. Plugin bundles compiled by the server have their
+ * `@loadout/ui` imports rewritten to that global, so every plugin shares
+ * the shell's bundled copy of `@noriginmedia/norigin-spatial-navigation`
+ * — which means a single `SpatialNavigation` singleton, and one focus
+ * tree across every React root in the overlay.
+ *
+ * No custom hook, no `window.__LOADOUT_SPATIAL_NAV` proxy. The shell calls
+ * `init()` once during boot; everything else is library default.
  */
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type RefObject,
-} from "react";
+export {
+  useFocusable,
+  FocusContext,
+} from "@noriginmedia/norigin-spatial-navigation";
+export {
+  init,
+  setFocus,
+  getCurrentFocusKey,
+  navigateByDirection,
+  pause as pauseNav,
+  resume as resumeNav,
+  updateAllLayouts,
+  destroy as destroyNav,
+  doesFocusableExist,
+  setKeyMap,
+  setThrottle,
+  updateRtl,
+  ROOT_FOCUS_KEY,
+  SpatialNavigation,
+} from "@noriginmedia/norigin-spatial-navigation";
 
-export interface FocusableLayout {
-  left: number;
-  top: number;
-  right: number;
-  bottom: number;
-  width: number;
-  height: number;
-  x: number;
-  y: number;
-  node: HTMLElement;
-}
-
-export interface FocusDetails {
-  event?: KeyboardEvent;
-}
-
-export interface UseFocusableConfig {
-  focusable?: boolean;
-  saveLastFocusedChild?: boolean;
-  trackChildren?: boolean;
-  autoRestoreFocus?: boolean;
-  forceFocus?: boolean;
-  isFocusBoundary?: boolean;
-  focusBoundaryDirections?: string[];
-  focusKey?: string;
-  preferredChildFocusKey?: string;
-  onEnterPress?: (details?: FocusDetails) => void;
-  onEnterRelease?: () => void;
-  onArrowPress?: (direction: string, details?: FocusDetails) => boolean;
-  onArrowRelease?: (direction: string) => void;
-  onFocus?: (layout: FocusableLayout, details?: FocusDetails) => void;
-  onBlur?: (layout: FocusableLayout, details?: FocusDetails) => void;
-}
-
-export interface UseFocusableResult<T extends HTMLElement = HTMLElement> {
-  // Cast as non-null for JSX `ref={ref}` compatibility — useRef<T>(null) returns
-  // RefObject<T | null>, which TS won't accept for the `ref` prop expecting
-  // RefObject<T>. The current value is null until React attaches the node.
-  ref: RefObject<T>;
-  focusSelf: (details?: object) => void;
-  focused: boolean;
-  hasFocusedChild: boolean;
-  focusKey: string;
-}
-
-const ROOT_FOCUS_KEY = "LOADOUT:ROOT";
-const noop = () => {};
-const noopArrow = () => true;
-
-function uniqueId(prefix: string): string {
-  if (typeof window === "undefined") return `${prefix}server`;
-  window.__LOADOUT_FOCUS_ID__ = (window.__LOADOUT_FOCUS_ID__ ?? 0) + 1;
-  return `${prefix}${window.__LOADOUT_FOCUS_ID__}`;
-}
-
-function getNav() {
-  return typeof window !== "undefined" ? (window.__LOADOUT_SPATIAL_NAV ?? null) : null;
-}
-
-export const FocusContext = createContext<string>(ROOT_FOCUS_KEY);
-FocusContext.displayName = "FocusContext";
-
-export function useFocusable<T extends HTMLElement = HTMLElement>(
-  config: UseFocusableConfig = {},
-): UseFocusableResult<T> {
-  const {
-    focusable = true,
-    saveLastFocusedChild = true,
-    trackChildren = false,
-    autoRestoreFocus = true,
-    forceFocus = false,
-    isFocusBoundary = false,
-    focusBoundaryDirections,
-    focusKey: propFocusKey,
-    preferredChildFocusKey,
-    onEnterPress = noop,
-    onEnterRelease = noop,
-    onArrowPress = noopArrow,
-    onArrowRelease = noop,
-    onFocus = noop,
-    onBlur = noop,
-  } = config;
-
-  const ref = useRef<T>(null as unknown as T);
-  const [focused, setFocused] = useState(false);
-  const [hasFocusedChild, setHasFocusedChild] = useState(false);
-  const parentFocusKey = useContext(FocusContext);
-
-  const focusKey = useMemo(
-    () => propFocusKey || uniqueId("loadout:focus-"),
-    [propFocusKey],
-  );
-
-  const onEnterPressHandler = useCallback(
-    (details?: FocusDetails) => onEnterPress(details),
-    [onEnterPress],
-  );
-  const onEnterReleaseHandler = useCallback(() => onEnterRelease(), [onEnterRelease]);
-  const onArrowPressHandler = useCallback(
-    (direction: string, details?: FocusDetails) => onArrowPress(direction, details),
-    [onArrowPress],
-  );
-  const onArrowReleaseHandler = useCallback(
-    (direction: string) => onArrowRelease(direction),
-    [onArrowRelease],
-  );
-  const onFocusHandler = useCallback(
-    (layout: FocusableLayout, details?: FocusDetails) => {
-      layout.node?.scrollIntoView?.({ behavior: "smooth", block: "nearest" });
-      onFocus(layout, details);
-    },
-    [onFocus],
-  );
-  const onBlurHandler = useCallback(
-    (layout: FocusableLayout, details?: FocusDetails) => onBlur(layout, details),
-    [onBlur],
-  );
-
-  const focusSelf = useCallback(
-    (details: object = {}) => getNav()?.setFocus(focusKey, details),
-    [focusKey],
-  );
-
-  useEffect(() => {
-    const nav = getNav();
-    const node = ref.current;
-    if (nav) {
-      nav.addFocusable({
-        focusKey,
-        node,
-        parentFocusKey,
-        preferredChildFocusKey,
-        onEnterPress: onEnterPressHandler,
-        onEnterRelease: onEnterReleaseHandler,
-        onArrowPress: onArrowPressHandler,
-        onArrowRelease: onArrowReleaseHandler,
-        onFocus: onFocusHandler,
-        onBlur: onBlurHandler,
-        onUpdateFocus: (isFocused: boolean = false) => setFocused(isFocused),
-        onUpdateHasFocusedChild: (isFocused: boolean = false) => setHasFocusedChild(isFocused),
-        saveLastFocusedChild,
-        trackChildren,
-        isFocusBoundary,
-        focusBoundaryDirections,
-        autoRestoreFocus,
-        forceFocus,
-        focusable,
-      });
-    }
-    const onPointerDown = () => {
-      if (nav && focusable) nav.setFocus(focusKey);
-    };
-    node?.addEventListener("pointerdown", onPointerDown);
-    return () => {
-      node?.removeEventListener("pointerdown", onPointerDown);
-      nav?.removeFocusable({ focusKey });
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    const nav = getNav();
-    if (!nav) return;
-    nav.updateFocusable(focusKey, {
-      node: ref.current,
-      preferredChildFocusKey,
-      focusable,
-      isFocusBoundary,
-      focusBoundaryDirections,
-      onEnterPress: onEnterPressHandler,
-      onEnterRelease: onEnterReleaseHandler,
-      onArrowPress: onArrowPressHandler,
-      onArrowRelease: onArrowReleaseHandler,
-      onFocus: onFocusHandler,
-      onBlur: onBlurHandler,
-    });
-  }, [
-    focusKey,
-    preferredChildFocusKey,
-    focusable,
-    isFocusBoundary,
-    focusBoundaryDirections,
-    onEnterPressHandler,
-    onEnterReleaseHandler,
-    onArrowPressHandler,
-    onArrowReleaseHandler,
-    onFocusHandler,
-    onBlurHandler,
-  ]);
-
-  return { ref, focusSelf, focused, hasFocusedChild, focusKey };
-}
-
-export function setFocus(key: string, details?: object) {
-  getNav()?.setFocus(key, details);
-}
-export function getCurrentFocusKey(): string {
-  return getNav()?.getCurrentFocusKey() ?? "";
-}
-export function navigateByDirection(direction: string, details?: object) {
-  getNav()?.navigateByDirection(direction, details ?? {});
-}
-export function pauseNav() {
-  getNav()?.pause();
-}
-export function resumeNav() {
-  getNav()?.resume();
-}
-
-// ---- Back interceptor stack -----------------------------------------------
+// ---- Back interceptor stack ------------------------------------------------
+//
+// Modal-style components (dropdowns, lightboxes) push an interceptor that
+// runs when the user presses B/Escape. If the interceptor returns true,
+// the shell's default back handler is suppressed for that press. LIFO so
+// the most recently opened modal handles back first.
 
 export type BackInterceptor = () => boolean;
 

--- a/packages/ui/src/spatial-nav.ts
+++ b/packages/ui/src/spatial-nav.ts
@@ -1,0 +1,251 @@
+/**
+ * Spatial navigation hook. Consumer-React hooks register with a SHARED
+ * SpatialNavigation singleton on `window.__LOADOUT_SPATIAL_NAV` so plugins
+ * loaded as separate React roots still navigate together via the shell.
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+
+export interface FocusableLayout {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+  node: HTMLElement;
+}
+
+export interface FocusDetails {
+  event?: KeyboardEvent;
+}
+
+export interface UseFocusableConfig {
+  focusable?: boolean;
+  saveLastFocusedChild?: boolean;
+  trackChildren?: boolean;
+  autoRestoreFocus?: boolean;
+  forceFocus?: boolean;
+  isFocusBoundary?: boolean;
+  focusBoundaryDirections?: string[];
+  focusKey?: string;
+  preferredChildFocusKey?: string;
+  onEnterPress?: (details?: FocusDetails) => void;
+  onEnterRelease?: () => void;
+  onArrowPress?: (direction: string, details?: FocusDetails) => boolean;
+  onArrowRelease?: (direction: string) => void;
+  onFocus?: (layout: FocusableLayout, details?: FocusDetails) => void;
+  onBlur?: (layout: FocusableLayout, details?: FocusDetails) => void;
+}
+
+export interface UseFocusableResult<T extends HTMLElement = HTMLElement> {
+  // Cast as non-null for JSX `ref={ref}` compatibility — useRef<T>(null) returns
+  // RefObject<T | null>, which TS won't accept for the `ref` prop expecting
+  // RefObject<T>. The current value is null until React attaches the node.
+  ref: RefObject<T>;
+  focusSelf: (details?: object) => void;
+  focused: boolean;
+  hasFocusedChild: boolean;
+  focusKey: string;
+}
+
+const ROOT_FOCUS_KEY = "LOADOUT:ROOT";
+const noop = () => {};
+const noopArrow = () => true;
+
+function uniqueId(prefix: string): string {
+  if (typeof window === "undefined") return `${prefix}server`;
+  window.__LOADOUT_FOCUS_ID__ = (window.__LOADOUT_FOCUS_ID__ ?? 0) + 1;
+  return `${prefix}${window.__LOADOUT_FOCUS_ID__}`;
+}
+
+function getNav() {
+  return typeof window !== "undefined" ? (window.__LOADOUT_SPATIAL_NAV ?? null) : null;
+}
+
+export const FocusContext = createContext<string>(ROOT_FOCUS_KEY);
+FocusContext.displayName = "FocusContext";
+
+export function useFocusable<T extends HTMLElement = HTMLElement>(
+  config: UseFocusableConfig = {},
+): UseFocusableResult<T> {
+  const {
+    focusable = true,
+    saveLastFocusedChild = true,
+    trackChildren = false,
+    autoRestoreFocus = true,
+    forceFocus = false,
+    isFocusBoundary = false,
+    focusBoundaryDirections,
+    focusKey: propFocusKey,
+    preferredChildFocusKey,
+    onEnterPress = noop,
+    onEnterRelease = noop,
+    onArrowPress = noopArrow,
+    onArrowRelease = noop,
+    onFocus = noop,
+    onBlur = noop,
+  } = config;
+
+  const ref = useRef<T>(null as unknown as T);
+  const [focused, setFocused] = useState(false);
+  const [hasFocusedChild, setHasFocusedChild] = useState(false);
+  const parentFocusKey = useContext(FocusContext);
+
+  const focusKey = useMemo(
+    () => propFocusKey || uniqueId("loadout:focus-"),
+    [propFocusKey],
+  );
+
+  const onEnterPressHandler = useCallback(
+    (details?: FocusDetails) => onEnterPress(details),
+    [onEnterPress],
+  );
+  const onEnterReleaseHandler = useCallback(() => onEnterRelease(), [onEnterRelease]);
+  const onArrowPressHandler = useCallback(
+    (direction: string, details?: FocusDetails) => onArrowPress(direction, details),
+    [onArrowPress],
+  );
+  const onArrowReleaseHandler = useCallback(
+    (direction: string) => onArrowRelease(direction),
+    [onArrowRelease],
+  );
+  const onFocusHandler = useCallback(
+    (layout: FocusableLayout, details?: FocusDetails) => {
+      layout.node?.scrollIntoView?.({ behavior: "smooth", block: "nearest" });
+      onFocus(layout, details);
+    },
+    [onFocus],
+  );
+  const onBlurHandler = useCallback(
+    (layout: FocusableLayout, details?: FocusDetails) => onBlur(layout, details),
+    [onBlur],
+  );
+
+  const focusSelf = useCallback(
+    (details: object = {}) => getNav()?.setFocus(focusKey, details),
+    [focusKey],
+  );
+
+  useEffect(() => {
+    const nav = getNav();
+    const node = ref.current;
+    if (nav) {
+      nav.addFocusable({
+        focusKey,
+        node,
+        parentFocusKey,
+        preferredChildFocusKey,
+        onEnterPress: onEnterPressHandler,
+        onEnterRelease: onEnterReleaseHandler,
+        onArrowPress: onArrowPressHandler,
+        onArrowRelease: onArrowReleaseHandler,
+        onFocus: onFocusHandler,
+        onBlur: onBlurHandler,
+        onUpdateFocus: (isFocused: boolean = false) => setFocused(isFocused),
+        onUpdateHasFocusedChild: (isFocused: boolean = false) => setHasFocusedChild(isFocused),
+        saveLastFocusedChild,
+        trackChildren,
+        isFocusBoundary,
+        focusBoundaryDirections,
+        autoRestoreFocus,
+        forceFocus,
+        focusable,
+      });
+    }
+    const onPointerDown = () => {
+      if (nav && focusable) nav.setFocus(focusKey);
+    };
+    node?.addEventListener("pointerdown", onPointerDown);
+    return () => {
+      node?.removeEventListener("pointerdown", onPointerDown);
+      nav?.removeFocusable({ focusKey });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const nav = getNav();
+    if (!nav) return;
+    nav.updateFocusable(focusKey, {
+      node: ref.current,
+      preferredChildFocusKey,
+      focusable,
+      isFocusBoundary,
+      focusBoundaryDirections,
+      onEnterPress: onEnterPressHandler,
+      onEnterRelease: onEnterReleaseHandler,
+      onArrowPress: onArrowPressHandler,
+      onArrowRelease: onArrowReleaseHandler,
+      onFocus: onFocusHandler,
+      onBlur: onBlurHandler,
+    });
+  }, [
+    focusKey,
+    preferredChildFocusKey,
+    focusable,
+    isFocusBoundary,
+    focusBoundaryDirections,
+    onEnterPressHandler,
+    onEnterReleaseHandler,
+    onArrowPressHandler,
+    onArrowReleaseHandler,
+    onFocusHandler,
+    onBlurHandler,
+  ]);
+
+  return { ref, focusSelf, focused, hasFocusedChild, focusKey };
+}
+
+export function setFocus(key: string, details?: object) {
+  getNav()?.setFocus(key, details);
+}
+export function getCurrentFocusKey(): string {
+  return getNav()?.getCurrentFocusKey() ?? "";
+}
+export function navigateByDirection(direction: string, details?: object) {
+  getNav()?.navigateByDirection(direction, details ?? {});
+}
+export function pauseNav() {
+  getNav()?.pause();
+}
+export function resumeNav() {
+  getNav()?.resume();
+}
+
+// ---- Back interceptor stack -----------------------------------------------
+
+export type BackInterceptor = () => boolean;
+
+function getBackStack(): BackInterceptor[] {
+  if (typeof window === "undefined") return [];
+  if (!window.__LOADOUT_BACK_INTERCEPTORS__) window.__LOADOUT_BACK_INTERCEPTORS__ = [];
+  return window.__LOADOUT_BACK_INTERCEPTORS__;
+}
+
+export function pushBackInterceptor(fn: BackInterceptor): () => void {
+  const stack = getBackStack();
+  stack.push(fn);
+  return () => {
+    const i = stack.indexOf(fn);
+    if (i >= 0) stack.splice(i, 1);
+  };
+}
+
+export function tryRunBackInterceptor(): boolean {
+  const stack = getBackStack();
+  for (let i = stack.length - 1; i >= 0; i--) {
+    if (stack[i]()) return true;
+  }
+  return false;
+}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,0 +1,13 @@
+/*
+ * Loadout UI base styles. Imported by the overlay shell so every plugin
+ * inherits the focus-pulse keyframe and any future global rules.
+ */
+
+@keyframes focusPulse {
+  0%, 100% {
+    box-shadow: 0 0 0 2px color-mix(in oklch, var(--color-primary) 60%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 4px color-mix(in oklch, var(--color-primary) 30%, transparent);
+  }
+}

--- a/packages/ui/src/ws-client.ts
+++ b/packages/ui/src/ws-client.ts
@@ -1,0 +1,144 @@
+import type { RpcRequest, RpcResponse, RpcEvent } from "@loadout/types";
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+};
+
+type EventHandler = (data: unknown) => void;
+
+let ws: WebSocket | null = null;
+let connectAttempt = 0;
+const pending = new Map<string, PendingRequest>();
+const eventListeners = new Map<string, Set<EventHandler>>();
+const connectListeners = new Set<() => void>();
+const queued: Array<{ args: CallArgs; resolve: (v: unknown) => void; reject: (e: Error) => void }> = [];
+
+export interface CallArgs {
+  plugin: string;
+  method: string;
+  args: unknown[];
+}
+
+const DEFAULT_PORT = 33820;
+
+function token(): string {
+  return typeof window !== "undefined" ? (window.__LOADOUT_TOKEN__ ?? "") : "";
+}
+
+export function getUrl(port = DEFAULT_PORT): string {
+  const t = token();
+  const base = `ws://127.0.0.1:${port}/ws`;
+  return t ? `${base}?token=${encodeURIComponent(t)}` : base;
+}
+
+export function rejectAllPending(err: Error): void {
+  for (const req of pending.values()) {
+    try {
+      req.reject(err);
+    } catch {}
+  }
+  pending.clear();
+}
+
+function connect(): void {
+  if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) return;
+  ws = new WebSocket(getUrl());
+
+  ws.onopen = () => {
+    connectAttempt = 0;
+    while (queued.length > 0) {
+      const item = queued.shift()!;
+      sendRequest(item.args, item.resolve, item.reject);
+    }
+    connectListeners.forEach((fn) => fn());
+  };
+
+  ws.onmessage = (ev) => {
+    let msg: RpcResponse | RpcEvent;
+    try {
+      msg = JSON.parse(ev.data as string);
+    } catch {
+      return;
+    }
+    if ("type" in msg && msg.type === "event") {
+      const key = `${msg.plugin}:${msg.event}`;
+      eventListeners.get(key)?.forEach((fn) => fn(msg.data));
+      return;
+    }
+    const res = msg as RpcResponse;
+    const req = pending.get(res.id);
+    if (req) {
+      pending.delete(res.id);
+      if (res.error) req.reject(new Error(res.error));
+      else req.resolve(res.result);
+    }
+  };
+
+  ws.onclose = () => {
+    rejectAllPending(new Error("WebSocket closed"));
+    const delay = Math.min(1000 * 2 ** connectAttempt, 10000);
+    connectAttempt++;
+    setTimeout(connect, delay);
+  };
+
+  ws.onerror = () => ws?.close();
+}
+
+export function ensureConnected(): void {
+  connect();
+}
+
+export function onConnect(fn: () => void): () => void {
+  connectListeners.add(fn);
+  return () => {
+    connectListeners.delete(fn);
+  };
+}
+
+function sendRequest(
+  request: CallArgs,
+  resolve: (v: unknown) => void,
+  reject: (e: Error) => void,
+): void {
+  const id = crypto.randomUUID();
+  pending.set(id, { resolve, reject });
+  const req: RpcRequest = {
+    id,
+    plugin: request.plugin,
+    method: request.method,
+    args: request.args,
+  };
+  ws!.send(JSON.stringify(req));
+}
+
+export function call(args: CallArgs): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      sendRequest(args, resolve, reject);
+    } else {
+      queued.push({ args, resolve, reject });
+      connect();
+    }
+  });
+}
+
+export interface SubscribeArgs {
+  plugin: string;
+  event: string;
+  handler: EventHandler;
+}
+
+export function subscribe({ plugin, event, handler }: SubscribeArgs): () => void {
+  const key = `${plugin}:${event}`;
+  let set = eventListeners.get(key);
+  if (!set) {
+    set = new Set();
+    eventListeners.set(key, set);
+  }
+  set.add(handler);
+  return () => {
+    set!.delete(handler);
+    if (set!.size === 0) eventListeners.delete(key);
+  };
+}

--- a/plugins/hello-world/app.tsx
+++ b/plugins/hello-world/app.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Panel, Text, Button, Field, useBackend, PluginProvider } from "@loadout/ui";
+
+interface DeviceSnapshot {
+  id: string;
+  gamescope: boolean;
+  capabilities: Record<string, boolean>;
+}
+
+function HelloWorldPanel() {
+  const backend = useBackend("hello-world");
+  const [reply, setReply] = useState<string>("(not pinged yet)");
+  const [device, setDevice] = useState<DeviceSnapshot | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!backend.ready) return;
+    backend
+      .call("getDevice")
+      .then((d) => setDevice(d as DeviceSnapshot))
+      .catch((err) => console.error("[hello-world] getDevice failed:", err));
+  }, [backend.ready, backend]);
+
+  async function ping() {
+    setBusy(true);
+    try {
+      const value = await backend.call("ping");
+      setReply(String(value));
+    } catch (err) {
+      setReply(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <Panel title="Hello, Loadout">
+        <Text variant="heading">Hello World</Text>
+        <Text variant="secondary">
+          The overlay is alive. Press Ping to call the backend RPC and confirm the device.
+        </Text>
+        <div className="mt-4">
+          <Button variant="primary" onClick={ping} disabled={busy}>
+            {busy ? "Pinging…" : "Ping"}
+          </Button>
+        </div>
+        <div className="mt-3">
+          <Text variant="body">{reply}</Text>
+        </div>
+      </Panel>
+
+      {device && (
+        <Panel title="Device">
+          <Field label="ID">{device.id}</Field>
+          <Field label="Gamescope">{device.gamescope ? "yes" : "no"}</Field>
+          {Object.entries(device.capabilities).map(([cap, on]) => (
+            <Field key={cap} label={cap}>
+              {on ? "yes" : "no"}
+            </Field>
+          ))}
+        </Panel>
+      )}
+    </div>
+  );
+}
+
+export function mount(
+  container: HTMLElement,
+  opts: { parentFocusKey?: string } = {},
+): () => void {
+  const root: Root = createRoot(container);
+  root.render(
+    <PluginProvider parentFocusKey={opts.parentFocusKey}>
+      <HelloWorldPanel />
+    </PluginProvider>,
+  );
+  return () => root.unmount();
+}
+
+export default mount;

--- a/plugins/hello-world/backend.ts
+++ b/plugins/hello-world/backend.ts
@@ -1,0 +1,21 @@
+import { detectDevice } from "@loadout/device";
+import type { PluginBackend, PluginLogger } from "@loadout/types";
+
+export default class HelloWorld implements PluginBackend {
+  log?: PluginLogger;
+
+  async ping(): Promise<string> {
+    const device = await detectDevice();
+    this.log?.info(`ping from ${device.id}`);
+    return `pong from ${device.id}`;
+  }
+
+  async getDevice() {
+    const device = await detectDevice();
+    return {
+      id: device.id,
+      gamescope: device.gamescope,
+      capabilities: { ...device.capabilities },
+    };
+  }
+}

--- a/plugins/hello-world/package.json
+++ b/plugins/hello-world/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@loadout/plugin-hello-world",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "plugin": {
+    "id": "hello-world",
+    "name": "Hello World",
+    "description": "M1 smoke test: renders a panel, calls one backend RPC, reports the device.",
+    "author": "loadout",
+    "target": { "type": "panel", "title": "Hello World" }
+  },
+  "dependencies": {
+    "@loadout/device": "*",
+    "@loadout/types": "*"
+  },
+  "peerDependencies": {
+    "@loadout/ui": "*",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  }
+}

--- a/plugins/hello-world/plugin.json
+++ b/plugins/hello-world/plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "hello-world",
+  "name": "Hello World",
+  "version": "0.0.1",
+  "description": "M1 smoke test plugin",
+  "author": "loadout",
+  "target": { "type": "panel", "title": "Hello World" }
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -42,14 +42,35 @@ if [ ! -d "$PROJECT_ROOT/node_modules" ]; then
   (cd "$PROJECT_ROOT" && bun install)
 fi
 
+# Pre-bundle every plugin backend so the installed layout (no workspace
+# node_modules) can still load them. `bundleBackend()` in @loadout/server
+# checks mtime and reuses these bundles at runtime.
+info "Pre-bundling plugin backends..."
+for plugin_dir in "$PROJECT_ROOT"/plugins/*/; do
+  backend="$plugin_dir/backend.ts"
+  [ -f "$backend" ] || continue
+  plugin_name="$(basename "$plugin_dir")"
+  cache_dir="$plugin_dir.cache"
+  mkdir -p "$cache_dir"
+  info "  $plugin_name/backend.ts"
+  (cd "$PROJECT_ROOT" && bun build "$backend" \
+    --target=bun \
+    --format=esm \
+    --outdir="$cache_dir" \
+    --entry-naming="backend.bundle.js") >/dev/null
+done
+
 info "Building webview (vite)..."
 (cd "$OVERLAY_DIR" && bunx vite build)
 
 info "Bundling overlay (electrobun)..."
-RELEASE_FLAG=""
+# `electrobun build` accepts `--env=stable|canary|dev` (default: dev). The
+# `--release` flag from earlier docs is silent-no-op — it ended up under
+# `dev-*-x64/` either way. Stable env produces `release-*/loadout/`.
+ENV_FLAG="--env=dev"
 case "${1:-}" in
-  --release) RELEASE_FLAG="--release" ;;
+  --release|--stable) ENV_FLAG="--env=stable" ;;
 esac
-(cd "$OVERLAY_DIR" && bunx electrobun build $RELEASE_FLAG)
+(cd "$OVERLAY_DIR" && bunx electrobun build $ENV_FLAG)
 
 success "Build complete. Tree under: $OVERLAY_DIR/build/"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Loadout build script.
+#
+# Loadout ships as a single Electrobun bundle. The Bun-side main process
+# spawns @loadout/server in-process, so there's no separate `bun build
+# --compile` step — Vite + Electrobun handle everything.
+#
+# Output: apps/overlay/build/dev-linux-x64/loadout/  (full Electrobun tree)
+#
+# Prereqs: Bun >= 1.3, dependencies installed (bun install at repo root).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OVERLAY_DIR="$PROJECT_ROOT/apps/overlay"
+
+if [ -t 1 ]; then
+  GREEN='\033[0;32m'; BLUE='\033[0;34m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+else
+  GREEN=''; BLUE=''; YELLOW=''; RED=''; NC=''
+fi
+
+info()    { printf "${BLUE}[BUILD]${NC} %s\n" "$1"; }
+success() { printf "${GREEN}[OK]${NC} %s\n" "$1"; }
+warn()    { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
+err()     { printf "${RED}[ERROR]${NC} %s\n" "$1" >&2; }
+
+command -v bun >/dev/null 2>&1 || { err "Bun is not installed. Install from https://bun.sh"; exit 1; }
+
+VERSION="$(grep '"version"' "$PROJECT_ROOT/package.json" 2>/dev/null | head -1 | sed 's/.*"version": *"//;s/".*//')"
+[ -z "$VERSION" ] && VERSION="dev"
+ARCH="$(uname -m)"
+
+info "Loadout build"
+info "  Version:  $VERSION"
+info "  Arch:     $ARCH"
+info "  Overlay:  $OVERLAY_DIR"
+
+if [ ! -d "$PROJECT_ROOT/node_modules" ]; then
+  warn "node_modules missing — running bun install..."
+  (cd "$PROJECT_ROOT" && bun install)
+fi
+
+info "Building webview (vite)..."
+(cd "$OVERLAY_DIR" && bunx vite build)
+
+info "Bundling overlay (electrobun)..."
+RELEASE_FLAG=""
+case "${1:-}" in
+  --release) RELEASE_FLAG="--release" ;;
+esac
+(cd "$OVERLAY_DIR" && bunx electrobun build $RELEASE_FLAG)
+
+success "Build complete. Tree under: $OVERLAY_DIR/build/"

--- a/scripts/deck-overlay-trigger/bin/ip-load-profile.sh
+++ b/scripts/deck-overlay-trigger/bin/ip-load-profile.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# ip-load-profile.sh — boot-time loader. Polls for IP's CompositeDevice to
+# appear on D-Bus, then loads the overlay-trigger profile via LoadProfilePath.
+#
+# Deployed to /etc/loadout/inputplumber/ip-load-profile.sh; invoked by
+# loadout-ip-profile.service ordered After=inputplumber, Before=graphical.
+#
+# Profile path is the second argument to LoadProfilePath; defaults to the
+# one written by the installer, overridable for ad-hoc reloads.
+SVC=org.shadowblip.InputPlumber
+PROFILE="${1:-/etc/loadout/inputplumber/overlay-profile.yaml}"
+
+for _ in $(seq 1 60); do
+  CD=$(busctl tree "$SVC" 2>/dev/null | grep -oE "/org/shadowblip/InputPlumber/CompositeDevice[0-9]+" | head -1)
+  [ -n "$CD" ] && break
+  sleep 0.5
+done
+
+if [ -z "${CD:-}" ]; then
+  echo "loadout: no IP composite device on D-Bus after 30s" >&2
+  exit 0
+fi
+
+busctl call "$SVC" "$CD" org.shadowblip.Input.CompositeDevice LoadProfilePath s "$PROFILE"

--- a/scripts/deck-overlay-trigger/inputplumber/devices/50-steam_deck.yaml
+++ b/scripts/deck-overlay-trigger/inputplumber/devices/50-steam_deck.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+#
+# Steam Deck device override — let InputPlumber claim the controller at boot.
+#
+# Mirrors the layout of the upstream config shipped at
+# /usr/share/inputplumber/devices/50-steam_deck.yaml, with one change:
+#
+#   options.auto_manage: true
+#
+# Steam Input owns the Deck's hid-steam interface by default; without
+# auto_manage the daemon will see the device but won't take it over. We need
+# IP managing it so the per-button profile we ship can actually map paddles.
+#
+# Deployed to /etc/inputplumber/devices.d/50-steam_deck.yaml — /etc takes
+# priority over /usr/share, so this overrides the shipped config cleanly.
+version: 1
+kind: CompositeDevice
+name: Steam Deck
+single_source: false
+matches:
+  - dmi_data: { product_name: Galileo, sys_vendor: Valve, cpu_vendor: AuthenticAMD }
+  - dmi_data: { product_name: Jupiter, sys_vendor: Valve, cpu_vendor: AuthenticAMD }
+source_devices:
+  - group: gamepad
+    hidraw: { vendor_id: 0x28de, product_id: 0x1205, interface_num: 2 }
+  - group: keyboard
+    evdev: { name: AT Translated Set 2 keyboard, phys_path: isa0060/serio0/input0, handler: event* }
+options:
+  auto_manage: true
+target_devices: [ deck-uhid, mouse, keyboard, touchpad ]

--- a/scripts/deck-overlay-trigger/inputplumber/profiles/overlay-trigger.header.yaml
+++ b/scripts/deck-overlay-trigger/inputplumber/profiles/overlay-trigger.header.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/device_profile_v1.json
+#
+# Profile header. The renderer (render-profile.sh) concatenates one
+# mapping entry per selected button beneath the `mapping:` key.
+#
+# target_devices must include `keyboard` — IP's deck-uhid target drops the
+# keyboard target by default, and without it our `keyboard: KeyF16` event
+# has nowhere to land.
+version: 1
+kind: DeviceProfile
+name: Loadout Overlay Trigger
+target_devices: [ deck-uhid, keyboard, mouse, touchpad ]
+mapping:

--- a/scripts/deck-overlay-trigger/inputplumber/render-profile.sh
+++ b/scripts/deck-overlay-trigger/inputplumber/render-profile.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# render-profile.sh — emit an InputPlumber DeviceProfile to stdout that maps
+# the given gamepad button source names to KEY_F16 (the overlay's QAM wake).
+#
+# Usage:
+#   render-profile.sh HEADER_PATH BUTTON [BUTTON ...]
+#
+# Example:
+#   render-profile.sh ./overlay-trigger.header.yaml RightPaddle1 LeftPaddle1
+#
+# The header file supplies version/kind/name/target_devices and the bare
+# `mapping:` key; this script appends one entry per button below it. Kept as
+# a separate script (not inlined into the installer) so a future TS backend
+# can shell out to the same renderer when the overlay UI lets the user
+# re-pick buttons live.
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 HEADER_PATH BUTTON [BUTTON ...]" >&2
+  exit 2
+fi
+
+HEADER="$1"; shift
+
+if [ ! -f "$HEADER" ]; then
+  echo "render-profile: header not found: $HEADER" >&2
+  exit 1
+fi
+
+cat "$HEADER"
+for button in "$@"; do
+  printf '  - name: %s -> F16\n' "$button"
+  printf '    source_event: { gamepad: { button: %s } }\n' "$button"
+  printf '    target_events: [ { keyboard: KeyF16 } ]\n'
+done

--- a/scripts/deck-overlay-trigger/systemd/loadout-ip-profile.service
+++ b/scripts/deck-overlay-trigger/systemd/loadout-ip-profile.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Loadout: load overlay-trigger InputPlumber profile
+# Order: IP must be up so its D-Bus surface exists; graphical.target must
+# be down so the overlay enumerates input devices AFTER the profile is loaded
+# (the profile adds IP's virtual keyboard, which the overlay only sees on
+# device enumeration at startup).
+After=inputplumber.service
+Requires=inputplumber.service
+Before=graphical.target
+
+[Service]
+Type=oneshot
+ExecStart=/etc/loadout/inputplumber/ip-load-profile.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=graphical.target

--- a/scripts/deck-overlay-trigger/udev/71-inputplumber-uaccess.rules
+++ b/scripts/deck-overlay-trigger/udev/71-inputplumber-uaccess.rules
@@ -1,0 +1,9 @@
+# Grant the active-session user (uaccess ACL) on InputPlumber's virtual
+# input devices. Without this the overlay can't open() IP's virtual
+# keyboard and logs "open failed for .../InputPlumber Keyboard".
+#
+# SteamOS ships /usr/lib/udev/rules.d/90-steam-inputplumber.rules which
+# applies the same TAG only when ENV{USE_INPUTPLUMBER}=="1" — that flag
+# isn't set on the Deck, so the rule never fires. This one is
+# unconditional for IP devices.
+SUBSYSTEM=="input", ATTRS{name}=="InputPlumber*", TAG+="uaccess"

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Install the Loadout overlay from the local build tree.
+#
+# Copies the Electrobun bundle + plugin tree to ~/.local/share/loadout/,
+# installs the systemd user unit, and starts it.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+INSTALL_DIR="$HOME/.local/share/loadout"
+SERVICE_DIR="$HOME/.config/systemd/user"
+
+# Pick the right Electrobun build output. `--release` produces
+# build/release-linux-<arch>/loadout/, `--dev` (default) produces
+# build/dev-linux-<arch>/loadout/.
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64) EB_ARCH="x64" ;;
+  aarch64) EB_ARCH="arm64" ;;
+  *) echo "Unsupported arch: $ARCH"; exit 1 ;;
+esac
+
+BUILD_BASE="$PROJECT_ROOT/apps/overlay/build"
+RELEASE_DIR="$BUILD_BASE/release-linux-$EB_ARCH/loadout"
+DEV_DIR="$BUILD_BASE/dev-linux-$EB_ARCH/loadout-dev"
+
+if [ -d "$RELEASE_DIR" ] && [ -x "$RELEASE_DIR/bin/launcher" ]; then
+  SOURCE_DIR="$RELEASE_DIR"
+elif [ -d "$DEV_DIR" ] && [ -x "$DEV_DIR/bin/launcher" ]; then
+  SOURCE_DIR="$DEV_DIR"
+else
+  echo "ERROR: no Electrobun build at $RELEASE_DIR or $DEV_DIR" >&2
+  echo "Run 'bun run build' first." >&2
+  exit 1
+fi
+
+echo "Installing from: $SOURCE_DIR"
+
+# Stop existing service before swapping files.
+systemctl --user stop loadout 2>/dev/null || true
+
+# Wipe + reinstall the bundle.
+rm -rf "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR"
+cp -a "$SOURCE_DIR/." "$INSTALL_DIR/"
+chmod +x "$INSTALL_DIR/bin/launcher"
+echo "Installed launcher: $INSTALL_DIR/bin/launcher"
+
+# Stage the plugin tree side-by-side with the binary. The Bun-side
+# server reads from LOADOUT_PLUGINS_DIR (set in the unit file below).
+PLUGINS_SRC="$PROJECT_ROOT/plugins"
+PLUGINS_DST="$INSTALL_DIR/plugins"
+mkdir -p "$PLUGINS_DST"
+for plugin in "$PLUGINS_SRC"/*/; do
+  [ -d "$plugin" ] || continue
+  name="$(basename "$plugin")"
+  echo "Copying plugin: $name"
+  rm -rf "$PLUGINS_DST/$name"
+  cp -a "$plugin" "$PLUGINS_DST/$name"
+  rm -rf "$PLUGINS_DST/$name/.cache"
+done
+
+# Install systemd unit.
+mkdir -p "$SERVICE_DIR"
+cp "$PROJECT_ROOT/loadout.service" "$SERVICE_DIR/loadout.service"
+
+systemctl --user daemon-reload
+systemctl --user enable loadout
+systemctl --user restart loadout
+
+echo "Done. Check status: systemctl --user status loadout"
+echo "Logs:               journalctl --user -u loadout -f"

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -93,3 +93,21 @@ systemctl --user restart loadout
 
 echo "Done. Check status: systemctl --user status loadout"
 echo "Logs:               journalctl --user -u loadout -f"
+
+# Steam Deck back-paddle wake hint. The Deck's controller HID is owned by
+# Steam Input under gamescope; the only way to fire an evdev key event the
+# overlay can see is to route a button through InputPlumber → F16. That
+# requires root, so install-local.sh (user-level) can't do it itself.
+PRODUCT="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+VENDOR="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+case "$VENDOR/$PRODUCT" in
+  Valve/Galileo|Valve/Jupiter)
+    if [ ! -f /etc/systemd/system/loadout-ip-profile.service ]; then
+      echo
+      echo "Steam Deck detected ($PRODUCT). To toggle the overlay from a back paddle:"
+      echo "  sudo bash $PROJECT_ROOT/scripts/setup-deck.sh"
+      echo
+      echo "(Reboot after; defaults to all four paddles. See docs/steam-deck-overlay-trigger.md.)"
+    fi
+    ;;
+esac

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -59,7 +59,15 @@ for plugin in "$PLUGINS_SRC"/*/; do
   echo "Copying plugin: $name"
   rm -rf "$PLUGINS_DST/$name"
   cp -a "$plugin" "$PLUGINS_DST/$name"
-  rm -rf "$PLUGINS_DST/$name/.cache"
+  # Keep .cache/backend.bundle.js — it's the pre-bundled backend produced
+  # by scripts/build.sh, and the install layout has no workspace node_modules
+  # to fall back on at runtime.
+  rm -rf "$PLUGINS_DST/$name/node_modules"
+  if [ -f "$plugin/backend.ts" ] && [ ! -f "$PLUGINS_DST/$name/.cache/backend.bundle.js" ]; then
+    echo "ERROR: $name has backend.ts but no .cache/backend.bundle.js." >&2
+    echo "Run 'bash scripts/build.sh' before install — it pre-bundles plugin backends." >&2
+    exit 1
+  fi
 done
 
 # Install systemd unit.
@@ -68,6 +76,19 @@ cp "$PROJECT_ROOT/loadout.service" "$SERVICE_DIR/loadout.service"
 
 systemctl --user daemon-reload
 systemctl --user enable loadout
+
+# Propagate gamescope/X11/Wayland env into the user systemd manager so the
+# overlay service inherits DISPLAY/GAMESCOPE_DISPLAY/etc. Without this the
+# Bun-side gamescope detection sees an empty env and falls back to desktop
+# mode even under a gamescope session.
+if [ -n "${GAMESCOPE_DISPLAY:-}${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]; then
+  systemctl --user import-environment \
+    DISPLAY WAYLAND_DISPLAY \
+    GAMESCOPE_DISPLAY GAMESCOPE_WAYLAND_DISPLAY \
+    XDG_RUNTIME_DIR XDG_SESSION_TYPE \
+    XAUTHORITY 2>/dev/null || true
+fi
+
 systemctl --user restart loadout
 
 echo "Done. Check status: systemctl --user status loadout"

--- a/scripts/setup-deck.sh
+++ b/scripts/setup-deck.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# setup-deck.sh — install the Steam Deck back-paddle → overlay toggle
+# wiring (paddle → InputPlumber → F16 → Loadout's evdev QAM wake).
+#
+# Run once on a Steam Deck. Idempotent. Reboot after.
+#
+# Usage:
+#   sudo bash scripts/setup-deck.sh [BUTTON ...]
+#     BUTTON defaults to all four back paddles:
+#       RightPaddle1 RightPaddle2 LeftPaddle1 LeftPaddle2
+#     e.g. sudo bash scripts/setup-deck.sh RightPaddle1
+#
+#   sudo bash scripts/setup-deck.sh --uninstall
+#
+# See docs/steam-deck-overlay-trigger.md for the full rationale.
+
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "run with sudo: sudo bash $0" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ASSETS="$SCRIPT_DIR/deck-overlay-trigger"
+
+# Destination paths — under /etc so they survive ostree deployment switches.
+DEV_OVERRIDE=/etc/inputplumber/devices.d/50-steam_deck.yaml
+PROFILE_DIR=/etc/loadout/inputplumber
+PROFILE=$PROFILE_DIR/overlay-profile.yaml
+LOADER=$PROFILE_DIR/ip-load-profile.sh
+UNIT=/etc/systemd/system/loadout-ip-profile.service
+UDEV_RULE=/etc/udev/rules.d/71-loadout-inputplumber-uaccess.rules
+
+if [ "${1:-}" = "--uninstall" ]; then
+  systemctl disable --now loadout-ip-profile.service 2>/dev/null || true
+  rm -f "$UNIT" "$DEV_OVERRIDE" "$UDEV_RULE" "$PROFILE" "$LOADER"
+  rmdir "$PROFILE_DIR" 2>/dev/null || true
+  systemctl disable --now inputplumber.service 2>/dev/null || true
+  systemctl daemon-reload
+  udevadm control --reload 2>/dev/null || true
+  echo "Removed. Reboot to fully restore Steam Input."
+  exit 0
+fi
+
+# DMI sanity check — refuse to write Deck-specific config on non-Deck hardware.
+PRODUCT="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+VENDOR="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+case "$VENDOR/$PRODUCT" in
+  Valve/Galileo|Valve/Jupiter) ;;
+  *)
+    echo "WARN: this machine reports $VENDOR/$PRODUCT, not a Steam Deck (Valve/Galileo or Valve/Jupiter)." >&2
+    echo "      Pass --force to install anyway. Otherwise nothing was changed." >&2
+    [ "${2:-${1:-}}" = "--force" ] || exit 1
+    ;;
+esac
+
+BUTTONS=()
+for arg in "$@"; do
+  case "$arg" in --force) ;; *) BUTTONS+=("$arg") ;; esac
+done
+[ ${#BUTTONS[@]} -eq 0 ] && BUTTONS=(RightPaddle1 RightPaddle2 LeftPaddle1 LeftPaddle2)
+
+install_file() {
+  # install_file SRC DST [MODE]
+  local src="$1" dst="$2" mode="${3:-0644}"
+  [ -f "$src" ] || { echo "missing vendored asset: $src" >&2; exit 1; }
+  mkdir -p "$(dirname "$dst")"
+  install -m "$mode" "$src" "$dst"
+  echo "  installed $dst"
+}
+
+echo "== 1. device override (auto_manage)"
+install_file "$ASSETS/inputplumber/devices/50-steam_deck.yaml" "$DEV_OVERRIDE"
+
+echo "== 2. overlay-trigger profile  [buttons: ${BUTTONS[*]}]"
+mkdir -p "$PROFILE_DIR"
+"$ASSETS/inputplumber/render-profile.sh" \
+  "$ASSETS/inputplumber/profiles/overlay-trigger.header.yaml" \
+  "${BUTTONS[@]}" > "$PROFILE"
+chmod 0644 "$PROFILE"
+echo "  rendered  $PROFILE"
+
+echo "== 3. boot loader script"
+install_file "$ASSETS/bin/ip-load-profile.sh" "$LOADER" 0755
+
+echo "== 4. boot one-shot unit"
+install_file "$ASSETS/systemd/loadout-ip-profile.service" "$UNIT"
+
+echo "== 5. uaccess udev rule"
+install_file "$ASSETS/udev/71-inputplumber-uaccess.rules" "$UDEV_RULE"
+
+echo "== 6. reload + enable"
+udevadm control --reload && udevadm trigger --subsystem-match=input 2>/dev/null || true
+systemctl daemon-reload
+systemctl enable inputplumber.service loadout-ip-profile.service
+
+cat <<DONE
+
+Done. Reboot, then press any of (${BUTTONS[*]}) — the Loadout overlay should
+open via the same F16 wake path used by handheld QAM buttons elsewhere.
+
+If the overlay still doesn't open after reboot, the uaccess rule may not have
+applied — fall back to adding your user to the input group:
+    sudo usermod -aG input \$USER   # then reboot
+
+Undo everything:  sudo bash $0 --uninstall
+DONE

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,9 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { expect } from "bun:test";
+
+if (typeof window === "undefined") {
+  GlobalRegistrator.register();
+}
+
+expect.extend(matchers);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "types": ["bun"],
+    "paths": {
+      "@loadout/types": ["./packages/types/src"],
+      "@loadout/types/*": ["./packages/types/src/*"],
+      "@loadout/device": ["./packages/device/src"],
+      "@loadout/device/*": ["./packages/device/src/*"],
+      "@loadout/server": ["./packages/server/src"],
+      "@loadout/server/*": ["./packages/server/src/*"],
+      "@loadout/ui": ["./packages/ui/src"],
+      "@loadout/ui/*": ["./packages/ui/src/*"],
+      "@loadout/overlay-shell": ["./packages/overlay-shell/src"],
+      "@loadout/overlay-shell/*": ["./packages/overlay-shell/src/*"]
+    }
+  },
+  "include": [
+    "types/**/*.d.ts",
+    "apps/*/src/**/*.ts",
+    "apps/*/src/**/*.tsx",
+    "packages/*/src/**/*.ts",
+    "packages/*/src/**/*.tsx",
+    "plugins/*/backend.ts",
+    "plugins/*/app.tsx",
+    "test/**/*.ts"
+  ]
+}

--- a/types/shims.d.ts
+++ b/types/shims.d.ts
@@ -1,0 +1,21 @@
+// Ambient type shims (no top-level imports/exports, so this stays a script).
+
+declare module "three";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, no-var
+declare var __electrobun: any;
+
+interface Window {
+  __electroview?: { rpc?: unknown };
+  // Electrobun's preload installs this; its source mutates it, so we type it
+  // permissively. Restricting to `unknown` would crash electrobun's own .ts
+  // source under tsc since it does `window.__electrobun!.receiveMessageFromBun = ...`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  __electrobun?: any;
+  __LOADOUT_REACT?: unknown;
+  __LOADOUT_REACT_JSX_RUNTIME?: unknown;
+  __LOADOUT_REACT_JSX_DEV_RUNTIME?: unknown;
+  __LOADOUT_REACT_DOM?: unknown;
+  __LOADOUT_REACT_DOM_CLIENT?: unknown;
+  __LOADOUT_UI?: unknown;
+}


### PR DESCRIPTION
## Summary

Clean-room rebuild of the [linux-gaming-plugin-manager](https://github.com/srsholmes/linux-gaming-plugin-manager) overlay (internal name `steam-loader`) into this repo. M1 establishes the load-bearing architecture end-to-end with a single `hello-world` plugin so we can verify the full path (Bun backend ↔ WebSocket IPC ↔ Electrobun overlay ↔ plugin compile + mount ↔ gamescope/evdev native layer) on Apex (Bazzite), Steam Deck (SteamOS), and OneXFly F1 Pro (CachyOS) before migrating real plugins.

Plan: `/Users/srsholmes/.claude/plans/i-have-started-a-polymorphic-zephyr.md`

## What's in this PR

| Area | What | Notes |
|---|---|---|
| Workspace | Bun workspaces `apps/* packages/* plugins/*`, tsconfig + `@loadout/*` aliases, eslint, prettier | `bun test`, `bun run typecheck`, `bun run lint` all pass on macOS |
| `@loadout/types` | IPC + plugin contracts (`RpcRequest/Response/Event`, `PluginManifest`, `resolveMethod`) | Slimmed from old `@steam-loader/types` — dropped Steam BPM patch/css/qam/menu surfaces |
| `@loadout/device` | **NEW** — `detectDevice()` with DMI fingerprints for Apex, Steam Deck OLED (Galileo) / LCD (Jupiter), OneXFly F1 Pro; capability flags (`hasRGB`, `hasFanControl`, `hasTDP`, `hasBatteryControl`) | Replaces ad-hoc device detection scattered across the old plugins. Future RGB/TDP/fan plugins gate on capabilities, not device IDs — so Steam Deck never sees RGB controls. |
| `@loadout/exec` | Faithful port of `@steam-loader/exec` | Pulled into M1 because the native layer depends on it (was M3 in the plan) |
| `@loadout/server` | Bun HTTP+WS server on `127.0.0.1:33820`, plugin manager (manifest scan + on-demand `Bun.build` of `app.tsx` with vendor globals), RPC dispatch, hot-reload watcher | Rewritten clean from `packages/loader`. Dropped: SteamInjector, sandboxed-fetch (M2+), __broadcast plugin id, game-detection service, debug-mode rethrow logic |
| `@loadout/ui` | Button / Panel / Text / Toggle / Field / Slider / TextInput / TabBar / IconButton / Spinner + spatial-nav proxy + BackendProvider + useBackend + ws-client | **DRY refactor** the plan called for: shared `applyFocusPulse` / `focusScaleClass` helpers replace duplicated focus-style boilerplate across every component. Globals renamed `__SL_*` → `__LOADOUT_*` |
| `@loadout/overlay-shell` | App with hash router, GamepadNavProvider, PluginHost, usePlugins, `installSpatialNav()` | Minimal — sidebar / homepage / OSK / theme UI all deferred to M2 |
| `apps/overlay` | Electrobun shell. Bun-side main spawns `@loadout/server` in-process. Faithful port of `gamescope-atoms` (1080 LOC), `input-intercept` (863 LOC), `nav-controller`, `process-control` (Steam SIGSTOP/SIGCONT), `wake-routing` (Guide+ABXY), `display-detect`, `ffi`, `x11`, `devices`, `device-hotplug`, `trace`, `overlay-state`. Webview entry installs spatial nav, fetches token, bridges all Bun→webview channels | `steam-quick-access` is a no-op stub (Steam BPM integration deferred). `restartServer/restartSteam/forceUnfreezeSteam/system{Shutdown,Reboot}/readSoundFile` RPC handlers dropped from M1 |
| `plugins/hello-world` | `plugin.json` + `backend.ts` (`ping()`, `getDevice()`) + `app.tsx` rendering a Panel via `@loadout/ui` | M1 smoke test |
| `scripts/` | `build.sh` (vite → electrobun bundle), `install-local.sh` (copy + systemd) + `loadout.service` | No distro-detect installer — that's a later milestone |

## Treat this as a migration, not a rewrite

A reviewer should weight risk this way:

- **Files copied verbatim with rename-only edits — leave them alone unless you see a real bug:**
  - `apps/overlay/src/bun/native/gamescope-atoms.ts`
  - `apps/overlay/src/bun/native/input-intercept.ts`
  - `apps/overlay/src/bun/native/nav-controller.ts`
  - `apps/overlay/src/bun/native/process-control.ts`
  - `apps/overlay/src/bun/native/device-hotplug.ts`, `devices.ts`, `display-detect.ts`, `ffi.ts`, `x11.ts`, `trace.ts`
  - `apps/overlay/src/bun/lib/overlay-state.ts`, `lib/wake-routing.ts`
  - `apps/overlay/src/bun/lifecycle.ts`, `rpc-validation.ts`
  - `apps/overlay/src/webview/lib/get-electro-rpc.ts`
  - `packages/exec/src/index.ts`

  These are working today on Apex hardware. Sed-renamed `@steam-loader/* → @loadout/*` and `steam-loader → loadout`. Any "while we're here" cleanup pushes risk into a milestone whose explicit goal is to test the gamescope path **unchanged**.

- **Files rewritten / new — fair game for design feedback:**
  - `packages/server/src/*` (server, plugin-manager, rpc, auth, bundler, vendor-globals, watcher, logger)
  - `packages/device/src/*` (new package)
  - `packages/ui/src/focus-style.ts` (DRY helper) and how it's used in `Button/Toggle/Slider/TextInput/IconButton`
  - `packages/overlay-shell/src/*` (App, GamepadNav, PluginHost, usePlugins, spatial-nav-init)
  - `apps/overlay/src/bun/index.ts` (orchestrator — simpler than old, fewer subsystems)
  - `apps/overlay/src/bun/rpc-handlers.ts` (RPC surface shrunk to M1 essentials)
  - `apps/overlay/src/webview/main.tsx` (entry; sets vendor globals, no theme/userConfig path yet)
  - `scripts/build.sh`, `scripts/install-local.sh`, `loadout.service`
  - `plugins/hello-world/*`

- **Deliberately deferred** — not in this PR, don't flag as missing:
  - User config persistence, themes, UI scale → M2
  - On-screen keyboard, toast notifications → later
  - Steam BPM injection / `@loadout/injector` → re-evaluate later milestone
  - `dev-server` package → folded into electrobun main; not coming back
  - Every other plugin from the old repo → milestone-per-plugin
  - `install.sh` distro autodetect, flatpak

## Local verification (macOS)

- ✅ `bun install` — 524 packages clean
- ✅ `bun test` — 51 pass, 0 fail
- ✅ `bun run typecheck` — clean
- ✅ `bun run lint` — clean

Linux-only paths (electrobun CEF bundling, X11/evdev, systemd) cannot be verified from this machine.

## Test plan

- [ ] `bun install` clean on Linux
- [ ] `bash scripts/build.sh` produces `apps/overlay/build/dev-linux-{x64,arm64}/loadout-dev/`
- [ ] `bash scripts/install-local.sh` copies binary + plugins to `~/.local/share/loadout/`, installs `loadout.service`, starts it
- [ ] On **Apex (Bazzite)**: launch Steam → press QAM (F16) → overlay window appears → hello-world plugin renders → Ping returns `pong from apex` → press QAM again → window hides, game input resumes
- [ ] On **Steam Deck (SteamOS)**: same flow, expect `pong from steamdeck-oled` (or `-lcd`)
- [ ] On **OneXFly F1 Pro (CachyOS)**: same flow, expect `pong from onexfly-f1-pro`
- [ ] `systemctl --user status loadout` shows healthy on all three
- [ ] No `STEAM_OVERLAY=1` left set after the process exits (no input lockup on close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)