### PR TITLE
feat(install): enable Steam CEF remote debugging (overlay focus + plugins)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -341,6 +341,7 @@ phase1() {
         else
             info "Keeping existing binary."
             setup_desktop
+            setup_steam_cef_debugging
             setup_service
             return
         fi
@@ -433,6 +434,7 @@ phase1() {
     # Create symlink in ~/.local/bin so it's on PATH
     setup_bin_link
     setup_desktop
+    setup_steam_cef_debugging
     setup_service
 }
 
@@ -701,6 +703,62 @@ DESKTOPEOF
     # Update desktop database if available
     if command -v update-desktop-database >/dev/null 2>&1; then
         update-desktop-database "$DESKTOP_DIR" 2>/dev/null || true
+    fi
+}
+
+# Enable Steam's Chromium DevTools Protocol endpoint (localhost:8080) by
+# dropping the empty `.cef-enable-remote-debugging` marker file in Steam's
+# root. Steam reads it once at startup. This is the SAME mechanism Decky
+# Loader uses — we set it ourselves so the overlay's Steam-CDP features work
+# on machines that don't have Decky installed.
+#
+# Why the overlay needs it: when Steam's Quick Access Menu is open and the
+# user triggers the overlay, the overlay closes the QAM via CDP *before*
+# claiming gamescope overlay focus. Without CDP it can't, and gamescope gets
+# into an overlay focus-fight that flickers and can freeze input device-wide
+# (recovers only on reboot). The injector + hltb + sound-loader plugins also
+# talk to this endpoint.
+CEF_DEBUG_FLAG=".cef-enable-remote-debugging"
+
+setup_steam_cef_debugging() {
+    info "Enabling Steam CEF remote debugging (for overlay focus + plugins)..."
+
+    # Steam reads the flag from its data root. `~/.steam/steam` is the
+    # canonical symlink (also where Decky writes it); `~/.local/share/Steam`
+    # is the native target it points at; the Flatpak path covers Flatpak
+    # Steam. Writing through any of them lands in the right place — a symlink
+    # target we already created is skipped by the `-e` check below.
+    created=0
+    existed=0
+    for root in \
+        "$HOME/.steam/steam" \
+        "$HOME/.local/share/Steam" \
+        "$HOME/.var/app/com.valvesoftware.Steam/data/Steam"; do
+        [ -d "$root" ] || continue
+        flag="$root/$CEF_DEBUG_FLAG"
+        if [ -e "$flag" ]; then
+            existed=1
+            continue
+        fi
+        if : > "$flag" 2>/dev/null; then
+            success "Created $flag"
+            created=1
+        else
+            warn "Could not write $flag (check permissions)."
+        fi
+    done
+
+    if [ "$created" = "0" ] && [ "$existed" = "0" ]; then
+        warn "No Steam install directory found — skipped CEF debugging flag."
+        warn "If Steam is installed elsewhere, create an empty file named"
+        warn "  $CEF_DEBUG_FLAG  in Steam's root, then restart Steam."
+        return
+    fi
+
+    if [ "$created" = "1" ]; then
+        warn "Restart Steam for CEF remote debugging to take effect."
+    else
+        info "CEF remote debugging already enabled."
     fi
 }
 
@@ -1039,6 +1097,10 @@ main() {
     echo ""
     info "Overlay:   http://localhost:$OVERLAY_PORT"
     info "Plugins:   $INSTALL_DIR/plugins"
+    echo ""
+    warn "Restart Steam once so it picks up CEF remote debugging — required for"
+    warn "the overlay to grab focus cleanly over Steam's menus (and for plugins"
+    warn "that talk to Steam). Big Picture: Steam > Power > Restart Steam."
     echo ""
 }
 


### PR DESCRIPTION
## Problem

On a fresh CachyOS / non-Decky install, opening the overlay while Steam's Quick Access Menu is up sends gamescope into an overlay focus-fight that flickers and can **freeze input device-wide (reboot required)**.

Root cause: the overlay closes Steam's QAM via Steam's Chromium DevTools Protocol (`localhost:8080`) *before* claiming gamescope overlay focus. CDP is **off by default** on Steam — Decky Loader is what enables it on most SteamOS/Bazzite handhelds (it writes the same `.cef-enable-remote-debugging` marker). On machines without Decky, `:8080` is dead, the QAM is never dismissed, and the overlay opens into the freeze. Classic "works on Bazzite, freezes on CachyOS."

`:8080` is also required by the injector + `hltb` + `sound-loader` plugins, so the installer shouldn't assume Decky enabled it.

## Change

`setup_steam_cef_debugging()` drops the empty `.cef-enable-remote-debugging` marker in Steam's root (handles the `~/.steam/steam` symlink, native `~/.local/share/Steam`, and Flatpak paths; idempotent; skips a symlink target already written). Wired into both phase-1 paths, with a restart-Steam reminder in the completion summary (Steam reads the flag only at startup).

## Verification so far

**CachyOS / OneXFly F1 Pro (fresh, no Decky):** after the flag + Steam restart, CDP came up on `:8080`, the QAM-open → overlay repro no longer freezes, and overlay d-pad nav works. (The separate d-pad regression was the unmerged `fix/inputplumber-grab-emulated-pad` branch grabbing the virtual pad — `main` is already correct; see #90.)

## Cross-device test plan (Steam Deck / Bazzite)

These already run Decky (CDP on), so the goal is to confirm this change is a **safe no-op** and doesn't regress them.

1. `git fetch && git checkout fix/enable-steam-cef-debugging`
2. Run the installer: `sh scripts/install.sh` (it'll create the flag — should report "already present" if Decky set it).
3. Confirm `curl -sf http://localhost:8080/json/version` still responds and Steam UI is normal.
4. Open the overlay over a game → d-pad navigates the overlay; B closes cleanly.
5. Open Steam's QAM, then trigger the overlay → no flicker/freeze.
6. `systemctl --user status loadout-overlay` clean; controller still works after closing.

Refs #90 (full investigation; the d-pad regression is documented there and needs no code change).