### PR TITLE
fix(overlay): default the window to 1920×1080 (#108)

### DIFF
--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -224,9 +224,16 @@ function sendToWebview<K extends keyof WebviewMessages>(
   }
 }
 
+// Default overlay window size. 1920×1080 so the overlay opens large on a
+// desktop monitor (issue #108). The window stays resizable, so Steam Deck
+// users on the 1280×800 panel can shrink it. Shared with GamescopeAtoms so
+// its on-show centring matches the real window size.
+const OVERLAY_WIDTH = 1920;
+const OVERLAY_HEIGHT = 1080;
+
 const overlay = new BrowserWindow({
   title: "Loadout Overlay",
-  frame: { x: 0, y: 0, width: 1280, height: 800 },
+  frame: { x: 0, y: 0, width: OVERLAY_WIDTH, height: OVERLAY_HEIGHT },
   titleBarStyle: "default",
   transparent: false,
   hidden: !DESKTOP_SMOKE_TEST,
@@ -254,6 +261,9 @@ const overlay = new BrowserWindow({
 const atoms = new GamescopeAtoms({
   display: DISPLAY,
   windowName: "Loadout Overlay",
+  // Keep on-show centring in sync with the BrowserWindow frame above.
+  windowWidth: OVERLAY_WIDTH,
+  windowHeight: OVERLAY_HEIGHT,
   // Kill switch: set OVERLAY_FORCE_XPROP=1 to bypass the libxcb fast
   // path and use the original xprop-subprocess writes. Useful for
   // bisecting if the libxcb port is suspected of new bugs.

--- a/apps/loadout-overlay/src/bun/native/gamescope-atoms.ts
+++ b/apps/loadout-overlay/src/bun/native/gamescope-atoms.ts
@@ -74,11 +74,20 @@ export interface AtomTargetOptions {
    *  available. Kill switch for the libxcb migration — set
    *  `OVERLAY_FORCE_XPROP=1` in the environment to flip this. */
   forceXprop?: boolean;
+  /** The overlay window's width/height, used by `_positionOnPrimary` to
+   *  centre it on the monitor. Must match the BrowserWindow `frame` size
+   *  or the centring is off. Defaults to the legacy 1280×800. */
+  windowWidth?: number;
+  windowHeight?: number;
 }
 
 export class GamescopeAtoms {
   private display: string;
   private windowName: string;
+  /** Overlay window size — used to centre it on the monitor in
+   *  `_positionOnPrimary`. Kept in sync with the BrowserWindow frame. */
+  private windowWidth: number;
+  private windowHeight: number;
   /** Cached window id; re-resolved on first failure. */
   private windowId: string | null = null;
   /** Cached Steam Big Picture window id — re-resolved on show(). */
@@ -126,6 +135,8 @@ export class GamescopeAtoms {
   constructor(opts: AtomTargetOptions) {
     this.display = opts.display;
     this.windowName = opts.windowName;
+    this.windowWidth = opts.windowWidth ?? 1280;
+    this.windowHeight = opts.windowHeight ?? 800;
 
     // Try to open a libxcb connection up front. Failure (server down,
     // wrong display, libxcb missing) is non-fatal — we silently fall
@@ -825,9 +836,10 @@ export class GamescopeAtoms {
       // Under gamescope's inner X usually: "DP-1 connected 2560x1440+0+0 ..."
       const geom = this._pickMonitorGeometry(stdout);
       if (!geom) return;
-      // windowmove + windowsize: center the overlay in the monitor.
-      const x = geom.x + Math.max(0, Math.floor((geom.w - 1280) / 2));
-      const y = geom.y + Math.max(0, Math.floor((geom.h - 800) / 2));
+      // Center the overlay in the monitor, using the real window size so
+      // a non-default frame (e.g. the 1920×1080 default) isn't mis-placed.
+      const x = geom.x + Math.max(0, Math.floor((geom.w - this.windowWidth) / 2));
+      const y = geom.y + Math.max(0, Math.floor((geom.h - this.windowHeight) / 2));
       await run([
         "env",
         `DISPLAY=${this.display}`,


### PR DESCRIPTION
Closes #108.

## Problem
The overlay window was created at **1280×800**, so on a desktop monitor it opened as a small window rather than filling the screen.

## Fix
Create the `BrowserWindow` at **1920×1080** by default. The window stays **resizable**, so Steam Deck users on the 1280×800 panel can shrink it to taste.

Sized at **window-creation time** (born at size) rather than resizing the live CEF window on `show()`. An earlier attempt did the latter via `xdotool windowsize` and it segfaulted CEF — under `GDK_GL=disable` (set to silence `GLXBadWindow` under gamescope) the GTK/CEF surface is software-rendered, and reallocating it on resize crashes. Born-at-size avoids any runtime resize.

The window dimensions are plumbed into `GamescopeAtoms` so its on-show centring uses the real frame size instead of the old hardcoded 1280×800.

## Tests
`gamescope-atoms.test.ts` green (23); `tsc --noEmit` clean. The centring tests use the 1280×800 default (unchanged); the live frame passes 1920×1080.