### PR TITLE
fix(overlay): grab D-pad focus on IP-managed handhelds (swap deck-uhid → xbox-elite)

### DIFF
--- a/plugins/input-plumber/lib/profile.test.ts
+++ b/plugins/input-plumber/lib/profile.test.ts
@@ -4,6 +4,7 @@ import {
   labelFor,
   buttonOptions,
   ensureKeyboard,
+  preferGrabbableGamepad,
   renderProfile,
   renderCaptureProfile,
   SENTINEL_KEYS,
@@ -80,8 +81,25 @@ describe("buttonOptions", () => {
 });
 
 describe("ensureKeyboard", () => {
-  it("appends keyboard, preserving existing controller targets", () => {
-    expect(ensureKeyboard(["deck-uhid"])).toEqual(["deck-uhid", "keyboard"]);
+  it("appends keyboard, preserving existing grabbable controller targets", () => {
+    expect(ensureKeyboard(["xb360"])).toEqual(["xb360", "keyboard"]);
+  });
+  it("swaps non-grabbable deck-uhid for a grabbable xbox-elite", () => {
+    // deck-uhid routes the pad through hid-steam, so the overlay can't
+    // EVIOCGRAB it in gaming mode — swap for a grabbable emulation.
+    expect(ensureKeyboard(["deck-uhid"])).toEqual(["xbox-elite", "keyboard"]);
+  });
+  it("swaps the HID-based deck target too", () => {
+    expect(ensureKeyboard(["deck", "mouse"])).toEqual([
+      "xbox-elite",
+      "mouse",
+      "keyboard",
+    ]);
+  });
+  it("leaves already-grabbable targets untouched", () => {
+    for (const t of ["xb360", "xbox-series", "xbox-elite", "ds5"]) {
+      expect(ensureKeyboard([t])).toEqual([t, "keyboard"]);
+    }
   });
   it("drops null sinks and seeds a gamepad when empty", () => {
     expect(ensureKeyboard(["null"])).toEqual(["gamepad", "keyboard"]);
@@ -92,11 +110,27 @@ describe("ensureKeyboard", () => {
   });
 });
 
+describe("preferGrabbableGamepad", () => {
+  it("maps deck-uhid and deck to xbox-elite, preserves the rest", () => {
+    expect(preferGrabbableGamepad(["deck-uhid", "keyboard"])).toEqual([
+      "xbox-elite",
+      "keyboard",
+    ]);
+    expect(preferGrabbableGamepad(["deck", "mouse"])).toEqual([
+      "xbox-elite",
+      "mouse",
+    ]);
+    expect(preferGrabbableGamepad(["xbox-series"])).toEqual(["xbox-series"]);
+  });
+});
+
 describe("renderProfile", () => {
   it("renders a gamepad-button → F16 mapping with preserved targets", () => {
     const yaml = renderProfile(parseCapability("Gamepad:Button:RightPaddle1"), ["deck-uhid"]);
     expect(yaml).toContain("kind: DefaultProfile");
-    expect(yaml).toContain("- deck-uhid");
+    // deck-uhid is swapped for a grabbable target so the overlay can grab it.
+    expect(yaml).toContain("- xbox-elite");
+    expect(yaml).not.toContain("- deck-uhid");
     expect(yaml).toContain("- keyboard");
     expect(yaml).toContain("gamepad:");
     expect(yaml).toContain("button: RightPaddle1");
@@ -144,7 +178,7 @@ describe("renderCaptureProfile", () => {
       "Gamepad:Button:Keyboard",
       "Keyboard:KeyRecord",
     ]);
-    const { yaml, sentinelToRaw } = renderCaptureProfile(opts, ["deck-uhid"]);
+    const { yaml, sentinelToRaw } = renderCaptureProfile(opts, ["xb360"]);
     // The sentinelToRaw map keys are Linux keycodes (numbers).
     const codes = Array.from(sentinelToRaw.keys());
     expect(codes.length).toBe(4);
@@ -161,7 +195,7 @@ describe("renderCaptureProfile", () => {
     const mappingCount = (yaml.match(/^\s*- name:/gm) || []).length;
     expect(mappingCount).toBe(4);
     expect(yaml).toContain("kind: DefaultProfile");
-    expect(yaml).toContain("- deck-uhid");
+    expect(yaml).toContain("- xb360");
     expect(yaml).toContain("- keyboard");
   });
 

--- a/plugins/input-plumber/lib/profile.ts
+++ b/plugins/input-plumber/lib/profile.ts
@@ -355,11 +355,40 @@ export function renderClearedProfile(targetDevices: string[]): string {
   );
 }
 
+/** InputPlumber controller emulations the overlay cannot EVIOCGRAB. Both route
+ *  the physical pad through Steam's `hid-steam` driver (deck-uhid is a uhid
+ *  device; `deck` presents a Steam Controller hidraw IP hides) rather than
+ *  exposing a plain gamepad evdev. On an IP-managed handheld in gaming mode
+ *  that leaves the overlay with no controller node to grab, so Steam BPM keeps
+ *  receiving the D-pad behind the open overlay. Verified on a OneXPlayer APEX
+ *  (SteamOS): `deck-uhid` → 0 controllers grabbed; `xbox-elite` → grab works.
+ *  Deck-only path is unaffected — a real Steam Deck uses wake-trigger-deck.ts,
+ *  which never renders an IP profile. */
+export const NON_GRABBABLE_TARGETS: readonly string[] = ["deck-uhid", "deck"];
+
+/** Grabbable replacement emulation. A standard evdev Xbox Elite pad: the
+ *  overlay can EVIOCGRAB it, and it exposes 4 paddles (these handhelds have
+ *  back paddles; `xb360` would drop them). Matches the Apex's upstream IP
+ *  default target (`50-onexplayer_apex.yaml`). */
+export const GRABBABLE_REPLACEMENT = "xbox-elite";
+
+/** Swap any non-grabbable controller emulation for a grabbable one so the
+ *  overlay's EVIOCGRAB can take controller input away from Steam in gaming
+ *  mode. Already-grabbable / non-controller targets pass through unchanged. */
+export function preferGrabbableGamepad(targetDevices: string[]): string[] {
+  return targetDevices.map((t) =>
+    NON_GRABBABLE_TARGETS.includes(t) ? GRABBABLE_REPLACEMENT : t,
+  );
+}
+
 /** Return targetDevices with `keyboard` guaranteed present (deduped, order
- *  preserved). If the device reported no targets we still emit a usable pair
- *  so the controller keeps working and a keyboard exists for F16. */
+ *  preserved) and any non-grabbable controller emulation swapped for one the
+ *  overlay can grab. If the device reported no targets we still emit a usable
+ *  pair so the controller keeps working and a keyboard exists for F16. */
 export function ensureKeyboard(targetDevices: string[]): string[] {
-  const base = targetDevices.filter((t) => t && t !== "null");
+  const base = preferGrabbableGamepad(
+    targetDevices.filter((t) => t && t !== "null"),
+  );
   const seed = base.length > 0 ? base : ["gamepad"];
   const out: string[] = [];
   for (const t of [...seed, "keyboard"]) {

--- a/plugins/input-plumber/lib/wake-trigger.ts
+++ b/plugins/input-plumber/lib/wake-trigger.ts
@@ -506,7 +506,10 @@ export async function reloadPersistedProfile(): Promise<WakeOpResult> {
 
   // Re-render from the live targets in case the device's emulation changed,
   // then load. (The file may already exist from a prior boot, but re-rendering
-  // keeps it correct if targets shifted.)
+  // keeps it correct if targets shifted.) This also auto-upgrades an older
+  // persisted profile whose target was a non-grabbable emulation: renderProfile
+  // → ensureKeyboard swaps deck-uhid/deck for xbox-elite so the overlay can
+  // grab the pad in gaming mode (see preferGrabbableGamepad in profile.ts).
   const targets = await getTargetKinds(device.path);
   await writeFileMkdir(PROFILE_PATH, renderProfile(parseCapability(wake.selectedRaw), targets));
   const loaded = await loadProfilePath(device.path, PROFILE_PATH);


### PR DESCRIPTION
## Problem

In gaming mode (gamescope/Big Picture Mode), opening the overlay on an **InputPlumber-managed handheld running SteamOS** does **not** grab D-pad focus from Steam. The overlay renders on top, but pressing the D-pad scrolls the Steam BPM menus *behind* it instead of navigating the overlay.

Reported as working on Bazzite/CachyOS and on a real Steam Deck, broken on a **OneXPlayer APEX (SteamOS)**.

## Root cause

The overlay takes input focus two ways: gamescope **atoms** (compositor focus) and a kernel **`EVIOCGRAB`** on the controller evdev. Live debugging on the Apex showed:

- **Atom layer is fine** — when open, our window has `STEAM_OVERLAY=1 / STEAM_INPUT_FOCUS=1` and Steam's BPM window is at `0/0`.
- **Grab layer finds 0 controllers** (`[overlay] input intercept ready — 0 controller(s)`). That's the layer that actually blocks BPM nav, and it had nothing to grab:
  - The user had configured an overlay wake button, so InputPlumber manages the pad. The composite device `ONEXPLAYER APEX` had its **target set to `deck-uhid`** ("Valve Steam Deck Controller").
  - `deck-uhid` routes the pad through Steam's `hid-steam` driver → Steam Input — there is **no plain gamepad evdev** to grab. IP also hides the physical source nodes (`event13/2/19` → `root:root 000`).
  - The only standard gamepad evdev (`event5`, `28de:11ff`) is Steam Input's virtual pad, which `devices.ts` deliberately skips.
- Confirmed empirically: `event5` D-pad events fire only while the overlay is **closed**; when open they reach Steam internally via IP → Steam Input, uninterceptable by any grab.

On Bazzite/CachyOS the same Apex uses a normal `xb360`/`xbox-series` target whose evdev the overlay *can* grab — which is why grab-to-block works there. The `deck-uhid` emulation SteamOS uses for handhelds puts the device in a gap: it *looks* like a Deck to Steam (no grabbable evdev) but doesn't get real-Deck focus yielding.

## Fix

Swap the non-grabbable controller emulation for a grabbable one at the single `ensureKeyboard()` chokepoint (used by bind / capture / off / boot-reload):

- New `preferGrabbableGamepad()` maps `deck-uhid` / `deck` → **`xbox-elite`**.
- `xbox-elite` chosen over `xb360` because these handhelds have **back paddles** — Elite exposes 4 paddles (`BTN_TRIGGER_HAPPY1-8`), `xb360` would drop them. It's also the Apex's upstream IP default (`50-onexplayer_apex.yaml`).
- Already-grabbable targets (`xb360`, `xbox-series`, `xbox-elite`, `ds5`) pass through **untouched** → Bazzite/CachyOS devices unaffected.
- Real Steam Decks are unaffected — they use the separate `wake-trigger-deck.ts` (deck-hidraw) path that never renders an IP gamepad profile.

### When the swap applies

- **New/changed bindings:** `setWakeButton()` / `captureWakeButton()` on the welcome/settings screen write `xbox-elite` directly.
- **Existing bindings:** `reloadPersistedProfile()` on backend `onLoad` re-renders through the same path, so an older `deck-uhid` profile **auto-upgrades** to `xbox-elite` on the next backend start — no re-bind needed.

The swap is intentionally implicit (a property of profile rendering) rather than a separate setup step.

## Consequence

The controller now presents to Steam as **"Microsoft X-Box One Elite 2 pad" (`045e:0b00`)** — Xbox glyphs instead of Steam Deck, paddles preserved.

## Verification (on-device, OneXPlayer APEX / SteamOS)

- ✅ Step 0 (live `busctl` profile swap before any code): `xbox-elite` target creates a grabbable `045e:0b00` evdev at `root:input`; overlay grabs it; **BPM nav stops** when open; paddles (`BTN_TRIGGER_HAPPY1-8`) present.
- ✅ Tested `deck` target too — also routes via `hid-steam` (no grab), confirming both belong in the non-grabbable set.
- ✅ After build/install: persisted on-disk profile **auto-corrected** `deck-uhid → xbox-elite` via `onLoad`.
- ✅ Press-to-capture (welcome/settings) still works — capture reads sentinel keys off the `keyboard` target, unaffected by the gamepad target.
- ✅ Unit tests: +4 new, all passing. (16 pre-existing failures in `wake-trigger-deck.test.ts` are environmental — Deck hidraw/udev needing root — confirmed present on a clean tree, not introduced here.)

## Files

- `plugins/input-plumber/lib/profile.ts` — `preferGrabbableGamepad()` + constants; applied in `ensureKeyboard()`.
- `plugins/input-plumber/lib/profile.test.ts` — swap cases.
- `plugins/input-plumber/lib/wake-trigger.ts` — comment clarifying the onLoad auto-upgrade.

## Follow-up (not in this PR)

- Only hardware-verified on the Apex. Mechanism is device-agnostic; other handhelds (ROG Ally, F1 Pro, MSI Claw) ideally want a quick on-device check.
- Possible refinement: instead of always using `xbox-elite`, read each device's *stock* target from `/usr/share/inputplumber/devices/*.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
