### PR TITLE
fix(fan-control): prefer real CPU die sensor over acpitz fallback

### DIFF
--- a/plugins/fan-control/backend.ts
+++ b/plugins/fan-control/backend.ts
@@ -24,6 +24,7 @@ import {
 } from "./lib/fan-curves";
 import {
   classifyTempZone,
+  cpuChipPriority,
   parsePwmMode,
   zoneSortWeight,
 } from "./lib/sensors";
@@ -752,8 +753,16 @@ export default class FanControlBackend implements PluginBackend {
       console.error("[fan-control] Error scanning temp sensors:", err);
     }
 
-    // Sort so CPU sensors come first, then GPU, then others
-    sensors.sort((a, b) => zoneSortWeight(a.zone) - zoneSortWeight(b.zone));
+    // Sort so CPU sensors come first, then GPU, then others. Within a zone,
+    // prefer a real CPU die sensor (k10temp/coretemp/zenpower) over the
+    // acpitz fallback — otherwise hwmon enumeration order decides, and acpitz
+    // (a slow board sensor that lags the die by tens of degrees) wins on
+    // AMD handhelds where it enumerates before k10temp.
+    sensors.sort((a, b) => {
+      const byZone = zoneSortWeight(a.zone) - zoneSortWeight(b.zone);
+      if (byZone !== 0) return byZone;
+      return cpuChipPriority(a.chipName) - cpuChipPriority(b.chipName);
+    });
 
     return sensors;
   }

--- a/plugins/fan-control/lib/sensors.test.ts
+++ b/plugins/fan-control/lib/sensors.test.ts
@@ -1,5 +1,48 @@
 import { describe, it, expect } from "bun:test";
-import { classifyTempZone, parsePwmMode, zoneSortWeight } from "./sensors";
+import {
+  classifyTempZone,
+  cpuChipPriority,
+  parsePwmMode,
+  zoneSortWeight,
+} from "./sensors";
+
+// ---------------------------------------------------------------------------
+// cpuChipPriority — within the CPU zone, the real die sensor must beat the
+// acpitz fallback. Regression: on the OXP APEX (and Deck) acpitz is a slow
+// board sensor reading ~70°C deep into idle; when k10temp is loaded it must
+// be the one shown / fed to the fan curve.
+// ---------------------------------------------------------------------------
+
+describe("cpuChipPriority()", () => {
+  it("ranks real CPU die chips ahead of acpitz", () => {
+    expect(cpuChipPriority("k10temp")).toBeLessThan(cpuChipPriority("acpitz"));
+    expect(cpuChipPriority("coretemp")).toBeLessThan(cpuChipPriority("acpitz"));
+    expect(cpuChipPriority("zenpower")).toBeLessThan(cpuChipPriority("acpitz"));
+  });
+
+  it("treats acpitz and other non-die chips as the fallback tier", () => {
+    expect(cpuChipPriority("acpitz")).toBe(1);
+    expect(cpuChipPriority("amdgpu")).toBe(1);
+  });
+
+  it("is case-insensitive on the chip name", () => {
+    expect(cpuChipPriority("K10TEMP")).toBe(0);
+  });
+
+  it("sorts a k10temp+acpitz mix so k10temp is selected first", () => {
+    // Mirrors backend scanTempSensors: zone weight first, then cpuChipPriority.
+    const sensors = [
+      { chipName: "acpitz", zone: "cpu" },
+      { chipName: "k10temp", zone: "cpu" },
+    ];
+    sensors.sort((a, b) => {
+      const byZone = zoneSortWeight(a.zone) - zoneSortWeight(b.zone);
+      if (byZone !== 0) return byZone;
+      return cpuChipPriority(a.chipName) - cpuChipPriority(b.chipName);
+    });
+    expect(sensors[0].chipName).toBe("k10temp");
+  });
+});
 
 // ---------------------------------------------------------------------------
 // classifyTempZone — moved out of backend.test.ts so the pure

--- a/plugins/fan-control/lib/sensors.ts
+++ b/plugins/fan-control/lib/sensors.ts
@@ -73,6 +73,18 @@ export function zoneSortWeight(zone: string): number {
   return order[zone] ?? 4;
 }
 
+/**
+ * Within a zone, prefer a real CPU die sensor (k10temp / coretemp / zenpower)
+ * over the `acpitz` ACPI-thermal-zone fallback. On AMD handhelds acpitz is a
+ * slow board/skin sensor that lags the die by tens of degrees, so when a real
+ * die chip is present it must win the "which sensor is the CPU" tiebreak.
+ * Both are classified `cpu` by `classifyTempZone`, so this is the secondary
+ * sort key. Lower = preferred. Pure.
+ */
+export function cpuChipPriority(chipName: string): number {
+  return CPU_TEMP_CHIPS.some((c) => chipName.toLowerCase().includes(c)) ? 0 : 1;
+}
+
 /** Parse a pwm_enable integer into a human-readable mode string. Pure. */
 export function parsePwmMode(value: number): "auto" | "manual" | "full" | "unknown" {
   switch (value) {


### PR DESCRIPTION
## Summary

Fan-control picks the wrong temperature sensor on AMD handhelds, showing a misleadingly high "CPU temp" (~70°C at idle on the OXP APEX and Steam Deck).

`scanTempSensors` sorted candidates **only by zone weight**. When more than one sensor lands in the `cpu` zone — e.g. `k10temp` (the real die sensor, Tctl) **and** `acpitz` (the ACPI thermal-zone fallback) — the tie was broken by `/sys/class/hwmon` enumeration order. `acpitz` usually enumerates first, so it won. It's a slow board/skin sensor that lags the die by tens of degrees and stays hot deep into idle, so the UI and fan curve were driven by a laggy, inflated reading.

**Fix:** add `cpuChipPriority()` and use it as the secondary sort key, so real die chips (`k10temp`/`coretemp`/`zenpower`) rank above the `acpitz` fallback. When no die sensor is loaded, `acpitz` is still used (unchanged behavior).

- `lib/sensors.ts` — new pure `cpuChipPriority(chipName)` (0 = real die chip, 1 = fallback).
- `backend.ts` — `scanTempSensors` sort: zone weight first, then `cpuChipPriority`.
- The displayed temp and fan curve now prefer the die sensor; the **safety watchdog is unaffected** (it takes the max across cpu/gpu/soc, so it's order-independent).

## Test Coverage
`lib/sensors.test.ts` — 4 new tests for `cpuChipPriority` (die-beats-acpitz ranking, fallback tier, case-insensitivity, and a k10temp+acpitz sort that asserts k10temp is selected first).

- Sensors suite: **21/21 pass**.
- Note: 8 pre-existing failures in `app.spec.tsx` are unrelated to this change (verified by stashing these edits and re-running — they fail identically on clean `main`). Separate test-harness issue, not touched here.

## Test plan
- [x] `bun test plugins/fan-control/lib/sensors.test.ts` — 21 pass, 0 fail
- [ ] On a device with `k10temp` loaded: confirm the Fan Control page shows the die temp (Tctl) that tracks load, not the laggy acpitz value

🤖 Generated with [Claude Code](https://claude.com/claude-code)