### PR TITLE
feat(external-cache): extract @loadout/external-cache from steam-loader

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,10 @@
       "name": "@loadout/exec",
       "version": "0.0.1",
     },
+    "packages/external-cache": {
+      "name": "@loadout/external-cache",
+      "version": "0.0.1",
+    },
     "packages/plugin-storage": {
       "name": "@loadout/plugin-storage",
       "version": "0.0.1",
@@ -294,6 +298,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@loadout/exec": ["@loadout/exec@workspace:packages/exec"],
+
+    "@loadout/external-cache": ["@loadout/external-cache@workspace:packages/external-cache"],
 
     "@loadout/loadout-overlay": ["@loadout/loadout-overlay@workspace:apps/loadout-overlay"],
 

--- a/packages/external-cache/package.json
+++ b/packages/external-cache/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@loadout/external-cache",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/external-cache/src/index.test.ts
+++ b/packages/external-cache/src/index.test.ts
@@ -1,0 +1,290 @@
+// Backend specs for @loadout/external-cache. Real disk I/O against
+// a per-test temp dir set via XDG_CACHE_HOME — same pattern
+// plugin-storage uses (see ./packages/plugin-storage/src/index.spec.ts)
+// to avoid the `mock.module("fs/promises", …)` cross-file leakage that
+// bit several other backend specs.
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+} from "fs";
+import { tmpdir, homedir } from "os";
+import { join } from "path";
+
+import {
+  cacheDir,
+  pluginCacheDir,
+  createExternalCache,
+  clearPluginCacheDir,
+} from "./index";
+
+let tempDir: string;
+let prevXdg: string | undefined;
+
+beforeEach(() => {
+  prevXdg = process.env.XDG_CACHE_HOME;
+  tempDir = mkdtempSync(join(tmpdir(), "external-cache-spec-"));
+  process.env.XDG_CACHE_HOME = tempDir;
+});
+
+afterEach(() => {
+  if (prevXdg === undefined) {
+    delete process.env.XDG_CACHE_HOME;
+  } else {
+    process.env.XDG_CACHE_HOME = prevXdg;
+  }
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("cacheDir / pluginCacheDir", () => {
+  it("honors XDG_CACHE_HOME when set", () => {
+    expect(cacheDir()).toBe(join(tempDir, "steam-loader"));
+    expect(pluginCacheDir("my-plugin")).toBe(
+      join(tempDir, "steam-loader", "my-plugin"),
+    );
+  });
+
+  it("falls back to ~/.cache when XDG_CACHE_HOME is unset or empty", () => {
+    delete process.env.XDG_CACHE_HOME;
+    expect(cacheDir()).toBe(join(homedir(), ".cache", "steam-loader"));
+
+    process.env.XDG_CACHE_HOME = "";
+    expect(cacheDir()).toBe(join(homedir(), ".cache", "steam-loader"));
+  });
+});
+
+describe("createExternalCache", () => {
+  it("rejects an empty pluginId", () => {
+    expect(() => createExternalCache("")).toThrow();
+  });
+
+  it("returns undefined for a missing key", async () => {
+    const cache = createExternalCache("p1");
+    expect(await cache.get("never-set")).toBeUndefined();
+  });
+});
+
+describe("getOrFetch", () => {
+  it("calls the fetcher on cache miss and caches the result", async () => {
+    const cache = createExternalCache("p1");
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      return { hello: "world" };
+    };
+
+    const first = await cache.getOrFetch("k", fetcher, { ttlSec: 60 });
+    expect(first).toEqual({ hello: "world" });
+    expect(calls).toBe(1);
+
+    // Second call within TTL — fetcher should NOT run again.
+    const second = await cache.getOrFetch("k", fetcher, { ttlSec: 60 });
+    expect(second).toEqual({ hello: "world" });
+    expect(calls).toBe(1);
+  });
+
+  it("caches null results too (negative-result caching)", async () => {
+    const cache = createExternalCache("p1");
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      return null;
+    };
+    const first = await cache.getOrFetch<null>("k", fetcher, { ttlSec: 60 });
+    expect(first).toBeNull();
+    const second = await cache.getOrFetch<null>("k", fetcher, { ttlSec: 60 });
+    expect(second).toBeNull();
+    expect(calls).toBe(1);
+  });
+
+  it("re-fetches after the entry expires", async () => {
+    const cache = createExternalCache("p1");
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      return calls;
+    };
+
+    // ttlSec: 0 means the entry is expired the moment after we write
+    // it (Date.now() === expiresAt is treated as expired).
+    const first = await cache.getOrFetch<number>("k", fetcher, { ttlSec: 0 });
+    expect(first).toBe(1);
+
+    // Sleep one millisecond so Date.now advances past expiresAt.
+    await new Promise((r) => setTimeout(r, 5));
+
+    const second = await cache.getOrFetch<number>("k", fetcher, { ttlSec: 0 });
+    expect(second).toBe(2);
+    expect(calls).toBe(2);
+  });
+
+  it("propagates fetcher errors and does not write a cache entry", async () => {
+    const cache = createExternalCache("p1");
+    const fetcher = async () => {
+      throw new Error("upstream is down");
+    };
+
+    await expect(
+      cache.getOrFetch("k", fetcher, { ttlSec: 60 }),
+    ).rejects.toThrow("upstream is down");
+
+    // After the failure, the cache should still be empty — i.e. the
+    // next call hits the fetcher again instead of returning a cached
+    // failure.
+    let okCalls = 0;
+    const okFetcher = async () => {
+      okCalls++;
+      return "ok";
+    };
+    const v = await cache.getOrFetch("k", okFetcher, { ttlSec: 60 });
+    expect(v).toBe("ok");
+    expect(okCalls).toBe(1);
+  });
+});
+
+describe("set / get / delete", () => {
+  it("round-trips via set + get", async () => {
+    const cache = createExternalCache("p1");
+    await cache.set("k", { count: 7 }, { ttlSec: 60 });
+    expect(await cache.get<{ count: number }>("k")).toEqual({ count: 7 });
+  });
+
+  it("get returns undefined once the entry has expired", async () => {
+    const cache = createExternalCache("p1");
+    await cache.set("k", { count: 7 }, { ttlSec: 0 });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(await cache.get("k")).toBeUndefined();
+  });
+
+  it("delete removes a single entry without touching others", async () => {
+    const cache = createExternalCache("p1");
+    await cache.set("a", 1, { ttlSec: 60 });
+    await cache.set("b", 2, { ttlSec: 60 });
+    await cache.delete("a");
+    expect(await cache.get("a")).toBeUndefined();
+    expect(await cache.get<number>("b")).toBe(2);
+  });
+
+  it("delete is a no-op when the entry doesn't exist", async () => {
+    const cache = createExternalCache("p1");
+    // Should not throw.
+    await cache.delete("never-existed");
+  });
+});
+
+describe("clear", () => {
+  it("removes the entire plugin cache directory", async () => {
+    const cache = createExternalCache("p1");
+    await cache.set("a", 1, { ttlSec: 60 });
+    await cache.set("b", 2, { ttlSec: 60 });
+    expect(existsSync(cache.dir)).toBe(true);
+
+    await cache.clear();
+    expect(existsSync(cache.dir)).toBe(false);
+
+    // Subsequent reads behave like a fresh cache.
+    expect(await cache.get("a")).toBeUndefined();
+  });
+
+  it("is a no-op on a never-warmed cache", async () => {
+    const cache = createExternalCache("never-warmed");
+    expect(existsSync(cache.dir)).toBe(false);
+    // Should not throw.
+    await cache.clear();
+  });
+
+  it("isolates plugins from each other", async () => {
+    const a = createExternalCache("plugin-a");
+    const b = createExternalCache("plugin-b");
+    await a.set("k", "from-a", { ttlSec: 60 });
+    await b.set("k", "from-b", { ttlSec: 60 });
+
+    await a.clear();
+
+    expect(await a.get("k")).toBeUndefined();
+    expect(await b.get<string>("k")).toBe("from-b");
+  });
+});
+
+describe("clearExpired", () => {
+  it("removes only entries whose TTL has lapsed", async () => {
+    const cache = createExternalCache("p1");
+    await cache.set("fresh", "still here", { ttlSec: 60 });
+    await cache.set("stale", "should die", { ttlSec: 0 });
+    await new Promise((r) => setTimeout(r, 5));
+
+    const removed = await cache.clearExpired();
+    expect(removed).toBe(1);
+
+    expect(await cache.get<string>("fresh")).toBe("still here");
+    expect(await cache.get("stale")).toBeUndefined();
+  });
+
+  it("returns 0 when the directory doesn't exist", async () => {
+    const cache = createExternalCache("never-warmed");
+    expect(await cache.clearExpired()).toBe(0);
+  });
+
+  it("removes corrupt files too", async () => {
+    const cache = createExternalCache("p1");
+    await cache.set("good", { ok: true }, { ttlSec: 60 });
+
+    // Write a garbage file alongside the good one.
+    const garbagePath = join(cache.dir, "garbage.json");
+    Bun.write(garbagePath, "{not valid json");
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Sanity: file should be there before we sweep.
+    expect(readdirSync(cache.dir)).toContain("garbage.json");
+
+    const removed = await cache.clearExpired();
+    expect(removed).toBeGreaterThanOrEqual(1);
+    expect(readdirSync(cache.dir)).not.toContain("garbage.json");
+    expect(await cache.get<{ ok: boolean }>("good")).toEqual({ ok: true });
+  });
+});
+
+describe("clearPluginCacheDir helper", () => {
+  it("removes a plugin's whole cache dir without an instance", async () => {
+    const cache = createExternalCache("p1");
+    await cache.set("k", 1, { ttlSec: 60 });
+    expect(existsSync(cache.dir)).toBe(true);
+    await clearPluginCacheDir("p1");
+    expect(existsSync(cache.dir)).toBe(false);
+  });
+
+  it("is a no-op for a plugin that never wrote anything", async () => {
+    // Should not throw.
+    await clearPluginCacheDir("nope");
+  });
+});
+
+describe("on-disk format", () => {
+  it("writes an entry with expiresAt + value as JSON", async () => {
+    const cache = createExternalCache("p1");
+    const before = Date.now();
+    await cache.set("k", { v: 1 }, { ttlSec: 60 });
+    const after = Date.now();
+
+    const files = readdirSync(cache.dir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^[0-9a-f]{40}\.json$/);
+
+    const raw = readFileSync(join(cache.dir, files[0]), "utf8");
+    const parsed = JSON.parse(raw);
+    expect(parsed.value).toEqual({ v: 1 });
+    expect(parsed.expiresAt).toBeGreaterThanOrEqual(before + 60_000);
+    expect(parsed.expiresAt).toBeLessThanOrEqual(after + 60_000 + 5);
+  });
+
+  it("writes are atomic — no .tmp sidecar after a successful set", async () => {
+    const cache = createExternalCache("p1");
+    await cache.set("k", { v: 1 }, { ttlSec: 60 });
+    const files = readdirSync(cache.dir);
+    expect(files.every((f) => !f.endsWith(".tmp"))).toBe(true);
+  });
+});

--- a/packages/external-cache/src/index.test.ts
+++ b/packages/external-cache/src/index.test.ts
@@ -42,18 +42,18 @@ afterEach(() => {
 
 describe("cacheDir / pluginCacheDir", () => {
   it("honors XDG_CACHE_HOME when set", () => {
-    expect(cacheDir()).toBe(join(tempDir, "steam-loader"));
+    expect(cacheDir()).toBe(join(tempDir, "loadout"));
     expect(pluginCacheDir("my-plugin")).toBe(
-      join(tempDir, "steam-loader", "my-plugin"),
+      join(tempDir, "loadout", "my-plugin"),
     );
   });
 
   it("falls back to ~/.cache when XDG_CACHE_HOME is unset or empty", () => {
     delete process.env.XDG_CACHE_HOME;
-    expect(cacheDir()).toBe(join(homedir(), ".cache", "steam-loader"));
+    expect(cacheDir()).toBe(join(homedir(), ".cache", "loadout"));
 
     process.env.XDG_CACHE_HOME = "";
-    expect(cacheDir()).toBe(join(homedir(), ".cache", "steam-loader"));
+    expect(cacheDir()).toBe(join(homedir(), ".cache", "loadout"));
   });
 });
 

--- a/packages/external-cache/src/index.ts
+++ b/packages/external-cache/src/index.ts
@@ -1,0 +1,299 @@
+/**
+ * Per-plugin disk cache for external API responses.
+ *
+ *   $XDG_CACHE_HOME/steam-loader/<plugin-id>/<sha1(key)>.json
+ *   (typically ~/.cache/steam-loader/<plugin-id>/<sha1(key)>.json)
+ *
+ * Plugins that fetch data from external sources (ProtonDB,
+ * HowLongToBeat, SteamGridDB, …) wrap their fetch sites in
+ * `cache.getOrFetch(key, fetcher, { ttlSec })`. The cache is
+ * per-plugin so uninstalling a plugin (rm -rf its data dir) takes
+ * the cache with it.
+ *
+ * **Why not tanstack-query**: TQ is a React-side request-state
+ * manager that lives in the browser tab; it has no notion of
+ * disk persistence and disappears on every tab reload. Our plugins
+ * fetch from a Bun backend process and stash data so the next
+ * session doesn't pay another network round-trip. JSON-on-disk
+ * keyed by URL is what we actually need.
+ *
+ * **Why XDG_CACHE_HOME and not XDG_CONFIG_HOME**: this is
+ * regenerable data, not user state. `~/.cache/` is exactly the
+ * dir XDG carves out for "things the app can re-fetch on demand"
+ * — fits the freedesktop spec, plays nicely with cleanup tools
+ * like `bleachbit`, and lets `plugin-storage` (config) and
+ * `external-cache` (cache) coexist on disk without one shadowing
+ * the other.
+ *
+ * **Per-entry TTL**: each cache file carries its own `expiresAt`
+ * timestamp. Read paths skip expired entries (treated as cache
+ * miss) and `clearExpired()` sweeps them off disk. The ttlSec
+ * argument to `getOrFetch` is per-call — different endpoints in
+ * the same plugin can use different freshness windows.
+ *
+ * Writes are atomic: `<file>.tmp` is renamed onto the final path,
+ * so a crash mid-write can't leave a torn file. Reads return
+ * `undefined` (cache miss) when the file is missing, unparseable,
+ * or expired — the caller treats all three the same way and
+ * re-fetches.
+ *
+ * Typing pattern:
+ *
+ *   const cache = createExternalCache("protondb-badges");
+ *   const report = await cache.getOrFetch<ProtonDBReport>(
+ *     `report:${appId}`,
+ *     () => fetch(url).then((r) => r.json()),
+ *     { ttlSec: 60 * 60 },
+ *   );
+ *
+ * Cache keys are arbitrary strings. They're SHA-1-hashed before
+ * hitting disk so URLs, query strings, and unicode names all map
+ * to the same fixed-width filename shape.
+ */
+
+// `fs/promises` (no node: prefix) matches the specifier plugin-storage
+// uses so tests can mock both packages with one `mock.module(...)`.
+import { readFile, mkdir, rename, rm, readdir, unlink } from "fs/promises";
+import { createHash } from "crypto";
+import { join, dirname } from "path";
+import { homedir } from "os";
+
+/** Public cache surface — what plugins import. */
+export interface ExternalCache {
+  /** Plugin id this cache is scoped to. */
+  readonly pluginId: string;
+  /** Absolute path of the plugin's cache directory. Resolved lazily
+   *  per call from `XDG_CACHE_HOME`, so a test that flips the env
+   *  var between runs sees the change without rebuilding the cache
+   *  instance — same convention `plugin-storage` follows for
+   *  `XDG_CONFIG_HOME`. */
+  readonly dir: string;
+  /**
+   * Cache-aside fetch. If a fresh entry exists for `key`, return it.
+   * Otherwise call `fetcher`, write the result with the given TTL,
+   * and return it. `null` and `undefined` results from `fetcher` are
+   * also cached — call sites that want negative-result caching get
+   * it for free; ones that don't should branch in the fetcher.
+   *
+   * Failures inside `fetcher` propagate up; we don't write a partial
+   * entry. This matches the in-memory caches the plugins already use.
+   */
+  getOrFetch<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    opts: { ttlSec: number },
+  ): Promise<T>;
+  /** Read a cached value if present and unexpired; otherwise undefined. */
+  get<T>(key: string): Promise<T | undefined>;
+  /** Write a value with the given TTL. Overwrites any existing entry. */
+  set<T>(key: string, value: T, opts: { ttlSec: number }): Promise<void>;
+  /** Delete one entry. No-op if it doesn't exist. */
+  delete(key: string): Promise<void>;
+  /** Nuke the whole cache directory for this plugin. */
+  clear(): Promise<void>;
+  /** Sweep expired entries off disk. Returns the number removed. */
+  clearExpired(): Promise<number>;
+}
+
+/** Wire shape of a cached entry — `expiresAt` is a Unix-ms timestamp. */
+interface CacheEntry<T> {
+  expiresAt: number;
+  value: T;
+}
+
+/**
+ * Resolve the cache root directory:
+ *   $XDG_CACHE_HOME/steam-loader/  (when set)
+ *   ~/.cache/steam-loader/         (fallback)
+ *
+ * Mirrors plugin-storage's `configDir` but rooted at the cache
+ * variant of the XDG base-dir spec.
+ */
+export function cacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME;
+  const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".cache");
+  return join(base, "steam-loader");
+}
+
+/** Absolute path of a plugin's cache subdirectory. Exposed for tests
+ *  + the loader's "clear all caches" RPC, which iterates plugins and
+ *  prefers calling each plugin's own `clearExternalCache` RPC, but
+ *  falls back to deleting this dir directly if the plugin doesn't
+ *  expose one (defence in depth). */
+export function pluginCacheDir(pluginId: string): string {
+  return join(cacheDir(), pluginId);
+}
+
+/** Hash a cache key into a flat `<sha1>.json` filename. SHA-1 is fine
+ *  here — collision resistance against an attacker isn't a concern,
+ *  and we want a fixed-width filename regardless of how long / weird
+ *  the source key is (URLs with query strings are typical). */
+function keyToFilename(key: string): string {
+  return createHash("sha1").update(key).digest("hex") + ".json";
+}
+
+/** Create a cache instance scoped to one plugin. Cheap — no disk
+ *  I/O happens until the first read/write.
+ *
+ *  The cache dir is resolved per-call from `pluginCacheDir(pluginId)`
+ *  rather than captured at construction time. That's load-bearing
+ *  for the loader's hot-reload path and for spec setups that swap
+ *  `XDG_CACHE_HOME` between tests — capturing once would freeze the
+ *  cache to the env var's value at first construction. */
+export function createExternalCache(pluginId: string): ExternalCache {
+  if (!pluginId || typeof pluginId !== "string") {
+    throw new Error("createExternalCache: pluginId is required");
+  }
+
+  function currentDir(): string {
+    return pluginCacheDir(pluginId);
+  }
+
+  async function readEntry<T>(key: string): Promise<CacheEntry<T> | undefined> {
+    const path = join(currentDir(), keyToFilename(key));
+    try {
+      const raw = await readFile(path, "utf8");
+      const parsed = JSON.parse(raw) as unknown;
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed) &&
+        typeof (parsed as { expiresAt?: unknown }).expiresAt === "number"
+      ) {
+        return parsed as CacheEntry<T>;
+      }
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async function writeEntry<T>(key: string, entry: CacheEntry<T>): Promise<void> {
+    const path = join(currentDir(), keyToFilename(key));
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp`;
+    const json = JSON.stringify(entry);
+    // Bun.write when available (loader runs under Bun); fall back to
+    // fs.writeFile so tests / non-Bun callers still work — same
+    // pattern plugin-storage uses.
+    const B = (globalThis as unknown as {
+      Bun?: { write?: (p: string, d: string) => Promise<unknown> };
+    }).Bun;
+    if (B?.write) {
+      await B.write(tmp, json);
+    } else {
+      const { writeFile } = await import("fs/promises");
+      await writeFile(tmp, json, "utf8");
+    }
+    await rename(tmp, path);
+  }
+
+  return {
+    pluginId,
+    get dir(): string {
+      return currentDir();
+    },
+
+    async get<T>(key: string): Promise<T | undefined> {
+      const entry = await readEntry<T>(key);
+      if (!entry) return undefined;
+      if (entry.expiresAt <= Date.now()) return undefined;
+      return entry.value;
+    },
+
+    async set<T>(
+      key: string,
+      value: T,
+      opts: { ttlSec: number },
+    ): Promise<void> {
+      await writeEntry<T>(key, {
+        expiresAt: Date.now() + opts.ttlSec * 1000,
+        value,
+      });
+    },
+
+    async getOrFetch<T>(
+      key: string,
+      fetcher: () => Promise<T>,
+      opts: { ttlSec: number },
+    ): Promise<T> {
+      const cached = await readEntry<T>(key);
+      if (cached && cached.expiresAt > Date.now()) {
+        return cached.value;
+      }
+      const value = await fetcher();
+      await writeEntry<T>(key, {
+        expiresAt: Date.now() + opts.ttlSec * 1000,
+        value,
+      });
+      return value;
+    },
+
+    async delete(key: string): Promise<void> {
+      const path = join(currentDir(), keyToFilename(key));
+      try {
+        await unlink(path);
+      } catch {
+        /* not present — fine */
+      }
+    },
+
+    async clear(): Promise<void> {
+      // `rm -rf` on the per-plugin cache dir — `force: true` so a
+      // missing dir isn't an error (clearing a never-warmed cache
+      // should be a no-op, not a throw).
+      await rm(currentDir(), { recursive: true, force: true });
+    },
+
+    async clearExpired(): Promise<number> {
+      const dir = currentDir();
+      let entries: string[];
+      try {
+        entries = await readdir(dir);
+      } catch {
+        return 0;
+      }
+      const now = Date.now();
+      let removed = 0;
+      for (const name of entries) {
+        if (!name.endsWith(".json")) continue;
+        const path = join(dir, name);
+        let parsed: unknown;
+        try {
+          const raw = await readFile(path, "utf8");
+          parsed = JSON.parse(raw);
+        } catch {
+          // Unreadable / corrupt — drop it; clearExpired is a janitor.
+          try {
+            await unlink(path);
+            removed++;
+          } catch {
+            /* ignore */
+          }
+          continue;
+        }
+        const expiresAt = (parsed as { expiresAt?: unknown })?.expiresAt;
+        if (typeof expiresAt !== "number" || expiresAt <= now) {
+          try {
+            await unlink(path);
+            removed++;
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+      return removed;
+    },
+  };
+}
+
+/**
+ * Loader-side helper: nuke the cache directory for a plugin without
+ * needing the plugin instance. Used as a defence-in-depth fallback
+ * by the loader's "Clear all data caches" RPC for plugins that
+ * don't expose a `clearExternalCache` method themselves. Also handy
+ * when uninstalling a plugin entirely.
+ */
+export async function clearPluginCacheDir(pluginId: string): Promise<void> {
+  await rm(pluginCacheDir(pluginId), { recursive: true, force: true });
+}

--- a/packages/external-cache/src/index.ts
+++ b/packages/external-cache/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Per-plugin disk cache for external API responses.
  *
- *   $XDG_CACHE_HOME/steam-loader/<plugin-id>/<sha1(key)>.json
+ *   $XDG_CACHE_HOME/loadout/<plugin-id>/<sha1(key)>.json
  *   (typically ~/.cache/loadout/<plugin-id>/<sha1(key)>.json)
  *
  * Plugins that fetch data from external sources (ProtonDB,
@@ -103,7 +103,7 @@ interface CacheEntry<T> {
 
 /**
  * Resolve the cache root directory:
- *   $XDG_CACHE_HOME/steam-loader/  (when set)
+ *   $XDG_CACHE_HOME/loadout/  (when set)
  *   ~/.cache/loadout/         (fallback)
  *
  * Mirrors plugin-storage's `configDir` but rooted at the cache

--- a/packages/external-cache/src/index.ts
+++ b/packages/external-cache/src/index.ts
@@ -2,7 +2,7 @@
  * Per-plugin disk cache for external API responses.
  *
  *   $XDG_CACHE_HOME/steam-loader/<plugin-id>/<sha1(key)>.json
- *   (typically ~/.cache/steam-loader/<plugin-id>/<sha1(key)>.json)
+ *   (typically ~/.cache/loadout/<plugin-id>/<sha1(key)>.json)
  *
  * Plugins that fetch data from external sources (ProtonDB,
  * HowLongToBeat, SteamGridDB, …) wrap their fetch sites in
@@ -104,7 +104,7 @@ interface CacheEntry<T> {
 /**
  * Resolve the cache root directory:
  *   $XDG_CACHE_HOME/steam-loader/  (when set)
- *   ~/.cache/steam-loader/         (fallback)
+ *   ~/.cache/loadout/         (fallback)
  *
  * Mirrors plugin-storage's `configDir` but rooted at the cache
  * variant of the XDG base-dir spec.
@@ -112,7 +112,7 @@ interface CacheEntry<T> {
 export function cacheDir(): string {
   const xdg = process.env.XDG_CACHE_HOME;
   const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".cache");
-  return join(base, "steam-loader");
+  return join(base, "loadout");
 }
 
 /** Absolute path of a plugin's cache subdirectory. Exposed for tests

--- a/scripts/prepare-plugins.sh
+++ b/scripts/prepare-plugins.sh
@@ -76,7 +76,6 @@ mkdir -p "$NM_DST/@loadout"
 # plugin starts importing them (e.g. plugin-storage for tdp-control /
 # fan-control / playtime).
 for pkg in types exec steam-paths ui plugin-storage vdf external-cache; do
-for pkg in types exec steam-paths ui plugin-storage external-cache; do
     if [ -d "$PROJECT_ROOT/packages/$pkg" ]; then
         cp -r "$PROJECT_ROOT/packages/$pkg" "$NM_DST/@loadout/$pkg"
     fi

--- a/scripts/prepare-plugins.sh
+++ b/scripts/prepare-plugins.sh
@@ -75,7 +75,8 @@ mkdir -p "$NM_DST/@loadout"
 # Workspace packages used by plugins. Add new packages here when a
 # plugin starts importing them (e.g. plugin-storage for tdp-control /
 # fan-control / playtime).
-for pkg in types exec steam-paths ui plugin-storage vdf; do
+for pkg in types exec steam-paths ui plugin-storage vdf external-cache; do
+for pkg in types exec steam-paths ui plugin-storage external-cache; do
     if [ -d "$PROJECT_ROOT/packages/$pkg" ]; then
         cp -r "$PROJECT_ROOT/packages/$pkg" "$NM_DST/@loadout/$pkg"
     fi


### PR DESCRIPTION
## Summary

Extracts the TTL JSON disk-cache helper. **5 source plugins** use it (hltb, protondb-badges, recomp, steamgriddb, store-bridge). protondb-badges (in-flight PR #50) currently has an inlined copy from before this strategy shift; that PR will migrate to the new package post-merge.

## Scope
- `src/index.ts` (299 LOC) + `src/index.test.ts` (290 LOC, renamed from `.spec.ts`).
- `@steam-loader/` → `@loadout/` scope rename. No logic changes.
- 22 tests pass via `bun test --isolate`.

## Test plan
- [x] `bun run typecheck` clean.
- [x] `bun run lint` 0 errors, baseline unchanged.
- [x] 22 tests pass in `packages/external-cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)