### PR TITLE
fix(overlay): stop freeze watchdog auto-closing a healthy overlay (#102)

### DIFF
--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -316,14 +316,19 @@ if (SUSPEND_STEAM_ENABLED) {
 //
 // Guarantees Steam is never left SIGSTOPped by a hung overlay. While Steam is
 // frozen we poll once a second: if the webview stopped sending
-// `overlayHeartbeat` pings (renderer wedged) OR the freeze has run past a hard
-// cap, we emergency-close the overlay and thaw Steam. A SIGKILL→restart is
-// handled by the startup SIGCONT above; this handles the HANG case (bun alive,
-// CEF renderer wedged) the startup path can't see.
+// `overlayHeartbeat` pings (renderer wedged) we emergency-close the overlay and
+// thaw Steam. A SIGKILL→restart is handled by the startup SIGCONT above; this
+// handles the HANG case (bun alive, CEF renderer wedged) the startup path can't
+// see.
+//
+// NOTE: there is deliberately NO time-since-open hard cap. Steam stays frozen
+// the whole time the overlay is open, so any fixed ceiling would force-close a
+// perfectly healthy overlay that the user is actively using (issue #102 — "the
+// overlay keeps closing automatically" was a 30s cap firing on every open).
+// A genuinely wedged renderer stops the heartbeat, which the staleness check
+// below catches within FREEZE_HEARTBEAT_TIMEOUT_MS — that is the real safety net.
 const FREEZE_HEARTBEAT_TIMEOUT_MS = 5_000; // no ping this long while frozen → hung
-const FREEZE_HARD_CAP_MS = 30_000; // absolute ceiling on a single freeze
 let freezeWatchTimer: ReturnType<typeof setInterval> | null = null;
-let frozenAt = 0;
 
 function stopFreezeWatchdog(): void {
   if (freezeWatchTimer) clearInterval(freezeWatchTimer);
@@ -331,7 +336,6 @@ function stopFreezeWatchdog(): void {
 }
 
 function startFreezeWatchdog(): void {
-  frozenAt = Date.now();
   lastHeartbeat.current = Date.now(); // assume alive at open; webview keeps it fresh
   stopFreezeWatchdog();
   freezeWatchTimer = setInterval(() => {
@@ -339,11 +343,12 @@ function startFreezeWatchdog(): void {
       stopFreezeWatchdog();
       return;
     }
-    const now = Date.now();
-    const sinceBeat = now - lastHeartbeat.current;
-    const frozenFor = now - frozenAt;
-    if (sinceBeat > FREEZE_HEARTBEAT_TIMEOUT_MS || frozenFor > FREEZE_HARD_CAP_MS) {
-      forceCloseOverlay(`unresponsive (sinceBeat=${sinceBeat}ms frozenFor=${frozenFor}ms)`);
+    const sinceBeat = Date.now() - lastHeartbeat.current;
+    // Only force-close when the renderer has actually gone quiet — a
+    // healthy overlay keeps the heartbeat fresh and stays open as long as
+    // the user wants (no time-since-open cap; see note above).
+    if (sinceBeat > FREEZE_HEARTBEAT_TIMEOUT_MS) {
+      forceCloseOverlay(`unresponsive (sinceBeat=${sinceBeat}ms)`);
     }
   }, 1_000);
 }


### PR DESCRIPTION
## Problem
The overlay "keeps closing automatically" (#102) — it force-closed itself ~30s after every open.

## Root cause
The freeze watchdog force-closed the overlay when `frozenFor` (time since open) exceeded `FREEZE_HARD_CAP_MS` (30s). But Steam stays SIGSTOPped the **entire** time the overlay is open, so `frozenFor` always crosses that ceiling during normal use — closing a perfectly healthy overlay.

**Empirical proof** from the device journal — every emergency close:
```
[freeze-watchdog] unresponsive (sinceBeat=530ms frozenFor=30008ms) — emergency close
[freeze-watchdog] unresponsive (sinceBeat=665ms frozenFor=30003ms) — emergency close
...
```
`sinceBeat` ≈ 0.5–0.9s every time (heartbeat healthy, far under the 5s timeout); `frozenFor` ≈ 30.0s every time. The hard cap fired in 100% of cases; the heartbeat check never did.

## Fix
Remove the time-since-open hard cap. The heartbeat-staleness check (`sinceBeat > FREEZE_HEARTBEAT_TIMEOUT_MS`) is the real safety net: a wedged renderer stops sending `overlayHeartbeat` and gets force-closed + Steam thawed within 5s, while a healthy overlay (heartbeat fresh, ~1×/s from `App.tsx`) now stays open as long as the user wants.

## Testing
- Typecheck + lint clean.
- Built and installed on-device; overlay now stays open past 30s.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)