### PR TITLE
fix(overlay): correct Tailwind @source paths (range slider + all plugin/ui classes)

### DIFF
--- a/apps/loadout-overlay/src/overlay/index.css
+++ b/apps/loadout-overlay/src/overlay/index.css
@@ -657,9 +657,17 @@ html[data-theme="terminal"] {
   --font-sans: "JetBrains Mono", ui-monospace, monospace;
 }
 
+/* Tailwind/daisyUI content sources. Paths are relative to THIS file
+   (apps/loadout-overlay/src/overlay/index.css), so the repo root is four
+   levels up. The shared component classes (e.g. Slider's `range
+   range-primary range-xs`) live in packages/ui, and plugins are scanned so
+   their classes get compiled into this global stylesheet. Keep these
+   anchored — a stale `../../ui/src` (the old packages/overlay layout)
+   silently resolves to a non-existent dir and daisyUI tree-shakes those
+   components away (this is what broke the range slider). */
 @source "./";
-@source "../../ui/src";
-@source "../../../plugins";
+@source "../../../../packages/ui/src";
+@source "../../../../plugins";
 
 /* Desktop app — pull every daisyUI utility into the bundle so plugin code
    that uses semantic colors renders correctly even if no scanned source


### PR DESCRIPTION
## Problem
The range slider (and, more broadly, **any class used only in `packages/ui` or `plugins/`**) rendered unstyled — daisyUI's `.range` component was missing entirely from the built CSS.

## Root cause
The Tailwind v4 `@source` directives in `apps/loadout-overlay/src/overlay/index.css` are relative to that file but were written for the **old `packages/overlay/src/` layout**. After the apps/ restructure they resolved to non-existent dirs:

- `../../ui/src` → `apps/loadout-overlay/ui/src` ❌ (should be `packages/ui/src`)
- `../../../plugins` → `apps/plugins` ❌ (should be repo-root `plugins`)

So Tailwind scanned neither `packages/ui` (where `Slider.tsx`'s `range range-primary range-xs` lives) nor `plugins/`. daisyUI v5 tree-shakes unused components, so `.range` was dropped. Buttons only survived because they're force-listed via `@source inline(...)`.

## Fix
Anchor the paths to the repo root (four levels up from `index.css`):
- `@source "../../../../packages/ui/src"`
- `@source "../../../../plugins"`

## Verified
- Built overlay CSS: `.range{` rules **0 → 4** (+ `range-xs`, `range-primary`, `slider-thumb`).
- Deployed to device (Bazzite): slider renders styled in **both** the settings page and the home widget, matching the old steam-loader look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)