### PR TITLE
feat(overlay): grab D-pad focus via InputPlumber intercept mode (Game…

### DIFF
--- a/apps/loadout-overlay/package.json
+++ b/apps/loadout-overlay/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@noriginmedia/norigin-spatial-navigation": "^3.0.0",
     "@loadout/deck-hid": "workspace:*",
+    "@loadout/exec": "workspace:*",
     "@loadout/plugin-storage": "workspace:*",
     "@loadout/types": "workspace:*",
     "@loadout/ui": "workspace:*",

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -287,9 +287,15 @@ function broadcastOverlayVisibility(): void {
 // it's kept behind an env flag as a fallback for hosts where IP can't manage a
 // pad. The watchdog + startup-resume below stay wired so the flag is safe.
 //
-// Enable with DECK_OVERLAY_SUSPEND_STEAM=1.
+// EXTERNAL-PAD FIX (under test): Steam reads external pads directly via hidraw
+// (outside gamescope's focus routing), so neither the evdev grab nor the focus
+// atoms stop Steam BPM navigating behind the overlay from an external pad. HHD
+// hits the same wall and solves it by freezing Steam ("to avoid HID device dual
+// input"). So freeze is now ON by default; disable with DECK_OVERLAY_SUSPEND_STEAM=0.
+// The resume-burst is mitigated by the deferred SIGCONT + (TODO) the virtual-pad
+// grab held across resume to absorb replayed input.
 const SUSPEND_STEAM_ENABLED =
-  process.env.DECK_OVERLAY_SUSPEND_STEAM === "1";
+  process.env.DECK_OVERLAY_SUSPEND_STEAM !== "0";
 
 // Startup safety net for the frozen-Steam risk: a previous overlay instance
 // that crashed or was SIGKILLed *while open* could have left Steam SIGSTOPped

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -27,6 +27,10 @@ import {
   type WakeEvent,
 } from "./native/input-intercept";
 import {
+  startIpIntercept,
+  type IpInterceptHandle,
+} from "./native/ip-intercept";
+import {
   startDeckHidrawWatcher,
   type DeckHidrawWatcherHandle,
 } from "./native/deck-hidraw-watcher";
@@ -137,6 +141,12 @@ const pendingResumeTimer: { current: ReturnType<typeof setTimeout> | null } = {
 // and to the close-path `intercept.current?.release()` inside
 // toggleOverlay.
 const intercept: { current: InputInterceptHandle | null } = { current: null };
+// InputPlumber intercept-mode path — runs alongside the evdev interceptor on
+// IP-managed handhelds (deck-uhid target, no grabbable evdev). On grab it sets
+// InterceptMode=2 so Steam BPM is starved and nav arrives over D-Bus; on hosts
+// without IP it's an inert no-op and the evdev grab above does the work. See
+// native/ip-intercept.ts.
+const ipIntercept: { current: IpInterceptHandle | null } = { current: null };
 const deckHidraw: { current: DeckHidrawWatcherHandle | null } = { current: null };
 // Picker changes flow back to the watcher via two mechanisms: (1) fs.watch
 // on the plugin-storage directory fires within ~10ms of the atomic rename,
@@ -299,6 +309,7 @@ function toggleOverlay(source: string) {
     overlay.minimize();
     atoms.hide().catch((e) => console.warn("[overlay] atoms.hide:", e));
     intercept.current?.release();
+    ipIntercept.current?.release();
     // Always SIGCONT Steam on close, even when SUSPEND_STEAM_ENABLED is
     // off. Users have reported Steam appearing frozen after the overlay
     // closes (menu visible but inputs ignored) — if anything left Steam
@@ -328,6 +339,7 @@ function toggleOverlay(source: string) {
       if (steamPid.current !== null) suspendSteam(steamPid.current);
     }
     intercept.current?.grab();
+    ipIntercept.current?.grab();
     overlay.show();
     atoms.show().catch((e) => console.warn("[overlay] atoms.show:", e));
     state.isOpen = true;
@@ -407,6 +419,33 @@ startInputIntercept({
   })
   .catch((err) => {
     console.error("[overlay] input intercept failed to start:", err);
+  });
+
+// InputPlumber intercept-mode path. Discovers IP composite devices and, when
+// present, drives focus via InterceptMode + the DBus ui_* signal stream
+// instead of (the ineffective, on deck-uhid) EVIOCGRAB. Nav/wake events flow
+// to the exact same webview surface as the evdev path. No-op when IP is absent.
+startIpIntercept({
+  onAction: (action) => {
+    sendToWebview("overlay-action", { action });
+  },
+  onAxis: (axis, value) => {
+    sendToWebview("overlay-scroll", { axis, value });
+  },
+  onWake,
+  onReady: (info) =>
+    console.log(
+      `[overlay] ip intercept ready — ${info.composites} composite device(s)`,
+    ),
+})
+  .then((handle) => {
+    ipIntercept.current = handle;
+    if (handle.available) {
+      console.log("[overlay] ip intercept ACTIVE — using InterceptMode + DBus nav");
+    }
+  })
+  .catch((err) => {
+    console.error("[overlay] ip intercept failed to start:", err);
   });
 
 // Steam-Deck-native wake button: read /dev/hidrawN (the controller's
@@ -548,6 +587,7 @@ function runShutdown(): Promise<void> {
     steamPid,
     atoms,
     intercept,
+    ipIntercept,
     deckHidraw,
     globalShortcut: GlobalShortcut,
   });

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -133,6 +133,14 @@ const pendingResumeTimer: { current: ReturnType<typeof setTimeout> | null } = {
   current: null,
 };
 
+// Freeze watchdog state. The webview pings `overlayHeartbeat` ~1×/s; we stamp
+// the time here. If pings stop while Steam is frozen (overlay hung) — or the
+// freeze exceeds a hard cap — the watchdog force-closes the overlay and thaws
+// Steam, so a hung/degraded overlay can never strand Steam. (A SIGKILL→restart
+// is already covered by the startup SIGCONT; this covers a HANG, where the bun
+// process is alive but the CEF renderer is wedged.)
+const lastHeartbeat: { current: number } = { current: 0 };
+
 // Input interceptor — opens every controller + keyboard + QAM device
 // up-front and toggles EVIOCGRAB on the controllers when the overlay
 // shows/hides. Also emits wake events (F16 / Guide+B / Ctrl+4) that
@@ -186,6 +194,7 @@ const rpc = BrowserView.defineRPC({
     gamescopeMode,
     cachedSteamSoundsPath,
     steamPid,
+    lastHeartbeat,
   }),
 });
 
@@ -266,13 +275,97 @@ function broadcastOverlayVisibility(): void {
   sendToWebview("overlay-visibility", { isOpen: state.isOpen });
 }
 
-// Suspending Steam is off by default now that the input interceptor
-// reads physical controllers directly + dispatches synthetic keyboard
-// events into the webview (matches the Tauri behavior). SIGSTOP is
-// kept as an optional belt-and-braces mechanism behind an env flag in
-// case hardware surfaces a path we missed.
+// Freeze Steam (SIGSTOP) while the overlay is open — OPT-IN (off by default).
+//
+// We tried this ON by default to block EXTERNAL pads + games, but freezing
+// Steam buffers the pad's hidraw input while it's stopped and Steam REPLAYS the
+// backlog on SIGCONT → BPM jumps after close (the "resume-burst"; the pad
+// reports on-change so the buffer can't be flushed with neutral). The clean fix
+// is to have IP MANAGE the external pad (the backend enables ManageAllDevices)
+// so the overlay's InterceptMode DIVERTS its input before Steam ever reads it —
+// nothing buffers, nothing replays. So the freeze is no longer the mechanism;
+// it's kept behind an env flag as a fallback for hosts where IP can't manage a
+// pad. The watchdog + startup-resume below stay wired so the flag is safe.
+//
+// Enable with DECK_OVERLAY_SUSPEND_STEAM=1.
 const SUSPEND_STEAM_ENABLED =
   process.env.DECK_OVERLAY_SUSPEND_STEAM === "1";
+
+// Startup safety net for the frozen-Steam risk: a previous overlay instance
+// that crashed or was SIGKILLed *while open* could have left Steam SIGSTOPped
+// (whole UI frozen, only fixable by reboot otherwise). On every startup,
+// unconditionally SIGCONT Steam once. SIGCONT on a running process is a kernel
+// no-op, so this is free; combined with systemd's auto-restart it bounds any
+// stuck-frozen window to a single overlay restart. (HHD does NOT do this — it's
+// our crash-recovery edge.)
+if (SUSPEND_STEAM_ENABLED) {
+  const bootSteamPid = findSteamPid();
+  if (bootSteamPid !== null) {
+    resumeSteam(bootSteamPid);
+    trace("[overlay] startup: SIGCONT Steam (thaw any stale freeze)");
+  }
+}
+
+// ---- Freeze watchdog -------------------------------------------------------
+//
+// Guarantees Steam is never left SIGSTOPped by a hung overlay. While Steam is
+// frozen we poll once a second: if the webview stopped sending
+// `overlayHeartbeat` pings (renderer wedged) OR the freeze has run past a hard
+// cap, we emergency-close the overlay and thaw Steam. A SIGKILL→restart is
+// handled by the startup SIGCONT above; this handles the HANG case (bun alive,
+// CEF renderer wedged) the startup path can't see.
+const FREEZE_HEARTBEAT_TIMEOUT_MS = 5_000; // no ping this long while frozen → hung
+const FREEZE_HARD_CAP_MS = 30_000; // absolute ceiling on a single freeze
+let freezeWatchTimer: ReturnType<typeof setInterval> | null = null;
+let frozenAt = 0;
+
+function stopFreezeWatchdog(): void {
+  if (freezeWatchTimer) clearInterval(freezeWatchTimer);
+  freezeWatchTimer = null;
+}
+
+function startFreezeWatchdog(): void {
+  frozenAt = Date.now();
+  lastHeartbeat.current = Date.now(); // assume alive at open; webview keeps it fresh
+  stopFreezeWatchdog();
+  freezeWatchTimer = setInterval(() => {
+    if (!state.isOpen) {
+      stopFreezeWatchdog();
+      return;
+    }
+    const now = Date.now();
+    const sinceBeat = now - lastHeartbeat.current;
+    const frozenFor = now - frozenAt;
+    if (sinceBeat > FREEZE_HEARTBEAT_TIMEOUT_MS || frozenFor > FREEZE_HARD_CAP_MS) {
+      forceCloseOverlay(`unresponsive (sinceBeat=${sinceBeat}ms frozenFor=${frozenFor}ms)`);
+    }
+  }, 1_000);
+}
+
+// Emergency teardown when the watchdog fires: thaw Steam IMMEDIATELY, drop the
+// grabs/intercept, hide the window and mark closed. Mirrors the close path but
+// skips the debounce/deferred-resume so a wedged overlay self-heals.
+function forceCloseOverlay(reason: string): void {
+  console.warn(`[freeze-watchdog] ${reason} — emergency close + thaw Steam`);
+  trace(`[freeze-watchdog] ${reason} — emergency close`);
+  stopFreezeWatchdog();
+  if (pendingResumeTimer.current !== null) {
+    clearTimeout(pendingResumeTimer.current);
+    pendingResumeTimer.current = null;
+  }
+  if (steamPid.current === null) steamPid.current = findSteamPid();
+  if (steamPid.current !== null) resumeSteam(steamPid.current);
+  intercept.current?.release();
+  ipIntercept.current?.release();
+  atoms.hide().catch((e) => console.warn("[freeze-watchdog] atoms.hide:", e));
+  try {
+    overlay.minimize();
+  } catch (e) {
+    console.warn("[freeze-watchdog] minimize:", e);
+  }
+  state.isOpen = false;
+  broadcastOverlayVisibility();
+}
 
 // Minimum gap between toggleOverlay() calls. On the OXP Apex, InputPlumber
 // emits F16 on several evdev nodes simultaneously when the user presses
@@ -306,6 +399,7 @@ function toggleOverlay(source: string) {
     // matches input_interceptor.rs::close_overlay — atoms go down
     // before the grab releases so Gamescope re-focuses the game
     // before any queued controller events slip through.
+    stopFreezeWatchdog();
     overlay.minimize();
     atoms.hide().catch((e) => console.warn("[overlay] atoms.hide:", e));
     intercept.current?.release();
@@ -336,7 +430,10 @@ function toggleOverlay(source: string) {
     // raise the window, set atoms. Also matches open_overlay().
     if (SUSPEND_STEAM_ENABLED) {
       if (steamPid.current === null) steamPid.current = findSteamPid();
-      if (steamPid.current !== null) suspendSteam(steamPid.current);
+      if (steamPid.current !== null) {
+        suspendSteam(steamPid.current);
+        startFreezeWatchdog();
+      }
     }
     intercept.current?.grab();
     ipIntercept.current?.grab();

--- a/apps/loadout-overlay/src/bun/lifecycle.ts
+++ b/apps/loadout-overlay/src/bun/lifecycle.ts
@@ -14,6 +14,7 @@ import type { GlobalShortcut as GlobalShortcutType } from "electrobun/bun";
 import { resumeSteam } from "./native/process-control";
 import type { GamescopeAtoms } from "./native/gamescope-atoms";
 import type { InputInterceptHandle } from "./native/input-intercept";
+import type { IpInterceptHandle } from "./native/ip-intercept";
 import type { DeckHidrawWatcherHandle } from "./native/deck-hidraw-watcher";
 import {
   isActiveTick,
@@ -91,6 +92,10 @@ export interface ShutdownDeps {
   atoms: GamescopeAtoms;
   /** Input interceptor handle — may be null if it failed to start. */
   intercept: Ref<InputInterceptHandle | null>;
+  /** InputPlumber intercept-mode handle — null off IP hosts / on start
+   *  failure. Shut down so InterceptMode is reset to 0 and the gdbus
+   *  monitor subprocess is killed rather than left running. */
+  ipIntercept: Ref<IpInterceptHandle | null>;
   /** Deck-native hidraw watcher — null on non-Deck hosts and when the open
    *  failed. Tracked so we close the hidraw fd on shutdown rather than
    *  relying on process-death cleanup. */
@@ -153,6 +158,7 @@ export async function shutdown(deps: ShutdownDeps): Promise<void> {
     // window where another process can't grab them because we
     // haven't fully exited yet.
     deps.intercept.current?.shutdown();
+    deps.ipIntercept.current?.shutdown();
     deps.deckHidraw.current?.stop();
     deps.globalShortcut.unregisterAll();
     deps.atoms.shutdown();

--- a/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
@@ -206,7 +206,7 @@ describe("startInputIntercept — device selection", () => {
     h.shutdown();
   });
 
-  it("skips the Steam Input virtual pad (vendor 28de / product 11ff)", async () => {
+  it("grab-only tracks the Steam Input virtual pad (28de:11ff): opened, and EVIOCGRAB'd alongside the physical pad on intercept", async () => {
     devicesOnSystem = [
       mkDevice("/dev/input/event5", "Microsoft X-Box 360 pad", { isController: true }, {
         isSteamVirtual: true,
@@ -216,9 +216,21 @@ describe("startInputIntercept — device selection", () => {
       mkDevice("/dev/input/event6", "Xbox Wireless Controller", { isController: true }),
     ];
     const h = await startInputIntercept({ onWake: () => {}, onAction: () => {} });
+    // Both the virtual pad and the physical pad are opened/tracked now —
+    // the virtual one so we can grab it to silence the game underneath.
     const opens = ffiCalls.filter((c) => c.kind === "open");
-    expect(opens).toHaveLength(1);
-    expect((opens[0] as { path: string }).path).toBe("/dev/input/event6");
+    expect(opens.map((c) => (c as { path: string }).path).sort()).toEqual([
+      "/dev/input/event5",
+      "/dev/input/event6",
+    ]);
+    // On intercept, BOTH get EVIOCGRAB'd (physical for nav, virtual grab-only).
+    expect(
+      ffiCalls.filter((c) => c.kind === "ioctl" && c.request === 0x40044590n),
+    ).toHaveLength(0);
+    h.grab();
+    expect(
+      ffiCalls.filter((c) => c.kind === "ioctl" && c.request === 0x40044590n),
+    ).toHaveLength(2);
     h.shutdown();
   });
 

--- a/apps/loadout-overlay/src/bun/native/input-intercept.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.ts
@@ -20,10 +20,20 @@
 // events reaching ANY userspace process. Belt-and-braces under
 // Gamescope, where atom-only routing has been flaky.
 //
+// Steam Input's VIRTUAL Xbox 360 pad (vendor 28de / product 11ff) is a
+// special "grab-only" case: while the overlay is open we EVIOCGRAB it but
+// never read it for nav. A running GAME under the overlay reads its input
+// from this virtual pad (Steam Input aggregates every physical pad into one
+// virtual pad per controller), so grabbing it at the kernel input_dev level
+// (blocks evdev AND joydev readers) stops the game receiving input — with NO
+// resume-burst, unlike a process-freeze: grabbed events are never delivered,
+// so nothing queues to replay on release. Overlay nav is unaffected (it comes
+// from the PHYSICAL pads below, not this mirror). Steam BPM is unaffected too —
+// it reads the physical pad via hidraw, not this virtual pad (verified
+// on-device), so the menu keeps working and BPM yielding stays the focus
+// atoms' job (gamescope-atoms.ts).
+//
 // What we intentionally do NOT grab:
-//   - Steam Input's VIRTUAL Xbox 360 pad (vendor 28de / product 11ff).
-//     Grabbing it would cut CEF's Gamepad API (overlay webview reads
-//     it too) and break Steam BPM when the overlay closes.
 //   - Physical keyboards. The user might want to type into the overlay
 //     UI or use external shortcuts while it's open.
 //   - The InputPlumber virtual keyboard for F16 — handled separately
@@ -490,6 +500,10 @@ interface TrackedDevice {
   path: string;
   dev: InputDevice;
   grabbed: boolean;
+  /** Steam Input virtual pad: EVIOCGRAB it while intercepting to silence the
+   *  game underneath, but never read it for nav/wake (the physical pads drive
+   *  nav; this mirrors them). See the file header. */
+  grabOnly: boolean;
   combo: ComboState;
   shortcut: ShortcutState;
   cal: Map<number, AxisCal>;
@@ -526,8 +540,11 @@ export interface InputInterceptHandle {
 export async function startInputIntercept(
   opts: InputInterceptOptions,
 ): Promise<InputInterceptHandle> {
+  // isController matches BOTH physical pads (read for nav) and Steam Input's
+  // virtual pads (grab-only — see file header). isSteamVirtual disambiguates
+  // them in openAndTrack via `grabOnly`.
   const devices = (await enumerateDevices()).filter(
-    (d) => (d.flags.isController && !d.isSteamVirtual) ||
+    (d) => d.flags.isController ||
            d.flags.isKeyboard ||
            d.flags.isQam,
   );
@@ -543,20 +560,29 @@ export async function startInputIntercept(
       );
       return null;
     }
-    applyIdleMasks(fd, dev);
-    const cal = dev.flags.isController ? readAxisCalibration(fd) : new Map();
+    const grabOnly = dev.isSteamVirtual;
+    // Grab-only virtual pads are never read for nav, so masks + axis
+    // calibration are irrelevant — skip them.
+    if (!grabOnly) applyIdleMasks(fd, dev);
+    const cal =
+      dev.flags.isController && !grabOnly ? readAxisCalibration(fd) : new Map();
     const t: TrackedDevice = {
       fd,
       path: dev.eventPath,
       dev,
       grabbed: false,
+      grabOnly,
       combo: newComboState(),
       shortcut: newShortcutState(),
       cal,
     };
     tracked.push(t);
     const kinds = [
-      dev.flags.isController ? "controller" : null,
+      grabOnly
+        ? "virtual(grab-only)"
+        : dev.flags.isController
+          ? "controller"
+          : null,
       dev.flags.isKeyboard ? "keyboard" : null,
       dev.flags.isQam ? "qam" : null,
     ].filter(Boolean).join("+");
@@ -571,7 +597,8 @@ export async function startInputIntercept(
   }
 
   opts.onReady?.({
-    controllers: tracked.filter((t) => t.dev.flags.isController).length,
+    controllers: tracked.filter((t) => t.dev.flags.isController && !t.grabOnly)
+      .length,
     keyboards: tracked.filter((t) => t.dev.flags.isKeyboard).length,
     qam: tracked.filter((t) => t.dev.flags.isQam).length,
   });
@@ -601,6 +628,14 @@ export async function startInputIntercept(
 
     for (const t of tracked) {
       const events = readRawEvents(t.fd, buf, view);
+
+      // Steam Input virtual pads are grab-only: while intercepting we hold
+      // EVIOCGRAB so the game underneath gets nothing. We never feed their
+      // events to NavController (the physical pads already drive overlay nav;
+      // this mirrors them, so processing both would double every input) and
+      // never run wake detection on them. readRawEvents above already drained
+      // the fd so its buffer can't back up — just skip the rest.
+      if (t.grabOnly) continue;
 
       // Wake detection runs in every mode on every device.
       for (const e of events) {
@@ -656,13 +691,15 @@ export async function startInputIntercept(
     nav.reset();
     for (const t of tracked) {
       if (!t.dev.flags.isController) continue;
-      applyInterceptMasks(t.fd);
+      if (!t.grabOnly) applyInterceptMasks(t.fd);
       if (!t.grabbed) {
         const intBuf = new Int32Array([1]);
         const rc = libc.symbols.ioctl(t.fd, EVIOCGRAB, ptr(intBuf));
         if (rc === 0) {
           t.grabbed = true;
-          console.log(`[input-intercept] grabbed ${t.path} '${t.dev.name}'`);
+          console.log(
+            `[input-intercept] grabbed ${t.path} '${t.dev.name}'${t.grabOnly ? " (virtual, grab-only)" : ""}`,
+          );
         } else {
           // EBUSY is normal if another app (old overlay instance,
           // steamcompmgr) has it — log and move on.
@@ -690,7 +727,7 @@ export async function startInputIntercept(
         libc.symbols.ioctl(t.fd, EVIOCGRAB, null);
         t.grabbed = false;
       }
-      applyIdleMasks(t.fd, t.dev);
+      if (!t.grabOnly) applyIdleMasks(t.fd, t.dev);
     }
     nav.reset();
     console.log(
@@ -723,7 +760,7 @@ export async function startInputIntercept(
     }
     if (!fresh) return;
     const eligible =
-      (fresh.flags.isController && !fresh.isSteamVirtual) ||
+      fresh.flags.isController ||
       fresh.flags.isKeyboard ||
       fresh.flags.isQam;
     if (!eligible) return;
@@ -731,15 +768,17 @@ export async function startInputIntercept(
     if (!t) return;
     // If the overlay is open, the new controller has to participate in
     // the intercept the same way the boot-time controllers do:
-    // broaden masks + EVIOCGRAB. Keyboards / qam don't get grabbed.
+    // broaden masks + EVIOCGRAB (grab-only virtual pads just get the grab,
+    // so a pad's Steam Input virtual node created on connect is silenced too).
+    // Keyboards / qam don't get grabbed.
     if (intercepting && t.dev.flags.isController) {
-      applyInterceptMasks(t.fd);
+      if (!t.grabOnly) applyInterceptMasks(t.fd);
       const intBuf = new Int32Array([1]);
       const rc = libc.symbols.ioctl(t.fd, EVIOCGRAB, ptr(intBuf));
       if (rc === 0) {
         t.grabbed = true;
         console.log(
-          `[input-intercept] hotplug grabbed ${t.path} '${t.dev.name}'`,
+          `[input-intercept] hotplug grabbed ${t.path} '${t.dev.name}'${t.grabOnly ? " (virtual, grab-only)" : ""}`,
         );
       } else {
         console.warn(
@@ -802,7 +841,7 @@ export async function startInputIntercept(
     for (const dev of all) {
       if (trackedPaths.has(dev.eventPath)) continue;
       const eligible =
-        (dev.flags.isController && !dev.isSteamVirtual) ||
+        dev.flags.isController ||
         dev.flags.isKeyboard ||
         dev.flags.isQam;
       if (!eligible) continue;
@@ -811,13 +850,13 @@ export async function startInputIntercept(
       );
       const t = openAndTrack(dev);
       if (t && intercepting && t.dev.flags.isController) {
-        applyInterceptMasks(t.fd);
+        if (!t.grabOnly) applyInterceptMasks(t.fd);
         const intBuf = new Int32Array([1]);
         const rc = libc.symbols.ioctl(t.fd, EVIOCGRAB, ptr(intBuf));
         if (rc === 0) {
           t.grabbed = true;
           console.log(
-            `[input-intercept] reconcile grabbed ${t.path} '${t.dev.name}'`,
+            `[input-intercept] reconcile grabbed ${t.path} '${t.dev.name}'${t.grabOnly ? " (virtual, grab-only)" : ""}`,
           );
         }
       }

--- a/apps/loadout-overlay/src/bun/native/ip-intercept.test.ts
+++ b/apps/loadout-overlay/src/bun/native/ip-intercept.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "bun:test";
+import {
+  parseInputEventLine,
+  uiToInputEvent,
+  pickCompositePaths,
+} from "./ip-intercept";
+
+describe("parseInputEventLine", () => {
+  // gdbus monitor line shape for the DBusDevice.InputEvent signal.
+  const line =
+    "/org/shadowblip/InputPlumber/devices/target/dbus0: " +
+    "org.shadowblip.Input.DBusDevice.InputEvent ('ui_up', 1.0)";
+
+  it("parses capability + value from a gdbus InputEvent line", () => {
+    expect(parseInputEventLine(line)).toEqual({ cap: "ui_up", value: 1 });
+  });
+
+  it("parses a release (value 0.0)", () => {
+    expect(
+      parseInputEventLine(
+        "/x: org.shadowblip.Input.DBusDevice.InputEvent ('ui_accept', 0.0)",
+      ),
+    ).toEqual({ cap: "ui_accept", value: 0 });
+  });
+
+  it("parses fractional + integer-looking values", () => {
+    expect(parseInputEventLine(".InputEvent ('ui_left', 0.5)")?.value).toBe(0.5);
+    expect(parseInputEventLine(".InputEvent ('ui_left', 1)")?.value).toBe(1);
+  });
+
+  it("ignores non-InputEvent lines (e.g. PropertiesChanged)", () => {
+    expect(
+      parseInputEventLine(
+        "/x: org.freedesktop.DBus.Properties.PropertiesChanged ('org.shadowblip.Input.CompositeDevice', {'InterceptMode': <uint32 3>}, @as [])",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null on the monitor header lines", () => {
+    expect(
+      parseInputEventLine("Monitoring signals from all objects owned by …"),
+    ).toBeNull();
+  });
+});
+
+describe("uiToInputEvent", () => {
+  it("maps direction caps to hat axes with the correct sign on press", () => {
+    expect(uiToInputEvent("ui_up", 1)).toEqual({
+      kind: "axis",
+      axis: "HatY",
+      value: -1,
+    });
+    expect(uiToInputEvent("ui_down", 1)).toEqual({
+      kind: "axis",
+      axis: "HatY",
+      value: 1,
+    });
+    expect(uiToInputEvent("ui_left", 1)).toEqual({
+      kind: "axis",
+      axis: "HatX",
+      value: -1,
+    });
+    expect(uiToInputEvent("ui_right", 1)).toEqual({
+      kind: "axis",
+      axis: "HatX",
+      value: 1,
+    });
+  });
+
+  it("zeroes the axis on release so NavController clears the held direction", () => {
+    expect(uiToInputEvent("ui_up", 0)).toEqual({
+      kind: "axis",
+      axis: "HatY",
+      value: 0,
+    });
+  });
+
+  it("maps accept/back/bumpers to buttons with pressed state", () => {
+    expect(uiToInputEvent("ui_accept", 1)).toEqual({
+      kind: "button",
+      button: "A",
+      pressed: true,
+    });
+    expect(uiToInputEvent("ui_back", 0)).toEqual({
+      kind: "button",
+      button: "B",
+      pressed: false,
+    });
+    expect(uiToInputEvent("ui_l1", 1)).toEqual({
+      kind: "button",
+      button: "LB",
+      pressed: true,
+    });
+    expect(uiToInputEvent("ui_r1", 1)).toEqual({
+      kind: "button",
+      button: "RB",
+      pressed: true,
+    });
+  });
+
+  it("treats the half-threshold as the press boundary", () => {
+    // < 0.5 is a release, >= 0.5 is a press.
+    expect(uiToInputEvent("ui_accept", 0.49)).toMatchObject({ pressed: false });
+    expect(uiToInputEvent("ui_accept", 0.5)).toMatchObject({ pressed: true });
+  });
+
+  it("returns null for non-nav capabilities (handled elsewhere / logged)", () => {
+    // ui_guide / ui_quick are wake-class, not nav — not in the nav table.
+    expect(uiToInputEvent("ui_guide", 1)).toBeNull();
+    expect(uiToInputEvent("ui_quick", 1)).toBeNull();
+    expect(uiToInputEvent("ui_osk", 1)).toBeNull();
+    expect(uiToInputEvent("KeyF16", 1)).toBeNull();
+  });
+});
+
+describe("pickCompositePaths", () => {
+  it("plucks top-level CompositeDeviceN paths from busctl tree output", () => {
+    const tree = [
+      "/org/shadowblip/InputPlumber",
+      "/org/shadowblip/InputPlumber/CompositeDevice0",
+      "/org/shadowblip/InputPlumber/devices/target/dbus0",
+      "/org/shadowblip/InputPlumber/devices/target/gamepad1",
+      "/org/shadowblip/InputPlumber/CompositeDevice1",
+    ].join("\n");
+    expect(pickCompositePaths(tree)).toEqual([
+      "/org/shadowblip/InputPlumber/CompositeDevice0",
+      "/org/shadowblip/InputPlumber/CompositeDevice1",
+    ]);
+  });
+
+  it("does not match nested composite-device children", () => {
+    const tree =
+      "/org/shadowblip/InputPlumber/CompositeDevice0/source/event5\n" +
+      "  /org/shadowblip/InputPlumber/CompositeDevice0";
+    // Leading whitespace is trimmed; the bare composite path matches, the
+    // /source/... child does not.
+    expect(pickCompositePaths(tree)).toEqual([
+      "/org/shadowblip/InputPlumber/CompositeDevice0",
+    ]);
+  });
+
+  it("returns [] when there are no composite devices", () => {
+    expect(pickCompositePaths("/org/shadowblip/InputPlumber\n")).toEqual([]);
+  });
+});

--- a/apps/loadout-overlay/src/bun/native/ip-intercept.ts
+++ b/apps/loadout-overlay/src/bun/native/ip-intercept.ts
@@ -1,0 +1,374 @@
+// InputPlumber "intercept mode" input path — an alternative to the
+// EVIOCGRAB grab in input-intercept.ts for hosts where InputPlumber (IP)
+// manages the controller.
+//
+// WHY THIS EXISTS
+// ----------------
+// On IP-managed handhelds running SteamOS (OneXPlayer APEX, ROG Ally, …)
+// the wake-button profile routes the pad through a `deck-uhid` target —
+// a HID device behind hid-steam → Steam Input, with NO grabbable evdev.
+// So the evdev path's EVIOCGRAB grabs 0 controllers and Steam BPM keeps
+// driving nav *behind* the open overlay. (See input-intercept.ts and the
+// fix/overlay-input-focus-grab branch for the full diagnosis.)
+//
+// IP's own mechanism solves this cleanly. Every IP composite device has:
+//   - a writable `InterceptMode` property (0=None, 1=Pass, 2=Always,
+//     3=GamepadOnly), and
+//   - a permanently-attached DBus *target* (`…/devices/target/dbusN`) that
+//     emits an `InputEvent(String capability, double value)` signal.
+//
+// We use mode 3 = GamepadOnly. In this mode IP routes only GAMEPAD events
+// to the DBus target (so Steam BPM is starved of d-pad/stick/face-button
+// nav → it stops) while KEYBOARD events still pass through to the normal
+// keyboard target. That keyboard pass-through is deliberate and load-
+// bearing: the overlay's wake button is rendered (by the input-plumber
+// plugin) as `gamepad button → KeyF16`, so under GamepadOnly the F16 still
+// reaches the IP keyboard evdev and the EXISTING evdev wake path
+// (input-intercept.ts) catches it to CLOSE the overlay. (Mode 2 = Always
+// swallows the keyboard event too, which is why the wake button couldn't
+// close the overlay — see git history of this module.)
+//
+// We subscribe to the DBus InputEvent signals, translate the `ui_*`
+// capabilities to the SAME NavController InputEvents the evdev path uses,
+// so the webview side is unchanged.
+//
+// Verified on-device (OXP APEX, SteamOS): GamepadOnly freezes Steam BPM
+// nav and the DBus target emits ui_up / ui_down / ui_left / ui_right /
+// ui_accept / ui_back / ui_guide / ui_quick as press(1.0)/release(0.0)
+// pairs, while the F16 wake button still closes via the evdev path.
+//
+// WHY ALONGSIDE, NOT INSTEAD OF, THE EVDEV PATH
+// ----------------------------------------------
+// This only works when IP is in the loop. On Bazzite/CachyOS/desktop where
+// IP isn't managing the pad there's no composite device to intercept, so
+// the evdev grab in input-intercept.ts stays as the universal fallback.
+// `available` is false there and grab()/release() are no-ops.
+//
+// Permissions: setting InterceptMode and receiving the DBus signals both
+// work for non-root clients — the IP D-Bus policy
+// (org.shadowblip.InputPlumber.conf) currently allows `context="default"`
+// to receive signals (there's an upstream TODO to gate this behind an
+// alternative API; if that lands, this path needs the backend to relay).
+//
+// We shell out to `busctl` (set InterceptMode, discover composites) and
+// `gdbus monitor` (receive InputEvent signals) rather than pulling in a
+// D-Bus library — both are present on every IP host and keep this module
+// dependency-free, matching the rest of native/.
+
+import { runFull, runStreaming } from "@loadout/exec";
+import { NavController, type InputEvent } from "./nav-controller";
+import { trace } from "./trace";
+
+const SERVICE = "org.shadowblip.InputPlumber";
+const COMPOSITE_IFACE = "org.shadowblip.Input.CompositeDevice";
+
+// busctl can block on the system-bus default timeout (~25s) while IP is
+// mid-restart; cap discovery/set calls so a stuck bus can't wedge a toggle.
+// Matches the backend ipdbus.ts client.
+const BUSCTL_TIMEOUT_MS = 5000;
+
+const COMPOSITE_PATH_RE = /^\/org\/shadowblip\/InputPlumber\/CompositeDevice\d+$/;
+
+/** Pump cadence while intercepting — services NavController key-repeat for
+ *  held d-pad directions between signal arrivals. Mirrors the evdev path's
+ *  POLL_ACTIVE_MS. */
+const PUMP_MS = 25;
+
+/** NavController keys per-controller state by id; the DBus stream is a
+ *  single logical controller, so a constant id is fine. */
+const NAV_CONTROLLER_ID = "ip-dbus";
+
+// ---- busctl helpers --------------------------------------------------------
+
+interface ExecResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+async function exec(cmd: string[]): Promise<ExecResult> {
+  try {
+    const { stdout, stderr, exitCode } = await runFull(cmd, {
+      timeoutMs: BUSCTL_TIMEOUT_MS,
+    });
+    return { ok: exitCode === 0, stdout, stderr };
+  } catch (e) {
+    return { ok: false, stdout: "", stderr: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+function busctl(args: string[]): Promise<ExecResult> {
+  return exec(["busctl", "--system", "--no-pager", ...args]);
+}
+
+/** Pluck top-level CompositeDevice paths from `busctl tree --list` output. */
+export function pickCompositePaths(treeStdout: string): string[] {
+  const out: string[] = [];
+  for (const line of treeStdout.split("\n")) {
+    const t = line.trim();
+    if (COMPOSITE_PATH_RE.test(t)) out.push(t);
+  }
+  return out;
+}
+
+async function listCompositePaths(): Promise<string[]> {
+  const r = await busctl(["tree", "--list", SERVICE]);
+  if (!r.ok) return [];
+  return pickCompositePaths(r.stdout);
+}
+
+/** InterceptMode values (org.shadowblip.Input.CompositeDevice):
+ *  0=None, 1=Pass, 2=Always, 3=GamepadOnly. We toggle between 0 (off) and
+ *  3 (gamepad-only intercept) — see the file header for why GamepadOnly. */
+const INTERCEPT_OFF = 0;
+const INTERCEPT_GAMEPAD_ONLY = 3;
+
+async function setInterceptMode(
+  path: string,
+  mode: typeof INTERCEPT_OFF | typeof INTERCEPT_GAMEPAD_ONLY,
+): Promise<void> {
+  const r = await busctl([
+    "set-property",
+    SERVICE,
+    path,
+    COMPOSITE_IFACE,
+    "InterceptMode",
+    "u",
+    String(mode),
+  ]);
+  if (!r.ok) {
+    console.warn(
+      `[ip-intercept] set InterceptMode=${mode} failed for ${path}: ${r.stderr.trim()}`,
+    );
+  }
+}
+
+// ---- ui_* capability → NavController InputEvent ----------------------------
+//
+// IP intercept translates physical input into the `ui_*` capability set
+// (the DBus:ui_* TargetCapabilities). We re-express them as the same
+// button/axis InputEvents the evdev reader produces, so NavController's
+// key-repeat + deadzone logic is reused verbatim. Directions map onto the
+// hat axes (value ±1 on press, 0 on release); accept/back/bumpers onto the
+// face/shoulder buttons.
+
+interface NavMap {
+  kind: "axis";
+  axis: "HatX" | "HatY";
+  sign: 1 | -1;
+}
+interface BtnMap {
+  kind: "button";
+  button: "A" | "B" | "LB" | "RB";
+}
+
+const UI_NAV: Record<string, NavMap | BtnMap> = {
+  ui_up: { kind: "axis", axis: "HatY", sign: -1 },
+  ui_down: { kind: "axis", axis: "HatY", sign: 1 },
+  ui_left: { kind: "axis", axis: "HatX", sign: -1 },
+  ui_right: { kind: "axis", axis: "HatX", sign: 1 },
+  ui_accept: { kind: "button", button: "A" },
+  ui_back: { kind: "button", button: "B" },
+  ui_l1: { kind: "button", button: "LB" },
+  ui_r1: { kind: "button", button: "RB" },
+};
+
+/** ui_* capabilities that ALSO toggle the overlay closed while it's open.
+ *  Under GamepadOnly the bound wake button (KeyF16) already closes via the
+ *  evdev path, so these are a redundant convenience: the Guide/QAM-class
+ *  buttons are gamepad buttons, so in GamepadOnly they arrive over DBus and
+ *  give a "get me out" control even if the user never bound a wake button.
+ *  Every received ui_* is trace-logged so unmapped controls are easy to
+ *  spot on-device. */
+const UI_WAKE = new Set(["ui_guide", "ui_quick", "ui_quick2", "ui_osk"]);
+
+/** Map a (capability, value) pair to a NavController InputEvent, or null if
+ *  it isn't a nav capability. `pressed` = value past the half threshold. */
+export function uiToInputEvent(cap: string, value: number): InputEvent | null {
+  const m = UI_NAV[cap];
+  if (!m) return null;
+  const pressed = value >= 0.5;
+  if (m.kind === "axis") {
+    return { kind: "axis", axis: m.axis, value: pressed ? m.sign : 0 };
+  }
+  return { kind: "button", button: m.button, pressed };
+}
+
+/** Parse one `gdbus monitor` line into a (capability, value) pair, or null.
+ *  Line shape:
+ *    /org/.../target/dbus0: org.shadowblip.Input.DBusDevice.InputEvent ('ui_up', 1.0)
+ */
+export function parseInputEventLine(
+  line: string,
+): { cap: string; value: number } | null {
+  const m = line.match(/\.InputEvent\s+\('([^']+)',\s*([-0-9.eE]+)\)/);
+  if (!m) return null;
+  const value = Number.parseFloat(m[2]);
+  if (Number.isNaN(value)) return null;
+  return { cap: m[1], value };
+}
+
+// ---- Public API ------------------------------------------------------------
+
+export interface IpInterceptOptions {
+  /** Nav actions for the webview — wire to sendToWebview("overlay-action"). */
+  onAction: (action: string) => void;
+  /** Continuous right-stick analog scroll — wire to "overlay-scroll".
+   *  (IP doesn't currently surface analog over the ui_* set, but the hook
+   *  matches the evdev path's shape for symmetry.) */
+  onAxis?: (axis: "RightStickX" | "RightStickY", value: number) => void;
+  /** A wake/close trigger seen on the DBus stream while intercepting — wire
+   *  to the same onWake() that evdev wake events use. */
+  onWake: (event: "QamToggle") => void;
+  /** Diagnostics: number of IP composite devices discovered. */
+  onReady?: (info: { composites: number }) => void;
+}
+
+export interface IpInterceptHandle {
+  /** True when ≥1 IP composite device exists — i.e. this path is usable on
+   *  this host. When false, grab()/release() are no-ops and the evdev path
+   *  in input-intercept.ts is the one doing the work. */
+  readonly available: boolean;
+  /** Begin intercept — InterceptMode=2 on every composite device. Steam is
+   *  starved; nav arrives over DBus. Safe to call when unavailable. */
+  grab(): void;
+  /** End intercept — InterceptMode=0; input flows back to Steam. */
+  release(): void;
+  /** Stop the signal monitor and ensure InterceptMode is back to 0. */
+  shutdown(): void;
+}
+
+export async function startIpIntercept(
+  opts: IpInterceptOptions,
+): Promise<IpInterceptHandle> {
+  const composites = await listCompositePaths();
+  const available = composites.length > 0;
+
+  opts.onReady?.({ composites: composites.length });
+
+  if (!available) {
+    // No IP in the loop — the evdev path handles this host. Return an inert
+    // handle so the orchestrator can call grab/release unconditionally.
+    return {
+      available: false,
+      grab() {},
+      release() {},
+      shutdown() {},
+    };
+  }
+
+  console.log(
+    `[ip-intercept] ${composites.length} IP composite device(s): ${composites.join(", ")}`,
+  );
+
+  // Belt-and-braces: clear any stale intercept on startup. Unlike EVIOCGRAB
+  // (auto-released by the kernel when the holding fd closes), InterceptMode
+  // is daemon-side state in InputPlumber that OUTLIVES this process — a
+  // crash, SIGKILL, or a service restart while the overlay was open leaves
+  // the composite stuck in GamepadOnly, deadening the pad in Steam. Forcing
+  // it back to 0 here means a fresh overlay always starts from a known-good
+  // state regardless of how the previous instance died.
+  for (const p of composites) {
+    await setInterceptMode(p, INTERCEPT_OFF);
+  }
+
+  let intercepting = false;
+  let pumpTimer: ReturnType<typeof setInterval> | null = null;
+
+  const nav = new NavController({
+    emit: (a) => opts.onAction(a),
+    emitAxis: (axis, value) => opts.onAxis?.(axis, value),
+  });
+
+  function feed(cap: string, value: number): void {
+    if (!intercepting) return;
+    const ev = uiToInputEvent(cap, value);
+    if (ev) {
+      nav.processEvents(NAV_CONTROLLER_ID, [ev]);
+      return;
+    }
+    if (UI_WAKE.has(cap) && value >= 0.5) {
+      trace(`[ip-intercept] wake=QamToggle from ${cap}`);
+      opts.onWake("QamToggle");
+      return;
+    }
+    // Unmapped capability — trace it so an unrecognised wake button or a
+    // nav cap we haven't mapped yet is easy to spot on-device.
+    if (value >= 0.5) trace(`[ip-intercept] unmapped ui event: ${cap}=${value}`);
+  }
+
+  // ---- gdbus signal monitor ----------------------------------------------
+  //
+  // One long-lived `gdbus monitor` over the whole IP service. It only ever
+  // emits InputEvent signals while some composite is intercepting, so
+  // leaving it running when idle is free. runStreaming drains stdout
+  // line-by-line; `feed` gates on `intercepting` so any stray late signal
+  // after release() is ignored. The promise stays pending until shutdown
+  // kills the captured subprocess.
+  let monitorProc: { kill: () => void } | null = null;
+  runStreaming(["gdbus", "monitor", "--system", "--dest", SERVICE], {
+    onSpawn: (proc) => {
+      monitorProc = proc;
+    },
+    onLine: (line) => {
+      const parsed = parseInputEventLine(line);
+      if (parsed) feed(parsed.cap, parsed.value);
+    },
+  }).catch((e) => console.warn("[ip-intercept] monitor reader threw:", e));
+
+  function startPump(): void {
+    if (pumpTimer) clearInterval(pumpTimer);
+    // Empty-batch pumps service held-direction key repeat between arrivals.
+    pumpTimer = setInterval(() => {
+      if (intercepting) nav.processEvents(NAV_CONTROLLER_ID, []);
+    }, PUMP_MS);
+  }
+
+  function stopPump(): void {
+    if (pumpTimer) clearInterval(pumpTimer);
+    pumpTimer = null;
+  }
+
+  function doGrab(): void {
+    if (intercepting) return;
+    intercepting = true;
+    nav.reset();
+    for (const p of composites) {
+      setInterceptMode(p, INTERCEPT_GAMEPAD_ONLY).catch(() => {});
+    }
+    startPump();
+    console.log(
+      `[ip-intercept] intercept ON — InterceptMode=GamepadOnly(3) on ${composites.length} device(s)`,
+    );
+  }
+
+  function doRelease(): void {
+    if (!intercepting) return;
+    intercepting = false;
+    for (const p of composites) {
+      setInterceptMode(p, INTERCEPT_OFF).catch(() => {});
+    }
+    stopPump();
+    nav.reset();
+    console.log("[ip-intercept] intercept OFF — InterceptMode=None(0)");
+  }
+
+  return {
+    available: true,
+    grab: doGrab,
+    release: doRelease,
+    shutdown() {
+      stopPump();
+      if (intercepting) {
+        // Best-effort synchronous-ish reset so we don't strand the pad.
+        for (const p of composites) setInterceptMode(p, INTERCEPT_OFF).catch(() => {});
+        intercepting = false;
+      }
+      try {
+        monitorProc?.kill();
+      } catch {
+        /* already gone */
+      }
+    },
+  };
+}

--- a/apps/loadout-overlay/src/bun/rpc-handlers.ts
+++ b/apps/loadout-overlay/src/bun/rpc-handlers.ts
@@ -64,6 +64,9 @@ export interface RpcHandlerDeps {
    *  successful SIGCONT) and restartSteam (clears it after kill so
    *  the next toggle rediscovers the respawned PID). */
   steamPid: Ref<number | null>;
+  /** Last time the webview sent an `overlayHeartbeat` (Date.now() ms). The
+   *  freeze watchdog in index.ts reads this to detect a hung overlay. */
+  lastHeartbeat: Ref<number>;
 }
 
 /**
@@ -83,6 +86,12 @@ export function buildRpcHandlers(deps: RpcHandlerDeps) {
       },
       toggle: async (): Promise<boolean> => requestToggle(deps.state),
       isGamescopeMode: async () => deps.gamescopeMode,
+      // Liveness ping from the webview (~1×/s). The freeze watchdog uses the
+      // last-seen time to tell a healthy overlay from a hung one. Fire-and-
+      // forget: returns nothing, never throws.
+      overlayHeartbeat: async () => {
+        deps.lastHeartbeat.current = Date.now();
+      },
       getControllerShortcuts: async () => deps.shortcuts.current,
       // BrowserView.defineRPC types every handler as (params?: unknown) => unknown,
       // so we accept unknown and validate the real shape inside. A

--- a/apps/loadout-overlay/src/overlay/App.tsx
+++ b/apps/loadout-overlay/src/overlay/App.tsx
@@ -19,7 +19,7 @@ import { useEnabledPlugins } from "./hooks/useEnabledPlugins";
 import { useConfigValue, getConfigValue, setConfigValue } from "./lib/userConfig";
 import { GamepadNavProvider, useFocusable, Focusable, FocusContext, setFocus, getCurrentFocusKey } from "./components/GamepadNav";
 import { ErrorBoundary } from "./components/ErrorBoundary";
-import { hideOverlay, isGamescopeMode, getControllerShortcuts, setControllerShortcuts } from "./lib/host";
+import { hideOverlay, isGamescopeMode, getControllerShortcuts, setControllerShortcuts, sendOverlayHeartbeat } from "./lib/host";
 import { OverlayKeyboard } from "./components/OverlayKeyboard";
 import { useOverlayKeyboard } from "@loadout/ui";
 import { isTextLike, rememberLastInput } from "./lib/keystrokeDispatcher";
@@ -115,6 +115,16 @@ export function App() {
     } else {
       hideOverlay().catch(() => {});
     }
+  }, []);
+
+  // Liveness heartbeat for the bun-side freeze watchdog. Runs whenever the
+  // webview is mounted (the window is minimized, never destroyed, on close).
+  // If this renderer wedges, the pings stop and bun thaws Steam + force-closes
+  // rather than leaving Steam SIGSTOPped. Cheap (one RPC/s).
+  useEffect(() => {
+    sendOverlayHeartbeat();
+    const id = setInterval(sendOverlayHeartbeat, 1000);
+    return () => clearInterval(id);
   }, []);
 
   // Plugin → shell toast bridge. Plugins call `notify(...)` from

--- a/apps/loadout-overlay/src/overlay/lib/host.ts
+++ b/apps/loadout-overlay/src/overlay/lib/host.ts
@@ -21,6 +21,13 @@ async function rpcInvoke(
   return await fn(args);
 }
 
+/** Liveness ping for the bun-side freeze watchdog. Fire-and-forget — if the
+ *  renderer wedges and these stop arriving while Steam is frozen, bun thaws
+ *  Steam and force-closes. No-op outside Electrobun. */
+export function sendOverlayHeartbeat(): void {
+  void rpcInvoke("overlayHeartbeat");
+}
+
 export async function showOverlay() {
   return rpcInvoke("show");
 }

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@loadout/deck-hid": "workspace:*",
+        "@loadout/exec": "workspace:*",
         "@loadout/plugin-storage": "workspace:*",
         "@loadout/steam-paths": "workspace:*",
         "@loadout/types": "workspace:*",

--- a/plugins/input-plumber/app.tsx
+++ b/plugins/input-plumber/app.tsx
@@ -339,6 +339,7 @@ function WakeButtonSection() {
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
   const [legacyAck, setLegacyAck] = useState(false);
+  const [restarting, setRestarting] = useState(false);
 
   // Mounted-ref guard so awaited callbacks don't `setState` after the user
   // navigates away mid-capture (10s windows are long enough to leave on).
@@ -412,6 +413,25 @@ function WakeButtonSection() {
     },
     [call, refresh, safeSet],
   );
+
+  // Recovery: restart the InputPlumber daemon (rebuilds composite devices) and
+  // re-load the wake profile. Slower than the other ops (daemon restart + a few
+  // retries for re-enumeration), so it has its own busy state + spinner.
+  const restartIp = useCallback(async () => {
+    safeSet(setRestarting, true);
+    safeSet(setError, null);
+    safeSet(setInfo, null);
+    try {
+      const r = (await call("restartInputPlumber")) as WakeOpResult;
+      if (r.ok) safeSet(setInfo, "InputPlumber restarted — controllers should be back.");
+      else safeSet(setError, r.error ?? "Restart failed.");
+      await refresh();
+    } catch (e) {
+      safeSet(setError, e instanceof Error ? e.message : String(e));
+    } finally {
+      safeSet(setRestarting, false);
+    }
+  }, [call, refresh, safeSet]);
 
   const cardWrap = (body: React.ReactNode) => (
     <div className="card mt-3.5">
@@ -553,6 +573,30 @@ function WakeButtonSection() {
           )}
         </div>
       )}
+
+      {/* Recovery: rebuild InputPlumber's devices when a controller stops
+          working (not showing in Steam, overlay won't grab focus, etc). */}
+      <div className="mt-3.5 pt-3 border-t border-base-content/10">
+        <div className="subsection-desc mb-2">
+          Controller acting up — not showing in Steam, or the overlay won&apos;t
+          grab focus? Restart InputPlumber to rebuild its devices from scratch.
+        </div>
+        <FocusButton
+          onClick={() => void restartIp()}
+          disabled={busy || capturing || restarting}
+          variant="ghost"
+        >
+          {restarting ? (
+            <>
+              <Spinner size={14} /> <span className="ml-1.5">Restarting…</span>
+            </>
+          ) : (
+            <>
+              <FaArrowsRotate className="w-3 h-3 mr-1" /> Restart InputPlumber
+            </>
+          )}
+        </FocusButton>
+      </div>
     </div>,
   );
 }

--- a/plugins/input-plumber/backend.ts
+++ b/plugins/input-plumber/backend.ts
@@ -292,4 +292,15 @@ export default class InputPlumberBackend implements PluginBackend {
     this.emit?.({ event: "wake-status", data: await wake.getWakeStatus() });
     return r;
   }
+
+  /** Recovery: restart the InputPlumber daemon and re-load the wake profile.
+   *  Rebuilds composite devices from scratch to fix stuck states (a controller
+   *  not presenting to Steam, deck-uhid emulation confused after churn). */
+  async restartInputPlumber(): Promise<WakeOpResult> {
+    this.log?.info("Restarting InputPlumber (user-requested recovery)…");
+    const r = await wake.restartInputPlumber();
+    if (!r.ok) this.log?.warn(`restartInputPlumber: ${r.error}`);
+    this.emit?.({ event: "wake-status", data: await wake.getWakeStatus() });
+    return r;
+  }
 }

--- a/plugins/input-plumber/lib/ipdbus.ts
+++ b/plugins/input-plumber/lib/ipdbus.ts
@@ -22,6 +22,8 @@ import { runFull } from "@loadout/exec";
 const SERVICE = "org.shadowblip.InputPlumber";
 const COMPOSITE_IFACE = "org.shadowblip.Input.CompositeDevice";
 const TARGET_IFACE = "org.shadowblip.Input.Target";
+const MANAGER_PATH = "/org/shadowblip/InputPlumber/Manager";
+const MANAGER_IFACE = "org.shadowblip.InputManager";
 
 // Match disable-controller-input's ceiling: busctl can block on the system
 // bus default timeout (~25s) while IP is mid-restart; 5s fails fast.
@@ -173,6 +175,25 @@ export interface CompositeDevice {
   path: string;
   name: string;
   capabilities: string[];
+}
+
+/** Enable/disable IP management of ALL supported devices (not just configs with
+ *  `auto_manage`). Enabling lets IP manage EXTERNAL controllers (Xbox/PS pads)
+ *  so the overlay can intercept their input instead of Steam reading them via
+ *  hidraw. Onboard-safe: the handheld config is `auto_manage`, so disabling only
+ *  releases the external pads. Enable EARLY (backend onLoad — before Steam grabs
+ *  external pads at boot) so IP wins the race and Steam never sees the physical
+ *  pad (a late enable causes a physical+emulated duplicate). */
+export async function setManageAllDevices(enable: boolean): Promise<ExecResult> {
+  return busctl([
+    "set-property",
+    SERVICE,
+    MANAGER_PATH,
+    MANAGER_IFACE,
+    "ManageAllDevices",
+    "b",
+    enable ? "true" : "false",
+  ]);
 }
 
 /** Enumerate the connected composite devices with their names + capabilities. */

--- a/plugins/input-plumber/lib/wake-trigger.ts
+++ b/plugins/input-plumber/lib/wake-trigger.ts
@@ -514,3 +514,38 @@ export async function reloadPersistedProfile(): Promise<WakeOpResult> {
     ? { ok: true }
     : { ok: false, error: `LoadProfilePath failed: exit ${loaded.code}` };
 }
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * User-triggered recovery: restart the InputPlumber daemon, then re-load the
+ * wake profile onto the freshly-recreated composite device.
+ *
+ * Rebuilding all composite devices + emulated targets from scratch is the
+ * reliable fix for the class of stuck states we can't always recover from in
+ * place — a controller stops presenting to Steam, the `deck-uhid` emulation
+ * gets confused after heavy device churn, or the boot-time wake reload lost its
+ * race. Exposed as a "Restart InputPlumber" button in the plugin UI.
+ *
+ * Best-effort and non-throwing. The retry loop covers the window where IP is
+ * back up but hasn't finished re-enumerating the controller's capabilities yet
+ * (the same race `reloadPersistedProfile` can hit at boot) — without it the
+ * wake button would silently fail to reload right after the restart.
+ */
+export async function restartInputPlumber(): Promise<WakeOpResult> {
+  const r = await exec(["systemctl", "restart", "inputplumber"]);
+  if (!r.ok) {
+    return { ok: false, error: `Failed to restart InputPlumber: ${r.err || "unknown error"}` };
+  }
+  // reloadPersistedProfile() already waits for IP to come up; retry it a few
+  // times so a not-yet-enumerated composite (transient post-restart) resolves
+  // rather than leaving the wake button unbound. No-op (ok) when no wake button
+  // is bound, so this returns quickly on those setups.
+  let last: WakeOpResult = { ok: true };
+  for (let attempt = 0; attempt < 5; attempt++) {
+    last = await reloadPersistedProfile();
+    if (last.ok) break;
+    await delay(1000);
+  }
+  return last;
+}


### PR DESCRIPTION
…padOnly + DBus nav)

On IP-managed handhelds (OneXPlayer APEX, ROG Ally, …) running SteamOS the
overlay's wake profile routes the pad through a `deck-uhid` target — a HID
device behind hid-steam with no grabbable evdev — so the evdev EVIOCGRAB path
grabs 0 controllers and Steam BPM keeps driving D-pad nav *behind* the open
overlay.

Instead of swapping the controller target to a grabbable emulation (the
xbox-elite approach in #93, which changes the pad's identity and loses Steam
Deck glyphs), use InputPlumber's own intercept mechanism — as suggested by the
IP maintainer:

  - On overlay open, set the composite device's `InterceptMode = 3`
    (GamepadOnly). IP then routes GAMEPAD events to its DBus target instead of
    to Steam (BPM nav starved) while letting KEYBOARD events pass through.
  - Subscribe to the DBus `InputEvent` signals and translate the semantic
    `ui_*` capabilities (ui_up/down/left/right/accept/back/…) into the same
    NavController InputEvents the evdev reader produces — so the webview /
    spatial-nav side is unchanged.
  - GamepadOnly (not Always=2) is deliberate: the wake button is rendered as
    `gamepad button → KeyF16`, a keyboard event. Under GamepadOnly that F16
    still reaches the IP keyboard evdev, so the overlay's existing evdev wake
    path closes the overlay. The bound wake button thus opens AND closes,
    with `deck-uhid` (and Deck glyphs) preserved.

Runs alongside the evdev interceptor, which stays as the universal fallback on
hosts without IP (Bazzite/CachyOS/desktop) — there `available` is false and
grab()/release() are no-ops.

Robustness: InterceptMode is daemon-side state that outlives this process
(unlike EVIOCGRAB, which the kernel auto-releases on fd close). A crash or
service restart while open would strand the pad in GamepadOnly, so we force
InterceptMode=0 on overlay startup. Verified on-device (OXP APEX, SteamOS):
Steam frozen while open, overlay navigates, wake button + B both close,
startup reset clears a stranded intercept.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>