### PR TITLE
fix(overlay): eliminate 100% CPU spin in CEF browser process

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,37 @@ bun install
 bun run build-and-install    # compile + install to ~/.local/share/, enable user units
 ```
 
-For development with hot reload:
+### Developing
+
+The overlay ships a **patched Electrobun native wrapper** (see
+[`apps/loadout-overlay/vendor/README.md`](apps/loadout-overlay/vendor/README.md))
+that fixes a 100% CPU spin in CEF's browser process. The build and install
+scripts swap it in automatically — but `electrobun dev` does not, so the
+**dev-mode overlay runs the stock wrapper and pins a CPU core**.
+
+**Recommended — build and install to see accurate results.** This is the only
+workflow that matches what users actually run: the patched wrapper, the real
+systemd user units, and production CEF flags. Re-run it after each change:
 
 ```sh
-bun run dev:overlay          # loader dev server + Electrobun overlay, live reload
+bun run build-and-install               # compile + install + enable user units
+systemctl --user restart loadout-overlay   # restart the overlay to pick up the build
+journalctl --user -u loadout-overlay -f    # follow overlay logs
 ```
 
-CEF DevTools are at `http://localhost:9222` in dev builds.
+CEF DevTools are at `http://localhost:9222` (attach any Chromium or use CDP).
+
+**Fast UI iteration (hot reload).** For quick webview/React work where the
+native runtime doesn't matter, `bun run dev:overlay` starts the loader dev
+server + Electrobun with live reload:
+
+```sh
+bun run dev:overlay
+```
+
+Caveat: dev mode uses the **stock** native wrapper, so expect a busy CPU core
+and none of the patched-wrapper behaviour. Always confirm a change with
+`build-and-install` before trusting it.
 
 Runtime requirements: an X11/Xwayland display, membership in the `input` group
 (so the overlay can grab evdev devices), and a working Steam install. The CEF

--- a/apps/loadout-overlay/package.json
+++ b/apps/loadout-overlay/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "electrobun dev",
-    "build": "vite build && electrobun build --release",
-    "build:dev": "vite build && electrobun build",
+    "build": "vite build && electrobun build --release && sh ../../scripts/inject-patched-wrapper.sh",
+    "build:dev": "vite build && electrobun build && sh ../../scripts/inject-patched-wrapper.sh",
     "webview:dev": "vite",
     "webview:build": "vite build",
-    "electrobun:only": "electrobun build"
+    "electrobun:only": "electrobun build && sh ../../scripts/inject-patched-wrapper.sh"
   },
   "dependencies": {
     "@noriginmedia/norigin-spatial-navigation": "^3.0.0",

--- a/apps/loadout-overlay/vendor/README.md
+++ b/apps/loadout-overlay/vendor/README.md
@@ -1,0 +1,91 @@
+# Patched Electrobun native wrapper (`libNativeWrapper.so`)
+
+This directory vendors a **patched build of Electrobun's Linux native wrapper**
+that fixes a 100%-CPU busy-loop in the overlay's CEF browser process. The build
+step (`scripts/build.sh`) copies `libNativeWrapper.so` from here over the stock
+one that `electrobun build --release` downloads, so clones and CI releases get
+the fix automatically.
+
+## The bug it fixes
+
+The overlay's CEF **browser process** pinned one full CPU core at ~100%
+continuously — even idle, hidden, and on a blank page. A real battery/thermal
+drain on a handheld. It did not break functionality, so it went unnoticed.
+
+Root cause: Electrobun drives the Linux event loop with a raw `gtk_main()`
+(a vanilla `g_main_loop_run`). CEF initializes lazily and installs its own GLib
+sources — `MessagePumpGlib`'s work source and Ozone's X11 event source
+(`ui::XSourcePrepare` / `x11::Connection::HasPendingResponses`) — onto the
+**default `GMainContext`** that `gtk_main()` is already iterating. Those sources'
+`prepare()` returns a 0 ms timeout unless `MessagePumpGlib::Run` has set up its
+run-state. A plain `gtk_main()` iterates them **without** that state, so prepare
+keeps reporting "work ready, timeout 0", the loop never blocks in `poll()`, and
+the core spins. (Confirmed with `perf`: pure `g_main_context_prepare`/`check`,
+~0 `ppoll`, ~0 dispatch.)
+
+Note this is **not** the CEF #2809 external-message-pump path; an earlier attempt
+using `external_message_pump=true` + `OnScheduleMessagePumpWork` was built,
+loaded, and verified live — CPU stayed at ~100%. That approach was discarded.
+
+## The fix
+
+Run CEF's own message loop instead of a raw `gtk_main()`. In `runCEFEventLoop()`:
+
+- Initialize CEF **eagerly** (was lazy, on first webview) so the loop exists.
+- Call `CefRunMessageLoop()` instead of `gtk_main()`. It runs
+  `MessagePumpGlib::Run`, which blocks correctly when idle while still servicing
+  the default context (GTK dialogs/tray, the wrapper's X11 timer keep working).
+- `settings.external_message_pump = false` (explicit; required for
+  `CefRunMessageLoop`).
+- Tear down with `CefQuitMessageLoop()` in `stopEventLoop()` (was
+  `gtk_main_quit()`, which would no-op under CEF's loop and hang shutdown).
+
+Result: idle CPU drops from ~100% to ~0%; the main thread blocks in `poll`.
+Verified on-device: overlay renders, opens/closes, window maps/unmaps, clean
+shutdown, no regressions.
+
+See `nativeWrapper.cpp.patch` for the exact diff.
+
+## Provenance
+
+- Upstream: `github.com/blackboardsh/electrobun` tag **v1.16.0**
+  (commit `73519358cdcb50f02c1df3ecc80c33faedfb9ad4`).
+- Patched file: `package/src/native/linux/nativeWrapper.cpp`.
+- Build marker (printed at startup, grep the journal to confirm it's live):
+  `=== ELECTROBUN NATIVE WRAPPER VERSION 1.0.2-loadout-cefloop ===`
+- Built against CEF **145.0.23+g3e7fe1c / chromium 145.0.7632.68** (must match
+  the `libcef.so` Electrobun bundles; `dlopen`'d at runtime).
+
+## Rebuilding (when bumping Electrobun or CEF)
+
+The wrapper must be rebuilt whenever Electrobun (and thus its bundled CEF) is
+bumped, or the ABI will mismatch. Build in a container (SteamOS is immutable):
+
+```sh
+# 1. Clone the matching tag and apply the patch
+git clone https://github.com/blackboardsh/electrobun.git
+cd electrobun && git checkout v<version>
+git apply /path/to/this/vendor/nativeWrapper.cpp.patch   # or re-port by hand
+
+# 2. Provide the host's prebuilt libasar.so at the repo root as ./libasar.so
+#    (electrobun build emits it; copy it out of a prior build)
+
+# 3. Build the .so in Ubuntu (matches package/build.ts's compile/link steps)
+podman run --rm -v "$PWD":/work:Z docker.io/library/ubuntu:24.04 \
+  bash /work/build-wrapper.sh        # build-wrapper.sh is vendored alongside this README
+
+# 4. Copy the result over the vendored copy
+cp package/src/native/build/libNativeWrapper_cef.so \
+   /path/to/apps/loadout-overlay/vendor/libNativeWrapper.so
+```
+
+`build-wrapper.sh` pins the CEF and electrobun-dawn URLs — bump those to match
+the new Electrobun version. Confirm the version marker changed, swap into
+`~/.local/share/loadout-overlay/bin/libNativeWrapper.so`, restart the service,
+and check idle CPU is ~0.
+
+## Upstreaming
+
+The fix is generic — it fixes the spin for any Electrobun Linux app. Opening an
+upstream PR (`CefRunMessageLoop` + eager init instead of `gtk_main`) would let us
+drop this vendored binary entirely. Tracked in srsholmes/loadout#104.

--- a/apps/loadout-overlay/vendor/build-wrapper.sh
+++ b/apps/loadout-overlay/vendor/build-wrapper.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Builds the patched libNativeWrapper_cef.so inside an Ubuntu container.
+# Mirrors package/build.ts's linux compile/link steps. Reuses the host's
+# already-built libasar.so (copied to /work/libasar.so) so we skip zig-asar,
+# and dlopen's libcef.so at runtime so we don't need it at link time.
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+cd /work/package
+
+CEF_URL="https://cef-builds.spotifycdn.com/cef_binary_145.0.23+g3e7fe1c%2Bchromium-145.0.7632.68_linux64_minimal.tar.bz2"
+
+echo "::: 1. apt deps"
+apt-get update -qq
+apt-get install -y -qq build-essential cmake pkg-config curl ca-certificates bzip2 \
+  libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev >/dev/null
+
+echo "::: 2. CEF minimal dist (145)"
+if [ ! -f vendors/cef/include/cef_version.h ]; then
+  mkdir -p vendors/cef
+  curl -fL "$CEF_URL" | tar -xj --strip-components=1 -C vendors/cef
+fi
+echo "    cef_version.h: $(grep -m1 CEF_VERSION vendors/cef/include/cef_version.h || true)"
+
+echo "::: 2b. electrobun-dawn (WGPU) headers"
+DAWN_URL="https://github.com/blackboardsh/electrobun-dawn/releases/download/v0.2.3/electrobun-dawn-linux-x64.tar.gz"
+if [ ! -f vendors/wgpu/linux-x64/include/dawn/webgpu.h ]; then
+  mkdir -p vendors/wgpu/linux-x64
+  curl -fL "$DAWN_URL" | tar -xz --strip-components=1 -C vendors/wgpu/linux-x64
+fi
+ls vendors/wgpu/linux-x64/include/dawn/webgpu.h
+
+echo "::: 3. build libcef_dll_wrapper.a"
+if [ ! -f vendors/cef/build/libcef_dll_wrapper/libcef_dll_wrapper.a ]; then
+  ( cd vendors/cef && mkdir -p build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release .. >/dev/null \
+    && make -j"$(nproc)" libcef_dll_wrapper >/dev/null )
+fi
+ls -la vendors/cef/build/libcef_dll_wrapper/libcef_dll_wrapper.a
+
+echo "::: 4. reuse host libasar.so"
+mkdir -p vendors/zig-asar
+cp -f /work/libasar.so vendors/zig-asar/libasar.so
+
+echo "::: 5. compile + link patched libNativeWrapper_cef.so"
+CEFINC=vendors/cef
+CFLAGS=$(pkg-config --cflags webkit2gtk-4.1 gtk+-3.0 ayatana-appindicator3-0.1)
+LIBS=$(pkg-config --libs webkit2gtk-4.1 gtk+-3.0 ayatana-appindicator3-0.1)
+mkdir -p src/native/linux/build src/native/build
+
+g++ -c -std=c++20 -fPIC $CFLAGS -I"$CEFINC" -Ivendors/wgpu/linux-x64/include \
+  -o src/native/linux/build/nativeWrapper.o src/native/linux/nativeWrapper.cpp
+g++ -c -std=c++20 -fPIC -I"$CEFINC" \
+  -o src/native/linux/build/cef_loader.o src/native/linux/cef_loader.cpp
+g++ -shared -o src/native/build/libNativeWrapper_cef.so \
+  src/native/linux/build/nativeWrapper.o src/native/linux/build/cef_loader.o \
+  vendors/zig-asar/libasar.so $LIBS \
+  -Wl,--whole-archive vendors/cef/build/libcef_dll_wrapper/libcef_dll_wrapper.a -Wl,--no-whole-archive \
+  -ldl -lpthread -Wl,-rpath,'$ORIGIN:$ORIGIN/cef'
+
+echo "::: DONE"
+ls -la src/native/build/libNativeWrapper_cef.so
+strings src/native/build/libNativeWrapper_cef.so | grep 'NATIVE WRAPPER VERSION' || true

--- a/apps/loadout-overlay/vendor/nativeWrapper.cpp.patch
+++ b/apps/loadout-overlay/vendor/nativeWrapper.cpp.patch
@@ -1,0 +1,88 @@
+diff --git a/package/src/native/linux/nativeWrapper.cpp b/package/src/native/linux/nativeWrapper.cpp
+index 36310d6..87818a6 100644
+--- a/package/src/native/linux/nativeWrapper.cpp
++++ b/package/src/native/linux/nativeWrapper.cpp
+@@ -802,8 +802,7 @@ public:
+         // In multi-process mode, return nullptr so render process uses the helper
+         return nullptr;
+     }
+-    
+-    
++
+     void OnContextInitialized() override {
+         CefRegisterSchemeHandlerFactory("views", "", new ViewsSchemeHandlerFactory());
+     }
+@@ -2046,6 +2045,7 @@ bool initializeCEF() {
+     CefSettings settings;
+     settings.no_sandbox = true;
+     settings.windowless_rendering_enabled = true;  // Required for OSR/transparent windows
++    settings.external_message_pump = false;  // loadout CPU-spin fix: drive CEF's own MessagePumpGlib via CefRunMessageLoop() (see runCEFEventLoop)
+     settings.log_severity = LOGSEVERITY_ERROR;  // Change to WARNING to see more CEF logs
+     // settings.remote_debugging_port = 9222;
+     
+@@ -5882,20 +5882,38 @@ gboolean process_x11_events(gpointer data) {
+ void runCEFEventLoop() {
+     // Initialize GTK on the main thread (this MUST be done here)
+     initializeGTK();
+-    printf("=== ELECTROBUN NATIVE WRAPPER VERSION 1.0.2 === CEF EVENT LOOP STARTED ===\n");
++    printf("=== ELECTROBUN NATIVE WRAPPER VERSION 1.0.2-loadout-cefloop === CEF EVENT LOOP STARTED ===\n");
+     fflush(stdout);
+-        
+-    // Set up a timer to periodically call CefDoMessageLoopWork()
+-    // This integrates CEF message loop with GTK main loop
+-    g_timeout_add(10, cef_timer_callback, nullptr); // 10ms interval
+-        
+-    
++
++    // CPU-spin fix: drive the loop with CEF's own CefRunMessageLoop() instead of
++    // a raw gtk_main(). CEF installs its MessagePumpGlib + Ozone X11 GSources on
++    // the default GMainContext; their prepare() returns a 0ms timeout unless
++    // MessagePumpGlib::Run has set up its RunState. A vanilla g_main_loop_run
++    // (gtk_main) iterates those sources WITHOUT that state, so prepare keeps
++    // returning timeout 0, the loop never blocks in poll(), and one core pins at
++    // 100% (this is the spin, NOT CEF #2809's external-pump path). CefRunMessageLoop
++    // runs MessagePumpGlib::Run, which blocks correctly when idle. It still services
++    // the default context, so our GTK dialogs/tray and the X11 timer below keep
++    // working. Quit via CefQuitMessageLoop() in stopEventLoop().
++
+     // Set up X11 event processing
+     g_timeout_add(10, process_x11_events, nullptr); // Process X11 events every 10ms
+ 
+     sleep(1); // Give time for output to flush
+-    gtk_main();
+-    
++
++    // Initialize CEF eagerly here so CefRunMessageLoop() below actually runs CEF's
++    // message loop. CEF was previously initialized lazily on first webview creation;
++    // if we call CefRunMessageLoop() before CefInitialize() it returns immediately
++    // (no UI thread loop to run) and the process exits. Eager init is safe — CEF
++    // needs no browser to initialize, and the lazy call sites are guarded by
++    // g_cefInitialized so they become no-ops. startEventLoop() has already set the
++    // identifier/channel globals used for the cache path.
++    if (!g_cefInitialized.load()) {
++        initializeCEF();
++    }
++
++    CefRunMessageLoop();
++
+     // Cleanup CEF on shutdown
+ 
+     if (g_cefInitialized) {
+@@ -8938,9 +8956,15 @@ ELECTROBUN_EXPORT void stopEventLoop() {
+     g_shuttingDown.store(true);
+     printf("[stopEventLoop] Initiating clean event loop exit\n");
+ 
+-    // gtk_main_quit should be called from the GTK thread
++    // Quit on the main loop thread. In CEF mode the loop is CefRunMessageLoop()
++    // (MessagePumpGlib), so it must be torn down with CefQuitMessageLoop();
++    // gtk_main_quit() would no-op there and the process would hang on shutdown.
+     g_idle_add([](gpointer) -> gboolean {
+-        gtk_main_quit();
++        if (isCEFAvailable()) {
++            CefQuitMessageLoop();
++        } else {
++            gtk_main_quit();
++        }
+         return G_SOURCE_REMOVE;
+     }, nullptr);
+ }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -61,6 +61,36 @@ error() {
     printf "${RED}[ERROR]${NC} %s\n" "$1"
 }
 
+# --- Inject patched Electrobun native wrapper ---
+# electrobun build downloads the stock libNativeWrapper.so. We ship a patched
+# build (apps/loadout-overlay/vendor/libNativeWrapper.so) that fixes a 100%-CPU
+# busy-loop in CEF's browser process — see that dir's README.md. Swap it over
+# the freshly built tree so clones and CI releases get the fix. Guarded and
+# idempotent: a missing vendor file just leaves the stock (spinning) wrapper.
+inject_patched_wrapper() {
+    electrobun_dir="$1"
+    patched="$electrobun_dir/vendor/libNativeWrapper.so"
+    if [ ! -f "$patched" ]; then
+        warn "No vendored libNativeWrapper.so — using stock wrapper (overlay will spin at 100% CPU)."
+        return 0
+    fi
+    # The build emits the wrapper under build/<variant>/loadout-overlay-*/bin/.
+    # Replace every libNativeWrapper*.so the build produced (the runtime dlopen's
+    # libNativeWrapper.so; the _cef.so variant, if present, is harmless to match).
+    # Build paths contain no spaces, so an unquoted find expansion is safe here
+    # and keeps this POSIX-sh compatible (build.sh runs under `sh`, not bash).
+    injected=0
+    for so in $(find "$electrobun_dir/build" -type f -name 'libNativeWrapper*.so' 2>/dev/null); do
+        cp -f "$patched" "$so"
+        injected=$((injected + 1))
+    done
+    if [ "$injected" -gt 0 ]; then
+        success "Injected patched libNativeWrapper.so into $injected build artifact(s) (CEF CPU-spin fix)."
+    else
+        warn "Patched wrapper present but no build artifact to inject into — did electrobun build emit a bin/?"
+    fi
+}
+
 # --- Determine version ---
 
 get_version() {
@@ -208,6 +238,7 @@ build() {
         info "Building Electrobun overlay..."
         if (cd "$ELECTROBUN_DIR" && bunx vite build 2>&1 && bunx electrobun build --release 2>&1); then
             success "Electrobun overlay built (see $ELECTROBUN_DIR/build/ for artifacts)"
+            inject_patched_wrapper "$ELECTROBUN_DIR"
         else
             warn "Electrobun overlay build failed. Backend binary is still usable."
         fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -61,36 +61,6 @@ error() {
     printf "${RED}[ERROR]${NC} %s\n" "$1"
 }
 
-# --- Inject patched Electrobun native wrapper ---
-# electrobun build downloads the stock libNativeWrapper.so. We ship a patched
-# build (apps/loadout-overlay/vendor/libNativeWrapper.so) that fixes a 100%-CPU
-# busy-loop in CEF's browser process — see that dir's README.md. Swap it over
-# the freshly built tree so clones and CI releases get the fix. Guarded and
-# idempotent: a missing vendor file just leaves the stock (spinning) wrapper.
-inject_patched_wrapper() {
-    electrobun_dir="$1"
-    patched="$electrobun_dir/vendor/libNativeWrapper.so"
-    if [ ! -f "$patched" ]; then
-        warn "No vendored libNativeWrapper.so — using stock wrapper (overlay will spin at 100% CPU)."
-        return 0
-    fi
-    # The build emits the wrapper under build/<variant>/loadout-overlay-*/bin/.
-    # Replace every libNativeWrapper*.so the build produced (the runtime dlopen's
-    # libNativeWrapper.so; the _cef.so variant, if present, is harmless to match).
-    # Build paths contain no spaces, so an unquoted find expansion is safe here
-    # and keeps this POSIX-sh compatible (build.sh runs under `sh`, not bash).
-    injected=0
-    for so in $(find "$electrobun_dir/build" -type f -name 'libNativeWrapper*.so' 2>/dev/null); do
-        cp -f "$patched" "$so"
-        injected=$((injected + 1))
-    done
-    if [ "$injected" -gt 0 ]; then
-        success "Injected patched libNativeWrapper.so into $injected build artifact(s) (CEF CPU-spin fix)."
-    else
-        warn "Patched wrapper present but no build artifact to inject into — did electrobun build emit a bin/?"
-    fi
-}
-
 # --- Determine version ---
 
 get_version() {
@@ -238,7 +208,11 @@ build() {
         info "Building Electrobun overlay..."
         if (cd "$ELECTROBUN_DIR" && bunx vite build 2>&1 && bunx electrobun build --release 2>&1); then
             success "Electrobun overlay built (see $ELECTROBUN_DIR/build/ for artifacts)"
-            inject_patched_wrapper "$ELECTROBUN_DIR"
+            # Swap our patched libNativeWrapper.so over the stock one electrobun
+            # downloaded (CEF 100%-CPU spin fix — see vendor/README.md). Shared
+            # with apps/loadout-overlay's package.json build scripts so every
+            # build path gets it.
+            sh "$PROJECT_ROOT/scripts/inject-patched-wrapper.sh" "$ELECTROBUN_DIR"
         else
             warn "Electrobun overlay build failed. Backend binary is still usable."
         fi

--- a/scripts/inject-patched-wrapper.sh
+++ b/scripts/inject-patched-wrapper.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Inject the patched libNativeWrapper.so over the stock one that
+# `electrobun build` downloads. The patched wrapper fixes a 100%-CPU busy-loop
+# in CEF's browser process — see apps/loadout-overlay/vendor/README.md for the
+# root cause and how the binary is produced.
+#
+# This is the single source of truth for the swap, called from every build
+# entry point (scripts/build.sh and apps/loadout-overlay's package.json build
+# scripts) so no path can silently ship the stock (spinning) wrapper. Run it
+# AFTER `electrobun build`. POSIX-sh, guarded, and idempotent: a missing vendor
+# file just warns and leaves the stock wrapper in place.
+#
+# Usage: inject-patched-wrapper.sh [OVERLAY_APP_DIR]
+#   OVERLAY_APP_DIR defaults to the apps/loadout-overlay sibling of this
+#   script's directory, so it works regardless of the caller's cwd.
+set -eu
+
+if [ -n "${1:-}" ]; then
+    ELECTROBUN_DIR="$1"
+else
+    SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+    ELECTROBUN_DIR="$SCRIPT_DIR/../apps/loadout-overlay"
+fi
+
+PATCHED="$ELECTROBUN_DIR/vendor/libNativeWrapper.so"
+if [ ! -f "$PATCHED" ]; then
+    echo "[inject-wrapper] WARNING: no vendored wrapper at $PATCHED — using stock wrapper (overlay will spin at 100% CPU)." >&2
+    exit 0
+fi
+
+# The build emits the wrapper under build/<variant>/loadout-overlay-*/bin/.
+# Replace every libNativeWrapper*.so the build produced (the runtime dlopen's
+# libNativeWrapper.so; the _cef.so variant, if present, is harmless to match).
+# Build paths contain no spaces, so an unquoted find expansion is safe here.
+injected=0
+for so in $(find "$ELECTROBUN_DIR/build" -type f -name 'libNativeWrapper*.so' 2>/dev/null); do
+    cp -f "$PATCHED" "$so"
+    injected=$((injected + 1))
+done
+
+if [ "$injected" -gt 0 ]; then
+    echo "[inject-wrapper] injected patched libNativeWrapper.so into $injected build artifact(s) (CEF CPU-spin fix)."
+else
+    echo "[inject-wrapper] WARNING: patched wrapper present but no build artifact found under $ELECTROBUN_DIR/build — did 'electrobun build' run?" >&2
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -853,6 +853,19 @@ ExecStartPre=/bin/sh -c 'for i in $(seq 1 30); do curl -sf "http://localhost:${L
 # src/bun/native/display-detect.ts).
 Environment=HOME=%h
 
+# Disable GDK's GLX path. libNativeWrapper hosts CEF inside a GTK3 window;
+# on the gamescope X server (:0) GTK's GLX probe throws a recurring
+# "X11 Error: GLXBadWindow (code 170)" at startup (the GL surface targets a
+# window that's invalid under gamescope/desktop-mode compositing). CEF
+# renders the actual UI itself, so the GTK host window needs no GL — forcing
+# GDK to its software/cairo path removes the error cleanly with no visual
+# change. Must be set in the unit env: libNativeWrapper opens X in
+# startEventLoop() before our worker thread runs, so JS can't set it in time
+# (same reason DISPLAY is resolved in the ExecStart wrapper below).
+# NOTE: this clears the GLXBadWindow noise only; it does NOT fix the separate
+# CEF/GTK event-loop 100%-CPU spin (tracked elsewhere).
+Environment=GDK_GL=disable
+
 # CEF remote DevTools — attach Chrome to http://localhost:9222 on the
 # device or over SSH tunnel. Port is baked into the build via
 # electrobun.config.ts → build.linux.chromiumFlags.


### PR DESCRIPTION
fixes https://github.com/srsholmes/loadout/issues/104 
## Symptom

The overlay's CEF browser process pinned one CPU core at ~100% continuously — even while idle, hidden, and showing a blank page.

## Root cause

Electrobun drives the Linux event loop with a raw `gtk_main()`. CEF installs its `MessagePumpGlib` + Ozone X11 GLib sources on the default `GMainContext`, whose `prepare()` returns a 0ms timeout unless `MessagePumpGlib::Run` has set up its run-state. A vanilla `gtk_main()` iterates those sources without ever establishing that run-state, so the loop never blocks in `poll()` and spins hot.

## The fix

A patched Electrobun v1.16.0 native wrapper that:
- eagerly initializes CEF, then
- drives the loop with `CefRunMessageLoop()` instead of `gtk_main()`, and
- tears down with `CefQuitMessageLoop()`.

This lets CEF establish its own message-pump run-state, so the loop blocks in `poll()` as intended.

## How it's consumed

- The prebuilt patched wrapper is vendored at `apps/loadout-overlay/vendor/libNativeWrapper.so` (~5MB).
- Provenance and rebuild instructions live in `apps/loadout-overlay/vendor/` (`README.md`, `nativeWrapper.cpp.patch`, `build-wrapper.sh`).
- `scripts/build.sh` gains an `inject_patched_wrapper()` step that swaps the vendored `.so` over the stock Electrobun wrapper after `electrobun build`. This means clones and CI releases pick up the fix automatically.

## Verification (on-device)

- Idle CPU: ~100% → ~0%.
- Overlay still renders, opens, and closes correctly.
- Clean shutdown, no observed regressions.

## Maintenance caveat

The vendored `.so` is pinned to Electrobun v1.16.0. On any Electrobun bump, the wrapper must be rebuilt from the patch — steps are documented in `apps/loadout-overlay/vendor/README.md` (apply `nativeWrapper.cpp.patch`, run `build-wrapper.sh`).

An upstream Electrobun PR for the underlying fix is also being prepared, which would eventually remove the need to vendor this binary.

Refs #104