### PR TITLE
fix(install-local): write Steam CEF remote-debugging marker

### DIFF
--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -146,6 +146,45 @@ fi
 # Bazzite/CachyOS/Fedora — those ship the libs in the base image.
 sh "$SCRIPT_DIR/fetch-deck-overlay-libs.sh" "$OVERLAY_INSTALL_DIR/bin"
 
+# --- Steam CEF remote debugging ---
+# Drop the empty `.cef-enable-remote-debugging` marker in Steam's root so
+# Steam opens its Chromium DevTools Protocol endpoint on localhost:8080.
+# Same mechanism Decky Loader uses. The overlay needs it to close the QAM
+# via CDP before claiming gamescope overlay focus (without it gamescope
+# gets into a focus-fight that can freeze input until reboot), and the
+# theme-loader / steamgriddb / protondb / quick-links plugins all talk to
+# this port. Mirrors setup_steam_cef_debugging() in install.sh.
+echo ""
+echo "Enabling Steam CEF remote debugging (for overlay focus + plugins)..."
+CEF_DEBUG_CREATED=0
+CEF_DEBUG_EXISTED=0
+for STEAM_ROOT in \
+    "$HOME/.steam/steam" \
+    "$HOME/.local/share/Steam" \
+    "$HOME/.var/app/com.valvesoftware.Steam/data/Steam"; do
+    [ -d "$STEAM_ROOT" ] || continue
+    CEF_FLAG="$STEAM_ROOT/.cef-enable-remote-debugging"
+    if [ -e "$CEF_FLAG" ]; then
+        CEF_DEBUG_EXISTED=1
+        continue
+    fi
+    if : > "$CEF_FLAG" 2>/dev/null; then
+        echo "Created $CEF_FLAG"
+        CEF_DEBUG_CREATED=1
+    else
+        echo "WARNING: could not write $CEF_FLAG (check permissions)." >&2
+    fi
+done
+if [ "$CEF_DEBUG_CREATED" = "0" ] && [ "$CEF_DEBUG_EXISTED" = "0" ]; then
+    echo "WARNING: no Steam install dir found — skipped CEF debugging flag." >&2
+    echo "         Create an empty .cef-enable-remote-debugging in Steam's root," >&2
+    echo "         then restart Steam." >&2
+elif [ "$CEF_DEBUG_CREATED" = "1" ]; then
+    echo "Restart Steam for CEF remote debugging to take effect."
+else
+    echo "CEF remote debugging already enabled."
+fi
+
 # --- Backend: root system service ---
 # The backend runs as root so plugins can write hardware sysfs / run
 # privileged tools without per-op sudo prompts at runtime (HHD/Decky


### PR DESCRIPTION
## Why

`install.sh` got `setup_steam_cef_debugging()` in #91, but `install-local.sh` (the local-build installer) was never updated — so dev/local installs left Steam's CDP endpoint (`localhost:8080`) disabled.

This is exactly the "can't connect to Steam CEF" symptom on a locally-installed machine: the `.cef-enable-remote-debugging` marker is missing, Steam launches without `--remote-debugging-port`, and port 8080 never listens. The overlay needs CDP to close the QAM before claiming gamescope overlay focus (without it a focus-fight can freeze input until reboot), and the theme-loader / steamgriddb / protondb / quick-links plugins all talk to that port.

## What

Port the same idempotent marker logic from `install.sh`: drop an empty `.cef-enable-remote-debugging` in each Steam root (`~/.steam/steam`, `~/.local/share/Steam`, Flatpak), skip ones already present, and remind to restart Steam since the flag is only read at startup.

## Follow-up

The block is now duplicated verbatim between `install.sh` and `install-local.sh` — worth factoring into a shared helper so they can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)