### PR TITLE
feat(vdf): extract @loadout/vdf from steam-loader

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -95,6 +95,10 @@
         "react": ">=18",
       },
     },
+    "packages/vdf": {
+      "name": "@loadout/vdf",
+      "version": "0.0.1",
+    },
     "plugins/bluetooth": {
       "name": "@loadout/plugin-bluetooth",
       "version": "0.0.1",
@@ -312,6 +316,8 @@
     "@loadout/types": ["@loadout/types@workspace:packages/types"],
 
     "@loadout/ui": ["@loadout/ui@workspace:packages/ui"],
+
+    "@loadout/vdf": ["@loadout/vdf@workspace:packages/vdf"],
 
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@1.1.1", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ=="],
 

--- a/packages/vdf/package.json
+++ b/packages/vdf/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@loadout/vdf",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/vdf/src/binary-vdf.test.ts
+++ b/packages/vdf/src/binary-vdf.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "bun:test";
+
+const _path = import.meta.dir + "/binary-vdf.ts";
+const { parseBinaryVdf, shortcutGameId64 } = await import(
+  _path + "?real"
+);
+
+/**
+ * Helper: build a binary VDF byte array from a series of typed entries.
+ * Mirrors the wire format described in binary-vdf.ts header.
+ */
+function buildVdf(entries: Uint8Array[]): Buffer {
+  let total = 0;
+  for (const e of entries) total += e.length;
+  total += 1; // closing 0x08
+  const buf = Buffer.alloc(total);
+  let off = 0;
+  for (const e of entries) {
+    buf.set(e, off);
+    off += e.length;
+  }
+  buf[off] = 0x08;
+  return buf;
+}
+
+function strField(key: string, value: string): Uint8Array {
+  const k = Buffer.from(key + "\0", "utf-8");
+  const v = Buffer.from(value + "\0", "utf-8");
+  const buf = Buffer.alloc(1 + k.length + v.length);
+  buf[0] = 0x01;
+  buf.set(k, 1);
+  buf.set(v, 1 + k.length);
+  return buf;
+}
+
+function int32Field(key: string, value: number): Uint8Array {
+  const k = Buffer.from(key + "\0", "utf-8");
+  const buf = Buffer.alloc(1 + k.length + 4);
+  buf[0] = 0x02;
+  buf.set(k, 1);
+  buf.writeInt32LE(value, 1 + k.length);
+  return buf;
+}
+
+function uint64Field(key: string, value: bigint): Uint8Array {
+  const k = Buffer.from(key + "\0", "utf-8");
+  const buf = Buffer.alloc(1 + k.length + 8);
+  buf[0] = 0x07;
+  buf.set(k, 1);
+  buf.writeBigUInt64LE(value, 1 + k.length);
+  return buf;
+}
+
+function objectFieldHeader(key: string): Uint8Array {
+  const k = Buffer.from(key + "\0", "utf-8");
+  const buf = Buffer.alloc(1 + k.length);
+  buf[0] = 0x00;
+  buf.set(k, 1);
+  return buf;
+}
+
+const END = Buffer.from([0x08]);
+
+describe("parseBinaryVdf", () => {
+  it("parses a single string entry", () => {
+    const out = parseBinaryVdf(buildVdf([strField("name", "Celeste")]));
+    expect(out).toEqual({ name: "Celeste" });
+  });
+
+  it("parses int32 (positive) and string mixed", () => {
+    const out = parseBinaryVdf(
+      buildVdf([int32Field("appid", 504230), strField("appname", "Celeste")]),
+    );
+    expect(out).toEqual({ appid: 504230, appname: "Celeste" });
+  });
+
+  it("parses int32 with high bit set as negative (signed)", () => {
+    // 0x9959500e — top bit set, so signed-int32 reading is negative.
+    // Callers use `value >>> 0` to recover the unsigned form Steam
+    // actually stores (see plugins/{game-browser,launch-options}).
+    const SIGNED = 0x9959500e | 0; // JS bitwise produces int32-correct signed
+    const out = parseBinaryVdf(buildVdf([int32Field("appid", SIGNED)]));
+    expect(out.appid as number).toBeLessThan(0);
+    expect(out.appid as number).toBe(SIGNED);
+    expect((out.appid as number) >>> 0).toBe(0x9959500e >>> 0);
+  });
+
+  it("parses uint64 as bigint", () => {
+    const id = (0x9959500en << 32n) | 0x02000000n;
+    const out = parseBinaryVdf(buildVdf([uint64Field("gameid", id)]));
+    expect(out.gameid).toBe(id);
+  });
+
+  it("parses a nested object terminated by 0x08", () => {
+    // shortcuts -> { 0 -> { appid, appname } }
+    const buf = Buffer.concat([
+      objectFieldHeader("shortcuts"),
+      objectFieldHeader("0"),
+      int32Field("appid", 12345),
+      strField("appname", "Foo"),
+      END, // close "0"
+      END, // close "shortcuts"
+      END, // close root
+    ]);
+    const out = parseBinaryVdf(buf);
+    expect(out).toEqual({
+      shortcuts: { "0": { appid: 12345, appname: "Foo" } },
+    });
+  });
+
+  it("throws on unknown type byte", () => {
+    const buf = Buffer.from([0x99, 0x6b, 0x00, 0x08]);
+    expect(() => parseBinaryVdf(buf)).toThrow(/unknown type byte 0x99/);
+  });
+
+  it("throws on unterminated key", () => {
+    const buf = Buffer.from([0x01, 0x6e, 0x6f, 0x6e]); // 0x01 "non" (no null)
+    expect(() => parseBinaryVdf(buf)).toThrow(/unterminated key/);
+  });
+});
+
+describe("shortcutGameId64", () => {
+  // Reference value computed independently via Python:
+  //   (0x9959500e << 32) | 0x02000000 = 11049951181823541248
+  const APPID_UINT32 = 0x9959500e;
+  const APPID_SIGNED = APPID_UINT32 | 0;
+  const EXPECTED_GAMEID = ((0x9959500en << 32n) | 0x02000000n).toString();
+
+  it("computes the gameid algebraically: (appid << 32) | 0x02000000", () => {
+    expect(shortcutGameId64(APPID_UINT32)).toBe(EXPECTED_GAMEID);
+  });
+
+  it("normalises negative signed input to its uint32 form", () => {
+    // The parser hands us a negative number when the appid's top bit is
+    // set; shortcutGameId64 should treat that as the unsigned uint32.
+    expect(shortcutGameId64(APPID_SIGNED)).toBe(EXPECTED_GAMEID);
+    expect(APPID_SIGNED).toBeLessThan(0);
+  });
+
+  it("matches expected literal for sanity", () => {
+    expect(EXPECTED_GAMEID).toBe("11049951181823541248");
+  });
+});

--- a/packages/vdf/src/binary-vdf.ts
+++ b/packages/vdf/src/binary-vdf.ts
@@ -1,0 +1,150 @@
+/**
+ * Binary VDF parser.
+ *
+ * Steam uses a compact binary VDF (a.k.a. "appinfo" format) for some files
+ * in the userdata tree — most notably `shortcuts.vdf`, which holds
+ * non-Steam app entries (added via "Add a non-Steam game" or by tools
+ * like EmuDeck).
+ *
+ * Layout: a flat byte stream where each entry is
+ *   <type-byte> <null-terminated key> <value>
+ * inside an implicit root object. Nested objects use a recursive entry list
+ * terminated by `0x08`. Top-level termination is also `0x08` at the end.
+ *
+ * Type bytes seen in the wild:
+ *   0x00  object   — value is a recursive entry list ended by 0x08
+ *   0x01  string   — value is a null-terminated UTF-8 string
+ *   0x02  int32    — value is a 4-byte little-endian signed int
+ *   0x07  uint64   — value is an 8-byte little-endian unsigned int
+ *   0x08  end      — closes the current object
+ *   (0x09 occurs as an alternate end marker in some old dumps; treated as 0x08)
+ *
+ * The parser is permissive about the top-level wrapper: we read entries
+ * directly into a root object until the buffer ends or we hit a stray 0x08.
+ *
+ * Numbers are returned as JS numbers (int32) or `bigint` (uint64). Callers
+ * that want unsigned 32-bit appids should do `(value >>> 0)` themselves —
+ * we don't apply that here because the parser shouldn't presume what the
+ * field means.
+ */
+
+const TYPE_OBJECT = 0x00;
+const TYPE_STRING = 0x01;
+const TYPE_INT32 = 0x02;
+const TYPE_UINT64 = 0x07;
+const TYPE_END = 0x08;
+const TYPE_END_ALT = 0x09;
+
+export type BinaryVdfValue =
+  | string
+  | number
+  | bigint
+  | { [key: string]: BinaryVdfValue };
+
+export interface BinaryVdfObject {
+  [key: string]: BinaryVdfValue;
+}
+
+/**
+ * Parse a binary VDF buffer into a nested JS object.
+ *
+ * Throws on truncated buffers, unknown type bytes, or non-UTF-8 keys.
+ */
+export function parseBinaryVdf(buf: Buffer | Uint8Array): BinaryVdfObject {
+  const view = buf instanceof Buffer ? buf : Buffer.from(buf);
+  let offset = 0;
+
+  function readKey(): string {
+    const start = offset;
+    while (offset < view.length && view[offset] !== 0) offset++;
+    if (offset >= view.length) {
+      throw new Error(
+        `binary VDF: unterminated key string starting at offset ${start}`,
+      );
+    }
+    const key = view.toString("utf-8", start, offset);
+    offset++; // consume the null terminator
+    return key;
+  }
+
+  function readString(): string {
+    const start = offset;
+    while (offset < view.length && view[offset] !== 0) offset++;
+    if (offset >= view.length) {
+      throw new Error(
+        `binary VDF: unterminated string value starting at offset ${start}`,
+      );
+    }
+    const s = view.toString("utf-8", start, offset);
+    offset++;
+    return s;
+  }
+
+  function readObject(): BinaryVdfObject {
+    const obj: BinaryVdfObject = {};
+    while (offset < view.length) {
+      const type = view[offset++];
+      if (type === TYPE_END || type === TYPE_END_ALT) {
+        return obj;
+      }
+
+      const key = readKey();
+
+      switch (type) {
+        case TYPE_OBJECT:
+          obj[key] = readObject();
+          break;
+        case TYPE_STRING:
+          obj[key] = readString();
+          break;
+        case TYPE_INT32: {
+          if (offset + 4 > view.length) {
+            throw new Error(
+              `binary VDF: truncated int32 for key "${key}" at offset ${offset}`,
+            );
+          }
+          obj[key] = view.readInt32LE(offset);
+          offset += 4;
+          break;
+        }
+        case TYPE_UINT64: {
+          if (offset + 8 > view.length) {
+            throw new Error(
+              `binary VDF: truncated uint64 for key "${key}" at offset ${offset}`,
+            );
+          }
+          obj[key] = view.readBigUInt64LE(offset);
+          offset += 8;
+          break;
+        }
+        default:
+          throw new Error(
+            `binary VDF: unknown type byte 0x${type
+              .toString(16)
+              .padStart(2, "0")} for key "${key}" at offset ${offset - 1}`,
+          );
+      }
+    }
+    return obj;
+  }
+
+  return readObject();
+}
+
+/**
+ * Compute Steam's 64-bit `gameid` for a non-Steam shortcut, given the
+ * shortcut's 32-bit appid (as stored in `shortcuts.vdf`).
+ *
+ *   gameid64 = (appid << 32) | 0x02000000
+ *
+ * Used as the filename stem under `userdata/<id>/config/grid/` when
+ * locating user-installed local artwork (header / capsule / hero / logo)
+ * for non-Steam apps.
+ *
+ * Returned as a decimal string because the value exceeds JS's safe-integer
+ * range (>2^53) once the high 32 bits are populated.
+ */
+export function shortcutGameId64(appIdUint32: number): string {
+  const id = (BigInt(appIdUint32 >>> 0) << 32n) | 0x02000000n;
+  return id.toString();
+}

--- a/packages/vdf/src/index.ts
+++ b/packages/vdf/src/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @loadout/vdf — Valve Data Format parsing, serialization, and surgical editing.
+ *
+ * VDF is used by Steam config files (localconfig.vdf, libraryfolders.vdf, appmanifest_*.acf).
+ *
+ * Also exposes launch-options string surgery (`appendLaunchToken` and friends)
+ * since that's a thin layer over the same VDF mutation primitives.
+ */
+export {
+  parseVdf,
+  serializeVdf,
+  patchVdfValue,
+  removeVdfKey,
+  type VdfNode,
+  type VdfObject,
+} from "./vdf";
+
+export {
+  appendLaunchToken,
+  removeLaunchToken,
+  hasLaunchToken,
+  type LaunchTokenOpts,
+} from "./launch-options";
+
+export {
+  parseBinaryVdf,
+  shortcutGameId64,
+  type BinaryVdfObject,
+  type BinaryVdfValue,
+} from "./binary-vdf";

--- a/packages/vdf/src/launch-options.test.ts
+++ b/packages/vdf/src/launch-options.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "bun:test";
+
+// Bypass Bun's mock.module contamination. See vdf.spec.ts for context —
+// other suites mock-replace `@loadout/vdf`, which would also stub out
+// these helpers if we imported them via the package barrel.
+const _path = import.meta.dir + "/launch-options.ts";
+const { appendLaunchToken, removeLaunchToken, hasLaunchToken } = await import(
+  _path + "?real"
+);
+
+// ─── appendLaunchToken ───────────────────────────────────────────────
+
+describe("appendLaunchToken", () => {
+  type Case = {
+    name: string;
+    existing: string;
+    token: string;
+    opts?: { key?: string; position?: "before" | "after"; ensureCommand?: boolean };
+    expected: string;
+  };
+
+  const cases: Case[] = [
+    {
+      name: "empty input gets `<token> %command%`",
+      existing: "",
+      token: "~/lsfg",
+      expected: "~/lsfg %command%",
+    },
+    {
+      name: "lone %command% gets the wrapper before it",
+      existing: "%command%",
+      token: "~/lsfg",
+      expected: "~/lsfg %command%",
+    },
+    {
+      name: "single existing wrapper stacks new wrapper closer to %command%",
+      existing: "mangohud %command%",
+      token: "~/lsfg",
+      expected: "mangohud ~/lsfg %command%",
+    },
+    {
+      name: "multiple existing wrappers preserved in order",
+      existing: "gamemoderun mangohud %command%",
+      token: "~/lsfg",
+      expected: "gamemoderun mangohud ~/lsfg %command%",
+    },
+    {
+      name: "trailing args after %command% are preserved",
+      existing: "mangohud %command% --fullscreen",
+      token: "~/lsfg",
+      expected: "mangohud ~/lsfg %command% --fullscreen",
+    },
+    {
+      name: "idempotent — re-append same wrapper is a no-op",
+      existing: "mangohud ~/lsfg %command%",
+      token: "~/lsfg",
+      expected: "mangohud ~/lsfg %command%",
+    },
+    {
+      name: "env-var prefix without %command% canonicalises to explicit form",
+      existing: "PROTON_USE_WINED3D=1",
+      token: "~/lsfg",
+      expected: "PROTON_USE_WINED3D=1 ~/lsfg %command%",
+    },
+    {
+      name: "env-var prefix with explicit %command% inserts before",
+      existing: "PROTON_USE_WINED3D=1 %command%",
+      token: "~/lsfg",
+      expected: "PROTON_USE_WINED3D=1 ~/lsfg %command%",
+    },
+    {
+      name: "env-var idempotency by KEY (no value) — already present",
+      existing: "PROTON_LOG=1 %command%",
+      token: "PROTON_LOG=2",
+      opts: { key: "PROTON_LOG" },
+      expected: "PROTON_LOG=1 %command%",
+    },
+    {
+      name: "position: 'after' puts the token after %command%",
+      existing: "mangohud %command% --foo",
+      token: "--bar",
+      opts: { position: "after" },
+      expected: "mangohud %command% --bar --foo",
+    },
+    {
+      name: "ensureCommand: false keeps absent %command% absent",
+      existing: "PROTON_LOG=1",
+      token: "PROTON_DEBUG=1",
+      opts: { ensureCommand: false },
+      expected: "PROTON_LOG=1 PROTON_DEBUG=1",
+    },
+    {
+      name: "double-quoted args stay intact across the merge",
+      existing: '"some quoted arg" %command%',
+      token: "~/lsfg",
+      expected: '"some quoted arg" ~/lsfg %command%',
+    },
+    {
+      name: "single-quoted args stay intact across the merge",
+      existing: "'sh -c \"foo bar\"' %command%",
+      token: "~/lsfg",
+      expected: "'sh -c \"foo bar\"' ~/lsfg %command%",
+    },
+    {
+      name: "multiple %command% markers — operate on the rightmost",
+      existing: "%command% mid %command% tail",
+      token: "~/lsfg",
+      expected: "%command% mid ~/lsfg %command% tail",
+    },
+    {
+      name: "empty token would be useless — but still idempotent",
+      existing: "mangohud %command%",
+      token: "mangohud",
+      expected: "mangohud %command%",
+    },
+    {
+      name: "explicit key overrides token-based idempotency",
+      existing: "MY_FLAG_a %command%",
+      token: "MY_FLAG_b",
+      opts: { key: "MY_FLAG_a" },
+      expected: "MY_FLAG_a %command%",
+    },
+  ];
+
+  for (const c of cases) {
+    it(c.name, () => {
+      expect(appendLaunchToken(c.existing, c.token, c.opts)).toBe(c.expected);
+    });
+  }
+});
+
+// ─── removeLaunchToken ───────────────────────────────────────────────
+
+describe("removeLaunchToken", () => {
+  type Case = {
+    name: string;
+    existing: string;
+    key: string;
+    expected: string;
+  };
+
+  const cases: Case[] = [
+    {
+      name: "removes wrapper, preserves other wrappers",
+      existing: "mangohud ~/lsfg %command%",
+      key: "~/lsfg",
+      expected: "mangohud %command%",
+    },
+    {
+      name: "removing the only wrapper collapses to empty (back to default)",
+      existing: "~/lsfg %command%",
+      key: "~/lsfg",
+      expected: "",
+    },
+    {
+      name: "no match — input returned unchanged",
+      existing: "%command%",
+      key: "~/lsfg",
+      expected: "%command%",
+    },
+    {
+      name: "removes by env-var KEY when value is unknown (collapses to empty)",
+      existing: "PROTON_LOG=1 %command%",
+      key: "PROTON_LOG",
+      expected: "",
+    },
+    {
+      name: "preserves trailing args after %command%",
+      existing: "~/lsfg %command% --fullscreen",
+      key: "~/lsfg",
+      expected: "%command% --fullscreen",
+    },
+    {
+      name: "preserves quoted args during removal",
+      existing: '"some quoted" ~/lsfg %command%',
+      key: "~/lsfg",
+      expected: '"some quoted" %command%',
+    },
+    {
+      name: "round-trip: append then remove returns the original",
+      existing: "mangohud %command%",
+      key: "~/lsfg",
+      // round-trip case: appendLaunchToken then removeLaunchToken
+      expected: "mangohud %command%",
+    },
+  ];
+
+  for (const c of cases) {
+    if (c.name.startsWith("round-trip")) {
+      it(c.name, () => {
+        const appended = appendLaunchToken(c.existing, c.key);
+        expect(removeLaunchToken(appended, c.key)).toBe(c.expected);
+      });
+    } else {
+      it(c.name, () => {
+        expect(removeLaunchToken(c.existing, c.key)).toBe(c.expected);
+      });
+    }
+  }
+});
+
+// ─── hasLaunchToken ──────────────────────────────────────────────────
+
+describe("hasLaunchToken", () => {
+  it("true when wrapper is present", () => {
+    expect(hasLaunchToken("mangohud ~/lsfg %command%", "~/lsfg")).toBe(true);
+  });
+
+  it("false when wrapper is absent", () => {
+    expect(hasLaunchToken("mangohud %command%", "~/lsfg")).toBe(false);
+  });
+
+  it("matches by env-var KEY without specifying value", () => {
+    expect(hasLaunchToken("PROTON_LOG=1 %command%", "PROTON_LOG")).toBe(true);
+  });
+
+  it("matches when key is the full env-var assignment", () => {
+    expect(hasLaunchToken("PROTON_LOG=1 %command%", "PROTON_LOG=1")).toBe(true);
+  });
+
+  it("false on empty input", () => {
+    expect(hasLaunchToken("", "~/lsfg")).toBe(false);
+  });
+});
+
+// ─── round-trip integration ──────────────────────────────────────────
+
+describe("append/remove round-trip", () => {
+  it("append on empty + remove returns empty", () => {
+    const appended = appendLaunchToken("", "~/lsfg");
+    expect(appended).toBe("~/lsfg %command%");
+    expect(removeLaunchToken(appended, "~/lsfg")).toBe("");
+  });
+
+  it("append on existing wrapper preserves outer wrapper after removal", () => {
+    const appended = appendLaunchToken("mangohud %command%", "~/lsfg");
+    expect(appended).toBe("mangohud ~/lsfg %command%");
+    expect(removeLaunchToken(appended, "~/lsfg")).toBe("mangohud %command%");
+  });
+
+  it("double-append is idempotent (second call no-ops)", () => {
+    const once = appendLaunchToken("%command%", "~/lsfg");
+    const twice = appendLaunchToken(once, "~/lsfg");
+    expect(twice).toBe(once);
+  });
+});

--- a/packages/vdf/src/launch-options.ts
+++ b/packages/vdf/src/launch-options.ts
@@ -1,0 +1,229 @@
+/**
+ * Launch-options string surgery.
+ *
+ * Steam's "launch options" field (per game) is a single string that the
+ * client substitutes into the actual exec string at launch time. Conventions:
+ *
+ *   - `%command%` is the placeholder for the game's own command + args.
+ *     Tokens before `%command%` are wrappers (`mangohud`, `gamemoderun`,
+ *     `~/lsfg`); tokens after `%command%` are extra args appended to the
+ *     game.
+ *   - If `%command%` is omitted, Steam appends the game args after whatever
+ *     the user wrote — so `PROTON_LOG=1` and `PROTON_LOG=1 %command%` are
+ *     equivalent. We canonicalise on the explicit form.
+ *
+ * This module exposes three pure helpers for adding / removing / detecting a
+ * single token, used by plugins that want to inject a wrapper without
+ * stomping on whatever the user (or another plugin) already configured.
+ *
+ * Used by:
+ *   - `plugins/launch-options` — exposes these as RPCs
+ *   - `plugins/lsfg-vk` — adds `~/lsfg` for frame-gen
+ *   - any future wrapper-style plugin
+ */
+
+const COMMAND_MARKER = "%command%";
+
+export interface LaunchTokenOpts {
+  /**
+   * Idempotency key. If a token whose canonical form starts with `key`
+   * (treating `key=` as an env-var prefix match) is already present, the
+   * append is a no-op. Defaults to `token` itself.
+   */
+  key?: string;
+  /**
+   * Where to insert relative to `%command%`. Default `"before"` — the
+   * common case for shell wrappers.
+   */
+  position?: "before" | "after";
+  /**
+   * If the existing string has no `%command%` marker, add one. Default
+   * `true` (canonicalises to the explicit form).
+   */
+  ensureCommand?: boolean;
+}
+
+/**
+ * Whitespace-separated tokenizer that respects single and double quotes.
+ * Quoted segments stay intact (including the quotes) so re-joining with
+ * spaces is faithful.
+ */
+function tokenize(input: string): string[] {
+  const tokens: string[] = [];
+  let buf = "";
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (quote) {
+      buf += ch;
+      if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch as '"' | "'";
+      buf += ch;
+      continue;
+    }
+
+    if (ch === " " || ch === "\t" || ch === "\n") {
+      if (buf.length > 0) {
+        tokens.push(buf);
+        buf = "";
+      }
+      continue;
+    }
+
+    buf += ch;
+  }
+
+  if (buf.length > 0) tokens.push(buf);
+  return tokens;
+}
+
+/**
+ * Strip surrounding quotes (if any) for comparison purposes. We match
+ * "wrapper" tokens regardless of how the user quoted them.
+ */
+function unquote(token: string): string {
+  if (token.length >= 2) {
+    const first = token[0];
+    const last = token[token.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return token.slice(1, -1);
+    }
+  }
+  return token;
+}
+
+/**
+ * Does any token in `tokens` match `key` — either exactly, or as the
+ * `KEY=value` env-var form where `key === "KEY"` or `key === "KEY=…"`.
+ */
+function tokenMatchesKey(tokens: string[], key: string): boolean {
+  const keyHead = key.includes("=") ? key.slice(0, key.indexOf("=") + 1) : key;
+  for (const raw of tokens) {
+    const tok = unquote(raw);
+    if (tok === key) return true;
+    // env-var match: token starts with "KEY=" and key is "KEY" (no =)
+    if (!key.includes("=") && tok.startsWith(`${key}=`)) return true;
+    // env-var match: both have = and prefixes line up exactly
+    if (key.includes("=") && tok === key) return true;
+    // supplied key is a prefix like "FOO=" and token starts with it
+    if (key.endsWith("=") && tok.startsWith(keyHead)) return true;
+  }
+  return false;
+}
+
+/**
+ * Find the index of the rightmost `%command%` marker in the token list.
+ * Returns -1 if none.
+ */
+function findCommandIndex(tokens: string[]): number {
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    if (tokens[i] === COMMAND_MARKER) return i;
+  }
+  return -1;
+}
+
+/**
+ * Append `token` to the launch-options string `existing`, respecting
+ * `%command%` position and idempotency.
+ *
+ * Pure. Returns the new string.
+ *
+ * Examples:
+ *   appendLaunchToken("",                    "~/lsfg")              → "~/lsfg %command%"
+ *   appendLaunchToken("%command%",           "~/lsfg")              → "~/lsfg %command%"
+ *   appendLaunchToken("mangohud %command%",  "~/lsfg")              → "mangohud ~/lsfg %command%"
+ *   appendLaunchToken("~/lsfg %command%",    "~/lsfg")              → "~/lsfg %command%"  (idempotent)
+ *   appendLaunchToken("PROTON_LOG=1",        "~/lsfg")              → "PROTON_LOG=1 ~/lsfg %command%"
+ *   appendLaunchToken("a %command% --foo",   "~/lsfg", { position: "after" })
+ *                                                                   → "a %command% ~/lsfg --foo"
+ */
+export function appendLaunchToken(
+  existing: string,
+  token: string,
+  opts?: LaunchTokenOpts,
+): string {
+  const key = opts?.key ?? token;
+  const position = opts?.position ?? "before";
+  const ensureCommand = opts?.ensureCommand ?? true;
+
+  const tokens = tokenize(existing);
+
+  // Idempotency — already present, no-op.
+  if (tokenMatchesKey(tokens, key)) {
+    return existing;
+  }
+
+  const cmdIdx = findCommandIndex(tokens);
+
+  if (cmdIdx === -1) {
+    if (!ensureCommand) {
+      // Append at the end without a marker.
+      tokens.push(token);
+      return tokens.join(" ");
+    }
+    // No %command% present — append `token %command%` to the right.
+    tokens.push(token, COMMAND_MARKER);
+    return tokens.join(" ");
+  }
+
+  const insertAt = position === "before" ? cmdIdx : cmdIdx + 1;
+  tokens.splice(insertAt, 0, token);
+  return tokens.join(" ");
+}
+
+/**
+ * Remove the first token matching `key` from `existing`. If the result
+ * collapses to nothing more than `%command%`, return an empty string
+ * (back to "no launch options"). Pure.
+ *
+ * Examples:
+ *   removeLaunchToken("mangohud ~/lsfg %command%", "~/lsfg")  → "mangohud %command%"
+ *   removeLaunchToken("~/lsfg %command%",          "~/lsfg")  → ""
+ *   removeLaunchToken("%command%",                 "~/lsfg")  → "%command%"  (no-op)
+ *   removeLaunchToken("PROTON_LOG=1 %command%",    "PROTON_LOG") → "%command%"
+ */
+export function removeLaunchToken(existing: string, key: string): string {
+  const tokens = tokenize(existing);
+
+  let removed = false;
+  const filtered: string[] = [];
+  const keyHead = key.includes("=") ? key.slice(0, key.indexOf("=") + 1) : key;
+
+  for (const raw of tokens) {
+    if (removed) {
+      filtered.push(raw);
+      continue;
+    }
+    const tok = unquote(raw);
+    const isMatch =
+      tok === key ||
+      (!key.includes("=") && tok.startsWith(`${key}=`)) ||
+      (key.endsWith("=") && tok.startsWith(keyHead));
+    if (isMatch) {
+      removed = true;
+      continue;
+    }
+    filtered.push(raw);
+  }
+
+  if (!removed) return existing;
+
+  // Collapse to "" if all that's left is %command%.
+  if (filtered.length === 1 && filtered[0] === COMMAND_MARKER) return "";
+  if (filtered.length === 0) return "";
+
+  return filtered.join(" ");
+}
+
+/**
+ * True if a token matching `key` is present in `existing`. Pure.
+ */
+export function hasLaunchToken(existing: string, key: string): boolean {
+  return tokenMatchesKey(tokenize(existing), key);
+}

--- a/packages/vdf/src/vdf.test.ts
+++ b/packages/vdf/src/vdf.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect } from "bun:test";
+
+// Dynamically load the VDF implementation to bypass Bun's mock.module
+// contamination. Other test files (launch-options/backend.spec.ts) call
+// mock.module("@loadout/vdf", ...) which globally replaces all imports
+// that resolve to files within this package — including relative imports.
+// Loading via an absolute-path dynamic import with a cache-busting query
+// string gives us a fresh, unmocked module instance.
+const _path = import.meta.dir + "/vdf.ts";
+const { parseVdf, serializeVdf, patchVdfValue, removeVdfKey } = await import(
+  _path + "?real"
+);
+
+const SAMPLE_VDF = `"UserLocalConfigStore"
+{
+\t"Software"
+\t{
+\t\t"Valve"
+\t\t{
+\t\t\t"Steam"
+\t\t\t{
+\t\t\t\t"apps"
+\t\t\t\t{
+\t\t\t\t\t"123456"
+\t\t\t\t\t{
+\t\t\t\t\t\t"LaunchOptions"\t\t"gamemoderun %command%"
+\t\t\t\t\t\t"LastPlayed"\t\t"1617000000"
+\t\t\t\t\t}
+\t\t\t\t\t"789012"
+\t\t\t\t\t{
+\t\t\t\t\t\t"LaunchOptions"\t\t"mangohud %command%"
+\t\t\t\t\t}
+\t\t\t\t}
+\t\t\t}
+\t\t}
+\t}
+}`;
+
+// ---------------------------------------------------------------------------
+// parseVdf
+// ---------------------------------------------------------------------------
+
+describe("parseVdf", () => {
+  it("parses simple key-value pairs", () => {
+    const input = `"root"\n{\n\t"key1"\t\t"value1"\n\t"key2"\t\t"value2"\n}`;
+    const result = parseVdf(input);
+    expect(result.root.key1).toBe("value1");
+    expect(result.root.key2).toBe("value2");
+  });
+
+  it("parses nested sections", () => {
+    const input = `"outer"\n{\n\t"inner"\n\t{\n\t\t"key"\t\t"val"\n\t}\n}`;
+    const result = parseVdf(input);
+    expect(result.outer.inner.key).toBe("val");
+  });
+
+  it("parses deeply nested structures (3+ levels)", () => {
+    const result = parseVdf(SAMPLE_VDF);
+    expect(
+      result.UserLocalConfigStore.Software.Valve.Steam.apps["123456"]
+        .LaunchOptions,
+    ).toBe("gamemoderun %command%");
+    expect(
+      result.UserLocalConfigStore.Software.Valve.Steam.apps["123456"]
+        .LastPlayed,
+    ).toBe("1617000000");
+    expect(
+      result.UserLocalConfigStore.Software.Valve.Steam.apps["789012"]
+        .LaunchOptions,
+    ).toBe("mangohud %command%");
+  });
+
+  it("skips comments", () => {
+    const input = `// This is a comment\n"root"\n{\n\t// Another comment\n\t"key"\t\t"value"\n}`;
+    const result = parseVdf(input);
+    expect(result.root.key).toBe("value");
+  });
+
+  it("skips empty lines", () => {
+    const input = `\n\n"root"\n{\n\n\t"key"\t\t"value"\n\n}\n\n`;
+    const result = parseVdf(input);
+    expect(result.root.key).toBe("value");
+  });
+
+  it("handles empty input", () => {
+    const result = parseVdf("");
+    expect(result).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeVdf
+// ---------------------------------------------------------------------------
+
+describe("serializeVdf", () => {
+  it("serializes a flat object", () => {
+    const obj = { root: { key1: "value1", key2: "value2" } };
+    const out = serializeVdf(obj);
+    expect(out).toContain('"root"');
+    expect(out).toContain('"key1"\t\t"value1"');
+    expect(out).toContain('"key2"\t\t"value2"');
+  });
+
+  it("serializes a nested object", () => {
+    const obj = { outer: { inner: { key: "val" } } };
+    const out = serializeVdf(obj);
+    expect(out).toContain('"outer"');
+    expect(out).toContain('"inner"');
+    expect(out).toContain('"key"\t\t"val"');
+  });
+
+  it("round-trips: parseVdf(serializeVdf(obj)) produces equivalent structure", () => {
+    const original = {
+      UserLocalConfigStore: {
+        Software: {
+          Valve: {
+            Steam: {
+              apps: {
+                "123456": {
+                  LaunchOptions: "gamemoderun %command%",
+                  LastPlayed: "1617000000",
+                },
+                "789012": {
+                  LaunchOptions: "mangohud %command%",
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const serialized = serializeVdf(original);
+    const reparsed = parseVdf(serialized);
+    expect(reparsed).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchVdfValue
+// ---------------------------------------------------------------------------
+
+describe("patchVdfValue", () => {
+  it("patches an existing value, preserving all other content", () => {
+    const patched = patchVdfValue(
+      SAMPLE_VDF,
+      [
+        "UserLocalConfigStore",
+        "Software",
+        "Valve",
+        "Steam",
+        "apps",
+        "123456",
+        "LaunchOptions",
+      ],
+      "mangohud %command%",
+    );
+
+    // The target value should be changed.
+    expect(patched).toContain('"LaunchOptions"\t\t"mangohud %command%"');
+    // The old value should be gone at the 123456 location.
+    expect(patched).not.toContain('"LaunchOptions"\t\t"gamemoderun %command%"');
+    // Other keys at the same level should be untouched.
+    expect(patched).toContain('"LastPlayed"\t\t"1617000000"');
+    // The other app's launch options should be untouched.
+    const parsed = parseVdf(patched);
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["789012"]
+        .LaunchOptions,
+    ).toBe("mangohud %command%");
+  });
+
+  it("patches a value in a deeply nested section", () => {
+    const patched = patchVdfValue(
+      SAMPLE_VDF,
+      [
+        "UserLocalConfigStore",
+        "Software",
+        "Valve",
+        "Steam",
+        "apps",
+        "123456",
+        "LastPlayed",
+      ],
+      "9999999999",
+    );
+
+    const parsed = parseVdf(patched);
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["123456"]
+        .LastPlayed,
+    ).toBe("9999999999");
+    // LaunchOptions should be untouched
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["123456"]
+        .LaunchOptions,
+    ).toBe("gamemoderun %command%");
+  });
+
+  it("inserts a new key when it doesn't exist", () => {
+    const patched = patchVdfValue(
+      SAMPLE_VDF,
+      [
+        "UserLocalConfigStore",
+        "Software",
+        "Valve",
+        "Steam",
+        "apps",
+        "123456",
+        "CloudEnabled",
+      ],
+      "1",
+    );
+
+    const parsed = parseVdf(patched);
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["123456"]
+        .CloudEnabled,
+    ).toBe("1");
+    // Existing keys should be untouched.
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["123456"]
+        .LaunchOptions,
+    ).toBe("gamemoderun %command%");
+  });
+
+  it("preserves comments before and after the patched line", () => {
+    const vdfWithComments = `"root"
+{
+\t// Comment above
+\t"key1"\t\t"old_value"
+\t// Comment below
+\t"key2"\t\t"keep_me"
+}`;
+
+    const patched = patchVdfValue(vdfWithComments, ["root", "key1"], "new_value");
+    expect(patched).toContain("// Comment above");
+    expect(patched).toContain("// Comment below");
+    expect(patched).toContain('"key1"\t\t"new_value"');
+    expect(patched).toContain('"key2"\t\t"keep_me"');
+  });
+
+  it("leaves other keys at the same level untouched", () => {
+    const patched = patchVdfValue(
+      SAMPLE_VDF,
+      [
+        "UserLocalConfigStore",
+        "Software",
+        "Valve",
+        "Steam",
+        "apps",
+        "789012",
+        "LaunchOptions",
+      ],
+      "PROTON_USE_WINED3D=1 %command%",
+    );
+
+    const parsed = parseVdf(patched);
+    // Patched app
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["789012"]
+        .LaunchOptions,
+    ).toBe("PROTON_USE_WINED3D=1 %command%");
+    // Other app untouched
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["123456"]
+        .LaunchOptions,
+    ).toBe("gamemoderun %command%");
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["123456"]
+        .LastPlayed,
+    ).toBe("1617000000");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeVdfKey
+// ---------------------------------------------------------------------------
+
+describe("removeVdfKey", () => {
+  it("removes an existing key-value pair", () => {
+    const result = removeVdfKey(SAMPLE_VDF, [
+      "UserLocalConfigStore",
+      "Software",
+      "Valve",
+      "Steam",
+      "apps",
+      "123456",
+      "LastPlayed",
+    ]);
+
+    const parsed = parseVdf(result);
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["123456"]
+        .LaunchOptions,
+    ).toBe("gamemoderun %command%");
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["123456"]
+        .LastPlayed,
+    ).toBeUndefined();
+  });
+
+  it("removes an existing section", () => {
+    const result = removeVdfKey(SAMPLE_VDF, [
+      "UserLocalConfigStore",
+      "Software",
+      "Valve",
+      "Steam",
+      "apps",
+      "789012",
+    ]);
+
+    const parsed = parseVdf(result);
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["789012"],
+    ).toBeUndefined();
+    // Other app should still exist.
+    expect(
+      parsed.UserLocalConfigStore.Software.Valve.Steam.apps["123456"]
+        .LaunchOptions,
+    ).toBe("gamemoderun %command%");
+  });
+
+  it("is a no-op when key doesn't exist", () => {
+    const result = removeVdfKey(SAMPLE_VDF, [
+      "UserLocalConfigStore",
+      "Software",
+      "Valve",
+      "Steam",
+      "apps",
+      "123456",
+      "NonExistentKey",
+    ]);
+
+    // Content should be unchanged.
+    expect(result).toBe(SAMPLE_VDF);
+  });
+});

--- a/packages/vdf/src/vdf.ts
+++ b/packages/vdf/src/vdf.ts
@@ -1,0 +1,347 @@
+/**
+ * @loadout/vdf — Valve Data Format parsing, serialization, and surgical editing.
+ *
+ * VDF is used by Steam config files (localconfig.vdf, libraryfolders.vdf, appmanifest_*.acf).
+ */
+
+/**
+ * Recursive VDF node — every leaf is a string, every interior node is a
+ * `{ [key: string]: VdfNode }` map. VDF has no native number/bool/array
+ * types; everything serializes as quoted strings on disk. Callers that
+ * need stronger typing of a specific known subtree should narrow on
+ * read via `as` at the boundary.
+ */
+export type VdfNode = string | { [key: string]: VdfNode };
+
+/** Convenience alias for the object branch — the parser always returns one of these. */
+export type VdfObject = { [key: string]: VdfNode };
+
+// ---------------------------------------------------------------------------
+// parseVdf
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse VDF text into a nested JS object.
+ * Handles quoted keys/values, nested braces, and // comments.
+ */
+export function parseVdf(content: string): VdfObject {
+  const lines = content.split("\n");
+  const root: VdfObject = {};
+  const stack: VdfObject[] = [root];
+  let pendingKey: string | null = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    // Skip empty lines and comments
+    if (!line || line.startsWith("//")) continue;
+
+    // Opening brace — push a new object onto the stack under pendingKey
+    if (line === "{") {
+      const obj: VdfObject = {};
+      const parent = stack[stack.length - 1];
+      if (pendingKey !== null) {
+        parent[pendingKey] = obj;
+        pendingKey = null;
+      }
+      stack.push(obj);
+      continue;
+    }
+
+    // Closing brace — pop the stack
+    if (line === "}") {
+      stack.pop();
+      continue;
+    }
+
+    // Try to match "key" "value" on the same line (tab or space separated)
+    const kvMatch = line.match(/^"([^"]*)"[\t\s]+"([^"]*)"$/);
+    if (kvMatch) {
+      const parent = stack[stack.length - 1];
+      parent[kvMatch[1]] = kvMatch[2];
+      continue;
+    }
+
+    // Otherwise it should be a standalone "key" (section header)
+    const keyMatch = line.match(/^"([^"]*)"$/);
+    if (keyMatch) {
+      pendingKey = keyMatch[1];
+      continue;
+    }
+  }
+
+  return root;
+}
+
+// ---------------------------------------------------------------------------
+// serializeVdf
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a nested JS object back to VDF format with proper indentation.
+ */
+export function serializeVdf(obj: VdfObject, indent: number = 0): string {
+  const tab = "\t".repeat(indent);
+  let out = "";
+
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+
+    if (typeof value === "object" && value !== null) {
+      out += `${tab}"${key}"\n`;
+      out += `${tab}{\n`;
+      out += serializeVdf(value, indent + 1);
+      out += `${tab}}\n`;
+    } else {
+      out += `${tab}"${key}"\t\t"${String(value)}"\n`;
+    }
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// patchVdfValue
+// ---------------------------------------------------------------------------
+
+/**
+ * Surgical text-level edit: navigate to a key via keyPath and replace ONLY its
+ * value, preserving all other formatting, comments, whitespace, and key ordering.
+ *
+ * If the final key doesn't exist at the target location, it is inserted.
+ *
+ * @param content  Raw VDF text
+ * @param keyPath  Array of nested keys, e.g. ["UserLocalConfigStore", "Software", "Valve", "Steam", "apps", "123456", "LaunchOptions"]
+ * @param newValue The new value string to set
+ * @returns Modified VDF text
+ */
+export function patchVdfValue(
+  content: string,
+  keyPath: string[],
+  newValue: string,
+): string {
+  if (keyPath.length === 0) return content;
+
+  const lines = content.split("\n");
+  const sectionPath = keyPath.slice(0, -1); // sections to navigate into
+  const targetKey = keyPath[keyPath.length - 1]; // leaf key to patch
+
+  // Track which depth of sectionPath we've matched so far.
+  // depth 0 = looking for sectionPath[0], etc.
+  let matchDepth = 0;
+  // The actual brace-nesting level inside the VDF text.
+  let braceDepth = 0;
+  // The brace depth at which we expect to see the section header for matchDepth.
+  let expectedBraceDepth = 0;
+  // Whether the previous meaningful line was the section header we're looking for.
+  let pendingSectionMatch = false;
+  // Whether we've fully navigated into the target section.
+  let insideTarget = false;
+  // The brace depth of the target section (so we know when we leave it).
+  let targetBraceDepth = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (!trimmed || trimmed.startsWith("//")) continue;
+
+    if (trimmed === "{") {
+      braceDepth++;
+      if (pendingSectionMatch) {
+        pendingSectionMatch = false;
+        if (matchDepth >= sectionPath.length) {
+          // We've navigated through all section keys; we're now inside the target section.
+          insideTarget = true;
+          targetBraceDepth = braceDepth;
+        } else {
+          expectedBraceDepth = braceDepth;
+        }
+      }
+      continue;
+    }
+
+    if (trimmed === "}") {
+      if (insideTarget && braceDepth === targetBraceDepth) {
+        // We're closing the target section without finding the key — insert it.
+        const indent = "\t".repeat(braceDepth);
+        const insertLine = `${indent}"${targetKey}"\t\t"${newValue}"`;
+        lines.splice(i, 0, insertLine);
+        return lines.join("\n");
+      }
+      braceDepth--;
+      // If we drop below the level where we matched a section, reset.
+      if (matchDepth > 0 && braceDepth < expectedBraceDepth) {
+        // We left a section we were tracking — this shouldn't happen in a valid
+        // path, but be defensive.
+        matchDepth--;
+        expectedBraceDepth--;
+        insideTarget = false;
+      }
+      continue;
+    }
+
+    // If we're inside the target section, look for the leaf key.
+    if (insideTarget && braceDepth === targetBraceDepth) {
+      const kvMatch = trimmed.match(/^"([^"]*)"([\t\s]+)"([^"]*)"$/);
+      if (kvMatch && kvMatch[1] === targetKey) {
+        // Replace just the value portion in the original (non-trimmed) line.
+        const original = lines[i];
+        // Find the last quoted value in the line and replace it.
+        const lastQuotePair = original.lastIndexOf(`"${kvMatch[3]}"`);
+        if (lastQuotePair !== -1) {
+          lines[i] =
+            original.substring(0, lastQuotePair) +
+            `"${newValue}"` +
+            original.substring(lastQuotePair + kvMatch[3].length + 2);
+          return lines.join("\n");
+        }
+      }
+
+      // Also check if targetKey is a section header at this level (standalone key).
+      const secMatch = trimmed.match(/^"([^"]*)"$/);
+      if (secMatch && secMatch[1] === targetKey) {
+        // The "leaf" is actually a section — this shouldn't normally happen
+        // for patchVdfValue (which patches scalar values), so skip.
+      }
+
+      continue;
+    }
+
+    // Not yet inside target — try to match the next section in sectionPath.
+    if (!insideTarget && matchDepth < sectionPath.length) {
+      const secMatch = trimmed.match(/^"([^"]*)"$/);
+      if (
+        secMatch &&
+        secMatch[1] === sectionPath[matchDepth] &&
+        braceDepth === expectedBraceDepth
+      ) {
+        matchDepth++;
+        pendingSectionMatch = true;
+      }
+    }
+  }
+
+  // If we get here and never found the target section at all, the keyPath doesn't
+  // match the document structure. Return content unchanged.
+  return content;
+}
+
+// ---------------------------------------------------------------------------
+// removeVdfKey
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove a specific key (and its value or sub-section) from VDF text,
+ * preserving all other content.
+ *
+ * @param content  Raw VDF text
+ * @param keyPath  Array of nested keys leading to the key to remove
+ * @returns Modified VDF text
+ */
+export function removeVdfKey(content: string, keyPath: string[]): string {
+  if (keyPath.length === 0) return content;
+
+  const lines = content.split("\n");
+  const sectionPath = keyPath.slice(0, -1);
+  const targetKey = keyPath[keyPath.length - 1];
+
+  let matchDepth = 0;
+  let braceDepth = 0;
+  let expectedBraceDepth = 0;
+  let pendingSectionMatch = false;
+  let insideTarget = false;
+  let targetBraceDepth = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (!trimmed || trimmed.startsWith("//")) continue;
+
+    if (trimmed === "{") {
+      braceDepth++;
+      if (pendingSectionMatch) {
+        pendingSectionMatch = false;
+        if (matchDepth >= sectionPath.length) {
+          insideTarget = true;
+          targetBraceDepth = braceDepth;
+        } else {
+          expectedBraceDepth = braceDepth;
+        }
+      }
+      continue;
+    }
+
+    if (trimmed === "}") {
+      if (insideTarget && braceDepth === targetBraceDepth) {
+        // Leaving target section without finding key — nothing to remove.
+        return content;
+      }
+      braceDepth--;
+      if (matchDepth > 0 && braceDepth < expectedBraceDepth) {
+        matchDepth--;
+        expectedBraceDepth--;
+        insideTarget = false;
+      }
+      continue;
+    }
+
+    if (insideTarget && braceDepth === targetBraceDepth) {
+      // Check for key-value pair
+      const kvMatch = trimmed.match(/^"([^"]*)"[\t\s]+"([^"]*)"$/);
+      if (kvMatch && kvMatch[1] === targetKey) {
+        lines.splice(i, 1);
+        return lines.join("\n");
+      }
+
+      // Check for section header
+      const secMatch = trimmed.match(/^"([^"]*)"$/);
+      if (secMatch && secMatch[1] === targetKey) {
+        // Remove the section header, its opening brace, all content, and closing brace.
+        const removeStart = i;
+        let j = i + 1;
+        // Find the opening brace.
+        while (j < lines.length) {
+          const t = lines[j].trim();
+          if (!t || t.startsWith("//")) {
+            j++;
+            continue;
+          }
+          if (t === "{") break;
+          break; // unexpected — bail
+        }
+        if (j < lines.length && lines[j].trim() === "{") {
+          // Find the matching closing brace.
+          let depth = 1;
+          let k = j + 1;
+          while (k < lines.length && depth > 0) {
+            const t = lines[k].trim();
+            if (t === "{") depth++;
+            else if (t === "}") depth--;
+            k++;
+          }
+          // Remove lines[removeStart..k-1]
+          lines.splice(removeStart, k - removeStart);
+          return lines.join("\n");
+        }
+        // If we couldn't find the brace, just remove the header line.
+        lines.splice(i, 1);
+        return lines.join("\n");
+      }
+
+      continue;
+    }
+
+    // Navigate sections
+    if (!insideTarget && matchDepth < sectionPath.length) {
+      const secMatch = trimmed.match(/^"([^"]*)"$/);
+      if (
+        secMatch &&
+        secMatch[1] === sectionPath[matchDepth] &&
+        braceDepth === expectedBraceDepth
+      ) {
+        matchDepth++;
+        pendingSectionMatch = true;
+      }
+    }
+  }
+
+  return content;
+}

--- a/scripts/prepare-plugins.sh
+++ b/scripts/prepare-plugins.sh
@@ -75,7 +75,7 @@ mkdir -p "$NM_DST/@loadout"
 # Workspace packages used by plugins. Add new packages here when a
 # plugin starts importing them (e.g. plugin-storage for tdp-control /
 # fan-control / playtime).
-for pkg in types exec steam-paths ui plugin-storage; do
+for pkg in types exec steam-paths ui plugin-storage vdf; do
     if [ -d "$PROJECT_ROOT/packages/$pkg" ]; then
         cp -r "$PROJECT_ROOT/packages/$pkg" "$NM_DST/@loadout/$pkg"
     fi


### PR DESCRIPTION
## Summary

Extracts the Steam VDF parser to a shared package. Audited consumer count: **7 source plugins** (game-browser, hltb, launch-options, quick-links, recomp, steamgriddb, store-bridge) — extracting before any of those migrate avoids 7 inline copies.

## Scope
- 4 source files (vdf, binary-vdf, launch-options, index barrel) + 3 test files.
- Test files renamed `.spec.ts` → `.test.ts` to match loadout's `test:backend` filename pattern.
- `@steam-loader/` → `@loadout/` scope rename. No logic changes.
- 58 tests pass via `bun test --isolate`.

## Test plan
- [x] `bun run typecheck` clean.
- [x] `bun run lint` 0 errors, 35 warnings (unchanged baseline).
- [x] `bun test --isolate` in packages/vdf — 58 pass.

## Follow-up
- Migrate the 7 consumer plugins to use `@loadout/vdf` as they're ported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)