### PR TITLE
feat(plugin-storage): extract @loadout/plugin-storage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,10 @@
       "name": "@loadout/exec",
       "version": "0.0.1",
     },
+    "packages/plugin-storage": {
+      "name": "@loadout/plugin-storage",
+      "version": "0.0.1",
+    },
     "packages/steam-paths": {
       "name": "@loadout/steam-paths",
       "version": "0.0.1",
@@ -295,6 +299,8 @@
     "@loadout/plugin-playtime": ["@loadout/plugin-playtime@workspace:plugins/playtime"],
 
     "@loadout/plugin-steam-gamescope-ipc": ["@loadout/plugin-steam-gamescope-ipc@workspace:plugins/steam-gamescope-ipc"],
+
+    "@loadout/plugin-storage": ["@loadout/plugin-storage@workspace:packages/plugin-storage"],
 
     "@loadout/plugin-tdp-control": ["@loadout/plugin-tdp-control@workspace:plugins/tdp-control"],
 

--- a/packages/plugin-storage/package.json
+++ b/packages/plugin-storage/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@loadout/plugin-storage",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "license": "MIT"
+}

--- a/packages/plugin-storage/src/index.test.ts
+++ b/packages/plugin-storage/src/index.test.ts
@@ -1,0 +1,172 @@
+// Real-disk I/O against a per-test temp XDG_CONFIG_HOME. No mock.module on
+// fs/promises — that pattern leaks across files in `bun test` (see
+// docs/test-mock-contamination.md).
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join, dirname } from "node:path";
+
+import {
+  loadoutConfigDir,
+  pluginStoragePath,
+  readPluginStorage,
+  writePluginStorage,
+} from "./index";
+
+let tempDir: string;
+let prevXdg: string | undefined;
+
+beforeEach(() => {
+  prevXdg = process.env.XDG_CONFIG_HOME;
+  tempDir = mkdtempSync(join(tmpdir(), "plugin-storage-test-"));
+  process.env.XDG_CONFIG_HOME = tempDir;
+});
+
+afterEach(() => {
+  if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = prevXdg;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("loadoutConfigDir + pluginStoragePath", () => {
+  it("honours XDG_CONFIG_HOME when set", () => {
+    expect(loadoutConfigDir()).toBe(join(tempDir, "loadout"));
+    expect(pluginStoragePath("my-plugin")).toBe(
+      join(tempDir, "loadout", "plugins", "my-plugin.json"),
+    );
+  });
+
+  it("falls back to ~/.config when XDG_CONFIG_HOME is unset", () => {
+    delete process.env.XDG_CONFIG_HOME;
+    expect(pluginStoragePath("my-plugin")).toBe(
+      join(homedir(), ".config", "loadout", "plugins", "my-plugin.json"),
+    );
+  });
+
+  it("treats XDG_CONFIG_HOME='' as unset", () => {
+    process.env.XDG_CONFIG_HOME = "";
+    expect(pluginStoragePath("my-plugin")).toBe(
+      join(homedir(), ".config", "loadout", "plugins", "my-plugin.json"),
+    );
+  });
+});
+
+describe("readPluginStorage", () => {
+  it("returns {} when the file doesn't exist", async () => {
+    expect(await readPluginStorage("missing-plugin")).toEqual({});
+  });
+
+  it("returns {} when the file is invalid JSON", async () => {
+    const path = pluginStoragePath("broken-plugin");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "{not valid json", "utf-8");
+    expect(await readPluginStorage("broken-plugin")).toEqual({});
+  });
+
+  it("returns {} when the JSON top-level isn't an object", async () => {
+    const cases: Array<[string, string]> = [
+      ["array", "[1,2,3]"],
+      ["null", "null"],
+      ["number", "42"],
+      ["string", '"hello"'],
+    ];
+
+    for (const [name, payload] of cases) {
+      const pluginId = `non-object-${name}`;
+      const path = pluginStoragePath(pluginId);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, payload, "utf-8");
+      expect(await readPluginStorage(pluginId)).toEqual({});
+    }
+  });
+
+  it("returns the parsed object for valid JSON on disk", async () => {
+    interface Shape {
+      foo: string;
+      n: number;
+      nested: { ok: boolean };
+    }
+    const stored: Shape = { foo: "bar", n: 7, nested: { ok: true } };
+    const path = pluginStoragePath("good-plugin");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(stored), "utf-8");
+
+    expect(await readPluginStorage<Shape>("good-plugin")).toEqual(stored);
+  });
+});
+
+describe("writePluginStorage", () => {
+  it("creates the parent directory on first write", async () => {
+    const path = pluginStoragePath("fresh-plugin");
+    expect(existsSync(dirname(path))).toBe(false);
+
+    await writePluginStorage("fresh-plugin", { hello: "world" });
+
+    expect(existsSync(dirname(path))).toBe(true);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("round-trips through readPluginStorage", async () => {
+    interface State {
+      bookmarks: string[];
+      count: number;
+    }
+    const payload: State = { bookmarks: ["a", "b"], count: 2 };
+
+    await writePluginStorage<State>("roundtrip", payload);
+    expect(await readPluginStorage<State>("roundtrip")).toEqual(payload);
+  });
+
+  it("is atomic — no .tmp sidecar after success, only the final file", async () => {
+    const path = pluginStoragePath("atomic");
+    await writePluginStorage("atomic", { v: 1 });
+
+    expect(existsSync(path)).toBe(true);
+    const entries = readdirSync(dirname(path));
+    expect(entries.filter((e) => e.endsWith(".tmp"))).toEqual([]);
+    expect(entries).toEqual(["atomic.json"]);
+
+    expect(JSON.parse(readFileSync(path, "utf-8"))).toEqual({ v: 1 });
+  });
+
+  it("overwrites — does not merge with existing contents", async () => {
+    interface State {
+      a?: number;
+      b?: number;
+    }
+    await writePluginStorage<State>("overwrite", { a: 1, b: 2 });
+    await writePluginStorage<State>("overwrite", { a: 99 });
+
+    const out = await readPluginStorage<State>("overwrite");
+    expect(out).toEqual({ a: 99 });
+    expect(out.b).toBeUndefined();
+  });
+
+  it("uses unique tmp filenames so parallel writes don't clobber each other", async () => {
+    // Two parallel writes must produce exactly one final file and no
+    // .tmp residue. randomUUID() makes each write's tmp name unique;
+    // POSIX rename keeps the final file atomic regardless of which write
+    // wins the race.
+    await Promise.all([
+      writePluginStorage("parallel", { who: "a" }),
+      writePluginStorage("parallel", { who: "b" }),
+    ]);
+    const dir = join(tempDir, "loadout", "plugins");
+    const entries = readdirSync(dir);
+    expect(entries.filter((e) => e.endsWith(".tmp"))).toEqual([]);
+    expect(entries).toEqual(["parallel.json"]);
+
+    const out = await readPluginStorage<{ who: string }>("parallel");
+    expect(out.who).toBeDefined();
+    expect(["a", "b"]).toContain(out.who as string);
+  });
+});

--- a/packages/plugin-storage/src/index.ts
+++ b/packages/plugin-storage/src/index.ts
@@ -1,0 +1,87 @@
+/**
+ * Per-plugin JSON storage under the user's Loadout config directory.
+ *
+ *   $XDG_CONFIG_HOME/loadout/plugins/<plugin-id>.json
+ *   (typically ~/.config/loadout/plugins/<plugin-id>.json)
+ *
+ * Plugin backends use this instead of inventing their own directory layout
+ * so user data lives in one well-known place that's visible to the user,
+ * backup-friendly, and survives overlay reinstalls (same dir as the
+ * overlay's `config.json`). Each plugin owns ONE JSON file keyed by its
+ * plugin ID. The overlay shell never touches these files — they're plugin
+ * state, not user preferences.
+ *
+ * Writes are atomic: tmp file + rename. POSIX rename is atomic when src
+ * and dst share a filesystem, so a crash mid-write never leaves a torn
+ * file — the previous successful write is still the one readers see. The
+ * tmp filename includes a randomUUID() so concurrent writes (or a retried
+ * write while a stale tmp is still on disk) can't clobber each other.
+ *
+ * Reads return `{}` (typed as `Partial<T>`) when the file is missing or
+ * unparseable. Callers are expected to treat "no stored data" and "stored
+ * data that isn't our shape" the same way — destructure with defaults:
+ *
+ *   const { sessions = [], pendingActive = null } =
+ *     await readPluginStorage<PlaytimeData>("playtime");
+ */
+
+import { readFile, mkdir, rename, writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+/** Base directory for Loadout config (XDG-aware). */
+export function loadoutConfigDir(): string {
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".config");
+  return join(base, "loadout");
+}
+
+/** Absolute path of a plugin's JSON storage file. Exposed for tests and
+ *  tooling that wants to know where state lives without invoking the
+ *  read/write helpers. */
+export function pluginStoragePath(pluginId: string): string {
+  return join(loadoutConfigDir(), "plugins", `${pluginId}.json`);
+}
+
+/** Read + parse the plugin's JSON file. Returns `{}` on any I/O or
+ *  parse failure — callers treat missing keys as "needs seeding". */
+export async function readPluginStorage<T extends object>(
+  pluginId: string,
+): Promise<Partial<T>> {
+  try {
+    const raw = await readFile(pluginStoragePath(pluginId), "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Partial<T>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/** Overwrite the plugin's JSON file atomically. Creates the `plugins/`
+ *  subdirectory on first write. Throws on I/O failure — callers should
+ *  catch and warn. */
+export async function writePluginStorage<T extends object>(
+  pluginId: string,
+  data: T,
+): Promise<void> {
+  const path = pluginStoragePath(pluginId);
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  const json = JSON.stringify(data, null, 2) + "\n";
+  // Prefer Bun.write when available (plugin backends run in the loader's
+  // Bun process); fall back to fs.writeFile so tests and non-Bun callers
+  // still work.
+  const B = (globalThis as unknown as {
+    Bun?: { write?: (p: string, d: string) => Promise<unknown> };
+  }).Bun;
+  if (B?.write) {
+    await B.write(tmp, json);
+  } else {
+    await writeFile(tmp, json, "utf-8");
+  }
+  await rename(tmp, path);
+}


### PR DESCRIPTION
## Summary

- Creates `packages/plugin-storage/` with the best-of-both API from the three inlined copies that have diverged across tdp-control, fan-control, and playtime.
- **PR 1 of 2.** No plugins migrated yet — that's a follow-up so this stays small and reviewable.

## API

Mirrors the old `@steam-loader/plugin-storage` surface; all three current call sites can adopt this with at most a destructure-defaults change.

```ts
loadoutConfigDir(): string
pluginStoragePath(pluginId: string): string
readPluginStorage<T extends object>(pluginId): Promise<Partial<T>>
writePluginStorage<T extends object>(pluginId, data): Promise<void>
```

## Behaviour decisions

- **XDG-aware base dir** with `~/.config` fallback (lifted from fan-control / tdp-control).
- **`randomUUID()` tmp suffix** so concurrent writes can't clobber each other's in-flight tmp file (modernised from playtime's `randomUUID` — old `<path>.tmp` literal had no concurrency safety).
- **`Bun.write` fast-path with `writeFile` fallback** (kept from the old `@steam-loader` package).
- **Reads coerce non-objects to `{}`** — arrays / null / numbers / strings — so the caller's `Partial<T>` destructure pattern doesn't blow up on malformed data on disk.
- **Single `Partial<T>` overload, no `defaultValue` arg.** Callers use destructured defaults: `const { sessions = [], pendingActive = null } = await readPluginStorage<PlaytimeData>("playtime");`. Simpler API, fewer ways for two plugins to disagree.

## Test plan

- [x] 12 tests covering: XDG vs `~/.config` fallback, empty-string XDG, missing file, unparseable JSON, non-object JSON coercion (array / null / number / string), parse round-trip, atomic `.tmp`-sidecar cleanup, overwrite (not merge), parallel-write tmp-collision safety. Uses real disk I/O against a per-test temp `XDG_CONFIG_HOME` — no `mock.module` on `fs/promises`.
- [x] `bun run typecheck`, `bun run lint`, `bun run test:backend`, `bun run test:ui` all green.
- [ ] PR 2: migrate tdp-control / fan-control / playtime to import from `@loadout/plugin-storage`; delete the three local copies; fold in the `mountComponent` dedup across the 5 plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)