### PR TITLE
feat(per-game-profiles): extract @loadout/per-game-profiles from steam-loader

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,13 @@
       "name": "@loadout/external-cache",
       "version": "0.0.1",
     },
+    "packages/per-game-profiles": {
+      "name": "@loadout/per-game-profiles",
+      "version": "0.0.1",
+      "dependencies": {
+        "@loadout/plugin-storage": "workspace:*",
+      },
+    },
     "packages/plugin-storage": {
       "name": "@loadout/plugin-storage",
       "version": "0.0.1",
@@ -304,6 +311,8 @@
     "@loadout/loadout-overlay": ["@loadout/loadout-overlay@workspace:apps/loadout-overlay"],
 
     "@loadout/loadout-server": ["@loadout/loadout-server@workspace:apps/loadout"],
+
+    "@loadout/per-game-profiles": ["@loadout/per-game-profiles@workspace:packages/per-game-profiles"],
 
     "@loadout/plugin-bluetooth": ["@loadout/plugin-bluetooth@workspace:plugins/bluetooth"],
 

--- a/packages/per-game-profiles/package.json
+++ b/packages/per-game-profiles/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@loadout/per-game-profiles",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@loadout/plugin-storage": "workspace:*"
+  }
+}

--- a/packages/per-game-profiles/src/index.test.ts
+++ b/packages/per-game-profiles/src/index.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from "bun:test";
+
+import {
+  createPerGameEngine,
+  type GameProfile,
+  type PerGameEnginePersistence,
+  type PerGameState,
+} from "./index";
+
+interface FakePayload {
+  watts: number;
+}
+interface FakeSnapshot {
+  preWatts: number;
+}
+
+/** Drop-in in-memory persistence so the engine tests don't touch disk. */
+function memoryPersistence<P>(
+  initial?: PerGameState<P>,
+): PerGameEnginePersistence<P> {
+  let state: PerGameState<P> = initial
+    ? { ...initial, profiles: [...initial.profiles] }
+    : { perGameEnabled: false, profiles: [] };
+  return {
+    load: async () => ({
+      perGameEnabled: state.perGameEnabled,
+      profiles: state.profiles.map((p) => ({ ...p })),
+    }),
+    save: async (next) => {
+      state = {
+        perGameEnabled: next.perGameEnabled,
+        profiles: next.profiles.map((p) => ({ ...p })),
+      };
+    },
+  };
+}
+
+describe("createPerGameEngine", () => {
+  it("returns empty state on first load", async () => {
+    const engine = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence: memoryPersistence<FakePayload>(),
+      onApply: async () => {},
+      onSnapshot: async () => ({ preWatts: 15 }),
+      onRestore: async () => {},
+    });
+    await engine.load();
+    expect(engine.getProfiles()).toEqual([]);
+    expect(engine.getActiveAppId()).toBeNull();
+    expect(engine.isPerGameEnabled()).toBe(false);
+  });
+
+  it("setProfile persists and round-trips through a fresh load()", async () => {
+    const persistence = memoryPersistence<FakePayload>();
+    const a = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence,
+      onApply: async () => {},
+      onSnapshot: async () => ({ preWatts: 0 }),
+      onRestore: async () => {},
+    });
+    await a.load();
+    await a.setProfile(440, "TF2", { watts: 12 });
+    await a.setProfile(730, "CSGO", { watts: 20 });
+
+    const b = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence,
+      onApply: async () => {},
+      onSnapshot: async () => ({ preWatts: 0 }),
+      onRestore: async () => {},
+    });
+    await b.load();
+    expect(b.getProfiles()).toEqual([
+      { appId: 440, gameName: "TF2", payload: { watts: 12 } },
+      { appId: 730, gameName: "CSGO", payload: { watts: 20 } },
+    ]);
+  });
+
+  it("setProfile overwrites an existing entry instead of duplicating", async () => {
+    const engine = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence: memoryPersistence<FakePayload>(),
+      onApply: async () => {},
+      onSnapshot: async () => ({ preWatts: 0 }),
+      onRestore: async () => {},
+    });
+    await engine.load();
+    await engine.setProfile(440, "TF2", { watts: 12 });
+    await engine.setProfile(440, "TF2", { watts: 18 });
+    expect(engine.getProfiles()).toHaveLength(1);
+    expect(engine.getProfile(440)?.payload.watts).toBe(18);
+  });
+
+  it("handleGameLaunch is a no-op when perGameEnabled is false", async () => {
+    let applied = 0;
+    const engine = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence: memoryPersistence<FakePayload>(),
+      onApply: async () => {
+        applied++;
+      },
+      onSnapshot: async () => ({ preWatts: 0 }),
+      onRestore: async () => {},
+    });
+    await engine.load();
+    await engine.setProfile(440, "TF2", { watts: 12 });
+    await engine.handleGameLaunch(440, "TF2");
+    expect(applied).toBe(0);
+    expect(engine.getActiveAppId()).toBeNull();
+  });
+
+  it("handleGameLaunch snapshots, applies, and binds the appId", async () => {
+    const calls: string[] = [];
+    const engine = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence: memoryPersistence<FakePayload>(),
+      onApply: async (payload, ctx) => {
+        calls.push(`apply ${ctx.appId} ${payload.watts}`);
+      },
+      onSnapshot: async () => {
+        calls.push("snapshot");
+        return { preWatts: 15 };
+      },
+      onRestore: async (snap) => {
+        calls.push(`restore ${snap.preWatts}`);
+      },
+    });
+    await engine.load();
+    await engine.setPerGameEnabled(true);
+    await engine.setProfile(440, "TF2", { watts: 12 });
+    await engine.handleGameLaunch(440, "TF2");
+    expect(calls).toEqual(["snapshot", "apply 440 12"]);
+    expect(engine.getActiveAppId()).toBe(440);
+  });
+
+  it("handleGameExit restores the snapshot for the bound appId", async () => {
+    const calls: string[] = [];
+    const engine = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence: memoryPersistence<FakePayload>(),
+      onApply: async () => {},
+      onSnapshot: async () => ({ preWatts: 15 }),
+      onRestore: async (snap) => {
+        calls.push(`restore ${snap.preWatts}`);
+      },
+    });
+    await engine.load();
+    await engine.setPerGameEnabled(true);
+    await engine.setProfile(440, "TF2", { watts: 12 });
+    await engine.handleGameLaunch(440, "TF2");
+    await engine.handleGameExit(440);
+    expect(calls).toEqual(["restore 15"]);
+    expect(engine.getActiveAppId()).toBeNull();
+  });
+
+  it("handleGameExit ignores apps that aren't currently bound", async () => {
+    let restored = 0;
+    const engine = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence: memoryPersistence<FakePayload>(),
+      onApply: async () => {},
+      onSnapshot: async () => ({ preWatts: 15 }),
+      onRestore: async () => {
+        restored++;
+      },
+    });
+    await engine.load();
+    await engine.setPerGameEnabled(true);
+    await engine.setProfile(440, "TF2", { watts: 12 });
+    await engine.handleGameLaunch(440, "TF2");
+    await engine.handleGameExit(730); // different appId
+    expect(restored).toBe(0);
+    expect(engine.getActiveAppId()).toBe(440);
+  });
+
+  it("guard returning false skips handleGameLaunch entirely", async () => {
+    let applied = 0;
+    let guardChecked = false;
+    const engine = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence: memoryPersistence<FakePayload>(),
+      onApply: async () => {
+        applied++;
+      },
+      onSnapshot: async () => ({ preWatts: 0 }),
+      onRestore: async () => {},
+      guard: () => {
+        guardChecked = true;
+        return false;
+      },
+    });
+    await engine.load();
+    await engine.setPerGameEnabled(true);
+    await engine.setProfile(440, "TF2", { watts: 12 });
+    await engine.handleGameLaunch(440, "TF2");
+    expect(guardChecked).toBe(true);
+    expect(applied).toBe(0);
+    expect(engine.getActiveAppId()).toBeNull();
+  });
+
+  it("removeProfile takes the entry out and persists", async () => {
+    const persistence = memoryPersistence<FakePayload>();
+    const engine = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence,
+      onApply: async () => {},
+      onSnapshot: async () => ({ preWatts: 0 }),
+      onRestore: async () => {},
+    });
+    await engine.load();
+    await engine.setProfile(440, "TF2", { watts: 12 });
+    await engine.removeProfile(440);
+    expect(engine.getProfile(440)).toBeNull();
+    const after = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence,
+      onApply: async () => {},
+      onSnapshot: async () => ({ preWatts: 0 }),
+      onRestore: async () => {},
+    });
+    await after.load();
+    expect(after.getProfiles()).toEqual([]);
+  });
+
+  it("onActiveChanged fires on launch with the active profile and on exit with null", async () => {
+    const events: Array<{ appId: number; watts: number } | null> = [];
+    const engine = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence: memoryPersistence<FakePayload>(),
+      onApply: async () => {},
+      onSnapshot: async () => ({ preWatts: 0 }),
+      onRestore: async () => {},
+      onActiveChanged: (active) => {
+        events.push(active ? { appId: active.appId, watts: active.payload.watts } : null);
+      },
+    });
+    await engine.load();
+    await engine.setPerGameEnabled(true);
+    await engine.setProfile(440, "TF2", { watts: 12 });
+    await engine.handleGameLaunch(440, "TF2");
+    await engine.handleGameExit(440);
+    expect(events).toEqual([{ appId: 440, watts: 12 }, null]);
+  });
+
+  it("custom persistence preserves out-of-band fields across writes", async () => {
+    // Simulates audio-mixer's storage shape: per-game state lives at the
+    // top level alongside other keys the engine doesn't know about.
+    const storage: Record<string, unknown> = { apps: { spotify: { volume: 60 } } };
+    const persistence: PerGameEnginePersistence<FakePayload> = {
+      load: async () => ({
+        perGameEnabled: Boolean(storage.perGameEnabled),
+        profiles: Array.isArray(storage.gameProfiles)
+          ? (storage.gameProfiles as GameProfile<FakePayload>[])
+          : [],
+      }),
+      save: async (state) => {
+        storage.perGameEnabled = state.perGameEnabled;
+        storage.gameProfiles = state.profiles;
+      },
+    };
+    const engine = createPerGameEngine<FakePayload, FakeSnapshot>({
+      persistence,
+      onApply: async () => {},
+      onSnapshot: async () => ({ preWatts: 0 }),
+      onRestore: async () => {},
+    });
+    await engine.load();
+    await engine.setProfile(440, "TF2", { watts: 12 });
+    expect((storage.apps as { spotify: { volume: number } }).spotify.volume).toBe(60);
+    expect(storage.perGameEnabled).toBe(false);
+    expect((storage.gameProfiles as unknown[]).length).toBe(1);
+  });
+});

--- a/packages/per-game-profiles/src/index.ts
+++ b/packages/per-game-profiles/src/index.ts
@@ -1,0 +1,262 @@
+/**
+ * Generic per-game profile engine.
+ *
+ * Three plugins (tdp-control, fan-control, audio-mixer) each maintained
+ * their own copy of "store-a-profile-per-Steam-appId, snapshot the
+ * pre-game state on launch, restore it on exit". The audit (2026-05
+ * D-001 cross-domain candidate) flagged this as a single pattern with
+ * three implementations.
+ *
+ * The shape every consumer needed:
+ *
+ *   - A list of `{ appId, gameName, payload }` profiles persisted to
+ *     plugin storage.
+ *   - A `perGameEnabled` toggle so the user can keep their profiles
+ *     stored but skip applying them on launch.
+ *   - On `handleGameLaunch(appId, gameName)`: find the matching profile,
+ *     snapshot the current state (mode/volume/sink/etc.), apply the
+ *     profile's payload, remember which app is bound so exit can revert
+ *     to the correct snapshot.
+ *   - On `handleGameExit(appId)`: if it matches the bound app, restore
+ *     the snapshot, clear bound state.
+ *   - CRUD over the profile list and a "what's active right now?" probe.
+ *
+ * The differences across plugins:
+ *
+ *   - The payload type — `{ tdpWatts: number }` vs `{ mode, speed }` vs
+ *     `{ defaultSinkName, perAppVolumes }`. Parameterised as `P`.
+ *   - The snapshot type — what each plugin needs to remember to restore
+ *     pre-game state. Parameterised as `S`.
+ *   - The apply / snapshot / restore operations — passed as callbacks.
+ *   - The persistence shape on disk. Persistence is passed as a `load` +
+ *     `save` callback pair so each plugin keeps its existing JSON
+ *     layout. Audio-mixer for example stores `apps` at the top level
+ *     alongside `perGameEnabled` and `gameProfiles`; fan-control's file
+ *     is just per-game state. The engine doesn't pick the shape.
+ *   - An optional `guard()` that returns false to skip launch handling
+ *     when hardware isn't ready (e.g., fan-control with no PWM device).
+ *
+ * `createPluginStoragePersistence(pluginId, { enabledKey, profilesKey })`
+ * is a convenience factory for the common case where the plugin's
+ * `@loadout/plugin-storage` file already has `perGameEnabled` and
+ * `<something>Profiles` as top-level keys. Plugins with a different
+ * layout pass their own load/save pair.
+ *
+ * tdp-control deliberately doesn't migrate yet — its `tdp-profiles.ts`
+ * carries a TDP-specific debounce queue + ROG Ally SMT workarounds that
+ * would need separate handling. TODO in plugins/tdp-control/lib/.
+ */
+
+import {
+  readPluginStorage,
+  writePluginStorage,
+} from "@loadout/plugin-storage";
+
+/** A stored profile entry: which game it's for + the plugin-specific payload. */
+export interface GameProfile<P> {
+  appId: number;
+  gameName: string;
+  payload: P;
+}
+
+/** The state shape the engine load/save callbacks deal in. */
+export interface PerGameState<P> {
+  perGameEnabled: boolean;
+  profiles: GameProfile<P>[];
+}
+
+export interface PerGameEnginePersistence<P> {
+  /** Read the persisted state. Called once during `engine.load()`. */
+  load: () => Promise<PerGameState<P>>;
+  /**
+   * Write the persisted state. Called after every mutation
+   * (setProfile / removeProfile / setPerGameEnabled). Plugins that
+   * cohabit per-game state with other keys in the same storage file
+   * are responsible for read-modify-writing inside this callback.
+   */
+  save: (state: PerGameState<P>) => Promise<void>;
+}
+
+export interface PerGameEngineOptions<P, S> {
+  /** Load + save callbacks. Use `createPluginStoragePersistence` for
+   *  the common case of `@loadout/plugin-storage`. */
+  persistence: PerGameEnginePersistence<P>;
+  /**
+   * Apply the profile's payload to the world. Called inside
+   * `handleGameLaunch` AFTER the snapshot is taken.
+   */
+  onApply: (payload: P, ctx: { appId: number; gameName: string }) => Promise<void>;
+  /** Snapshot the current state. Saved internally so `onRestore` can revert. */
+  onSnapshot: () => Promise<S>;
+  /** Restore the previously snapshotted state. Called from `handleGameExit`. */
+  onRestore: (snapshot: S) => Promise<void>;
+  /**
+   * Optional gate. If returns `false`, `handleGameLaunch` is a no-op
+   * for this tick (e.g., the plugin's hardware isn't ready). The
+   * `perGameEnabled` toggle is checked separately.
+   */
+  guard?: () => boolean;
+  /**
+   * Optional callback fired whenever the active profile changes — both
+   * the launch and exit edges. Use it to emit a UI event.
+   */
+  onActiveChanged?: (active: GameProfile<P> | null) => void;
+}
+
+export interface PerGameEngine<P> {
+  /** Load persisted state. Call once in the plugin's `onLoad`. */
+  load: () => Promise<void>;
+  /** Steam game launched — apply matching profile if one exists + perGameEnabled. */
+  handleGameLaunch: (appId: number, gameName: string) => Promise<void>;
+  /** Steam game exited — restore snapshot if this appId is bound. */
+  handleGameExit: (appId: number) => Promise<void>;
+  /** Read APIs for RPC handlers / UI. */
+  getProfile: (appId: number) => GameProfile<P> | null;
+  getProfiles: () => GameProfile<P>[];
+  getActiveAppId: () => number | null;
+  isPerGameEnabled: () => boolean;
+  /** Write APIs — each one persists before returning. */
+  setProfile: (appId: number, gameName: string, payload: P) => Promise<GameProfile<P>>;
+  removeProfile: (appId: number) => Promise<void>;
+  setPerGameEnabled: (enabled: boolean) => Promise<void>;
+}
+
+export function createPerGameEngine<P, S>(
+  opts: PerGameEngineOptions<P, S>,
+): PerGameEngine<P> {
+  let profiles: GameProfile<P>[] = [];
+  let perGameEnabled = false;
+  let preGameSnapshot: S | null = null;
+  let boundAppId: number | null = null;
+
+  async function persist(): Promise<void> {
+    await opts.persistence.save({ perGameEnabled, profiles });
+  }
+
+  function emitActive(): void {
+    if (!opts.onActiveChanged) return;
+    const active = boundAppId !== null
+      ? (profiles.find((p) => p.appId === boundAppId) ?? null)
+      : null;
+    opts.onActiveChanged(active);
+  }
+
+  return {
+    async load() {
+      const state = await opts.persistence.load();
+      perGameEnabled = Boolean(state.perGameEnabled);
+      profiles = Array.isArray(state.profiles) ? state.profiles : [];
+    },
+
+    async handleGameLaunch(appId, gameName) {
+      if (!perGameEnabled) return;
+      if (opts.guard && !opts.guard()) return;
+      const profile = profiles.find((p) => p.appId === appId);
+      if (!profile) return;
+
+      preGameSnapshot = await opts.onSnapshot();
+      boundAppId = appId;
+      await opts.onApply(profile.payload, { appId, gameName });
+      emitActive();
+    },
+
+    async handleGameExit(appId) {
+      if (boundAppId !== appId) return;
+      const snapshot = preGameSnapshot;
+      boundAppId = null;
+      preGameSnapshot = null;
+      if (snapshot !== null) {
+        await opts.onRestore(snapshot);
+      }
+      emitActive();
+    },
+
+    getProfile(appId) {
+      const found = profiles.find((p) => p.appId === appId);
+      return found ? { ...found } : null;
+    },
+
+    getProfiles() {
+      return profiles.map((p) => ({ ...p }));
+    },
+
+    getActiveAppId() {
+      return boundAppId;
+    },
+
+    isPerGameEnabled() {
+      return perGameEnabled;
+    },
+
+    async setProfile(appId, gameName, payload) {
+      const next: GameProfile<P> = { appId, gameName, payload };
+      const idx = profiles.findIndex((p) => p.appId === appId);
+      if (idx === -1) profiles.push(next);
+      else profiles[idx] = next;
+      await persist();
+      return { ...next };
+    },
+
+    async removeProfile(appId) {
+      const before = profiles.length;
+      profiles = profiles.filter((p) => p.appId !== appId);
+      if (profiles.length !== before) await persist();
+      // If the active profile was removed, we still keep boundAppId so
+      // handleGameExit can fire onRestore. The next launch with a
+      // different appId clears it.
+    },
+
+    async setPerGameEnabled(enabled) {
+      perGameEnabled = enabled;
+      await persist();
+    },
+  };
+}
+
+/**
+ * Convenience factory for plugins that store per-game state alongside
+ * other keys in a single `@loadout/plugin-storage` JSON file.
+ *
+ * The plugin's storage file ends up looking like:
+ *
+ *   {
+ *     // ... other plugin state ...
+ *     [enabledKey]: boolean,
+ *     [profilesKey]: GameProfile<P>[],
+ *   }
+ *
+ * The factory reads and merges back, so other top-level keys (e.g.
+ * audio-mixer's `apps`) survive every save. Profiles default to `[]`
+ * and the enabled flag defaults to `false` on first load.
+ */
+export function createPluginStoragePersistence<P>(
+  pluginId: string,
+  opts: {
+    /** Top-level key for the perGameEnabled flag. Default `"perGameEnabled"`. */
+    enabledKey?: string;
+    /** Top-level key for the profiles array. Default `"gameProfiles"`. */
+    profilesKey?: string;
+  } = {},
+): PerGameEnginePersistence<P> {
+  const enabledKey = opts.enabledKey ?? "perGameEnabled";
+  const profilesKey = opts.profilesKey ?? "gameProfiles";
+  return {
+    async load() {
+      const stored = await readPluginStorage<Record<string, unknown>>(pluginId);
+      return {
+        perGameEnabled: Boolean(stored[enabledKey]),
+        profiles: Array.isArray(stored[profilesKey])
+          ? (stored[profilesKey] as GameProfile<P>[])
+          : [],
+      };
+    },
+    async save(state) {
+      const existing = await readPluginStorage<Record<string, unknown>>(pluginId);
+      await writePluginStorage(pluginId, {
+        ...existing,
+        [enabledKey]: state.perGameEnabled,
+        [profilesKey]: state.profiles,
+      });
+    },
+  };
+}

--- a/scripts/prepare-plugins.sh
+++ b/scripts/prepare-plugins.sh
@@ -75,7 +75,7 @@ mkdir -p "$NM_DST/@loadout"
 # Workspace packages used by plugins. Add new packages here when a
 # plugin starts importing them (e.g. plugin-storage for tdp-control /
 # fan-control / playtime).
-for pkg in types exec steam-paths ui plugin-storage vdf external-cache; do
+for pkg in types exec steam-paths ui plugin-storage vdf external-cache per-game-profiles; do
     if [ -d "$PROJECT_ROOT/packages/$pkg" ]; then
         cp -r "$PROJECT_ROOT/packages/$pkg" "$NM_DST/@loadout/$pkg"
     fi


### PR DESCRIPTION
## Summary

Extracts the per-app profile engine — bind a settings payload to a Steam appId so the loader's `__core:game-detection` broadcast can apply it on game launch.

## Why now

- **2 source consumers** (audio-mixer, fan-control).
- **Already duplicated on loadout main** — `fan-control/lib/per-game-profiles.ts` and `tdp-control/lib/tdp-profiles.ts` both implement nearly the same engine. This package will retro-migrate both.

## Scope
- `src/index.ts` (262 LOC) — `createPerGameEngine<Payload>()` + types.
- `src/index.test.ts` (262 LOC) — 11 tests.
- Depends on `@loadout/plugin-storage` (workspace).
- `@steam-loader/` → `@loadout/` scope rename. No logic changes.

## Test plan
- [x] typecheck clean.
- [x] 11 tests pass.
- [ ] Follow-up: retro-migrate fan-control + tdp-control to consume this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)