### PR TITLE
feat(game-library): __core:game-library core service + server-only lint

### DIFF
--- a/apps/loadout/src/loader/index.ts
+++ b/apps/loadout/src/loader/index.ts
@@ -21,6 +21,10 @@ import {
   GAME_DETECTION_SERVICE_ID,
 } from "./services/game-detection";
 import {
+  GameLibraryService,
+  GAME_LIBRARY_SERVICE_ID,
+} from "./services/game-library";
+import {
   buildInjectBundles,
   sdkGlobalPlugin,
   vendorGlobalsPlugin,
@@ -247,6 +251,25 @@ export async function startServer(options: ServerOptions = {}) {
     hasApp: false,
   });
   log.info(`Registered core service: ${GAME_DETECTION_SERVICE_ID}`);
+
+  const gameLibrary = new GameLibraryService();
+  gameLibrary.emit = ({ event, data }) => {
+    broadcast({ type: "event", plugin: GAME_LIBRARY_SERVICE_ID, event, data });
+  };
+  plugins.set(GAME_LIBRARY_SERVICE_ID, {
+    meta: {
+      id: GAME_LIBRARY_SERVICE_ID,
+      name: "Game Library",
+      version: "0.0.0",
+      description:
+        "Core service: enumerates installed Steam apps and non-Steam shortcuts.",
+      author: "core",
+    },
+    instance: gameLibrary,
+    sandboxedFetch: globalThis.fetch,
+    hasApp: false,
+  });
+  log.info(`Registered core service: ${GAME_LIBRARY_SERVICE_ID}`);
 
   const rpcHandler = createRpcHandler(
     new Map(

--- a/apps/loadout/src/loader/services/game-library.test.ts
+++ b/apps/loadout/src/loader/services/game-library.test.ts
@@ -1,0 +1,160 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import type { GameInfo, GameLibraryChangedEvent } from "@loadout/types";
+
+// Mock the underlying scan helpers. The service should treat
+// `@loadout/game-library` as an opaque scan function — only the
+// caching and broadcast wiring lives in the loader.
+let mockGames: GameInfo[] = [];
+let scanCalls = 0;
+mock.module("@loadout/game-library", () => ({
+  scanLibrary: async () => {
+    scanCalls += 1;
+    return mockGames.map((g) => ({ ...g }));
+  },
+  getCollectionsFromGames: (games: GameInfo[]) => {
+    const counts = new Map<string, number>();
+    for (const g of games) {
+      for (const t of g.tags) counts.set(t, (counts.get(t) ?? 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([id, count]) => ({ id, count }))
+      .sort((a, b) => b.count - a.count || a.id.localeCompare(b.id));
+  },
+}));
+
+import {
+  GameLibraryService,
+  GAME_LIBRARY_SERVICE_ID,
+} from "./game-library";
+
+function game(appId: string, name: string, tags: string[] = []): GameInfo {
+  return {
+    appId,
+    name,
+    sizeOnDisk: 0,
+    headerUrl: "",
+    capsuleUrl: "",
+    localHeaderUrl: "",
+    localCapsuleUrl: "",
+    source: "steam",
+    tags,
+  };
+}
+
+describe("GameLibraryService", () => {
+  let service: GameLibraryService;
+  let events: GameLibraryChangedEvent[];
+
+  beforeEach(() => {
+    mockGames = [];
+    scanCalls = 0;
+    service = new GameLibraryService();
+    events = [];
+    service.emit = ({ event, data }) => {
+      if (event === "libraryChanged")
+        events.push(data as GameLibraryChangedEvent);
+    };
+  });
+
+  afterEach(() => {
+    mockGames = [];
+  });
+
+  test("exports the canonical service id", () => {
+    expect(GAME_LIBRARY_SERVICE_ID).toBe("__core:game-library");
+  });
+
+  test("getGames starts with an empty cache and triggers a scan on first call", async () => {
+    expect(scanCalls).toBe(0);
+    const games = await service.getGames();
+    expect(games).toEqual([]);
+    expect(scanCalls).toBe(1);
+  });
+
+  test("getGames returns cached results without re-scanning on repeat calls", async () => {
+    mockGames = [game("1", "Alpha")];
+    await service.getGames();
+    await service.getGames();
+    expect(scanCalls).toBe(1);
+  });
+
+  test("rescan populates the cache and broadcasts when the library transitions from empty to populated", async () => {
+    mockGames = [game("1", "Alpha", ["fav"])];
+    const result = await service.rescan();
+    expect(result).toHaveLength(1);
+    expect(result[0].appId).toBe("1");
+    expect(events).toHaveLength(1);
+    expect(events[0].games).toHaveLength(1);
+    expect(events[0].collections).toEqual([{ id: "fav", count: 1 }]);
+  });
+
+  test("rescan with identical data does NOT broadcast (signature unchanged)", async () => {
+    mockGames = [game("1", "Alpha"), game("2", "Beta")];
+    await service.rescan();
+    expect(events).toHaveLength(1);
+
+    // Same games, same order — signature unchanged, no re-broadcast.
+    await service.rescan();
+    expect(events).toHaveLength(1);
+  });
+
+  test("rescan with a new appId DOES broadcast", async () => {
+    mockGames = [game("1", "Alpha")];
+    await service.rescan();
+    expect(events).toHaveLength(1);
+
+    mockGames = [game("1", "Alpha"), game("2", "Beta")];
+    await service.rescan();
+    expect(events).toHaveLength(2);
+    expect(events[1].games.map((g) => g.appId).sort()).toEqual(["1", "2"]);
+  });
+
+  test("rescan with the same membership in a different order is still a no-op broadcast", async () => {
+    mockGames = [game("1", "Alpha"), game("2", "Beta")];
+    await service.rescan();
+    expect(events).toHaveLength(1);
+
+    // Mock returns the same set; scanLibrary in production already
+    // sorts alphabetically. Signature is membership-based, so a
+    // shuffled-but-identical set is treated as no-change.
+    mockGames = [game("2", "Beta"), game("1", "Alpha")];
+    await service.rescan();
+    expect(events).toHaveLength(1);
+  });
+
+  test("getCollections derives counts from the cached library", async () => {
+    mockGames = [
+      game("1", "Alpha", ["fav", "rpg"]),
+      game("2", "Beta", ["fav"]),
+    ];
+    await service.getGames(); // prime cache
+    const collections = await service.getCollections();
+    expect(collections).toEqual([
+      { id: "fav", count: 2 },
+      { id: "rpg", count: 1 },
+    ]);
+  });
+
+  test("emit is optional — methods don't throw without it", async () => {
+    mockGames = [game("1", "Alpha")];
+    const s = new GameLibraryService();
+    await s.getGames();
+    await s.rescan();
+    expect(await s.getCollections()).toEqual([]);
+  });
+
+  test("rescan returns a defensive copy — callers can't mutate the cache", async () => {
+    mockGames = [game("1", "Alpha", ["fav"])];
+    const a = await service.rescan();
+    a[0].tags.push("hacked");
+    const b = await service.getGames();
+    expect(b[0].tags).toEqual(["fav"]);
+  });
+});

--- a/apps/loadout/src/loader/services/game-library.ts
+++ b/apps/loadout/src/loader/services/game-library.ts
@@ -1,0 +1,86 @@
+import type {
+  EmitPayload,
+  GameCollection,
+  GameInfo,
+  GameLibraryChangedEvent,
+  PluginBackend,
+} from "@loadout/types";
+import {
+  getCollectionsFromGames,
+  scanLibrary,
+} from "@loadout/game-library";
+
+/**
+ * `__core:game-library` core service. Replaces the deprecated
+ * `game-browser` plugin (the panel had no UX value; the backend was
+ * load-bearing for hltb / launch-options / sgdb / lsfg-vk /
+ * protondb-badges). Lives in the loader so we have a single cache
+ * shared across every consumer.
+ *
+ * Pattern mirrors `__core:game-detection`: the service owns the
+ * cache, emits a `libraryChanged` event when the rescan result
+ * differs from the prior cache (signature-compared so identical
+ * rescans don't spam every subscriber), and exposes its RPC surface
+ * through the normal `PluginBackend` resolver. The actual scan logic
+ * is in `@loadout/game-library` and stays mockable as a separate
+ * package.
+ */
+export class GameLibraryService implements PluginBackend {
+  private cache: GameInfo[] | null = null;
+  // Audit precedent A-026 in `__core:game-detection`: cache the
+  // signature of the last broadcast so a no-op rescan (same games,
+  // same order) doesn't trigger a re-render on every subscriber.
+  // Seeded with the empty-state signature so the very first no-op
+  // call also short-circuits.
+  private lastBroadcastSig: string = "0|";
+  emit?: (payload: EmitPayload) => void;
+
+  /** Return the cached library, scanning on first access. */
+  async getGames(): Promise<GameInfo[]> {
+    if (this.cache === null) {
+      this.cache = await scanLibrary();
+    }
+    return this.cache.map((g) => ({ ...g, tags: [...g.tags] }));
+  }
+
+  /** Derive collections from the cached library. */
+  async getCollections(): Promise<GameCollection[]> {
+    const games = this.cache ?? (await this.getGames());
+    return getCollectionsFromGames(games);
+  }
+
+  /**
+   * Force a re-scan. Broadcasts `libraryChanged` if the result differs
+   * from the prior cache. Returns the fresh list either way.
+   */
+  async rescan(): Promise<GameInfo[]> {
+    const fresh = await scanLibrary();
+    this.cache = fresh;
+    this.broadcastChange();
+    return fresh.map((g) => ({ ...g, tags: [...g.tags] }));
+  }
+
+  private broadcastChange(): void {
+    const games = this.cache ?? [];
+    const sig = this.signature(games);
+    if (sig === this.lastBroadcastSig) return;
+    this.lastBroadcastSig = sig;
+    const payload: GameLibraryChangedEvent = {
+      games: games.map((g) => ({ ...g, tags: [...g.tags] })),
+      collections: getCollectionsFromGames(games),
+    };
+    this.emit?.({ event: "libraryChanged", data: payload });
+  }
+
+  private signature(games: GameInfo[]): string {
+    // Compact projection: count + sorted appId list. Two libraries with
+    // identical membership are treated as identical; an appId or
+    // shortcut added/removed flips the sig. Names/tags shifts don't
+    // bump the signature today — consumers re-poll on `libraryChanged`
+    // for fresh metadata when they care.
+    const ids = games.map((g) => g.appId).sort();
+    return `${games.length}|${ids.join(",")}`;
+  }
+}
+
+export const GAME_LIBRARY_SERVICE_ID = "__core:game-library";

--- a/bun.lock
+++ b/bun.lock
@@ -84,6 +84,15 @@
         "@loadout/exec": "workspace:*",
       },
     },
+    "packages/game-library": {
+      "name": "@loadout/game-library",
+      "version": "0.0.1",
+      "dependencies": {
+        "@loadout/steam-paths": "workspace:*",
+        "@loadout/types": "workspace:*",
+        "@loadout/vdf": "workspace:*",
+      },
+    },
     "packages/per-game-profiles": {
       "name": "@loadout/per-game-profiles",
       "version": "0.0.1",
@@ -350,6 +359,8 @@
     "@loadout/external-cache": ["@loadout/external-cache@workspace:packages/external-cache"],
 
     "@loadout/file-picker": ["@loadout/file-picker@workspace:packages/file-picker"],
+
+    "@loadout/game-library": ["@loadout/game-library@workspace:packages/game-library"],
 
     "@loadout/loadout-overlay": ["@loadout/loadout-overlay@workspace:apps/loadout-overlay"],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,39 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import reactHooks from "eslint-plugin-react-hooks";
 import prettier from "eslint-config-prettier";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Discover server-only packages by reading every `packages/*/package.json`
+// and collecting names where `loadout.serverOnly === true`. The
+// corresponding `no-restricted-imports` block forbids plugins (and any
+// non-loader code) from importing the implementation — they must consume
+// the matching `__core:*` RPC surface instead. New server-only packages
+// opt in by adding `"loadout": { "serverOnly": true }` to their
+// package.json; this loop picks them up automatically.
+const serverOnlyPackages = (() => {
+  try {
+    return readdirSync("packages", { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .flatMap((d) => {
+        try {
+          const pkg = JSON.parse(
+            readFileSync(join("packages", d.name, "package.json"), "utf8"),
+          );
+          return pkg.loadout?.serverOnly ? [pkg.name] : [];
+        } catch {
+          return [];
+        }
+      });
+  } catch {
+    return [];
+  }
+})();
+
+const serverOnlyPathBlocks = serverOnlyPackages.map((name) => ({
+  name,
+  message: `${name} is server-only — it's consumed by the loader's __core:* services. Plugins must call the matching RPC surface (e.g. useBackend("__core:game-library")) instead of importing the implementation.`,
+}));
 
 export default tseslint.config(
   {
@@ -112,12 +145,22 @@ export default tseslint.config(
   // another plugin in its dependencies today, so that vector is moot.
   //
   // Depth 1 (`plugins/<name>/<file>.ts`): any `../<x>` escapes.
+  //
+  // The `paths` entry seals server-only packages (those whose
+  // package.json declares `"loadout": { "serverOnly": true }`).
+  // Importing one of those by name from a plugin is forbidden — the
+  // plugin must call the matching `__core:*` RPC surface instead. The
+  // list is discovered at config-load time; new server-only packages
+  // opt in by flipping the flag. ESLint replaces (not merges) rule
+  // options across configs, so the seal has to live inside the same
+  // `no-restricted-imports` entry as the plugin-seal patterns.
   {
     files: ["plugins/*/*.ts", "plugins/*/*.tsx"],
     rules: {
       "no-restricted-imports": [
         "error",
         {
+          paths: serverOnlyPathBlocks,
           patterns: [
             {
               regex:
@@ -142,6 +185,7 @@ export default tseslint.config(
       "no-restricted-imports": [
         "error",
         {
+          paths: serverOnlyPathBlocks,
           patterns: [
             {
               regex:
@@ -166,6 +210,7 @@ export default tseslint.config(
       "no-restricted-imports": [
         "error",
         {
+          paths: serverOnlyPathBlocks,
           patterns: [
             {
               regex:

--- a/packages/game-library/README.md
+++ b/packages/game-library/README.md
@@ -1,0 +1,61 @@
+# @loadout/game-library
+
+> **⚠️ Server-only.** This package is consumed by the loader's
+> `__core:game-library` core service. **Plugins MUST NOT import it.**
+> Use `useBackend("__core:game-library").call("getGames")` from a
+> plugin instead — the RPC surface is the contract; the implementation
+> is internal to the loader.
+>
+> Enforced by the `serverOnly` lint rule in `eslint.config.js` (reads
+> `loadout.serverOnly: true` from this package.json).
+
+## Purpose
+
+Pure async scan logic for the installed Steam library: walks every
+`appmanifest_*.acf`, merges in non-Steam `shortcuts.vdf` entries, and
+attaches user-defined Library Collection tags from
+`localconfig.vdf`. The result is a deduped, alphabetised `GameInfo[]`
+the loader caches and exposes via the `__core:game-library` RPC.
+
+This package is the implementation; the runtime service wrapper
+(caching, debounced broadcast, RPC method names) lives in
+`apps/loadout/src/loader/services/game-library.ts`.
+
+## API
+
+```ts
+import {
+  scanLibrary,
+  getCollectionsFromGames,
+} from "@loadout/game-library";
+import type { GameInfo, GameCollection } from "@loadout/types";
+
+const games: GameInfo[] = await scanLibrary();
+const collections: GameCollection[] = getCollectionsFromGames(games);
+
+// Optional: override the loader origin used to build local artwork URLs
+// (defaults to `http://localhost:33820`).
+await scanLibrary({ loaderOrigin: "http://localhost:33820" });
+```
+
+Types are re-exported from `@loadout/types` so plugins can type the
+RPC return without importing this package.
+
+## Consumers
+
+- **Loader only**, via `apps/loadout/src/loader/services/game-library.ts`.
+
+Plugins that need library listings (e.g. hltb, launch-options, sgdb,
+lsfg-vk, protondb-badges) call the service over RPC:
+
+```ts
+const library = useBackend<{
+  getGames(): Promise<GameInfo[]>;
+  getCollections(): Promise<GameCollection[]>;
+  rescan(): Promise<GameInfo[]>;
+}>("__core:game-library");
+const games = await library.call("getGames");
+```
+
+Subscribe to `libraryChanged` to get pushed updates when the scan
+result changes between rescans.

--- a/packages/game-library/package.json
+++ b/packages/game-library/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@loadout/game-library",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT",
+  "loadout": { "serverOnly": true },
+  "dependencies": {
+    "@loadout/types": "workspace:*",
+    "@loadout/steam-paths": "workspace:*",
+    "@loadout/vdf": "workspace:*"
+  }
+}

--- a/packages/game-library/src/index.test.ts
+++ b/packages/game-library/src/index.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for the pure scan helpers in @loadout/game-library.
+ *
+ * `os.homedir()` ignores `$HOME` on Linux (reads from passwd), so we
+ * can't redirect the steam-paths helpers via env vars. We mock the
+ * `@loadout/steam-paths` module and let each test point the scan at
+ * its own per-test temp tree. The mock is module-local to this file
+ * — there's no cross-spec leakage to worry about because our
+ * `test:backend` runner is one-process-per-file
+ * (`scripts/test-backend.sh`).
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tempRoot: string;
+
+mock.module("@loadout/steam-paths", () => ({
+  getLibraryPaths: async () => {
+    if (!tempRoot) return [];
+    return [join(tempRoot, "steamapps")];
+  },
+  getUserdataDir: () => join(tempRoot, "userdata"),
+  getUserIds: async () => {
+    if (!tempRoot) return [];
+    try {
+      const { readdirSync } = await import("node:fs");
+      return readdirSync(join(tempRoot, "userdata"), {
+        withFileTypes: true,
+      })
+        .filter((d) => d.isDirectory() && /^\d+$/.test(d.name))
+        .map((d) => d.name);
+    } catch {
+      return [];
+    }
+  },
+}));
+
+import { getCollectionsFromGames, scanLibrary } from "./index";
+import type { GameInfo } from "@loadout/types";
+
+// --- Binary VDF builder helpers (mirror packages/vdf binary-vdf.test.ts) ---
+
+function strField(key: string, value: string): Uint8Array {
+  const k = Buffer.from(key + "\0", "utf-8");
+  const v = Buffer.from(value + "\0", "utf-8");
+  const buf = Buffer.alloc(1 + k.length + v.length);
+  buf[0] = 0x01;
+  buf.set(k, 1);
+  buf.set(v, 1 + k.length);
+  return buf;
+}
+
+function int32Field(key: string, value: number): Uint8Array {
+  const k = Buffer.from(key + "\0", "utf-8");
+  const buf = Buffer.alloc(1 + k.length + 4);
+  buf[0] = 0x02;
+  buf.set(k, 1);
+  // Steam stores appids as uint32, but the binary VDF type byte is
+  // generic int32. Use the unsigned writer so callers can pass uint32
+  // values with the top bit set; the parser sign-extends and the
+  // production reader does `>>> 0` to recover the unsigned form.
+  buf.writeUInt32LE(value >>> 0, 1 + k.length);
+  return buf;
+}
+
+function objectFieldHeader(key: string): Uint8Array {
+  const k = Buffer.from(key + "\0", "utf-8");
+  const buf = Buffer.alloc(1 + k.length);
+  buf[0] = 0x00;
+  buf.set(k, 1);
+  return buf;
+}
+
+const END = Buffer.from([0x08]);
+
+function concat(parts: Uint8Array[]): Buffer {
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = Buffer.alloc(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+function buildShortcutsVdf(
+  shortcuts: Array<{ appid: number; appname: string; tags?: string[] }>,
+): Buffer {
+  const inner: Uint8Array[] = [];
+  shortcuts.forEach((sc, idx) => {
+    inner.push(objectFieldHeader(String(idx)));
+    inner.push(int32Field("appid", sc.appid));
+    inner.push(strField("appname", sc.appname));
+    if (sc.tags && sc.tags.length > 0) {
+      inner.push(objectFieldHeader("tags"));
+      sc.tags.forEach((t, ti) => inner.push(strField(String(ti), t)));
+      inner.push(END); // close tags
+    }
+    inner.push(END); // close this shortcut
+  });
+  // Top-level: `shortcuts` object containing the entries, then root end.
+  return concat([objectFieldHeader("shortcuts"), ...inner, END, END]);
+}
+
+function writeAcf(
+  appsPath: string,
+  appId: string,
+  name: string,
+  size = 0,
+): void {
+  mkdirSync(appsPath, { recursive: true });
+  const body = `"AppState"\n{\n\t"appid"\t\t"${appId}"\n\t"name"\t\t"${name}"\n\t"SizeOnDisk"\t\t"${size}"\n}\n`;
+  writeFileSync(join(appsPath, `appmanifest_${appId}.acf`), body, "utf-8");
+}
+
+function writeShortcuts(
+  userdataRoot: string,
+  userId: string,
+  shortcuts: Array<{ appid: number; appname: string; tags?: string[] }>,
+): void {
+  const cfg = join(userdataRoot, userId, "config");
+  mkdirSync(cfg, { recursive: true });
+  writeFileSync(join(cfg, "shortcuts.vdf"), buildShortcutsVdf(shortcuts));
+}
+
+function writeLocalConfigWithCollections(
+  userdataRoot: string,
+  userId: string,
+  collections: Record<string, { id: string; added: number[] }>,
+): void {
+  const cfg = join(userdataRoot, userId, "config");
+  mkdirSync(cfg, { recursive: true });
+  // Steam serialises user-collections as an escaped JSON string. The
+  // surgical regex only needs a `"user-collections" "<escaped>"` pair.
+  const escaped = JSON.stringify(collections)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+  const body = `"UserLocalConfigStore"\n{\n\t"WebStorage"\n\t{\n\t\t"user-collections"\t\t"${escaped}"\n\t}\n}\n`;
+  writeFileSync(join(cfg, "localconfig.vdf"), body, "utf-8");
+}
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), "game-library-spec-"));
+});
+
+afterEach(() => {
+  rmSync(tempRoot, { recursive: true, force: true });
+  tempRoot = "";
+});
+
+describe("scanLibrary", () => {
+  test("returns an empty array when no library paths or users exist", async () => {
+    const games = await scanLibrary();
+    expect(games).toEqual([]);
+  });
+
+  test("merges one ACF + one shortcut into the library", async () => {
+    writeAcf(join(tempRoot, "steamapps"), "504230", "Celeste", 1234567);
+    writeShortcuts(join(tempRoot, "userdata"), "12345", [
+      { appid: 2147483649, appname: "Yuzu", tags: ["Emulation"] },
+    ]);
+
+    const games = await scanLibrary();
+
+    expect(games).toHaveLength(2);
+    const celeste = games.find((g) => g.appId === "504230");
+    expect(celeste).toBeDefined();
+    expect(celeste?.source).toBe("steam");
+    expect(celeste?.sizeOnDisk).toBe(1234567);
+    expect(celeste?.headerUrl).toContain(
+      "cdn.cloudflare.steamstatic.com/steam/apps/504230/header.jpg",
+    );
+    expect(celeste?.capsuleUrl).toContain("library_600x900.jpg");
+    expect(celeste?.localHeaderUrl).toContain(
+      "/api/steam-grid/504230/12345/header",
+    );
+
+    const shortcut = games.find((g) => g.source === "shortcut");
+    expect(shortcut).toBeDefined();
+    expect(shortcut?.name).toBe("Yuzu");
+    // appid 2147483649 has the top bit set; reader recovers via `>>> 0`.
+    expect(shortcut?.appId).toBe(String(2147483649 >>> 0));
+    expect(shortcut?.tags).toEqual(["Emulation"]);
+    expect(shortcut?.headerUrl).toContain("/api/steam-grid/");
+    expect(shortcut?.localHeaderUrl).toEqual(shortcut?.headerUrl);
+  });
+
+  test("attaches user-collection tags from localconfig.vdf to matching Steam apps", async () => {
+    writeAcf(join(tempRoot, "steamapps"), "504230", "Celeste");
+    // Need a shortcuts.vdf so the user-config dir is materialised; an
+    // empty payload is fine.
+    writeShortcuts(join(tempRoot, "userdata"), "12345", []);
+    writeLocalConfigWithCollections(join(tempRoot, "userdata"), "12345", {
+      favorite: { id: "favorite", added: [504230] },
+    });
+
+    const games = await scanLibrary();
+    const celeste = games.find((g) => g.appId === "504230");
+    expect(celeste?.tags).toEqual(["favorite"]);
+  });
+
+  test("respects a custom loaderOrigin for local-art URLs", async () => {
+    writeAcf(join(tempRoot, "steamapps"), "504230", "Celeste");
+    writeShortcuts(join(tempRoot, "userdata"), "12345", []);
+
+    const games = await scanLibrary({ loaderOrigin: "http://example:1234" });
+    const celeste = games.find((g) => g.appId === "504230");
+    expect(celeste?.localHeaderUrl).toBe(
+      "http://example:1234/api/steam-grid/504230/12345/header",
+    );
+  });
+});
+
+describe("getCollectionsFromGames", () => {
+  function game(appId: string, tags: string[]): GameInfo {
+    return {
+      appId,
+      name: appId,
+      sizeOnDisk: 0,
+      headerUrl: "",
+      capsuleUrl: "",
+      localHeaderUrl: "",
+      localCapsuleUrl: "",
+      source: "steam",
+      tags,
+    };
+  }
+
+  test("returns [] for an empty library", () => {
+    expect(getCollectionsFromGames([])).toEqual([]);
+  });
+
+  test("counts tag occurrences and sorts most-populated first", () => {
+    const out = getCollectionsFromGames([
+      game("1", ["fav", "rpg"]),
+      game("2", ["fav"]),
+      game("3", ["rpg"]),
+      game("4", ["fav", "rpg", "indie"]),
+    ]);
+    expect(out).toEqual([
+      { id: "fav", count: 3 },
+      { id: "rpg", count: 3 },
+      { id: "indie", count: 1 },
+    ]);
+  });
+});

--- a/packages/game-library/src/index.ts
+++ b/packages/game-library/src/index.ts
@@ -1,0 +1,322 @@
+/**
+ * @loadout/game-library — pure scan logic for the `__core:game-library`
+ * core service. **Server-only**: plugins must consume the service via
+ * `useBackend("__core:game-library")`, not import this package
+ * directly. The seal is enforced by the `serverOnly` lint rule in
+ * `eslint.config.js` (which reads `loadout.serverOnly: true` from this
+ * package's `package.json`).
+ *
+ * Lifted from the retired `game-browser` plugin's backend; the
+ * `PluginBackend`/`EmitPayload` class wrapper was dropped — the loader
+ * now hosts the service wrapper (see
+ * `apps/loadout/src/loader/services/game-library.ts`). What lives here
+ * is pure, mockable async functions.
+ */
+
+import type { GameInfo, GameCollection } from "@loadout/types";
+import {
+  getLibraryPaths,
+  getUserdataDir,
+  getUserIds,
+} from "@loadout/steam-paths";
+import { parseBinaryVdf, shortcutGameId64 } from "@loadout/vdf";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Default loader origin. Loader-hosted artwork URLs must be absolute:
+ * the CEF webview loads from `views://overlay/index.html`, so a
+ * relative `/api/...` resolves to `views:///api/...` and never reaches
+ * the Bun server. The loader binds 33820 in both dev and prod, so we
+ * hardcode it — same convention as `packages/ui/src/ws-client.ts`.
+ * Overridable via `scanLibrary({ loaderOrigin })` for tests and
+ * forward-compat with port-discovery wiring.
+ */
+const DEFAULT_LOADER_ORIGIN = "http://localhost:33820";
+
+export interface ScanLibraryOptions {
+  /** Origin used to build local `/api/steam-grid/*` URLs. */
+  loaderOrigin?: string;
+}
+
+/**
+ * Build the local-endpoint URL the loader exposes for an art stem. The
+ * route lives in the loader and probes a small set of filename
+ * suffixes server-side.
+ */
+function localArtUrl(
+  origin: string,
+  stem: string,
+  userId: string,
+  type: "header" | "capsule",
+): string {
+  return `${origin}/api/steam-grid/${stem}/${userId}/${type}`;
+}
+
+/**
+ * Read all non-Steam shortcut entries (added via "Add a non-Steam game"
+ * or by tools like EmuDeck) from `userdata/<id>/config/shortcuts.vdf`.
+ * Each entry includes its own appid, display name, and embedded `tags`
+ * set.
+ */
+async function readShortcutsForUser(
+  origin: string,
+  userId: string,
+): Promise<GameInfo[]> {
+  const path = join(getUserdataDir(), userId, "config", "shortcuts.vdf");
+  let buf: Buffer;
+  try {
+    buf = await readFile(path);
+  } catch {
+    return []; // file may not exist if the user has never added a shortcut
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseBinaryVdf(buf) as Record<string, unknown>;
+  } catch (err) {
+    console.warn(
+      `[game-library] Failed to parse shortcuts.vdf for user ${userId}:`,
+      err instanceof Error ? err.message : err,
+    );
+    return [];
+  }
+
+  const shortcuts = (parsed.shortcuts ?? {}) as Record<string, unknown>;
+  const games: GameInfo[] = [];
+
+  for (const entry of Object.values(shortcuts)) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const sc = entry as Record<string, unknown>;
+
+    // Required fields. `appid` may be parsed as signed (top bit set →
+    // negative); `>>> 0` re-interprets it as the uint32 Steam stores.
+    const rawAppId = sc.appid;
+    if (typeof rawAppId !== "number") continue;
+    const appIdUint = rawAppId >>> 0;
+    const appIdStr = String(appIdUint);
+
+    const name = typeof sc.appname === "string" ? sc.appname : appIdStr;
+
+    // Tags live as a sub-object with numeric keys mapping to tag strings:
+    //   tags: { "0": "Nintendo Switch - Eden", "1": "Emulation" }
+    const tagsObj = (sc.tags ?? {}) as Record<string, unknown>;
+    const tags: string[] = Object.values(tagsObj).filter(
+      (t): t is string => typeof t === "string" && t.length > 0,
+    );
+
+    // Local artwork lives under userdata/<id>/config/grid/ keyed by the
+    // 64-bit gameid (NOT the 32-bit appid). The HTTP route on the
+    // loader resolves the actual file extension (png / jpg) at request
+    // time.
+    const gameid64 = shortcutGameId64(appIdUint);
+    const localHeader = localArtUrl(origin, gameid64, userId, "header");
+    const localCapsule = localArtUrl(origin, gameid64, userId, "capsule");
+
+    games.push({
+      appId: appIdStr,
+      name,
+      sizeOnDisk: 0,
+      headerUrl: localHeader,
+      capsuleUrl: localCapsule,
+      localHeaderUrl: localHeader,
+      localCapsuleUrl: localCapsule,
+      source: "shortcut",
+      tags,
+    });
+  }
+
+  return games;
+}
+
+/**
+ * Read user-defined Steam Library Collections from
+ * `userdata/<id>/config/localconfig.vdf`. Steam serialises these as a
+ * single string value `"user-collections"` whose body is escape-encoded
+ * JSON of shape `{ <collectionId>: { id, added: [appid, …], removed: [] }}`.
+ *
+ * Returns a Map: `appId` (string) → list of collection ids that include it.
+ */
+async function readUserCollections(
+  userId: string,
+): Promise<Map<string, string[]>> {
+  const path = join(getUserdataDir(), userId, "config", "localconfig.vdf");
+  let text: string;
+  try {
+    text = await readFile(path, "utf-8");
+  } catch {
+    return new Map();
+  }
+
+  // Surgical extraction so we don't have to parse the whole VDF tree.
+  // The value is a single JSON string with backslash-escaped quotes.
+  const match = text.match(/"user-collections"\s*"((?:[^"\\]|\\.)*)"/);
+  if (!match) return new Map();
+
+  const escaped = match[1];
+  const unescaped = escaped.replace(/\\\\/g, "\\").replace(/\\"/g, '"');
+
+  let collections: Record<string, { id?: string; added?: number[] }>;
+  try {
+    collections = JSON.parse(unescaped);
+  } catch (err) {
+    console.warn(
+      `[game-library] Failed to parse user-collections for user ${userId}:`,
+      err instanceof Error ? err.message : err,
+    );
+    return new Map();
+  }
+
+  const byApp = new Map<string, string[]>();
+  for (const [collectionKey, c] of Object.entries(collections)) {
+    if (!c || typeof c !== "object") continue;
+    const collectionId = c.id ?? collectionKey;
+    const added = Array.isArray(c.added) ? c.added : [];
+    for (const rawId of added) {
+      if (typeof rawId !== "number") continue;
+      const appIdStr = String(rawId >>> 0);
+      const list = byApp.get(appIdStr);
+      if (list) {
+        if (!list.includes(collectionId)) list.push(collectionId);
+      } else {
+        byApp.set(appIdStr, [collectionId]);
+      }
+    }
+  }
+  return byApp;
+}
+
+/** Extract a value from Steam's VDF/ACF key-value format. */
+function parseVdfValue(content: string, key: string): string | null {
+  const regex = new RegExp(`"${key}"\\s+"([^"]*)"`, "i");
+  const match = content.match(regex);
+  return match ? match[1] : null;
+}
+
+/**
+ * Walk every Steam library path on disk, merge in non-Steam shortcuts
+ * and user-defined collection tags, and return the deduped library
+ * sorted alphabetically (case-insensitive).
+ *
+ * - Dedupes by appId. Steam can leave stale `appmanifest_*.acf` files
+ *   in a previous library folder when a game is moved between drives,
+ *   so the same appId can appear under multiple library paths. First
+ *   occurrence wins (libraryPaths is in Steam's own preferred order).
+ * - Steam apps always use Steam's CDN `library_600x900.jpg` for the
+ *   tile artwork — that's the canonical 2:3 portrait every other
+ *   surface (Steam Library, Big Picture) shows. We keep
+ *   `localCapsuleUrl` / `localHeaderUrl` on every GameInfo so consumers
+ *   that just wrote custom art can refresh the tile via the local
+ *   endpoint without waiting for the public `Cache-Control: max-age`.
+ *   We intentionally don't try to detect pre-existing local art at
+ *   scan time — landscape files would crop weirdly in the portrait
+ *   tiles, and any wins from showing local portraits up-front aren't
+ *   worth that visual regression.
+ */
+export async function scanLibrary(
+  opts: ScanLibraryOptions = {},
+): Promise<GameInfo[]> {
+  const origin = opts.loaderOrigin ?? DEFAULT_LOADER_ORIGIN;
+  const byAppId = new Map<string, GameInfo>();
+
+  const userIds = await getUserIds();
+  const primaryUserId = userIds[0] ?? null;
+
+  try {
+    // Real Steam games — appmanifest_*.acf scan
+    const libraryPaths = await getLibraryPaths();
+    for (const appsPath of libraryPaths) {
+      let entries: string[];
+      try {
+        entries = await readdir(appsPath);
+      } catch {
+        continue;
+      }
+
+      for (const entry of entries) {
+        if (!entry.startsWith("appmanifest_") || !entry.endsWith(".acf"))
+          continue;
+
+        try {
+          const content = await readFile(join(appsPath, entry), "utf-8");
+          const appId = parseVdfValue(content, "appid");
+          const name = parseVdfValue(content, "name");
+          const sizeStr = parseVdfValue(content, "SizeOnDisk");
+
+          if (!appId || !name) continue;
+          if (byAppId.has(appId)) continue;
+
+          const sizeOnDisk = sizeStr ? parseInt(sizeStr) : 0;
+          // `header.jpg` is 460×215 landscape (fallback). `library_600x900.jpg`
+          // is the 600×900 portrait Steam itself shows in the library
+          // grid — every picker UI wants this for its tiles.
+          const cdnHeader = `https://cdn.cloudflare.steamstatic.com/steam/apps/${appId}/header.jpg`;
+          const cdnCapsule = `https://cdn.cloudflare.steamstatic.com/steam/apps/${appId}/library_600x900.jpg`;
+          const localHeader = primaryUserId
+            ? localArtUrl(origin, appId, primaryUserId, "header")
+            : cdnHeader;
+          const localCapsule = primaryUserId
+            ? localArtUrl(origin, appId, primaryUserId, "capsule")
+            : cdnCapsule;
+
+          byAppId.set(appId, {
+            appId,
+            name,
+            sizeOnDisk,
+            headerUrl: cdnHeader,
+            capsuleUrl: cdnCapsule,
+            localHeaderUrl: localHeader,
+            localCapsuleUrl: localCapsule,
+            source: "steam",
+            tags: [],
+          });
+        } catch {
+          // Skip unreadable manifests
+        }
+      }
+    }
+
+    // Non-Steam shortcuts + collections — per Steam user
+    for (const userId of userIds) {
+      const shortcuts = await readShortcutsForUser(origin, userId);
+      for (const sc of shortcuts) {
+        if (byAppId.has(sc.appId)) continue; // shouldn't happen but defensive
+        byAppId.set(sc.appId, sc);
+      }
+
+      // User-collection tags also apply to real Steam games (e.g. the
+      // `favorite` collection). Merge those into existing entries' tags.
+      const collectionsByApp = await readUserCollections(userId);
+      for (const [appId, collections] of collectionsByApp) {
+        const game = byAppId.get(appId);
+        if (!game) continue;
+        for (const c of collections) {
+          if (!game.tags.includes(c)) game.tags.push(c);
+        }
+      }
+    }
+  } catch (err) {
+    console.error("[game-library] Failed to scan library:", err);
+  }
+
+  // Sort alphabetically, case-insensitive
+  const games = Array.from(byAppId.values());
+  games.sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+  );
+  return games;
+}
+
+/**
+ * Derive the set of collection / tag names across the given library,
+ * ordered most-populated first. Powers picker filter dropdowns.
+ */
+export function getCollectionsFromGames(games: GameInfo[]): GameCollection[] {
+  const counts = new Map<string, number>();
+  for (const g of games) {
+    for (const t of g.tags) counts.set(t, (counts.get(t) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([id, count]) => ({ id, count }))
+    .sort((a, b) => b.count - a.count || a.id.localeCompare(b.id));
+}

--- a/packages/types/src/game-library.ts
+++ b/packages/types/src/game-library.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared types for the `__core:game-library` core service.
+ *
+ * Implementation lives in `@loadout/game-library` (server-only) and is
+ * hosted by the loader as the `__core:game-library` service. Plugins
+ * MUST consume the service via its RPC surface — `useBackend("__core:game-library")`
+ * — not import the implementation package. These types are the
+ * compile-time contract for both sides of that RPC.
+ */
+
+export type GameSource = "steam" | "shortcut";
+
+export interface GameInfo {
+  appId: string;
+  name: string;
+  /** Size on disk in bytes (manifest-reported; 0 for shortcuts). */
+  sizeOnDisk: number;
+  /** Header artwork URL — local `/api/steam-grid/*` when the user has
+   *  applied custom art (file exists in `userdata/<id>/config/grid/`),
+   *  Steam CDN otherwise for real games. Shortcuts always use local. */
+  headerUrl: string;
+  /** Capsule artwork URL — same scheme as `headerUrl`. */
+  capsuleUrl: string;
+  /** Forced local-endpoint URL for the header — always points at the
+   *  loader's `/api/steam-grid/<stem>/<userId>/header` route regardless
+   *  of whether a file exists right now. Consumers that just wrote
+   *  custom art use this with a cache-busting query string to refresh
+   *  the tile without waiting for the public `Cache-Control: max-age`. */
+  localHeaderUrl: string;
+  /** Forced local-endpoint URL for the capsule. See `localHeaderUrl`. */
+  localCapsuleUrl: string;
+  /** Where the entry came from. */
+  source: GameSource;
+  /** Steam categories / collections this game belongs to (collection ids
+   *  or legacy tag names). Used by callers to build collection filters. */
+  tags: string[];
+}
+
+export interface GameCollection {
+  id: string;
+  count: number;
+}
+
+/**
+ * Payload broadcast on the `libraryChanged` event when the library
+ * rescan produces a different result from the prior cache.
+ */
+export interface GameLibraryChangedEvent {
+  games: GameInfo[];
+  collections: GameCollection[];
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,3 +4,9 @@ export type { RpcRequest, RpcResponse, RpcEvent } from "./ipc";
 export type { RetryScanner, RetryScannerOptions } from "./scanner";
 export { createRetryScanner } from "./scanner";
 export type { WebviewMessages, WebviewAnalogAxis } from "./webview-messages";
+export type {
+  GameSource,
+  GameInfo,
+  GameCollection,
+  GameLibraryChangedEvent,
+} from "./game-library";


### PR DESCRIPTION
## Why

`game-browser` is a 5-consumer service plugin — hltb, launch-options,
sgdb, lsfg-vk, and protondb-badges all hit it for `getGames` /
`getCollections` library listings. The user-facing `panel.tsx` has no
real UX value (it was a debug panel for the scan output), but the
backend is load-bearing. Lift the backend into a `__core:` service
that mirrors the existing `__core:game-detection` pattern.

Closes #8. Supersedes any standing "migrate game-browser" plan — there
was no point porting the panel; we just need the service.

## Three layers

1. **`@loadout/types`** — compile-time contract. Adds `GameInfo`,
   `GameSource`, `GameCollection`, `GameLibraryChangedEvent`. Plugins
   import these for type safety on the RPC return without pulling in
   the (server-only) implementation.

2. **`@loadout/game-library`** — server-only implementation. Pure async
   helpers (`scanLibrary`, `getCollectionsFromGames`) lifted from the
   retired `game-browser/backend.ts`. The `PluginBackend` class
   wrapper is dropped — the service wrapper lives in the loader. This
   package is just the scan logic, mockable in isolation.

3. **`__core:game-library` service** at
   `apps/loadout/src/loader/services/game-library.ts`. Owns the cache,
   emits `libraryChanged` when a rescan produces a different
   membership (signature-compared so identical rescans don't spam
   subscribers — same A-026 pattern as game-detection). RPC surface:
   `getGames()`, `getCollections()`, `rescan()`. Registered next to
   `__core:game-detection` in `loader/index.ts`.

## Server-only lint rule

New `eslint.config.js` mechanism: at config-load time, every
`packages/*/package.json` is read and any whose
`loadout.serverOnly === true` is added to a `paths` block of
`no-restricted-imports`, merged into each of the three existing
plugin-seal depth blocks. Plugins importing one of those packages by
name fail lint with a message pointing them at the matching `__core:*`
RPC surface.

**Opt-in for future packages:** add `"loadout": { "serverOnly": true }`
to the package's `package.json`. The rule auto-picks it up — no
ESLint config change required.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 35 warnings, 0 errors (baseline preserved)
- `bun run test` — all 1038 tests pass (878 backend + 160 UI)
- `bun run build` — clean
- Lint rule fires: `import { scanLibrary } from "@loadout/game-library";` from a plugin file produces:
  ```
  error  '@loadout/game-library' import is restricted from being used.
         @loadout/game-library is server-only — it's consumed by the loader's
         __core:* services. Plugins must call the matching RPC surface
         (e.g. useBackend("__core:game-library")) instead of importing the
         implementation
         no-restricted-imports
  ```

## Follow-ups (NOT in this PR)

PRs #65 (hltb) and #66 (launch-options) must be rebased once this
lands to:

- Switch `useBackend("game-browser")` → `useBackend("__core:game-library")`.
- Replace local `GameInfo` / `CollectionEntry` type mirrors with
  imports from `@loadout/types`.

Don't try to fix those PRs in this one — clean handoff.