### PR TITLE
fix(install): branch binary path on /etc/os-release per docs/install-locations.md

### DIFF
--- a/loadout.service
+++ b/loadout.service
@@ -13,24 +13,30 @@ Type=simple
 # (per-plugin command capability policy) to bound what running-as-root
 # means for them.
 #
-# The binary lives in /usr/local/bin (a system path, SELinux `bin_t`) —
-# NOT the user's home. A system-domain service (init_t) is denied `execute`
-# on a binary labelled `data_home_t` under ~/.local/share (SELinux is
-# enforcing on Bazzite), so it must exec from a system path. This mirrors
-# HHD, whose root service execs /usr/bin/hhd (its RPM-installed, bin_t
-# binary). The plugins, config, and logs still live under the user's home
-# — a system service CAN read/write there, only `execute` is blocked.
+# The binary path is distro-dependent (see docs/install-locations.md):
+#   - Bazzite / Fedora-ostree / generic: /usr/local/bin/loadout (writable
+#     on ostree → /var/usrlocal; SELinux `bin_t` — required because a
+#     system-domain init_t service is denied `execute` on a binary under
+#     ~/.local/share which is labelled `data_home_t`). Mirrors HHD's
+#     /usr/bin/hhd (RPM-installed, bin_t).
+#   - SteamOS: ~/.local/share/loadout/loadout. /usr is read-only and would
+#     be wiped on the next A/B image update, and SteamOS doesn't run
+#     SELinux in enforcing mode so a binary under data_home_t execs fine
+#     from a root unit. Persists across SteamOS updates (on /home).
+# In every case plugins/config/logs live under the user's home (a system
+# service CAN read/write there; only `execute` is the SELinux concern).
 #
 # This file is a TEMPLATE: install-local.sh / install.sh substitute
-# __HOME__ and __USER__ (a system unit can't expand %h — that would be
-# root's home) and install the result to /etc/systemd/system/loadout.service.
+# __BIN__, __HOME__, and __USER__ (a system unit can't expand %h — that
+# would be root's home) and install the result to
+# /etc/systemd/system/loadout.service.
 #
 # $HOME is set so os.homedir() / @loadout/steam-paths resolve ~/.config
 # and the user's Steam as the user, even though the process is root.
 # --user chowns files written under that home back to the user.
 Environment=HOME=__HOME__
 Environment=PLUGINS_DIR=__HOME__/.local/share/loadout/plugins
-ExecStart=/usr/local/bin/loadout --user __USER__
+ExecStart=__BIN__ --user __USER__
 WorkingDirectory=__HOME__/.local/share/loadout
 Restart=on-failure
 RestartSec=5

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -31,16 +31,48 @@ fi
 systemctl --user stop loadout-overlay 2>/dev/null || true
 systemctl --user stop loadout 2>/dev/null || true
 
-# The plugin tree lives in the user's home; the binary does NOT — SELinux
-# (enforcing on Bazzite) denies a root system service `execute` on a binary
-# labelled data_home_t under ~/.local/share. It must exec from a system
-# path (bin_t), exactly like HHD's /usr/bin/hhd. So the binary goes to
-# /usr/local/bin (writable on ostree → /var/usrlocal, labels bin_t).
+# Pick the binary install path based on host distro — there is no single
+# path that works everywhere. See docs/install-locations.md for the full
+# rationale.
+#
+#   SteamOS — $INSTALL_DIR/loadout (under ~/.local/share):
+#     /usr is read-only by default and `steamos-readonly disable` is the
+#     wrong fix — the next SteamOS A/B image swap would wipe it. SteamOS
+#     does NOT enforce SELinux, so the data_home_t / init_t exec restriction
+#     that bites on Bazzite doesn't apply here, and a binary in the home
+#     dir execs fine from a root unit. /home is persistent across SteamOS
+#     image updates.
+#
+#   Bazzite / Fedora-ostree / generic (Arch, CachyOS, Ubuntu, ...) —
+#   /usr/local/bin/loadout:
+#     Writable on ostree systems (→ /var/usrlocal), labelled bin_t. Bazzite
+#     runs SELinux in enforcing mode, where a root systemd unit (init_t) is
+#     denied `execute` on a binary labelled data_home_t (everything under
+#     ~/.local/share / ~/.config). The binary must live at a bin_t-labelled
+#     system path — exactly like HHD's RPM-installed /usr/bin/hhd. On non-
+#     SELinux distros it just works; same path keeps things consistent.
+DISTRO_ID=""
+[ -r /etc/os-release ] && DISTRO_ID="$(. /etc/os-release && printf '%s' "${ID:-}")"
+case "$DISTRO_ID" in
+    steamos)
+        BIN_PATH="$INSTALL_DIR/loadout"
+        BIN_NEEDS_SUDO=0
+        ;;
+    *)
+        BIN_PATH="/usr/local/bin/loadout"
+        BIN_NEEDS_SUDO=1
+        ;;
+esac
+
 mkdir -p "$INSTALL_DIR/plugins"
-# The binary used to live here; it's a system-path binary now. Drop the
-# stale copy so the install dir only holds the plugin tree.
-rm -f "$INSTALL_DIR/loadout"
-SYSTEM_BIN="/usr/local/bin/loadout"
+# Remove any stale binary at the *other* possible location — handles
+# users moving between distros (e.g. dual-booting SteamOS desktop mode
+# into a Bazzite-installed copy) and the older "binary in $INSTALL_DIR"
+# layout. Idempotent — the install step below puts a fresh one at the
+# chosen $BIN_PATH for this distro.
+if [ "$BIN_PATH" = "/usr/local/bin/loadout" ]; then
+    rm -f "$INSTALL_DIR/loadout"
+fi
 
 # Smoke-check the freshly built binary BEFORE installing it system-wide.
 # A truncated / corrupted build still copies fine, then the service
@@ -66,12 +98,19 @@ if ! printf '%s' "$SMOKE_OUT" | grep -q '^loadout '; then
 fi
 echo "Smoke check OK: $SMOKE_OUT"
 
-# Install the binary system-wide (needs sudo). restorecon forces the
-# bin_t label so init_t can exec it even if the default context drifts.
-echo "Installing the backend binary to $SYSTEM_BIN (needs sudo)..."
-sudo install -m 0755 "$DIST_DIR/loadout" "$SYSTEM_BIN"
-command -v restorecon >/dev/null 2>&1 && sudo restorecon -F "$SYSTEM_BIN" 2>/dev/null || true
-echo "Installed $SYSTEM_BIN"
+# Install the binary at the chosen path. On a system path (/usr/local/bin)
+# this needs sudo + restorecon to force the bin_t label so init_t can exec
+# it even if the default context drifts. On SteamOS the binary lives in
+# the user's home and is plain user-owned — no sudo, no SELinux concern.
+if [ "$BIN_NEEDS_SUDO" = "1" ]; then
+    echo "Installing the backend binary to $BIN_PATH (needs sudo)..."
+    sudo install -m 0755 "$DIST_DIR/loadout" "$BIN_PATH"
+    command -v restorecon >/dev/null 2>&1 && sudo restorecon -F "$BIN_PATH" 2>/dev/null || true
+else
+    echo "Installing the backend binary to $BIN_PATH (user-writable on this distro)..."
+    install -m 0755 "$DIST_DIR/loadout" "$BIN_PATH"
+fi
+echo "Installed $BIN_PATH"
 
 # The root service writes plugin build caches (.cache/) into this tree as
 # root. Reclaim ownership before staging so the user-run prepare-plugins
@@ -121,7 +160,7 @@ systemctl --user disable loadout 2>/dev/null || true
 rm -f "$SERVICE_DIR/loadout.service"
 
 GENERATED_UNIT="$(mktemp)"
-sed -e "s#__HOME__#${HOME}#g" -e "s#__USER__#${TARGET_USER}#g" \
+sed -e "s#__HOME__#${HOME}#g" -e "s#__USER__#${TARGET_USER}#g" -e "s#__BIN__#${BIN_PATH}#g" \
     "$PROJECT_ROOT/loadout.service" > "$GENERATED_UNIT"
 sudo cp "$GENERATED_UNIT" "$SYSTEM_UNIT"
 rm -f "$GENERATED_UNIT"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,11 +12,29 @@ set -e
 REPO="srsholmes/loadout"
 INSTALL_DIR="$HOME/.local/share/loadout"
 BINARY_NAME="loadout"
-# System path (SELinux bin_t) so the root service can exec it — exec from
-# ~/.local/share (data_home_t) is denied for a system-domain service.
-# /usr/local/bin is writable on ostree (→ /var/usrlocal) and persists
-# across updates. Mirrors HHD's /usr/bin/hhd.
-BINARY_PATH="/usr/local/bin/$BINARY_NAME"
+# Distro-dependent binary path — there is no single path that works on
+# every supported distro. See docs/install-locations.md for the full
+# rationale.
+#   SteamOS: $INSTALL_DIR/$BINARY_NAME (under ~/.local/share). /usr is
+#            read-only and would be wiped on the next A/B image update;
+#            SteamOS doesn't enforce SELinux so a binary under
+#            data_home_t execs fine from a root unit.
+#   Otherwise (Bazzite / Fedora-ostree / Arch / CachyOS / Ubuntu / ...):
+#            /usr/local/bin/$BINARY_NAME. Writable on ostree (→
+#            /var/usrlocal), labelled bin_t — Bazzite's enforcing SELinux
+#            denies init_t `execute` on data_home_t, so the binary MUST
+#            be at a bin_t-labelled system path. Mirrors HHD's
+#            /usr/bin/hhd. Non-SELinux distros: same path, just works.
+case "$(. /etc/os-release 2>/dev/null && printf '%s' "${ID:-}")" in
+    steamos)
+        BINARY_PATH="$INSTALL_DIR/$BINARY_NAME"
+        BIN_NEEDS_SUDO=0
+        ;;
+    *)
+        BINARY_PATH="/usr/local/bin/$BINARY_NAME"
+        BIN_NEEDS_SUDO=1
+        ;;
+esac
 BIN_LINK="$HOME/.local/bin/loadout"
 SERVICE_DIR="$HOME/.config/systemd/user"
 # Legacy per-user backend unit — removed on install now the backend is a
@@ -386,12 +404,22 @@ phase1() {
         exit 1
     fi
 
-    # Install binary into the system path (needs sudo). restorecon forces
-    # the bin_t label so the root service (init_t) can exec it.
-    info "Installing the binary to $BINARY_PATH (needs sudo)..."
-    sudo install -m 0755 "$TEMP_FILE" "$BINARY_PATH"
-    rm -f "$TEMP_FILE"
-    command -v restorecon >/dev/null 2>&1 && sudo restorecon -F "$BINARY_PATH" 2>/dev/null || true
+    # Install the binary at the chosen path. On a system path
+    # (/usr/local/bin) this needs sudo + restorecon to force bin_t so the
+    # root service (init_t) can exec it under enforcing SELinux. On SteamOS
+    # the binary lives in the user's home (BIN_NEEDS_SUDO=0) — plain user-
+    # owned, no SELinux concern, no /usr write (the rootfs is read-only).
+    if [ "$BIN_NEEDS_SUDO" = "1" ]; then
+        info "Installing the binary to $BINARY_PATH (needs sudo)..."
+        sudo install -m 0755 "$TEMP_FILE" "$BINARY_PATH"
+        rm -f "$TEMP_FILE"
+        command -v restorecon >/dev/null 2>&1 && sudo restorecon -F "$BINARY_PATH" 2>/dev/null || true
+    else
+        info "Installing the binary to $BINARY_PATH (user-writable on this distro)..."
+        mkdir -p "$(dirname "$BINARY_PATH")"
+        install -m 0755 "$TEMP_FILE" "$BINARY_PATH"
+        rm -f "$TEMP_FILE"
+    fi
     success "Binary installed to $BINARY_PATH"
 
     # Download the overlay binary

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -8,8 +8,21 @@ set -e
 # Configuration
 INSTALL_DIR="$HOME/.local/share/loadout"
 OVERLAY_INSTALL_DIR="$HOME/.local/share/loadout-overlay"
-# Binary lives in a system path now (root service execs it; SELinux).
-BINARY_PATH="/usr/local/bin/loadout"
+# Binary path is distro-dependent — must mirror install.sh's branching
+# so we remove from the path it was actually written to. See
+# docs/install-locations.md. SteamOS: ~/.local/share/loadout/loadout
+# (user-writable, no /usr); everywhere else: /usr/local/bin/loadout
+# (system path, removal needs sudo).
+case "$(. /etc/os-release 2>/dev/null && printf '%s' "${ID:-}")" in
+    steamos)
+        BINARY_PATH="$INSTALL_DIR/loadout"
+        BIN_NEEDS_SUDO=0
+        ;;
+    *)
+        BINARY_PATH="/usr/local/bin/loadout"
+        BIN_NEEDS_SUDO=1
+        ;;
+esac
 BIN_LINK="$HOME/.local/bin/loadout"
 SERVICE_DIR="$HOME/.config/systemd/user"
 # Obsolete per-user backend unit (the backend is now a root system unit).
@@ -123,10 +136,15 @@ main() {
 
     echo ""
 
-    # --- Remove the system binary (root-owned, needs sudo) ---
+    # --- Remove the binary (sudo only when system-owned, per install.sh) ---
     if [ -f "$BINARY_PATH" ]; then
-        info "Removing $BINARY_PATH (needs sudo)..."
-        sudo rm -f "$BINARY_PATH"
+        if [ "$BIN_NEEDS_SUDO" = "1" ]; then
+            info "Removing $BINARY_PATH (needs sudo)..."
+            sudo rm -f "$BINARY_PATH"
+        else
+            info "Removing $BINARY_PATH..."
+            rm -f "$BINARY_PATH"
+        fi
         success "Binary removed."
     else
         info "Binary not found at $BINARY_PATH (already removed)."


### PR DESCRIPTION
## Summary
PR 33 hardcoded `/usr/local/bin/loadout` for the backend binary. On stock SteamOS that fails (`cannot create regular file: Read-only file system`). `docs/install-locations.md` (in `plugin/tdp-control`) spells out the right answer: **branch on `/etc/os-release`** and install to `~/.local/share/loadout/loadout` on SteamOS, keep `/usr/local/bin/loadout` everywhere else.

## What changed
- **`loadout.service`** — `ExecStart=__BIN__` (was hardcoded). The doc said "the template already uses `__BIN__`" — it now actually does.
- **`scripts/install-local.sh`** / **`scripts/install.sh`** — detect distro via `/etc/os-release`; pick `BINARY_PATH` + `BIN_NEEDS_SUDO`; conditional `sudo install` (none on SteamOS — binary is in `$HOME`); pass `__BIN__` into the `loadout.service` sed in `install-local`.
- **`scripts/uninstall.sh`** — symmetric detection; conditional sudo on binary removal.

## Tested on SteamOS 3.7.25 (Steam Deck)
- `ID=steamos` detected ✓
- Installed `/home/deck/.local/share/loadout/loadout` (no sudo for binary) ✓
- System unit `ExecStart=/home/deck/.local/share/loadout/loadout --user deck` ✓
- `/usr/local/bin/loadout` does **not** exist; `steamos-readonly` remains **enabled** (never disabled, per the doc's explicit "do NOT") ✓
- `loadout` (system) + `loadout-overlay` (user) both `active`, 0 restarts ✓

Bazzite / generic path unchanged (still `/usr/local/bin/loadout` + sudo + `restorecon`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
