### PR TITLE
fix(loader): guard SDK hot-reload watch against missing source dir

### DIFF
--- a/apps/loadout/src/loader/index.ts
+++ b/apps/loadout/src/loader/index.ts
@@ -447,7 +447,7 @@ export async function startServer(options: ServerOptions = {}) {
   });
 
   // --- File watching for hot reload ---
-  const { watch } = await import("node:fs");
+  const { watch, existsSync } = await import("node:fs");
   const watchers: ReturnType<typeof watch>[] = [];
 
   const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -473,17 +473,24 @@ export async function startServer(options: ServerOptions = {}) {
     watchers.push(watcher);
   }
 
-  // Watch packages/ui/ for SDK changes
+  // Watch packages/ui/ for SDK changes. Dev-only: in an installed layout
+  // `projectRoot` isn't the source repo, so this dir doesn't exist —
+  // `watch()` on a missing path throws ENOENT, which previously surfaced as
+  // an uncaught exception at startup. Guard on existence and skip cleanly.
   const uiSrcDir = join(projectRoot, "packages/ui/src");
-  const uiWatcher = watch(uiSrcDir, { recursive: true }, (_eventType, filename) => {
-    if (!filename) return;
-    debounced("sdk", () => {
-      log.debug(`[hot-reload] SDK changed: ${filename}`);
-      bundleCache.clear(); // SDK change invalidates all bundles
-      broadcast({ type: "event", plugin: "__system", event: "reload", data: { plugin: "__sdk" } });
+  if (existsSync(uiSrcDir)) {
+    const uiWatcher = watch(uiSrcDir, { recursive: true }, (_eventType, filename) => {
+      if (!filename) return;
+      debounced("sdk", () => {
+        log.debug(`[hot-reload] SDK changed: ${filename}`);
+        bundleCache.clear(); // SDK change invalidates all bundles
+        broadcast({ type: "event", plugin: "__system", event: "reload", data: { plugin: "__sdk" } });
+      });
     });
-  });
-  watchers.push(uiWatcher);
+    watchers.push(uiWatcher);
+  } else {
+    log.debug(`[hot-reload] SDK source dir absent (${uiSrcDir}); skipping SDK watch`);
+  }
 
   return { server, watchers };
 }


### PR DESCRIPTION
## Problem
At backend startup in an **installed** layout, the loader logged an uncaught exception:

```
[ERROR] Uncaught exception: Error: ENOENT: no such file or directory, watch '/packages/ui/src'
```

The SDK hot-reload watcher (`loader/index.ts`) does `watch(join(projectRoot, "packages/ui/src"))` unconditionally. In the installed layout `projectRoot` isn't the source repo (resolves to `/`), so that dir doesn't exist and `fs.watch` throws. Non-fatal (the backend keeps running) but noisy and surfaced as an uncaught exception. Pre-existing — unrelated to the recent injector work.

## Fix
Guard the watch with `existsSync` — it's a dev-only convenience (watch the repo's SDK source to invalidate bundles on change). When the dir is absent (installed/prod), skip it with a debug log. Per-plugin watches are untouched (those dirs exist in the staged install and hot-reload already works there).

## Verification
`tsc --noEmit` clean. Built + installed + restarted: the uncaught ENOENT is gone, replaced by `[hot-reload] SDK source dir absent (/packages/ui/src); skipping SDK watch` (debug); backend boots clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)