### PR TITLE
fix(game-library): prefer local route for Steam-app art so custom SGDB art persists

### DIFF
--- a/packages/game-library/src/index.test.ts
+++ b/packages/game-library/src/index.test.ts
@@ -179,13 +179,24 @@ describe("scanLibrary", () => {
     expect(celeste).toBeDefined();
     expect(celeste?.source).toBe("steam");
     expect(celeste?.sizeOnDisk).toBe(1234567);
+    // Steam apps now expose the loader's local route as the canonical
+    // header URL so the per-userdata custom-art lookup wins over the
+    // public CDN, and freshly-applied SGDB art shows up the next time
+    // the grid mounts. The CDN URL is still available as
+    // `cdnHeaderUrl` for plugins that explicitly want it.
     expect(celeste?.headerUrl).toContain(
-      "cdn.cloudflare.steamstatic.com/steam/apps/504230/header.jpg",
+      "/api/steam-grid/504230/12345/header",
     );
-    expect(celeste?.capsuleUrl).toContain("library_600x900.jpg");
+    expect(celeste?.capsuleUrl).toContain(
+      "/api/steam-grid/504230/12345/capsule",
+    );
     expect(celeste?.localHeaderUrl).toContain(
       "/api/steam-grid/504230/12345/header",
     );
+    expect(celeste?.cdnHeaderUrl).toContain(
+      "cdn.cloudflare.steamstatic.com/steam/apps/504230/header.jpg",
+    );
+    expect(celeste?.cdnCapsuleUrl).toContain("library_600x900.jpg");
 
     const shortcut = games.find((g) => g.source === "shortcut");
     expect(shortcut).toBeDefined();

--- a/packages/game-library/src/index.ts
+++ b/packages/game-library/src/index.ts
@@ -259,14 +259,33 @@ export async function scanLibrary(
             ? localArtUrl(origin, appId, primaryUserId, "capsule")
             : cdnCapsule;
 
+          // Prefer the loader's local `/api/steam-grid/...` route as
+          // the canonical art URL — its handler probes the user's
+          // `userdata/<id>/config/grid/` first (custom SGDB art wins),
+          // falls back to Steam's downloaded appcache, and only then
+          // 302-redirects to the public CDN when nothing is local.
+          // With `Cache-Control: no-cache` + an mtime-derived ETag,
+          // browsers revalidate on every reload so newly-applied
+          // custom art appears the next time a grid mounts — without
+          // this, plugins that used `headerUrl` would see Steam's
+          // CDN art forever regardless of what the user customised.
+          //
+          // The pure CDN URLs are kept on `cdnHeaderUrl` /
+          // `cdnCapsuleUrl` for the rare plugin that wants the
+          // public, longer-cacheable variant explicitly.
+          //
+          // If we couldn't resolve a primary user id (no userdata yet)
+          // the local route can't be built — fall back to CDN.
           byAppId.set(appId, {
             appId,
             name,
             sizeOnDisk,
-            headerUrl: cdnHeader,
-            capsuleUrl: cdnCapsule,
+            headerUrl: primaryUserId ? localHeader : cdnHeader,
+            capsuleUrl: primaryUserId ? localCapsule : cdnCapsule,
             localHeaderUrl: localHeader,
             localCapsuleUrl: localCapsule,
+            cdnHeaderUrl: cdnHeader,
+            cdnCapsuleUrl: cdnCapsule,
             source: "steam",
             tags: [],
           });

--- a/packages/types/src/game-library.ts
+++ b/packages/types/src/game-library.ts
@@ -15,20 +15,33 @@ export interface GameInfo {
   name: string;
   /** Size on disk in bytes (manifest-reported; 0 for shortcuts). */
   sizeOnDisk: number;
-  /** Header artwork URL — local `/api/steam-grid/*` when the user has
-   *  applied custom art (file exists in `userdata/<id>/config/grid/`),
-   *  Steam CDN otherwise for real games. Shortcuts always use local. */
+  /** Header artwork URL — points at the loader's local
+   *  `/api/steam-grid/<stem>/<userId>/header` route. That route's
+   *  handler probes the user's `userdata/<id>/config/grid/` first
+   *  (custom SGDB art wins), falls back to Steam's downloaded
+   *  appcache, and only 302-redirects to the public CDN as a last
+   *  resort. With its `Cache-Control: no-cache` + mtime-derived ETag
+   *  the browser revalidates on every reload, so freshly-applied
+   *  custom art shows up the next time a plugin grid mounts. */
   headerUrl: string;
   /** Capsule artwork URL — same scheme as `headerUrl`. */
   capsuleUrl: string;
-  /** Forced local-endpoint URL for the header — always points at the
-   *  loader's `/api/steam-grid/<stem>/<userId>/header` route regardless
-   *  of whether a file exists right now. Consumers that just wrote
-   *  custom art use this with a cache-busting query string to refresh
-   *  the tile without waiting for the public `Cache-Control: max-age`. */
+  /** Local-endpoint URL for the header — always points at the loader's
+   *  `/api/steam-grid/<stem>/<userId>/header` route. Now identical to
+   *  `headerUrl` for both Steam apps and shortcuts; the field stays
+   *  for backwards-compat and for the rare consumer that wants to
+   *  append its own cache-busting query string after a write. */
   localHeaderUrl: string;
-  /** Forced local-endpoint URL for the capsule. See `localHeaderUrl`. */
+  /** Local-endpoint URL for the capsule. See `localHeaderUrl`. */
   localCapsuleUrl: string;
+  /** Steam CDN URL for the header — only set for Steam apps (shortcuts
+   *  have no CDN counterpart). Plugins that explicitly want the public,
+   *  longer-cacheable CDN variant (skipping local custom art) can read
+   *  this. Most plugins should prefer `headerUrl` so user customisation
+   *  is respected. */
+  cdnHeaderUrl?: string;
+  /** Steam CDN URL for the capsule. See `cdnHeaderUrl`. */
+  cdnCapsuleUrl?: string;
   /** Where the entry came from. */
   source: GameSource;
   /** Steam categories / collections this game belongs to (collection ids


### PR DESCRIPTION
## Bug

When the user applies custom artwork (e.g. via the SteamGridDB plugin), the new art shows up correctly in that plugin's own grid. But closing the overlay or changing route resets the art back to Steam's CDN artwork across all plugin grids — the custom art only persists *inside* the steamgriddb plugin while it's mounted.

## Root cause

`scanLibrary()` set `headerUrl` / `capsuleUrl` to Steam's CDN URL for installed Steam apps (`cdn.cloudflare.steamstatic.com/steam/apps/<appId>/header.jpg`). The CDN doesn't know about the user's local `userdata/<id>/config/grid/` customisation, so plugins that consume `headerUrl` always see Steam's official art regardless of what the user customised.

The loader's `/api/steam-grid/<appId>/<userId>/<type>` route already handles the full fallback chain correctly:
1. Probe `userdata/<id>/config/grid/` (custom SGDB art wins)
2. Fall back to Steam's downloaded appcache
3. Last resort: 302 redirect to the public CDN

With `Cache-Control: no-cache` + an mtime-derived ETag the browser revalidates on each remount, so freshly-applied art picks up automatically the next time a plugin grid mounts.

## Fix

Point `headerUrl` / `capsuleUrl` at the local route — same way shortcuts already do. Custom art wins; if no custom and no appcache, the route 302s to CDN; if no userdata at all, we fall back to CDN at the `scanLibrary` level (no `primaryUserId` to build the local URL with).

Adds two new optional fields to `GameInfo`:
- `cdnHeaderUrl?: string` — Steam CDN header URL (preserved for plugins that explicitly want the public, longer-cacheable variant)
- `cdnCapsuleUrl?: string` — same for capsule

`localHeaderUrl` / `localCapsuleUrl` are unchanged but now identical to `headerUrl` / `capsuleUrl` for Steam apps.

## Behaviour change

| Field | Before | After |
|---|---|---|
| `headerUrl` (Steam app) | `cdn.cloudflare.steamstatic.com/.../header.jpg` | `/api/steam-grid/<appId>/<userId>/header` |
| `capsuleUrl` (Steam app) | `cdn.cloudflare.steamstatic.com/.../library_600x900.jpg` | `/api/steam-grid/<appId>/<userId>/capsule` |
| `headerUrl` (shortcut) | local | local *(unchanged)* |
| `cdnHeaderUrl` | *(absent)* | CDN URL when Steam app, `undefined` for shortcuts |

## Affected plugins

All grid-rendering plugins that consume `__core:game-library`:
- steamgriddb (PR #78)
- hltb (#65, merged)
- lsfg-vk (#75)
- launch-options (#66, merged)
- protondb-badges (#50, merged) — settings-only grid
- recomp (#80) — card grid
- store-bridge (#79) — picker

## CI

- typecheck clean
- lint baseline held (44 warnings = main)
- 1252 backend / 239 UI pass
- new test case pins the local-URL preference and the CDN URL on `cdnHeaderUrl` / `cdnCapsuleUrl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)