### PR TITLE
fix(protondb-badges): restore CDP badge injection (#59)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -287,6 +287,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@loadout/plugin-storage": "workspace:*",
+        "@loadout/steam-cdp": "workspace:*",
         "@loadout/steam-paths": "workspace:*",
         "@loadout/types": "workspace:*",
         "@loadout/ui": "workspace:*",

--- a/plugins/protondb-badges/README.md
+++ b/plugins/protondb-badges/README.md
@@ -4,6 +4,16 @@
 
 ![Screenshot](./assets/screenshot.png)
 
+## Steam-side badges
+
+Beyond the overlay UI, the backend connects to Steam's CEF debug port over
+CDP and injects a tier badge directly into Steam's Big Picture Mode game
+pages and store pages (`store.steampowered.com`). The injected runtime
+(`window.__protondb_badges`) is a passive renderer; the backend polls the
+viewed app's route, fetches the ProtonDB report server-side, and pushes it
+in. Style, position, the submit button, and the library/store toggles are
+all driven from the plugin's settings.
+
 ## See also
 
 - [All plugins](../../README.md#plugins)

--- a/plugins/protondb-badges/app.tsx
+++ b/plugins/protondb-badges/app.tsx
@@ -198,9 +198,18 @@ function ProtonDBBadges() {
   useEvent({
     event: "stateChanged",
     handler: (data: unknown) => {
-      const d = data as { settings?: ProtonDBSettings };
+      const d = data as {
+        settings?: ProtonDBSettings;
+        connected?: boolean;
+        tabs?: number;
+      };
       if (d.settings) {
         setSettings(d.settings);
+      }
+      // Backend emits connection state alongside settings on connect /
+      // health-check changes — reflect it live in the Steam CEF section.
+      if (typeof d.connected === "boolean") {
+        setStatus({ connected: d.connected, tabs: d.tabs ?? 0 });
       }
     },
   });

--- a/plugins/protondb-badges/backend.test.ts
+++ b/plugins/protondb-badges/backend.test.ts
@@ -497,22 +497,27 @@ describe("ProtonDBBadgesBackend", () => {
     });
   });
 
-  // ── CEF status stubs ─────────────────────────────────────────
+  // ── Steam-CEF injection ──────────────────────────────────────
+  //
+  // No Steam CEF debug port is reachable in the test env (localhost:8080
+  // /json fails against the mocked fetch), so the CDP layer reports
+  // disconnected and reconnect fails cleanly. These assert the graceful-
+  // degradation contract; the injection itself is exercised on-device.
 
-  describe("CEF status stubs", () => {
-    it("getStatus reports disconnected (CEF injection not yet ported)", async () => {
+  describe("Steam-CEF injection", () => {
+    it("getStatus reports disconnected when no Steam CEF is reachable", async () => {
       const status = await backend.getStatus();
       expect(status.connected).toBe(false);
       expect(status.tabs).toBe(0);
     });
 
-    it("reconnect returns an error explaining CEF is unsupported", async () => {
+    it("reconnect fails cleanly when Steam CEF is unreachable", async () => {
       const result = await backend.reconnect();
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
     });
 
-    it("getCurrentRouteAppId returns null", async () => {
+    it("getCurrentRouteAppId returns null before any route is observed", async () => {
       const appId = await backend.getCurrentRouteAppId();
       expect(appId).toBeNull();
     });

--- a/plugins/protondb-badges/backend.test.ts
+++ b/plugins/protondb-badges/backend.test.ts
@@ -499,10 +499,11 @@ describe("ProtonDBBadgesBackend", () => {
 
   // ── Steam-CEF injection ──────────────────────────────────────
   //
-  // No Steam CEF debug port is reachable in the test env (localhost:8080
-  // /json fails against the mocked fetch), so the CDP layer reports
-  // disconnected and reconnect fails cleanly. These assert the graceful-
-  // degradation contract; the injection itself is exercised on-device.
+  // No Steam CEF debug port is reachable in the test env: the module-
+  // level fetch mock returns HTTP 500 for localhost:8080/json (and never
+  // touches the real network), so `_tryConnect` bails, the CDP layer
+  // reports disconnected, and reconnect fails cleanly. These assert the
+  // graceful-degradation contract; injection itself is exercised on-device.
 
   describe("Steam-CEF injection", () => {
     it("getStatus reports disconnected when no Steam CEF is reachable", async () => {

--- a/plugins/protondb-badges/backend.ts
+++ b/plugins/protondb-badges/backend.ts
@@ -39,11 +39,13 @@ export interface ProtonDBSettings {
   enableStoreBadge: boolean;
 }
 
-/** Combined payload pushed into the injected CEF badge runtime. */
+/** Combined payload pushed into the injected CEF badge runtime. The
+ *  injected scripts only read `report` + `settings`; Linux-support is
+ *  deliberately NOT carried here so the 500 ms push path never pays the
+ *  extra (rate-limited) Steam appdetails fetch. */
 interface BadgeData {
   appId: string;
   report: ProtonDBReport | null;
-  linuxSupport: boolean;
   settings: ProtonDBSettings;
 }
 
@@ -531,11 +533,18 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
         if (!targetAppId) {
           expr = `if (window.__protondb_badges) window.__protondb_badges.removeBadge();`;
         } else {
-          const badgeData = await this.getBadgeData(targetAppId);
+          // Fetch only the report — the injected runtime never reads
+          // Linux-support, so don't pay `checkLinuxSupport` on every
+          // navigation (see `BadgeData`).
+          const report = await this.getReport(targetAppId);
           // If a newer appId arrived while awaiting the fetch, drop this
           // batch and let the loop re-run for the latest.
           if (this.pendingPushSet) continue;
-          const data: BadgeData = { appId: targetAppId, ...badgeData };
+          const data: BadgeData = {
+            appId: targetAppId,
+            report,
+            settings: this.settings,
+          };
           expr = `if (window.__protondb_badges) window.__protondb_badges.updateBadge(${JSON.stringify(data)});`;
         }
 
@@ -597,6 +606,13 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
       // render targets.
       const prefixTargets = ["MainMenu"];
 
+      // Tabs we've already opened a socket to this pass — so the store
+      // loop below never opens a second WebSocket to a tab that already
+      // matched an exact/prefix target (which would orphan one socket
+      // from health-check pruning, since the two are stored under
+      // different keys).
+      const connectedTabIds = new Set<string>();
+
       for (const tab of tabs) {
         if (!tab.webSocketDebuggerUrl) continue;
 
@@ -612,6 +628,7 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
             ? "SharedJSContext"
             : tab.title;
           this.connections.set(key, conn);
+          connectedTabIds.add(tab.id);
           if (
             prefixHit === "MainMenu" ||
             tab.title === "Steam Big Picture Mode"
@@ -628,9 +645,11 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
       for (const tab of tabs) {
         if (!tab.webSocketDebuggerUrl) continue;
         if (!tab.url.includes("store.steampowered.com")) continue;
+        if (connectedTabIds.has(tab.id)) continue;
         try {
           const conn = await this._openCDP(tab.webSocketDebuggerUrl, tab.title);
           this.connections.set(`store:${tab.title}`, conn);
+          connectedTabIds.add(tab.id);
           console.log(`[protondb-badges] Connected to store: ${tab.title}`);
         } catch {
           /* store tab optional */
@@ -738,7 +757,8 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
         if (appIdMatch) {
           badgeData = {
             appId: appIdMatch[1],
-            ...(await this.getBadgeData(appIdMatch[1])),
+            report: await this.getReport(appIdMatch[1]),
+            settings: this.settings,
           };
         }
 

--- a/plugins/protondb-badges/backend.ts
+++ b/plugins/protondb-badges/backend.ts
@@ -3,6 +3,7 @@ import {
   listInstalledGames,
   type InstalledGame,
 } from "@loadout/steam-paths";
+import { CDPClient } from "@loadout/steam-cdp";
 import {
   readPluginStorage,
   writePluginStorage,
@@ -38,6 +39,27 @@ export interface ProtonDBSettings {
   enableStoreBadge: boolean;
 }
 
+/** Combined payload pushed into the injected CEF badge runtime. */
+interface BadgeData {
+  appId: string;
+  report: ProtonDBReport | null;
+  linuxSupport: boolean;
+  settings: ProtonDBSettings;
+}
+
+interface CEFTab {
+  id: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl: string;
+  type: string;
+}
+
+interface CDPConnection {
+  client: CDPClient;
+  tabTitle: string;
+}
+
 // ─── Constants ──────────────────────────────────────────────────────
 
 const PLUGIN_ID = "protondb-badges";
@@ -50,6 +72,12 @@ const CACHE_TTL = 30 * 60 * 1000;
  *  in-memory map (30 min) so a freshly-restarted loader doesn't cold-
  *  start by re-fetching every report when warm data is on disk. */
 const DISK_CACHE_TTL_SEC = 24 * 60 * 60;
+
+/** Steam's CEF remote-debugging port. */
+const DEBUG_PORT = 8080;
+/** Per-evaluate CDP timeout. Steam can stall mid game-state transition;
+ *  5 s matches the sibling CEF-injection plugins (hltb / theme-loader). */
+const CDP_TIMEOUT_MS = 5000;
 
 const DEFAULT_SETTINGS: ProtonDBSettings = {
   size: "regular",
@@ -65,28 +93,30 @@ const DEFAULT_SETTINGS: ProtonDBSettings = {
 /**
  * ProtonDB Badges backend.
  *
- * Exposes the ProtonDB compatibility tier (plus a few Steam-store
- * side fetches: per-title Linux support, free-text search) as RPC
- * methods consumed by `app.tsx`. The grid view in the overlay fans
- * out one `getReport` call per installed game, so the backend caps
- * concurrent ProtonDB requests at 4 (cache hits skip the queue) to
- * avoid 429s from a 100+ game library.
+ * Two surfaces:
+ *
+ *  1. **Overlay UI** — exposes the ProtonDB compatibility tier (plus a
+ *     few Steam-store side fetches: per-title Linux support, free-text
+ *     search) as RPC methods consumed by `app.tsx`. The grid view fans
+ *     out one `getReport` call per installed game, so the backend caps
+ *     concurrent ProtonDB requests at 4 (cache hits skip the queue) to
+ *     avoid 429s from a 100+ game library.
+ *
+ *  2. **Steam-CEF badge injection** — connects to Steam's CEF debug
+ *     port over CDP, discovers the Big Picture Mode / SharedJSContext /
+ *     store tabs, and injects a CSS rule + a passive JS runtime
+ *     (`window.__protondb_badges = { updateBadge, removeBadge, cleanup }`)
+ *     into each. The backend polls the SharedJSContext route for the
+ *     viewed appId, fetches the report server-side, and pushes it into
+ *     the runtime — so a tier badge appears on the live Steam game /
+ *     store page, not just inside the overlay. This is the layer PR #50
+ *     dropped and issue #59 restored; it mirrors the sibling `hltb`
+ *     plugin's injection architecture.
  *
  * Settings persist via `@loadout/plugin-storage` at
  * `~/.config/loadout/plugins/protondb-badges.json`. API responses
  * persist via the inlined `lib/external-cache.ts` TTL disk cache at
  * `~/.cache/loadout/protondb-badges/`.
- *
- * **Removed vs source steam-loader plugin**: the source also did
- * CEF-side badge injection into Steam Big Picture Mode via the
- * `@steam-loader/steam-cdp` `CDPClient`. That helper isn't exposed
- * to Loadout plugins (no public package; lives in `apps/loadout/`),
- * and Steam-CEF panel injection is the responsibility of
- * `target: { type: "panel" }` + `patches[]` in loadout — a
- * fundamentally different mechanism. The native overlay UI is the
- * primary surface in loadout, so the migration drops the CEF-side
- * badge renderer; the overlay's `app.tsx` (library grid + home
- * widget) carries the user-facing functionality.
  */
 export default class ProtonDBBadgesBackend implements PluginBackend {
   emit?: (payload: EmitPayload) => void;
@@ -112,14 +142,93 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
   private lookupQueue: Array<() => void> = [];
   private static readonly MAX_CONCURRENT_LOOKUPS = 4;
 
+  // ─── CDP injection state ────────────────────────────────────────
+
+  /** Open CDP connections keyed by tab title (SharedJSContext variants
+   *  collapse to the canonical `SharedJSContext` key; store tabs use a
+   *  `store:<title>` key; BPM popups keep their per-session title). */
+  private connections = new Map<string, CDPConnection>();
+  private connected = false;
+  private healthInterval?: ReturnType<typeof setInterval>;
+  private urlPollInterval?: ReturnType<typeof setInterval>;
+
+  /** appId of the game page currently viewed in BPM (route-derived). */
+  private currentAppId: string | null = null;
+
+  /** Re-entrancy guards for the two background interval ticks
+   *  (`_checkHealth` 5 s, `_pollCurrentAppId` 500 ms). A slow CDP
+   *  evaluate (up to `CDP_TIMEOUT_MS`) must not let the next tick fire
+   *  on top and race on `connections` / `bpmRenderKeys`. */
+  private polling = false;
+  private healthChecking = false;
+
+  /** Tail-queue for `_pushBadgeDataToBPM`: when a push is in flight and
+   *  a new appId arrives, stash the latest and let the running push
+   *  drain to it. `pendingPushSet` (not a null check) because `null` is
+   *  a valid pending value (= "navigated away from a game page"). */
+  private pushingBadgeData = false;
+  private pendingPushAppId: string | null = null;
+  private pendingPushSet = false;
+
+  /**
+   * Connection keys that are candidate render targets for the BPM badge
+   * — either the parent `Steam Big Picture Mode` tab or any per-session
+   * `MainMenu_uid<N>` popup. Which one hosts the visible React UI is
+   * build-dependent, so we inject into all of them and push data to all
+   * of them; only the visible tab composites to the user. Refilled by
+   * health-check rediscovery when popups die.
+   */
+  private bpmRenderKeys: string[] = [];
+
+  /**
+   * Debounce window for re-injecting the badge system after a settings
+   * change. Dragging a position/style control fires `updateSettings`
+   * many times a second; re-pushing the full CSS+script bundle over CDP
+   * on every call stalls the bridge. Trailing-edge debounce collapses
+   * the burst into one re-injection.
+   */
+  private static readonly INJECT_DEBOUNCE_MS = 250;
+  private injectDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
   // ─── Lifecycle ──────────────────────────────────────────────────
 
   async onLoad(): Promise<void> {
     console.log("[protondb-badges] Plugin loaded");
     await this._loadSettings();
+
+    // Try the initial CEF connection, but don't block startup if Steam
+    // isn't up yet — the health check retries every 5 s.
+    this._tryConnect()
+      .then((ok) => {
+        if (ok) void this._injectBadgeSystem();
+      })
+      .catch(() => {
+        console.log("[protondb-badges] Steam CEF not available yet, will retry");
+      });
+
+    this.healthInterval = setInterval(() => void this._checkHealth(), 5000);
+    this.urlPollInterval = setInterval(() => void this._pollCurrentAppId(), 500);
   }
 
   async onUnload(): Promise<void> {
+    clearInterval(this.healthInterval);
+    clearInterval(this.urlPollInterval);
+    if (this.injectDebounceTimer) clearTimeout(this.injectDebounceTimer);
+    await this._removeBadgeSystem();
+
+    // Silent catch: `ws.close()` may throw if the socket is already
+    // CLOSING/CLOSED — harmless during unload.
+    for (const conn of this.connections.values()) {
+      try {
+        conn.client.close();
+      } catch {
+        /* already closed */
+      }
+    }
+    this.connections.clear();
+    this.bpmRenderKeys = [];
+    this.connected = false;
+
     this.reportCache.clear();
     this.searchCache.clear();
     this.linuxCache.clear();
@@ -311,29 +420,648 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
     this.settings = { ...DEFAULT_SETTINGS, ...settings };
     await this._saveSettings();
     this._emitState();
+
+    // Re-inject the badge system so style/position/toggle changes show
+    // up live on the Steam side. Debounced so dragging a control doesn't
+    // peg the CDP bridge.
+    if (!this.connected) return;
+    if (this.injectDebounceTimer) clearTimeout(this.injectDebounceTimer);
+    this.injectDebounceTimer = setTimeout(() => {
+      this.injectDebounceTimer = null;
+      void this._injectBadgeSystem();
+    }, ProtonDBBadgesBackend.INJECT_DEBOUNCE_MS);
   }
 
-  // ─── RPC: CEF status (stubs) ────────────────────────────────────
-  // The source plugin also drove CEF-side badge injection (Big Picture
-  // Mode + Steam store tabs) via CDP. That mechanism doesn't exist in
-  // Loadout yet — a future panel-target migration would re-add it.
-  // These stubs let the existing settings UI render its "Steam CEF"
-  // status section without errors; users see "Disconnected" and the
-  // Reconnect button is a no-op.
+  // ─── RPC: Steam-CEF status ──────────────────────────────────────
 
   async getStatus(): Promise<{ connected: boolean; tabs: number }> {
-    return { connected: false, tabs: 0 };
+    return { connected: this.connected, tabs: this.connections.size };
   }
 
   async reconnect(): Promise<{ success: boolean; error?: string }> {
-    return {
-      success: false,
-      error: "Steam CEF injection is not yet supported in Loadout",
-    };
+    for (const conn of this.connections.values()) {
+      try {
+        conn.client.close();
+      } catch {
+        /* already closed */
+      }
+    }
+    this.connections.clear();
+    this.bpmRenderKeys = [];
+    this.connected = false;
+
+    const ok = await this._tryConnect();
+    if (ok) {
+      await this._injectBadgeSystem();
+      this._emitState();
+      return { success: true };
+    }
+    return { success: false, error: "Could not connect to Steam CEF. Is Steam running?" };
   }
 
+  /**
+   * appId of the game page currently viewed in Steam BPM (route-derived,
+   * NOT the running game). Mirrors hltb's route polling; will fold into a
+   * `__core:game-detection` subscribe once that lands for backends.
+   */
   async getCurrentRouteAppId(): Promise<string | null> {
-    return null;
+    return this.currentAppId;
+  }
+
+  // ─── Route Polling (SharedJSContext) ────────────────────────────
+  //
+  // In BPM / gamescope, window.location.href stays pinned to the BPM
+  // entry URL forever — navigation happens inside a React Router SPA.
+  // Steam exposes the router on SharedJSContext as `window.tempNavStore`
+  // (a MobX store mirroring React Router v5); on a game page the
+  // pathname is `/library/app/<id>` (or `/routes/library/app/<id>` on
+  // some builds). Polling that covers both BPM and Desktop Steam, with a
+  // fallback to window.location.pathname.
+
+  private async _pollCurrentAppId(): Promise<void> {
+    if (this.polling) return;
+    const conn = this.connections.get("SharedJSContext");
+    if (!conn || !conn.client.connected) return;
+
+    this.polling = true;
+    try {
+      const pathname = (await this._cdpEvaluate(
+        conn,
+        "(window.tempNavStore && window.tempNavStore.m_history && window.tempNavStore.m_history.location && window.tempNavStore.m_history.location.pathname) || window.location.pathname || ''",
+      )) as string;
+      const match = pathname?.match?.(/^\/(?:routes\/)?library\/app\/(\d+)/);
+      const newAppId = match ? match[1] : null;
+
+      if (newAppId !== this.currentAppId) {
+        this.currentAppId = newAppId;
+        this._pushBadgeDataToBPM(newAppId).catch(() => {});
+      }
+    } catch {
+      // Ignore — will retry next tick.
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  /**
+   * Fetch ProtonDB data server-side and push it into the BPM tab(s) via
+   * CDP. Pushing server-side (rather than letting the injected script
+   * fetch) sidesteps the mixed-content block on https://steamloopback.host.
+   */
+  private async _pushBadgeDataToBPM(appId: string | null): Promise<void> {
+    // Coalesce rapid route changes: stash the latest appId and let the
+    // running push drain to it, so a fast navigation never strands a
+    // stale badge on screen.
+    this.pendingPushAppId = appId;
+    this.pendingPushSet = true;
+    if (this.pushingBadgeData) return;
+    this.pushingBadgeData = true;
+
+    try {
+      while (this.pendingPushSet) {
+        const targetAppId = this.pendingPushAppId;
+        this.pendingPushSet = false;
+
+        const targets = this.bpmRenderKeys
+          .map((k) => ({ key: k, conn: this.connections.get(k) }))
+          .filter((t) => t.conn && t.conn.client.connected);
+        if (targets.length === 0) continue;
+
+        let expr: string;
+        if (!targetAppId) {
+          expr = `if (window.__protondb_badges) window.__protondb_badges.removeBadge();`;
+        } else {
+          const badgeData = await this.getBadgeData(targetAppId);
+          // If a newer appId arrived while awaiting the fetch, drop this
+          // batch and let the loop re-run for the latest.
+          if (this.pendingPushSet) continue;
+          const data: BadgeData = { appId: targetAppId, ...badgeData };
+          expr = `if (window.__protondb_badges) window.__protondb_badges.updateBadge(${JSON.stringify(data)});`;
+        }
+
+        const pushed: string[] = [];
+        for (const t of targets) {
+          try {
+            await this._cdpEvaluate(t.conn!, expr);
+            pushed.push(t.key);
+          } catch (err) {
+            console.warn(
+              `[protondb-badges] Failed to push badge data to ${t.key}:`,
+              err,
+            );
+          }
+        }
+        if (targetAppId && pushed.length > 0) {
+          console.log(
+            `[protondb-badges] Pushed badge data to ${pushed.join(", ")} for app ${targetAppId}`,
+          );
+        }
+      }
+    } finally {
+      this.pushingBadgeData = false;
+    }
+  }
+
+  // ─── CDP Infrastructure ─────────────────────────────────────────
+
+  private async _tryConnect(): Promise<boolean> {
+    try {
+      const res = await fetch(`http://localhost:${DEBUG_PORT}/json`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      if (!res.ok) throw new Error(`/json returned ${res.status}`);
+
+      const tabs = (await res.json()) as CEFTab[];
+
+      // Close any existing connections before rediscovering.
+      for (const conn of this.connections.values()) {
+        try {
+          conn.client.close();
+        } catch {
+          /* already closed */
+        }
+      }
+      this.connections.clear();
+      this.bpmRenderKeys = [];
+
+      const sharedJSNames = [
+        "SharedJSContext",
+        "Steam Shared Context presented by Valve™",
+        "SP",
+        "Steam",
+      ];
+      const exactTargets = [...sharedJSNames, "Steam Big Picture Mode"];
+      // Steam splits the BPM UI across the parent `Steam Big Picture
+      // Mode` tab and per-session `MainMenu_uid<N>` popups; which hosts
+      // the visible React UI is build-dependent, so both are candidate
+      // render targets.
+      const prefixTargets = ["MainMenu"];
+
+      for (const tab of tabs) {
+        if (!tab.webSocketDebuggerUrl) continue;
+
+        const isExact = exactTargets.includes(tab.title);
+        const prefixHit = prefixTargets.find((p) => tab.title.startsWith(p));
+        if (!isExact && !prefixHit) continue;
+
+        try {
+          const conn = await this._openCDP(tab.webSocketDebuggerUrl, tab.title);
+          // Collapse SharedJSContext title variants to one canonical key;
+          // MainMenu popups keep their per-session title.
+          const key = sharedJSNames.includes(tab.title)
+            ? "SharedJSContext"
+            : tab.title;
+          this.connections.set(key, conn);
+          if (
+            prefixHit === "MainMenu" ||
+            tab.title === "Steam Big Picture Mode"
+          ) {
+            this.bpmRenderKeys.push(key);
+          }
+          console.log(`[protondb-badges] Connected to: ${tab.title} (key: ${key})`);
+        } catch (err) {
+          console.warn(`[protondb-badges] Failed to connect to ${tab.title}:`, err);
+        }
+      }
+
+      // Also connect to Steam store tabs (store.steampowered.com).
+      for (const tab of tabs) {
+        if (!tab.webSocketDebuggerUrl) continue;
+        if (!tab.url.includes("store.steampowered.com")) continue;
+        try {
+          const conn = await this._openCDP(tab.webSocketDebuggerUrl, tab.title);
+          this.connections.set(`store:${tab.title}`, conn);
+          console.log(`[protondb-badges] Connected to store: ${tab.title}`);
+        } catch {
+          /* store tab optional */
+        }
+      }
+
+      this.connected =
+        this.connections.has("SharedJSContext") ||
+        this.bpmRenderKeys.length > 0;
+      this._emitState();
+      return this.connected;
+    } catch {
+      this.connected = false;
+      return false;
+    }
+  }
+
+  private async _openCDP(
+    wsUrl: string,
+    tabTitle: string,
+  ): Promise<CDPConnection> {
+    const client = new CDPClient(wsUrl);
+    await client.connect();
+    return { client, tabTitle };
+  }
+
+  private _cdpEvaluate(
+    conn: CDPConnection,
+    expression: string,
+  ): Promise<unknown> {
+    return conn.client.evaluate(expression, { timeoutMs: CDP_TIMEOUT_MS });
+  }
+
+  // ─── CSS / JS Injection ─────────────────────────────────────────
+
+  private async _injectCSSToTab(
+    conn: CDPConnection,
+    styleId: string,
+    css: string,
+  ): Promise<void> {
+    const escaped = css
+      .replace(/\\/g, "\\\\")
+      .replace(/`/g, "\\`")
+      .replace(/\$/g, "\\$");
+    await this._cdpEvaluate(
+      conn,
+      `
+      (function() {
+        var e = document.getElementById("${styleId}");
+        if (e) e.remove();
+        var s = document.createElement("style");
+        s.id = "${styleId}";
+        s.dataset.loadoutPlugin = "protondb-badges";
+        document.head.appendChild(s);
+        s.textContent = \`${escaped}\`;
+      })()
+    `,
+    );
+  }
+
+  private async _injectBadgeSystem(): Promise<void> {
+    const css = this._generateBadgeCSS();
+
+    // Inject into every candidate BPM render tab — only the visible one
+    // composites to the user; hidden tabs update their off-screen DOM
+    // harmlessly. See `bpmRenderKeys` for why we fan out.
+    const bpmConns = this.bpmRenderKeys
+      .map((k) => ({ key: k, conn: this.connections.get(k) }))
+      .filter((t) => t.conn && t.conn.client.connected);
+
+    if (bpmConns.length > 0) {
+      for (const t of bpmConns) {
+        try {
+          await this._injectCSSToTab(t.conn!, "protondb-badges-styles", css);
+          await this._cdpEvaluate(t.conn!, this._generateBPMScript());
+          console.log(`[protondb-badges] Injected badge system into ${t.key}`);
+        } catch (err) {
+          console.warn(`[protondb-badges] Failed to inject into ${t.key}:`, err);
+        }
+      }
+      if (this.currentAppId) {
+        this._pushBadgeDataToBPM(this.currentAppId).catch(() => {});
+      }
+    } else {
+      console.warn(
+        "[protondb-badges] No BPM render tab discovered — badge will not appear. Tabs:",
+        Array.from(this.connections.keys()).join(", "),
+      );
+    }
+
+    // Inject into store tabs — fetch the report server-side and embed it
+    // at injection time (no fetch() from inside CEF).
+    for (const [key, conn] of this.connections) {
+      if (!key.startsWith("store:")) continue;
+      if (!conn.client.connected) continue;
+      try {
+        const url = (await this._cdpEvaluate(
+          conn,
+          "window.location.href",
+        )) as string;
+        const appIdMatch = url?.match?.(
+          /store\.steampowered\.com\/app\/(\d+)/,
+        );
+        let badgeData: BadgeData | null = null;
+        if (appIdMatch) {
+          badgeData = {
+            appId: appIdMatch[1],
+            ...(await this.getBadgeData(appIdMatch[1])),
+          };
+        }
+
+        await this._injectCSSToTab(conn, "protondb-badges-styles", css);
+        await this._cdpEvaluate(conn, this._generateStoreScript(badgeData));
+      } catch {
+        /* store tab transient — health check will retry */
+      }
+    }
+  }
+
+  private async _removeBadgeSystem(): Promise<void> {
+    for (const conn of this.connections.values()) {
+      if (!conn.client.connected) continue;
+      try {
+        await this._cdpEvaluate(
+          conn,
+          `
+          if (window.__protondb_badges) window.__protondb_badges.cleanup();
+          if (window.__protondb_store_badges) window.__protondb_store_badges.cleanup();
+          var s = document.getElementById("protondb-badges-styles"); if (s) s.remove();
+        `,
+        );
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+
+  // ─── Badge CSS ──────────────────────────────────────────────────
+
+  private _generateBadgeCSS(): string {
+    return `
+/* ProtonDB Badges - loadout */
+#protondb-badge-container {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  pointer-events: auto;
+  transition: filter 0.2s, transform 0.2s;
+}
+#protondb-badge-container:hover {
+  filter: brightness(1.12);
+}
+#protondb-badge-container .pdb-inner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+#protondb-badge-container .pdb-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.35);
+  background: rgba(14,20,27,0.9);
+  backdrop-filter: blur(8px);
+}
+#protondb-badge-container .pdb-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.5);
+}
+#protondb-badge-container .pdb-dot-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #fff;
+  background: rgba(14,20,27,0.9);
+  padding: 3px 8px;
+  border-radius: 5px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+#protondb-badge-container.pdb-show-label .pdb-dot-label,
+#protondb-badge-container:hover .pdb-dot-label {
+  opacity: 1;
+}
+#protondb-badge-container .pdb-submit {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #fff;
+  background: rgba(26,159,255,0.92);
+  padding: 5px 9px;
+  border-radius: 5px;
+  cursor: pointer;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.35);
+}
+#protondb-badge-container .pdb-submit:hover { filter: brightness(1.12); }
+`;
+  }
+
+  // ─── Big Picture Mode Badge Script ──────────────────────────────
+
+  /**
+   * Passive renderer injected into the BPM / SharedJSContext tab(s). It
+   * does NOT fetch — the backend pushes data via
+   * `window.__protondb_badges.updateBadge(data)`. Exposes the exact
+   * surface the source plugin used:
+   *   `{ updateBadge, removeBadge, cleanup }`.
+   */
+  private _generateBPMScript(): string {
+    return `
+(function() {
+  if (window.__protondb_badges) window.__protondb_badges.cleanup();
+
+  var TIER_INFO = {
+    platinum: { label: "Platinum", color: "#b4c7dc", text: "#1a1a1a" },
+    gold:     { label: "Gold",     color: "#cfb53b", text: "#1a1a1a" },
+    silver:   { label: "Silver",   color: "#a6a6a6", text: "#1a1a1a" },
+    bronze:   { label: "Bronze",   color: "#cd7f32", text: "#1a1a1a" },
+    borked:   { label: "Borked",   color: "#ff5c5c", text: "#1a1a1a" },
+    pending:  { label: "Pending",  color: "#6b7280", text: "#ffffff" }
+  };
+
+  var badgeEl = null;
+
+  function removeBadge() {
+    if (badgeEl) { badgeEl.remove(); badgeEl = null; }
+  }
+
+  function positionStyle(container, position) {
+    var p = position || "tl";
+    container.style.position = "fixed";
+    container.style.zIndex = "99999";
+    if (p[0] === "t") container.style.top = "60px"; else container.style.bottom = "60px";
+    if (p[1] === "l") container.style.left = "20px";
+    else if (p[1] === "m") { container.style.left = "50%"; container.style.transform = "translateX(-50%)"; }
+    else container.style.right = "20px";
+  }
+
+  function createBadge(data) {
+    var settings = data.settings || {};
+    var report = data.report;
+    if (!settings.enableLibraryBadge || !report || !report.tier) { removeBadge(); return; }
+
+    var tier = String(report.tier).toLowerCase();
+    var info = TIER_INFO[tier] || { label: tier, color: "#6b7280", text: "#ffffff" };
+
+    removeBadge();
+
+    var container = document.createElement("div");
+    container.id = "protondb-badge-container";
+    container.style.cursor = "pointer";
+    positionStyle(container, settings.position);
+
+    var inner = document.createElement("div");
+    inner.className = "pdb-inner";
+
+    var size = settings.size || "regular";
+    if (size === "minimalist") {
+      var dot = document.createElement("span");
+      dot.className = "pdb-dot";
+      dot.style.background = info.color;
+      inner.appendChild(dot);
+
+      var hover = settings.labelOnHover || "off";
+      if (hover !== "off") {
+        var dlabel = document.createElement("span");
+        dlabel.className = "pdb-dot-label";
+        dlabel.textContent = info.label;
+        if (hover === "regular") dlabel.style.fontSize = "13px";
+        inner.appendChild(dlabel);
+      }
+    } else {
+      var pill = document.createElement("span");
+      pill.className = "pdb-pill";
+      pill.style.background = info.color;
+      pill.style.color = info.text;
+      if (size === "small") {
+        pill.style.fontSize = "11px";
+        pill.style.padding = "4px 9px";
+      }
+      pill.textContent = info.label;
+      inner.appendChild(pill);
+    }
+
+    if (settings.showSubmitButton && data.appId) {
+      var submit = document.createElement("span");
+      submit.className = "pdb-submit";
+      submit.textContent = "Submit";
+      submit.addEventListener("click", function(ev) {
+        ev.stopPropagation();
+        window.open("https://www.protondb.com/app/" + data.appId, "_blank");
+      });
+      inner.appendChild(submit);
+    }
+
+    container.appendChild(inner);
+    container.addEventListener("click", function() {
+      if (data.appId) window.open("https://www.protondb.com/app/" + data.appId, "_blank");
+    });
+
+    document.body.appendChild(container);
+    badgeEl = container;
+  }
+
+  window.__protondb_badges = {
+    cleanup: function() { removeBadge(); },
+    removeBadge: function() { removeBadge(); },
+    updateBadge: function(data) {
+      if (!data) { removeBadge(); return; }
+      createBadge(data);
+    }
+  };
+})();
+`;
+  }
+
+  // ─── Store Badge Script ─────────────────────────────────────────
+
+  /**
+   * Store-page badge script with data embedded at injection time (no
+   * HTTP fetch from inside CEF). Exposes
+   * `window.__protondb_store_badges = { updateBadge, removeBadge, cleanup }`.
+   */
+  private _generateStoreScript(badgeData: BadgeData | null): string {
+    const settingsJson = JSON.stringify(this.settings);
+    const dataJson = badgeData ? JSON.stringify(badgeData) : "null";
+    return `
+(function() {
+  if (window.__protondb_store_badges) window.__protondb_store_badges.cleanup();
+
+  var SETTINGS = ${settingsJson};
+  var BADGE_DATA = ${dataJson};
+
+  var TIER_INFO = {
+    platinum: { label: "Platinum", color: "#b4c7dc", text: "#1a1a1a" },
+    gold:     { label: "Gold",     color: "#cfb53b", text: "#1a1a1a" },
+    silver:   { label: "Silver",   color: "#a6a6a6", text: "#1a1a1a" },
+    bronze:   { label: "Bronze",   color: "#cd7f32", text: "#1a1a1a" },
+    borked:   { label: "Borked",   color: "#ff5c5c", text: "#1a1a1a" },
+    pending:  { label: "Pending",  color: "#6b7280", text: "#ffffff" }
+  };
+
+  var badgeEl = null;
+  function removeBadge() { if (badgeEl) { badgeEl.remove(); badgeEl = null; } }
+
+  function showBadge(data) {
+    if (!data || !SETTINGS.enableStoreBadge) { removeBadge(); return; }
+    var report = data.report;
+    if (!report || !report.tier) { removeBadge(); return; }
+    removeBadge();
+
+    var tier = String(report.tier).toLowerCase();
+    var info = TIER_INFO[tier] || { label: tier, color: "#6b7280", text: "#ffffff" };
+
+    var el = document.createElement("div");
+    el.id = "protondb-store-badge";
+    el.style.cssText = "position:fixed;bottom:20px;left:50%;transform:translateX(-50%);z-index:999999;display:flex;align-items:center;gap:10px;cursor:pointer;font-family:sans-serif;";
+
+    var pill = document.createElement("span");
+    pill.style.cssText = "display:inline-flex;align-items:center;padding:8px 16px;border-radius:6px;font-weight:700;font-size:14px;letter-spacing:0.04em;text-transform:uppercase;box-shadow:0 2px 12px rgba(0,0,0,0.4);";
+    pill.style.background = info.color;
+    pill.style.color = info.text;
+    pill.textContent = "ProtonDB: " + info.label;
+    el.appendChild(pill);
+
+    if (SETTINGS.showSubmitButton && data.appId) {
+      var submit = document.createElement("span");
+      submit.style.cssText = "font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.04em;color:#fff;background:rgba(26,159,255,0.92);padding:6px 11px;border-radius:5px;box-shadow:0 2px 12px rgba(0,0,0,0.4);";
+      submit.textContent = "Submit";
+      submit.addEventListener("click", function(ev) {
+        ev.stopPropagation();
+        window.open("https://www.protondb.com/app/" + data.appId, "_blank");
+      });
+      el.appendChild(submit);
+    }
+
+    el.addEventListener("click", function() {
+      if (data.appId) window.open("https://www.protondb.com/app/" + data.appId, "_blank");
+    });
+    document.body.appendChild(el);
+    badgeEl = el;
+  }
+
+  if (BADGE_DATA) showBadge(BADGE_DATA);
+
+  window.__protondb_store_badges = {
+    cleanup: function() { removeBadge(); },
+    removeBadge: function() { removeBadge(); },
+    updateBadge: function(data) { showBadge(data); }
+  };
+})();
+`;
+  }
+
+  // ─── Health Check ───────────────────────────────────────────────
+
+  private async _checkHealth(): Promise<void> {
+    if (this.healthChecking) return;
+    this.healthChecking = true;
+    try {
+      for (const [key, conn] of this.connections) {
+        if (!conn.client.connected) {
+          this.connections.delete(key);
+          this.bpmRenderKeys = this.bpmRenderKeys.filter((k) => k !== key);
+          console.log(`[protondb-badges] Pruned dead connection: ${key}`);
+        }
+      }
+
+      const wasConnected = this.connected;
+      this.connected =
+        this.connections.has("SharedJSContext") ||
+        this.bpmRenderKeys.length > 0;
+
+      if (!this.connected || this.bpmRenderKeys.length === 0) {
+        if (wasConnected && !this.connected) this._emitState();
+        // Re-run discovery so a reopened BPM (new MainMenu popup set) or
+        // a freshly-started Steam reconnects without a manual nudge.
+        const ok = await this._tryConnect();
+        if (ok) await this._injectBadgeSystem();
+      }
+    } finally {
+      this.healthChecking = false;
+    }
   }
 
   // ─── Private helpers ────────────────────────────────────────────
@@ -396,7 +1124,11 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
   private _emitState(): void {
     this.emit?.({
       event: "stateChanged",
-      data: { settings: this.settings },
+      data: {
+        settings: this.settings,
+        connected: this.connected,
+        tabs: this.connections.size,
+      },
     });
   }
 }

--- a/plugins/protondb-badges/package.json
+++ b/plugins/protondb-badges/package.json
@@ -9,7 +9,8 @@
     "@loadout/ui": "workspace:*",
     "@loadout/types": "workspace:*",
     "@loadout/steam-paths": "workspace:*",
-    "@loadout/plugin-storage": "workspace:*"
+    "@loadout/plugin-storage": "workspace:*",
+    "@loadout/steam-cdp": "workspace:*"
   },
   "plugin": {
     "id": "protondb-badges",
@@ -18,7 +19,8 @@
     "permissions": {
       "network": [
         "www.protondb.com",
-        "store.steampowered.com"
+        "store.steampowered.com",
+        "localhost"
       ],
       "filesystem": [
         "read:~/.local/share/Steam",


### PR DESCRIPTION
PR #50 migrated the plugin without the source's ~400 LOC CDP injection layer — on the mistaken belief Loadout had no @steam-loader/steam-cdp equivalent — so badges never rendered on Steam's library/store tiles. That guidance was retracted (PR #58) and @loadout/steam-cdp exists and is used by the sibling hltb plugin.

Restore the Steam-side injection, mirroring hltb's proven architecture:

- tryConnect: discover + open CDP WebSockets to the SharedJSContext / BPM parent + MainMenu_uid popups / store.steampowered.com tabs.
- injectCSSToTab + generateBPMScript + generateStoreScript: inject a CSS rule + a passive JS runtime exposing window.__protondb_badges = { updateBadge, removeBadge, cleanup } (and __protondb_store_badges) into each tab.
- Route polling (SharedJSContext tempNavStore) derives the viewed appId; pushBadgeDataToBPM fetches the report server-side and pushes it in, with tail-queue coalescing for rapid navigation.
- Store-tab injection embeds the report at injection time.
- 5s health-check reconnect + 500ms route poll, debounced re-inject on settings change.

Replace the getStatus/reconnect/getCurrentRouteAppId stubs with real connection state; emit connected/tabs on stateChanged so the overlay's Steam CEF status section updates live. Add @loadout/steam-cdp dependency and localhost network permission.

https://claude.ai/code/session_01FvSaimiqmDfjAbcSCP6TTB