### PR TITLE
feat(overlay): grab D-pad focus via InputPlumber intercept mode (GamepadOnly + DBus nav)

### DIFF
--- a/apps/loadout-overlay/package.json
+++ b/apps/loadout-overlay/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@noriginmedia/norigin-spatial-navigation": "^3.0.0",
     "@loadout/deck-hid": "workspace:*",
+    "@loadout/exec": "workspace:*",
     "@loadout/plugin-storage": "workspace:*",
     "@loadout/types": "workspace:*",
     "@loadout/ui": "workspace:*",

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -27,6 +27,10 @@ import {
   type WakeEvent,
 } from "./native/input-intercept";
 import {
+  startIpIntercept,
+  type IpInterceptHandle,
+} from "./native/ip-intercept";
+import {
   startDeckHidrawWatcher,
   type DeckHidrawWatcherHandle,
 } from "./native/deck-hidraw-watcher";
@@ -137,6 +141,12 @@ const pendingResumeTimer: { current: ReturnType<typeof setTimeout> | null } = {
 // and to the close-path `intercept.current?.release()` inside
 // toggleOverlay.
 const intercept: { current: InputInterceptHandle | null } = { current: null };
+// InputPlumber intercept-mode path — runs alongside the evdev interceptor on
+// IP-managed handhelds (deck-uhid target, no grabbable evdev). On grab it sets
+// InterceptMode=2 so Steam BPM is starved and nav arrives over D-Bus; on hosts
+// without IP it's an inert no-op and the evdev grab above does the work. See
+// native/ip-intercept.ts.
+const ipIntercept: { current: IpInterceptHandle | null } = { current: null };
 const deckHidraw: { current: DeckHidrawWatcherHandle | null } = { current: null };
 // Picker changes flow back to the watcher via two mechanisms: (1) fs.watch
 // on the plugin-storage directory fires within ~10ms of the atomic rename,
@@ -299,6 +309,7 @@ function toggleOverlay(source: string) {
     overlay.minimize();
     atoms.hide().catch((e) => console.warn("[overlay] atoms.hide:", e));
     intercept.current?.release();
+    ipIntercept.current?.release();
     // Always SIGCONT Steam on close, even when SUSPEND_STEAM_ENABLED is
     // off. Users have reported Steam appearing frozen after the overlay
     // closes (menu visible but inputs ignored) — if anything left Steam
@@ -328,6 +339,7 @@ function toggleOverlay(source: string) {
       if (steamPid.current !== null) suspendSteam(steamPid.current);
     }
     intercept.current?.grab();
+    ipIntercept.current?.grab();
     overlay.show();
     atoms.show().catch((e) => console.warn("[overlay] atoms.show:", e));
     state.isOpen = true;
@@ -407,6 +419,33 @@ startInputIntercept({
   })
   .catch((err) => {
     console.error("[overlay] input intercept failed to start:", err);
+  });
+
+// InputPlumber intercept-mode path. Discovers IP composite devices and, when
+// present, drives focus via InterceptMode + the DBus ui_* signal stream
+// instead of (the ineffective, on deck-uhid) EVIOCGRAB. Nav/wake events flow
+// to the exact same webview surface as the evdev path. No-op when IP is absent.
+startIpIntercept({
+  onAction: (action) => {
+    sendToWebview("overlay-action", { action });
+  },
+  onAxis: (axis, value) => {
+    sendToWebview("overlay-scroll", { axis, value });
+  },
+  onWake,
+  onReady: (info) =>
+    console.log(
+      `[overlay] ip intercept ready — ${info.composites} composite device(s)`,
+    ),
+})
+  .then((handle) => {
+    ipIntercept.current = handle;
+    if (handle.available) {
+      console.log("[overlay] ip intercept ACTIVE — using InterceptMode + DBus nav");
+    }
+  })
+  .catch((err) => {
+    console.error("[overlay] ip intercept failed to start:", err);
   });
 
 // Steam-Deck-native wake button: read /dev/hidrawN (the controller's
@@ -548,6 +587,7 @@ function runShutdown(): Promise<void> {
     steamPid,
     atoms,
     intercept,
+    ipIntercept,
     deckHidraw,
     globalShortcut: GlobalShortcut,
   });

--- a/apps/loadout-overlay/src/bun/lifecycle.ts
+++ b/apps/loadout-overlay/src/bun/lifecycle.ts
@@ -14,6 +14,7 @@ import type { GlobalShortcut as GlobalShortcutType } from "electrobun/bun";
 import { resumeSteam } from "./native/process-control";
 import type { GamescopeAtoms } from "./native/gamescope-atoms";
 import type { InputInterceptHandle } from "./native/input-intercept";
+import type { IpInterceptHandle } from "./native/ip-intercept";
 import type { DeckHidrawWatcherHandle } from "./native/deck-hidraw-watcher";
 import {
   isActiveTick,
@@ -91,6 +92,10 @@ export interface ShutdownDeps {
   atoms: GamescopeAtoms;
   /** Input interceptor handle — may be null if it failed to start. */
   intercept: Ref<InputInterceptHandle | null>;
+  /** InputPlumber intercept-mode handle — null off IP hosts / on start
+   *  failure. Shut down so InterceptMode is reset to 0 and the gdbus
+   *  monitor subprocess is killed rather than left running. */
+  ipIntercept: Ref<IpInterceptHandle | null>;
   /** Deck-native hidraw watcher — null on non-Deck hosts and when the open
    *  failed. Tracked so we close the hidraw fd on shutdown rather than
    *  relying on process-death cleanup. */
@@ -153,6 +158,7 @@ export async function shutdown(deps: ShutdownDeps): Promise<void> {
     // window where another process can't grab them because we
     // haven't fully exited yet.
     deps.intercept.current?.shutdown();
+    deps.ipIntercept.current?.shutdown();
     deps.deckHidraw.current?.stop();
     deps.globalShortcut.unregisterAll();
     deps.atoms.shutdown();

--- a/apps/loadout-overlay/src/bun/native/ip-intercept.test.ts
+++ b/apps/loadout-overlay/src/bun/native/ip-intercept.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "bun:test";
+import {
+  parseInputEventLine,
+  uiToInputEvent,
+  pickCompositePaths,
+} from "./ip-intercept";
+
+describe("parseInputEventLine", () => {
+  // gdbus monitor line shape for the DBusDevice.InputEvent signal.
+  const line =
+    "/org/shadowblip/InputPlumber/devices/target/dbus0: " +
+    "org.shadowblip.Input.DBusDevice.InputEvent ('ui_up', 1.0)";
+
+  it("parses capability + value from a gdbus InputEvent line", () => {
+    expect(parseInputEventLine(line)).toEqual({ cap: "ui_up", value: 1 });
+  });
+
+  it("parses a release (value 0.0)", () => {
+    expect(
+      parseInputEventLine(
+        "/x: org.shadowblip.Input.DBusDevice.InputEvent ('ui_accept', 0.0)",
+      ),
+    ).toEqual({ cap: "ui_accept", value: 0 });
+  });
+
+  it("parses fractional + integer-looking values", () => {
+    expect(parseInputEventLine(".InputEvent ('ui_left', 0.5)")?.value).toBe(0.5);
+    expect(parseInputEventLine(".InputEvent ('ui_left', 1)")?.value).toBe(1);
+  });
+
+  it("ignores non-InputEvent lines (e.g. PropertiesChanged)", () => {
+    expect(
+      parseInputEventLine(
+        "/x: org.freedesktop.DBus.Properties.PropertiesChanged ('org.shadowblip.Input.CompositeDevice', {'InterceptMode': <uint32 3>}, @as [])",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null on the monitor header lines", () => {
+    expect(
+      parseInputEventLine("Monitoring signals from all objects owned by …"),
+    ).toBeNull();
+  });
+});
+
+describe("uiToInputEvent", () => {
+  it("maps direction caps to hat axes with the correct sign on press", () => {
+    expect(uiToInputEvent("ui_up", 1)).toEqual({
+      kind: "axis",
+      axis: "HatY",
+      value: -1,
+    });
+    expect(uiToInputEvent("ui_down", 1)).toEqual({
+      kind: "axis",
+      axis: "HatY",
+      value: 1,
+    });
+    expect(uiToInputEvent("ui_left", 1)).toEqual({
+      kind: "axis",
+      axis: "HatX",
+      value: -1,
+    });
+    expect(uiToInputEvent("ui_right", 1)).toEqual({
+      kind: "axis",
+      axis: "HatX",
+      value: 1,
+    });
+  });
+
+  it("zeroes the axis on release so NavController clears the held direction", () => {
+    expect(uiToInputEvent("ui_up", 0)).toEqual({
+      kind: "axis",
+      axis: "HatY",
+      value: 0,
+    });
+  });
+
+  it("maps accept/back/bumpers to buttons with pressed state", () => {
+    expect(uiToInputEvent("ui_accept", 1)).toEqual({
+      kind: "button",
+      button: "A",
+      pressed: true,
+    });
+    expect(uiToInputEvent("ui_back", 0)).toEqual({
+      kind: "button",
+      button: "B",
+      pressed: false,
+    });
+    expect(uiToInputEvent("ui_l1", 1)).toEqual({
+      kind: "button",
+      button: "LB",
+      pressed: true,
+    });
+    expect(uiToInputEvent("ui_r1", 1)).toEqual({
+      kind: "button",
+      button: "RB",
+      pressed: true,
+    });
+  });
+
+  it("treats the half-threshold as the press boundary", () => {
+    // < 0.5 is a release, >= 0.5 is a press.
+    expect(uiToInputEvent("ui_accept", 0.49)).toMatchObject({ pressed: false });
+    expect(uiToInputEvent("ui_accept", 0.5)).toMatchObject({ pressed: true });
+  });
+
+  it("returns null for non-nav capabilities (handled elsewhere / logged)", () => {
+    // ui_guide / ui_quick are wake-class, not nav — not in the nav table.
+    expect(uiToInputEvent("ui_guide", 1)).toBeNull();
+    expect(uiToInputEvent("ui_quick", 1)).toBeNull();
+    expect(uiToInputEvent("ui_osk", 1)).toBeNull();
+    expect(uiToInputEvent("KeyF16", 1)).toBeNull();
+  });
+});
+
+describe("pickCompositePaths", () => {
+  it("plucks top-level CompositeDeviceN paths from busctl tree output", () => {
+    const tree = [
+      "/org/shadowblip/InputPlumber",
+      "/org/shadowblip/InputPlumber/CompositeDevice0",
+      "/org/shadowblip/InputPlumber/devices/target/dbus0",
+      "/org/shadowblip/InputPlumber/devices/target/gamepad1",
+      "/org/shadowblip/InputPlumber/CompositeDevice1",
+    ].join("\n");
+    expect(pickCompositePaths(tree)).toEqual([
+      "/org/shadowblip/InputPlumber/CompositeDevice0",
+      "/org/shadowblip/InputPlumber/CompositeDevice1",
+    ]);
+  });
+
+  it("does not match nested composite-device children", () => {
+    const tree =
+      "/org/shadowblip/InputPlumber/CompositeDevice0/source/event5\n" +
+      "  /org/shadowblip/InputPlumber/CompositeDevice0";
+    // Leading whitespace is trimmed; the bare composite path matches, the
+    // /source/... child does not.
+    expect(pickCompositePaths(tree)).toEqual([
+      "/org/shadowblip/InputPlumber/CompositeDevice0",
+    ]);
+  });
+
+  it("returns [] when there are no composite devices", () => {
+    expect(pickCompositePaths("/org/shadowblip/InputPlumber\n")).toEqual([]);
+  });
+});

--- a/apps/loadout-overlay/src/bun/native/ip-intercept.ts
+++ b/apps/loadout-overlay/src/bun/native/ip-intercept.ts
@@ -1,0 +1,374 @@
+// InputPlumber "intercept mode" input path — an alternative to the
+// EVIOCGRAB grab in input-intercept.ts for hosts where InputPlumber (IP)
+// manages the controller.
+//
+// WHY THIS EXISTS
+// ----------------
+// On IP-managed handhelds running SteamOS (OneXPlayer APEX, ROG Ally, …)
+// the wake-button profile routes the pad through a `deck-uhid` target —
+// a HID device behind hid-steam → Steam Input, with NO grabbable evdev.
+// So the evdev path's EVIOCGRAB grabs 0 controllers and Steam BPM keeps
+// driving nav *behind* the open overlay. (See input-intercept.ts and the
+// fix/overlay-input-focus-grab branch for the full diagnosis.)
+//
+// IP's own mechanism solves this cleanly. Every IP composite device has:
+//   - a writable `InterceptMode` property (0=None, 1=Pass, 2=Always,
+//     3=GamepadOnly), and
+//   - a permanently-attached DBus *target* (`…/devices/target/dbusN`) that
+//     emits an `InputEvent(String capability, double value)` signal.
+//
+// We use mode 3 = GamepadOnly. In this mode IP routes only GAMEPAD events
+// to the DBus target (so Steam BPM is starved of d-pad/stick/face-button
+// nav → it stops) while KEYBOARD events still pass through to the normal
+// keyboard target. That keyboard pass-through is deliberate and load-
+// bearing: the overlay's wake button is rendered (by the input-plumber
+// plugin) as `gamepad button → KeyF16`, so under GamepadOnly the F16 still
+// reaches the IP keyboard evdev and the EXISTING evdev wake path
+// (input-intercept.ts) catches it to CLOSE the overlay. (Mode 2 = Always
+// swallows the keyboard event too, which is why the wake button couldn't
+// close the overlay — see git history of this module.)
+//
+// We subscribe to the DBus InputEvent signals, translate the `ui_*`
+// capabilities to the SAME NavController InputEvents the evdev path uses,
+// so the webview side is unchanged.
+//
+// Verified on-device (OXP APEX, SteamOS): GamepadOnly freezes Steam BPM
+// nav and the DBus target emits ui_up / ui_down / ui_left / ui_right /
+// ui_accept / ui_back / ui_guide / ui_quick as press(1.0)/release(0.0)
+// pairs, while the F16 wake button still closes via the evdev path.
+//
+// WHY ALONGSIDE, NOT INSTEAD OF, THE EVDEV PATH
+// ----------------------------------------------
+// This only works when IP is in the loop. On Bazzite/CachyOS/desktop where
+// IP isn't managing the pad there's no composite device to intercept, so
+// the evdev grab in input-intercept.ts stays as the universal fallback.
+// `available` is false there and grab()/release() are no-ops.
+//
+// Permissions: setting InterceptMode and receiving the DBus signals both
+// work for non-root clients — the IP D-Bus policy
+// (org.shadowblip.InputPlumber.conf) currently allows `context="default"`
+// to receive signals (there's an upstream TODO to gate this behind an
+// alternative API; if that lands, this path needs the backend to relay).
+//
+// We shell out to `busctl` (set InterceptMode, discover composites) and
+// `gdbus monitor` (receive InputEvent signals) rather than pulling in a
+// D-Bus library — both are present on every IP host and keep this module
+// dependency-free, matching the rest of native/.
+
+import { runFull, runStreaming } from "@loadout/exec";
+import { NavController, type InputEvent } from "./nav-controller";
+import { trace } from "./trace";
+
+const SERVICE = "org.shadowblip.InputPlumber";
+const COMPOSITE_IFACE = "org.shadowblip.Input.CompositeDevice";
+
+// busctl can block on the system-bus default timeout (~25s) while IP is
+// mid-restart; cap discovery/set calls so a stuck bus can't wedge a toggle.
+// Matches the backend ipdbus.ts client.
+const BUSCTL_TIMEOUT_MS = 5000;
+
+const COMPOSITE_PATH_RE = /^\/org\/shadowblip\/InputPlumber\/CompositeDevice\d+$/;
+
+/** Pump cadence while intercepting — services NavController key-repeat for
+ *  held d-pad directions between signal arrivals. Mirrors the evdev path's
+ *  POLL_ACTIVE_MS. */
+const PUMP_MS = 25;
+
+/** NavController keys per-controller state by id; the DBus stream is a
+ *  single logical controller, so a constant id is fine. */
+const NAV_CONTROLLER_ID = "ip-dbus";
+
+// ---- busctl helpers --------------------------------------------------------
+
+interface ExecResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+async function exec(cmd: string[]): Promise<ExecResult> {
+  try {
+    const { stdout, stderr, exitCode } = await runFull(cmd, {
+      timeoutMs: BUSCTL_TIMEOUT_MS,
+    });
+    return { ok: exitCode === 0, stdout, stderr };
+  } catch (e) {
+    return { ok: false, stdout: "", stderr: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+function busctl(args: string[]): Promise<ExecResult> {
+  return exec(["busctl", "--system", "--no-pager", ...args]);
+}
+
+/** Pluck top-level CompositeDevice paths from `busctl tree --list` output. */
+export function pickCompositePaths(treeStdout: string): string[] {
+  const out: string[] = [];
+  for (const line of treeStdout.split("\n")) {
+    const t = line.trim();
+    if (COMPOSITE_PATH_RE.test(t)) out.push(t);
+  }
+  return out;
+}
+
+async function listCompositePaths(): Promise<string[]> {
+  const r = await busctl(["tree", "--list", SERVICE]);
+  if (!r.ok) return [];
+  return pickCompositePaths(r.stdout);
+}
+
+/** InterceptMode values (org.shadowblip.Input.CompositeDevice):
+ *  0=None, 1=Pass, 2=Always, 3=GamepadOnly. We toggle between 0 (off) and
+ *  3 (gamepad-only intercept) — see the file header for why GamepadOnly. */
+const INTERCEPT_OFF = 0;
+const INTERCEPT_GAMEPAD_ONLY = 3;
+
+async function setInterceptMode(
+  path: string,
+  mode: typeof INTERCEPT_OFF | typeof INTERCEPT_GAMEPAD_ONLY,
+): Promise<void> {
+  const r = await busctl([
+    "set-property",
+    SERVICE,
+    path,
+    COMPOSITE_IFACE,
+    "InterceptMode",
+    "u",
+    String(mode),
+  ]);
+  if (!r.ok) {
+    console.warn(
+      `[ip-intercept] set InterceptMode=${mode} failed for ${path}: ${r.stderr.trim()}`,
+    );
+  }
+}
+
+// ---- ui_* capability → NavController InputEvent ----------------------------
+//
+// IP intercept translates physical input into the `ui_*` capability set
+// (the DBus:ui_* TargetCapabilities). We re-express them as the same
+// button/axis InputEvents the evdev reader produces, so NavController's
+// key-repeat + deadzone logic is reused verbatim. Directions map onto the
+// hat axes (value ±1 on press, 0 on release); accept/back/bumpers onto the
+// face/shoulder buttons.
+
+interface NavMap {
+  kind: "axis";
+  axis: "HatX" | "HatY";
+  sign: 1 | -1;
+}
+interface BtnMap {
+  kind: "button";
+  button: "A" | "B" | "LB" | "RB";
+}
+
+const UI_NAV: Record<string, NavMap | BtnMap> = {
+  ui_up: { kind: "axis", axis: "HatY", sign: -1 },
+  ui_down: { kind: "axis", axis: "HatY", sign: 1 },
+  ui_left: { kind: "axis", axis: "HatX", sign: -1 },
+  ui_right: { kind: "axis", axis: "HatX", sign: 1 },
+  ui_accept: { kind: "button", button: "A" },
+  ui_back: { kind: "button", button: "B" },
+  ui_l1: { kind: "button", button: "LB" },
+  ui_r1: { kind: "button", button: "RB" },
+};
+
+/** ui_* capabilities that ALSO toggle the overlay closed while it's open.
+ *  Under GamepadOnly the bound wake button (KeyF16) already closes via the
+ *  evdev path, so these are a redundant convenience: the Guide/QAM-class
+ *  buttons are gamepad buttons, so in GamepadOnly they arrive over DBus and
+ *  give a "get me out" control even if the user never bound a wake button.
+ *  Every received ui_* is trace-logged so unmapped controls are easy to
+ *  spot on-device. */
+const UI_WAKE = new Set(["ui_guide", "ui_quick", "ui_quick2", "ui_osk"]);
+
+/** Map a (capability, value) pair to a NavController InputEvent, or null if
+ *  it isn't a nav capability. `pressed` = value past the half threshold. */
+export function uiToInputEvent(cap: string, value: number): InputEvent | null {
+  const m = UI_NAV[cap];
+  if (!m) return null;
+  const pressed = value >= 0.5;
+  if (m.kind === "axis") {
+    return { kind: "axis", axis: m.axis, value: pressed ? m.sign : 0 };
+  }
+  return { kind: "button", button: m.button, pressed };
+}
+
+/** Parse one `gdbus monitor` line into a (capability, value) pair, or null.
+ *  Line shape:
+ *    /org/.../target/dbus0: org.shadowblip.Input.DBusDevice.InputEvent ('ui_up', 1.0)
+ */
+export function parseInputEventLine(
+  line: string,
+): { cap: string; value: number } | null {
+  const m = line.match(/\.InputEvent\s+\('([^']+)',\s*([-0-9.eE]+)\)/);
+  if (!m) return null;
+  const value = Number.parseFloat(m[2]);
+  if (Number.isNaN(value)) return null;
+  return { cap: m[1], value };
+}
+
+// ---- Public API ------------------------------------------------------------
+
+export interface IpInterceptOptions {
+  /** Nav actions for the webview — wire to sendToWebview("overlay-action"). */
+  onAction: (action: string) => void;
+  /** Continuous right-stick analog scroll — wire to "overlay-scroll".
+   *  (IP doesn't currently surface analog over the ui_* set, but the hook
+   *  matches the evdev path's shape for symmetry.) */
+  onAxis?: (axis: "RightStickX" | "RightStickY", value: number) => void;
+  /** A wake/close trigger seen on the DBus stream while intercepting — wire
+   *  to the same onWake() that evdev wake events use. */
+  onWake: (event: "QamToggle") => void;
+  /** Diagnostics: number of IP composite devices discovered. */
+  onReady?: (info: { composites: number }) => void;
+}
+
+export interface IpInterceptHandle {
+  /** True when ≥1 IP composite device exists — i.e. this path is usable on
+   *  this host. When false, grab()/release() are no-ops and the evdev path
+   *  in input-intercept.ts is the one doing the work. */
+  readonly available: boolean;
+  /** Begin intercept — InterceptMode=2 on every composite device. Steam is
+   *  starved; nav arrives over DBus. Safe to call when unavailable. */
+  grab(): void;
+  /** End intercept — InterceptMode=0; input flows back to Steam. */
+  release(): void;
+  /** Stop the signal monitor and ensure InterceptMode is back to 0. */
+  shutdown(): void;
+}
+
+export async function startIpIntercept(
+  opts: IpInterceptOptions,
+): Promise<IpInterceptHandle> {
+  const composites = await listCompositePaths();
+  const available = composites.length > 0;
+
+  opts.onReady?.({ composites: composites.length });
+
+  if (!available) {
+    // No IP in the loop — the evdev path handles this host. Return an inert
+    // handle so the orchestrator can call grab/release unconditionally.
+    return {
+      available: false,
+      grab() {},
+      release() {},
+      shutdown() {},
+    };
+  }
+
+  console.log(
+    `[ip-intercept] ${composites.length} IP composite device(s): ${composites.join(", ")}`,
+  );
+
+  // Belt-and-braces: clear any stale intercept on startup. Unlike EVIOCGRAB
+  // (auto-released by the kernel when the holding fd closes), InterceptMode
+  // is daemon-side state in InputPlumber that OUTLIVES this process — a
+  // crash, SIGKILL, or a service restart while the overlay was open leaves
+  // the composite stuck in GamepadOnly, deadening the pad in Steam. Forcing
+  // it back to 0 here means a fresh overlay always starts from a known-good
+  // state regardless of how the previous instance died.
+  for (const p of composites) {
+    await setInterceptMode(p, INTERCEPT_OFF);
+  }
+
+  let intercepting = false;
+  let pumpTimer: ReturnType<typeof setInterval> | null = null;
+
+  const nav = new NavController({
+    emit: (a) => opts.onAction(a),
+    emitAxis: (axis, value) => opts.onAxis?.(axis, value),
+  });
+
+  function feed(cap: string, value: number): void {
+    if (!intercepting) return;
+    const ev = uiToInputEvent(cap, value);
+    if (ev) {
+      nav.processEvents(NAV_CONTROLLER_ID, [ev]);
+      return;
+    }
+    if (UI_WAKE.has(cap) && value >= 0.5) {
+      trace(`[ip-intercept] wake=QamToggle from ${cap}`);
+      opts.onWake("QamToggle");
+      return;
+    }
+    // Unmapped capability — trace it so an unrecognised wake button or a
+    // nav cap we haven't mapped yet is easy to spot on-device.
+    if (value >= 0.5) trace(`[ip-intercept] unmapped ui event: ${cap}=${value}`);
+  }
+
+  // ---- gdbus signal monitor ----------------------------------------------
+  //
+  // One long-lived `gdbus monitor` over the whole IP service. It only ever
+  // emits InputEvent signals while some composite is intercepting, so
+  // leaving it running when idle is free. runStreaming drains stdout
+  // line-by-line; `feed` gates on `intercepting` so any stray late signal
+  // after release() is ignored. The promise stays pending until shutdown
+  // kills the captured subprocess.
+  let monitorProc: { kill: () => void } | null = null;
+  runStreaming(["gdbus", "monitor", "--system", "--dest", SERVICE], {
+    onSpawn: (proc) => {
+      monitorProc = proc;
+    },
+    onLine: (line) => {
+      const parsed = parseInputEventLine(line);
+      if (parsed) feed(parsed.cap, parsed.value);
+    },
+  }).catch((e) => console.warn("[ip-intercept] monitor reader threw:", e));
+
+  function startPump(): void {
+    if (pumpTimer) clearInterval(pumpTimer);
+    // Empty-batch pumps service held-direction key repeat between arrivals.
+    pumpTimer = setInterval(() => {
+      if (intercepting) nav.processEvents(NAV_CONTROLLER_ID, []);
+    }, PUMP_MS);
+  }
+
+  function stopPump(): void {
+    if (pumpTimer) clearInterval(pumpTimer);
+    pumpTimer = null;
+  }
+
+  function doGrab(): void {
+    if (intercepting) return;
+    intercepting = true;
+    nav.reset();
+    for (const p of composites) {
+      setInterceptMode(p, INTERCEPT_GAMEPAD_ONLY).catch(() => {});
+    }
+    startPump();
+    console.log(
+      `[ip-intercept] intercept ON — InterceptMode=GamepadOnly(3) on ${composites.length} device(s)`,
+    );
+  }
+
+  function doRelease(): void {
+    if (!intercepting) return;
+    intercepting = false;
+    for (const p of composites) {
+      setInterceptMode(p, INTERCEPT_OFF).catch(() => {});
+    }
+    stopPump();
+    nav.reset();
+    console.log("[ip-intercept] intercept OFF — InterceptMode=None(0)");
+  }
+
+  return {
+    available: true,
+    grab: doGrab,
+    release: doRelease,
+    shutdown() {
+      stopPump();
+      if (intercepting) {
+        // Best-effort synchronous-ish reset so we don't strand the pad.
+        for (const p of composites) setInterceptMode(p, INTERCEPT_OFF).catch(() => {});
+        intercepting = false;
+      }
+      try {
+        monitorProc?.kill();
+      } catch {
+        /* already gone */
+      }
+    },
+  };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@loadout/deck-hid": "workspace:*",
+        "@loadout/exec": "workspace:*",
         "@loadout/plugin-storage": "workspace:*",
         "@loadout/steam-paths": "workspace:*",
         "@loadout/types": "workspace:*",


### PR DESCRIPTION
## Problem

On IP-managed handhelds (OneXPlayer APEX, ROG Ally, MSI Claw, …) running SteamOS, the overlay's wake profile routes the pad through a **`deck-uhid`** target — a HID device behind `hid-steam` with **no grabbable evdev**. So the evdev `EVIOCGRAB` path grabs **0 controllers** and Steam BPM keeps driving D-pad nav *behind* the open overlay. (Worked on Bazzite/CachyOS, where the pad uses a normal grabbable target.)

## Approach — InputPlumber intercept mode (maintainer-suggested)

Rather than swapping the controller target to a grabbable emulation (the xbox-elite approach in #93, which changes the pad's identity and **loses Steam Deck glyphs**), this uses InputPlumber's own mechanism:

- On overlay open, set the composite device's **`InterceptMode = 3` (GamepadOnly)**. IP routes **gamepad** events to its DBus target instead of to Steam (BPM nav starved) while letting **keyboard** events pass through.
- Subscribe to the DBus `InputEvent` signals and translate the semantic `ui_*` capabilities (`ui_up/down/left/right/accept/back/…`) into the **same `NavController` InputEvents** the evdev reader produces — so the webview / spatial-nav side is unchanged.

### Why GamepadOnly (3), not Always (2)

The wake button is rendered by the input-plumber plugin as `gamepad button → KeyF16`, a **keyboard** event. Under `Always` (2) IP swallows *everything*, so the wake button can't close the overlay. Under **GamepadOnly** (3) the `KeyF16` still reaches the IP keyboard evdev, so the overlay's **existing evdev wake path** closes it. The bound wake button thus **opens AND closes**, with `deck-uhid` (and Deck glyphs) preserved. Confirmed against the upstream IP source (`write_event` only diverts gamepad caps in `GamepadOnly`).

## Dual-path

Runs **alongside** the evdev interceptor, which stays as the universal fallback on hosts without IP (Bazzite/CachyOS/desktop). There no composite device exists, `available` is false, and `grab()`/`release()` are no-ops — the evdev `EVIOCGRAB` path does the work exactly as before.

## Robustness

`InterceptMode` is **daemon-side state that outlives this process** (unlike `EVIOCGRAB`, which the kernel auto-releases on fd close). A crash or service restart while the overlay is open would strand the pad in GamepadOnly — deadening the gamepad in Steam. So the overlay **forces `InterceptMode = 0` on startup**. Validated: stranded `3` → overlay restart → cleared to `0`.

## Files

- **`native/ip-intercept.ts`** (new) — composite discovery (`busctl tree`), `InterceptMode` toggle, `gdbus monitor` → parse `InputEvent` → `NavController` (reuses key-repeat/deadzone), startup reset. Uses `@loadout/exec` (`runFull` / `runStreaming`).
- **`native/ip-intercept.test.ts`** (new) — 13 tests for the pure helpers (`parseInputEventLine`, `uiToInputEvent`, `pickCompositePaths`).
- **`index.ts` / `lifecycle.ts`** — start alongside the evdev path; `grab`/`release` in `toggleOverlay`; `shutdown` resets intercept + kills the monitor.
- **`package.json` / `bun.lock`** — add `@loadout/exec` workspace dep.

## Verification

- **Unit:** 13 pass; typecheck + lint clean.
- **On-device (OXP APEX, SteamOS, `deck-uhid` target):** Steam BPM frozen while the overlay is open; overlay navigates via the `ui_*` DBus stream; **wake button and B both close**; controller restored to Steam on close; startup reset clears a stranded intercept.

## Supersedes #93

Replaces the `deck-uhid → xbox-elite` target swap. This keeps the user's real controller identity (Steam Deck glyphs intact) and needs no kernel grab. #93 will be closed in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)