### PR TITLE
fix(overlay): wire status bar to the real fan-control event + field

### DIFF
--- a/apps/loadout-overlay/src/overlay/hooks/useStatusMetrics.ts
+++ b/apps/loadout-overlay/src/overlay/hooks/useStatusMetrics.ts
@@ -11,7 +11,7 @@ import { call, subscribe } from "@loadout/ui/ws-client";
  * values it has.
  */
 export interface StatusMetrics {
-  cpuTemp: number | null;      // °C — from fan-control `fanUpdate` / `getFanInfo`
+  cpuTemp: number | null;      // °C — from fan-control `fan-update` / `getFanInfo` (`cpuTempC`)
   fanRpm: number | null;       // RPM — same source
   batteryPct: number | null;   // % — from battery-tracker `batteryUpdate` / `getBatteryInfo`
   charging: boolean | null;
@@ -39,12 +39,12 @@ export function useStatusMetrics(): StatusMetrics {
           plugin: "fan-control",
           method: "getFanInfo",
           args: [],
-        })) as { fans?: { rpm?: number }[]; cpuTemp?: number } | null;
+        })) as { fans?: { rpm?: number }[]; cpuTempC?: number } | null;
         if (!info) return;
         const rpm = info.fans?.[0]?.rpm;
         update({
           fanRpm: typeof rpm === "number" ? rpm : null,
-          cpuTemp: typeof info.cpuTemp === "number" ? info.cpuTemp : null,
+          cpuTemp: typeof info.cpuTempC === "number" ? info.cpuTempC : null,
         });
       } catch {
         /* plugin not installed or not ready — metric stays null */
@@ -73,13 +73,13 @@ export function useStatusMetrics(): StatusMetrics {
     // Event subscriptions — backends broadcast on their own cadence.
     const unsubFan = subscribe({
       plugin: "fan-control",
-      event: "fanUpdate",
+      event: "fan-update",
       handler: (data: unknown) => {
-        const d = data as { fans?: { rpm?: number }[]; cpuTemp?: number };
+        const d = data as { fans?: { rpm?: number }[]; cpuTempC?: number };
         const rpm = d?.fans?.[0]?.rpm;
         update({
           fanRpm: typeof rpm === "number" ? rpm : null,
-          cpuTemp: typeof d?.cpuTemp === "number" ? d.cpuTemp : null,
+          cpuTemp: typeof d?.cpuTempC === "number" ? d.cpuTempC : null,
         });
       },
     });


### PR DESCRIPTION
## Summary

The overlay status bar's CPU-temp and fan-RPM readouts were broken because `useStatusMetrics` didn't match what the fan-control backend actually sends.

Two mismatches in `apps/loadout-overlay/src/overlay/hooks/useStatusMetrics.ts`:

1. **Event name** — subscribed to `"fanUpdate"`, but the backend emits `"fan-update"`. The subscription never fired, so the status bar's live 2s telemetry never arrived — values froze at the first-paint poll.
2. **Field name** — read `info.cpuTemp` / `d.cpuTemp`, but `getFanInfo`/`fan-update` return `cpuTempC`. So `metrics.cpuTemp` was always `null` and `App.tsx` (guards `!= null`) rendered nothing for CPU temp.

Fix: subscribe to `"fan-update"` and read `cpuTempC` in both the poll and the event handler (plus the inline type annotations and a stale comment). The hook's own output field stays `cpuTemp` — only the backend-payload reads change.

The fan-control plugin's own card was already correct (`fan-update` + `cpuTempC`); this just brings the shared status bar in line.

## Test plan
- [x] `bun run typecheck` (tsc --noEmit) — exit 0
- [x] `eslint` on the changed file — exit 0
- [ ] On device: status bar shows a live CPU temp + fan RPM that update every ~2s (previously blank/frozen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)