### PR TITLE
chore: drop panel-target from docs + types — nonsense, no consumers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,11 +3,12 @@
 > **Doc currency (2026-05).** This page describes the system as it ships today.
 > Two notes worth reading before you trust everything below:
 >
-> - Most plugins render in the **Electrobun overlay**, not Steam's CEF UI.
->   The overlay entry is `app.tsx` (consumed by `packages/overlay-electrobun`
->   via the `@overlay/*` alias). `panel.tsx` is reserved for plugins that
->   inject UI directly into Steam's CEF — currently only `game-browser/` does
->   that. Both shapes are supported; pick based on where the user sees it.
+> - All plugins render in the **Electrobun overlay**. The overlay entry is
+>   `app.tsx` (consumed by `packages/overlay-electrobun` via the `@overlay/*`
+>   alias). Backends that need to drive Steam's CEF UI talk to it via
+>   `@loadout/steam-cdp` (the loader's CDP client, exposed as a workspace
+>   package) — same pattern protondb-badges, hltb, sgdb-art etc. use to
+>   inject CSS + JS into Steam's BPM / store / SharedJSContext tabs.
 > - Plugin process isolation (child-process spawn) is on the roadmap
 >   (TODOS.md P1) but **not shipped yet** — backends are still loaded with
 >   `import(backendPath)` in `plugin-manager.ts`. Treat the "child procs"
@@ -81,15 +82,13 @@ my-plugin/
 ├── backend.ts       # PluginBackend class with RPC methods
 └── app.tsx          # React component rendered in the Electrobun overlay
 
-# Steam-injection plugin (renders into Steam's own UI instead)
+# Steam-injection plugin (also renders the user-facing UI in the overlay;
+# the backend pushes CSS+JS into Steam's CEF over CDP for the Steam-side bits)
 my-plugin/
 ├── package.json
-├── backend.ts
-└── panel.tsx        # React component injected into Steam's CEF
+├── backend.ts       # imports @loadout/steam-cdp; calls inject*() over CDP
+└── app.tsx          # settings UI in the Electrobun overlay
 ```
-
-Plugins can also ship both `app.tsx` and `panel.tsx` if they need surfaces
-in both places.
 
 ## Plugin Backend Isolation
 
@@ -120,7 +119,7 @@ async function loadPlugin(pluginDir: string) {
 1. **Boot** — Bun server starts via systemd
 2. **Scan** — Reads `plugins/` directory, loads each `plugin.json`
 3. **Import backends** — Spawns each plugin's `backend.ts` as a child process, calls `onLoad()`
-4. **Build frontends** — Runs `Bun.build()` on each `panel.tsx`, outputs browser-compatible bundles to `/tmp/plugin-bundles/`
+4. **Build frontends** — Runs `Bun.build()` on each plugin's `app.tsx`, outputs browser-compatible bundles to `/tmp/plugin-bundles/`
 5. **CEF inject** — Connects to Steam's CEF debug port, injects loader script into `SharedJSContext`
 6. **Plugin load** — Injected script fetches `/plugins` manifest, then fetches and `eval()`s each plugin's compiled bundle
 
@@ -180,9 +179,9 @@ User's Deck
 │   ├── loadout                 (the binary)
 │   └── plugins/
 │       └── protondb-badges/
-│           ├── plugin.json
+│           ├── package.json
 │           ├── backend.ts
-│           └── panel.tsx
+│           └── app.tsx
 └── ~/.config/systemd/user/
     └── loadout.service
 ```

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,18 +1,14 @@
 # Plugin Development Guide
 
-> **Doc currency (2026-05).** This guide was originally written for the
-> Steam-CEF injection model. Most plugins today render in the **Electrobun
-> overlay** instead — the only structural difference is the UI file:
->
-> | Surface | UI entry | When to use |
-> |---|---|---|
-> | Electrobun overlay (default) | `app.tsx` | The user opens the overlay (QAM tile, F16, Ctrl+Shift+O); your plugin renders inside it. **This is the default for most plugins.** |
-> | Steam CEF injection | `panel.tsx` | Your plugin needs to render directly inside Steam's UI (e.g. a game-library overlay). |
->
-> Plugin metadata also moved from a separate `plugin.json` to a `plugin`
-> field on the workspace `package.json` — see any of the live plugins for
-> the current shape. The hello-world examples below pre-date that change
-> and may show the old `plugin.json` shape.
+> **Doc currency (2026-05).** This guide predates the Electrobun-overlay-
+> only decision. Treat any `panel.tsx` references below as historical —
+> **all plugins now use `app.tsx`** and render in the Electrobun overlay.
+> Backends that need to drive Steam's CEF UI talk to it via
+> `@loadout/steam-cdp` (the loader's CDP client, exposed as a workspace
+> package). Plugin metadata also moved from a separate `plugin.json` to
+> a `plugin` field on the workspace `package.json` — see any of the live
+> plugins for the current shape. The hello-world examples below show the
+> old shape but the structural points still apply.
 
 This guide covers everything you need to build plugins for Loadout — from a simple hello world to advanced patterns like using Steam's native UI components, hooking into Steam events, and communicating between frontend and backend.
 

--- a/docs/plugin-migration.md
+++ b/docs/plugin-migration.md
@@ -44,7 +44,7 @@ One plugin per issue, migrated one at a time.
   ```
   `id` / `name` / `description` are required; `permissions` / `category` / `target` / `routes` are optional. See `PluginMeta` in `packages/types/src/plugin.ts`.
 - `backend.ts` (optional) — default-export a class `implements PluginBackend` (from `@loadout/types`). Lifecycle: `onLoad?` / `onUnload?` / `emit?` / `log?`. **Every public, non-underscore method becomes an RPC endpoint.** Prefix private helpers with `_` to keep them off the wire.
-- UI entry — `app.tsx` for the **overlay** (the default for almost every plugin) OR `panel.tsx` for **Steam CEF injection**. Use whichever the source plugin used.
+- UI entry — `app.tsx`. The plugin renders in the Electrobun overlay. Backends that need to drive Steam's CEF UI talk to it via `@loadout/steam-cdp` (extracted from `apps/loadout/src/steam-cdp/`).
 - `lib/**` (optional) — inlined helper modules.
 - Carry over `assets/`, `README.md`, `LICENSE` if present.
 
@@ -141,7 +141,7 @@ Loadout targets Linux gaming handhelds + gaming desktops. The reviewer classifie
 2. **Rename the scope** on every ported file: `sed -i 's#@steam-loader/#@loadout/#g'` (review the diff — only the four allowed packages should remain after step 4).
 3. **Fold `plugin.json` into `package.json`.** Move the manifest fields into the `plugin` field of `package.json`, set `name` to `@loadout/plugin-{{PLUGIN_ID}}`, add `"type": "module"` and the real `dependencies`. Delete the standalone `plugin.json`.
 4. **Resolve removed-package deps by inlining** (see the decision rule below). The packages `plugin-storage`, `vdf`, `external-cache`, `sgdb-art`, `steam-shortcut`, `file-picker`, and `per-game-profiles` DO NOT exist in the target — replace each import with inlined code in this plugin's `lib/` *by default*.
-5. **Adapt to the current SDK / manifest shape.** Reconcile any `@loadout/ui` / `@loadout/types` API drift against the reference plugin and `packages/types/src/plugin.ts`. If the source used `panel.tsx` but renders in the overlay, keep `panel.tsx` only if it's a real Steam-injection plugin; otherwise it stays `app.tsx`. Ensure the `mount` / `PluginProvider` / `icon` shape matches `plugins/steam-gamescope-ipc/app.tsx`.
+5. **Adapt to the current SDK / manifest shape.** Reconcile any `@loadout/ui` / `@loadout/types` API drift against the reference plugin and `packages/types/src/plugin.ts`. The source repo's `panel.tsx` plugins (Steam-CEF injection) port to `app.tsx` — the Electrobun overlay is the surface; backends drive Steam's CEF via `@loadout/steam-cdp` when needed. Ensure the `mount` / `PluginProvider` / `icon` shape matches `plugins/steam-gamescope-ipc/app.tsx`.
 6. **Port the tests to `bun:test`.** Convert the source's backend `*.spec.ts` → `*.test.ts` and keep UI tests as `*.spec.tsx`; rewrite any vitest API to `bun:test` (see **Tests** above). Add tests for any ≥100-LOC `lib/**` module.
 7. **Wire it into `plugins/`** so the workspace picks it up (it's a workspace via `plugins/*`). Confirm it loads (see Definition of Done).
 
@@ -212,7 +212,7 @@ All green from the TARGET repo root (`/var/home/srsholmes/Work/loadout`):
 - **Plugin id:** `{{PLUGIN_ID}}`
 - **Plugin name:** `{{PLUGIN_NAME}}`
 - **Source path:** `linux-gaming-plugin-manager/plugins/{{PLUGIN_ID}}/`
-- **UI surface:** overlay (`app.tsx`) | Steam injection (`panel.tsx`)
+- **UI surface:** overlay (`app.tsx`) — only surface. Steam-CEF UI driven from the backend via `@loadout/steam-cdp`.
 - **Removed-package deps used:** (e.g. plugin-storage, vdf) → inline target(s)
 - **Network domains to declare:** …
 - **Subprocess usage:** y/n (must route through `@loadout/exec`)

--- a/packages/types/src/plugin.ts
+++ b/packages/types/src/plugin.ts
@@ -67,8 +67,8 @@ export interface PluginPatch {
 
 export interface PluginTarget {
   /** Where the plugin renders */
-  type: "qam" | "panel" | "overlay" | "css" | "menu";
-  /** Which named export from panel.tsx to render. Defaults to "default" || "Panel" */
+  type: "qam" | "overlay" | "css" | "menu";
+  /** Which named export from the plugin's app to render. Defaults to "default". */
   export?: string;
   /** Display name in the QAM tab bar (required for type: "qam") */
   title?: string;
@@ -97,9 +97,9 @@ export interface PluginMeta {
   description: string;
   author: string;
   permissions?: PluginPermissions;
-  /** Rendering target(s). If omitted, defaults to overlay panel behavior. Array for multi-target plugins. */
+  /** Rendering target(s). If omitted, defaults to overlay. Array for multi-target plugins. */
   target?: PluginTarget | PluginTarget[];
-  /** Map of route path → named export from panel.tsx. Paths must be prefixed with /loadout/{pluginId}/ */
+  /** Map of route path → named export from the plugin's UI. Paths must be prefixed with /loadout/{pluginId}/ */
   routes?: Record<string, string>;
   /** Webpack module patches — modify Steam's components before they render (Vencord-style) */
   patches?: PluginPatch[];


### PR DESCRIPTION
## Summary

Removes the `panel.tsx` / `target.type === \"panel\"` concept from Loadout's docs + type union. The concept was a misreading of how steam-loader's CEF-injection plugins actually work.

## Why

Audit of the source repo's two representative CEF-injection plugins (protondb-badges, hltb):

- Both use **`app.tsx`** for the settings UI in the loader's overlay (not `panel.tsx`).
- Both backends import **`CDPClient from \"@steam-loader/steam-cdp\"`** and call `injectCSSToTab()` + `cdpEvaluate()` to push CSS + JS into Steam's BPM / store / SharedJSContext tabs over CDP.

Loadout's type union had `\"panel\"` as a render target and the docs described it as a CEF-injection surface, but **zero plugins on main use it**.

## Scope

- `packages/types/src/plugin.ts` — drop `\"panel\"` from `PluginTarget.type` (keeps `qam | overlay | css | menu`).
- `docs/plugin-migration.md` — rewrite UI-entry guidance.
- `docs/architecture.md` — rewrite overlay-vs-CEF intro + plugin-layout examples.
- `docs/plugin-development.md` — banner notes that `panel.tsx` mentions below are historical.
- `~/.claude/skills/review-migration/SKILL.md` — fix the skill prompt.

## Not in this PR

Loader-side `panel.tsx` scaffolding (`inject-builder.ts` panelPath loop, `injector.ts` hasPanel branch, `routes/inject.ts` bundle serving) is dead but wired through multiple call sites; clean removal is a separate follow-up.

PR #50 (protondb-badges) and PR #51 (docs/extract-shared-packages) carry the bad guidance — fixed separately.

## Test plan

- [x] `bun run typecheck` clean.
- [x] `bun run lint` 0 errors, 35 warnings (baseline unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)