### PR TITLE
fix(overlay): size the window to the gamescope resolution in gaming mode (#106)

### DIFF
--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -21,6 +21,7 @@ import type {
   ControllerShortcuts,
 } from "../webview/lib/electrobun";
 import { GamescopeAtoms } from "./native/gamescope-atoms";
+import { detectGamescopeScreenSizeSync } from "./native/screen-size";
 import {
   startInputIntercept,
   type InputInterceptHandle,
@@ -224,12 +225,25 @@ function sendToWebview<K extends keyof WebviewMessages>(
   }
 }
 
-// Default overlay window size. 1920×1080 so the overlay opens large on a
-// desktop monitor (issue #108). The window stays resizable, so Steam Deck
-// users on the 1280×800 panel can shrink it. Shared with GamescopeAtoms so
-// its on-show centring matches the real window size.
-const OVERLAY_WIDTH = 1920;
-const OVERLAY_HEIGHT = 1080;
+// Overlay window size, decided once at startup and *born at size* — the
+// window is never resized live, because under `GDK_GL=disable` the
+// software-rendered CEF surface segfaults on reallocation (PR #113).
+//
+// Desktop: 1920×1080 so the overlay opens large on a monitor (issue #108).
+//
+// Gaming Mode: size to the gamescope inner-X resolution so the X11 window
+// maps 1:1 to the visible output. Born too large (the 1920×1080 default on
+// a 1280×800 panel), gamescope scales the visual down but routes pointer
+// input in unscaled window space — the cursor only reaches a corner and
+// clicks land far from where they're drawn (issue #106). Fall back to the
+// Deck's native 1280×800 if xrandr can't be read.
+const DESKTOP_SIZE = { width: 1920, height: 1080 };
+const GAMESCOPE_FALLBACK_SIZE = { width: 1280, height: 800 };
+const overlaySize = gamescopeMode
+  ? (detectGamescopeScreenSizeSync(DISPLAY) ?? GAMESCOPE_FALLBACK_SIZE)
+  : DESKTOP_SIZE;
+const OVERLAY_WIDTH = overlaySize.width;
+const OVERLAY_HEIGHT = overlaySize.height;
 
 const overlay = new BrowserWindow({
   title: "Loadout Overlay",

--- a/apps/loadout-overlay/src/bun/native/gamescope-atoms.ts
+++ b/apps/loadout-overlay/src/bun/native/gamescope-atoms.ts
@@ -15,6 +15,7 @@ import { run as _runRaw, commandExists } from "@loadout/exec";
 import { trace } from "./trace";
 import { X11Connection } from "./x11";
 import { dismissSteamMenusIfOpen } from "./steam-quick-access";
+import { parseScreenGeometry } from "./screen-size";
 
 // From overlay_display.rs
 const OVERLAY_APP_ID = 0x534c; // 21324, "SL"
@@ -857,31 +858,9 @@ export class GamescopeAtoms {
   private _pickMonitorGeometry(
     xrandr: string,
   ): { x: number; y: number; w: number; h: number } | null {
-    // Each monitor line looks roughly:
-    //   "<name> connected [primary] <W>x<H>+<X>+<Y> ..."
-    // We prefer the line marked "primary"; otherwise the first connected
-    // output with a concrete geometry.
-    const geomRe = /(\d+)x(\d+)\+(\d+)\+(\d+)/;
-    let primary: RegExpMatchArray | null = null;
-    let firstConnected: RegExpMatchArray | null = null;
-    for (const line of xrandr.split("\n")) {
-      if (!line.includes(" connected")) continue;
-      const m = line.match(geomRe);
-      if (!m) continue;
-      if (line.includes(" primary ")) {
-        primary = m;
-        break;
-      }
-      if (!firstConnected) firstConnected = m;
-    }
-    const m = primary ?? firstConnected;
-    if (!m) return null;
-    return {
-      w: Number(m[1]),
-      h: Number(m[2]),
-      x: Number(m[3]),
-      y: Number(m[4]),
-    };
+    // Shared with the startup window-sizing probe (native/screen-size.ts)
+    // so both centring and born-at-size sizing parse xrandr identically.
+    return parseScreenGeometry(xrandr);
   }
 
   /** Hide: zero our atoms, drop opacity, force Steam's atoms back to 0,

--- a/apps/loadout-overlay/src/bun/native/screen-size.test.ts
+++ b/apps/loadout-overlay/src/bun/native/screen-size.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "bun:test";
+import { parseScreenGeometry } from "./screen-size";
+
+describe("parseScreenGeometry", () => {
+  it("prefers the output marked primary over earlier connected ones", () => {
+    const xrandr = [
+      "Screen 0: minimum 320 x 200, current 1920 x 1080, maximum 16384 x 16384",
+      "HDMI-1 connected 1920x1080+0+0 (normal left inverted right) 600mm x 340mm",
+      "DP-2 connected primary 2560x1440+1920+0 (normal left inverted) 597mm x 336mm",
+    ].join("\n");
+    expect(parseScreenGeometry(xrandr)).toEqual({
+      w: 2560,
+      h: 1440,
+      x: 1920,
+      y: 0,
+    });
+  });
+
+  it("falls back to the first connected output when none is primary", () => {
+    const xrandr = [
+      "HDMI-1 connected 1366x768+0+0 (normal left inverted) 510mm x 290mm",
+      "VGA-1 connected 1024x768+1366+0 (normal left inverted) 410mm x 230mm",
+    ].join("\n");
+    expect(parseScreenGeometry(xrandr)).toEqual({
+      w: 1366,
+      h: 768,
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it("parses the gamescope single-output shape (the #106 case)", () => {
+    // gamescope's inner Xwayland typically exposes one output at the
+    // panel resolution; this is what the overlay should be born at.
+    const xrandr =
+      "DP-1 connected 1280x800+0+0 (normal left inverted right x axis y axis) 0mm x 0mm";
+    expect(parseScreenGeometry(xrandr)).toEqual({
+      w: 1280,
+      h: 800,
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it("ignores disconnected outputs without geometry", () => {
+    const xrandr = [
+      "HDMI-2 disconnected (normal left inverted right x axis y axis)",
+      "eDP-1 connected primary 1280x800+0+0 (normal left inverted) 290mm x 180mm",
+    ].join("\n");
+    expect(parseScreenGeometry(xrandr)).toEqual({
+      w: 1280,
+      h: 800,
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it("returns null when no connected output exposes a geometry", () => {
+    const xrandr = [
+      "Screen 0: minimum 320 x 200, current 0 x 0, maximum 16384 x 16384",
+      "HDMI-1 disconnected (normal left inverted right x axis y axis)",
+    ].join("\n");
+    expect(parseScreenGeometry(xrandr)).toBeNull();
+  });
+});

--- a/apps/loadout-overlay/src/bun/native/screen-size.ts
+++ b/apps/loadout-overlay/src/bun/native/screen-size.ts
@@ -1,0 +1,89 @@
+// Detect the gamescope display resolution so the overlay window can be
+// *born* at the right size. This matters because under gamescope the
+// X11 window's coordinate space is the inner (Xwayland) screen: if the
+// window is larger than the screen, gamescope scales the visual down to
+// fit but routes pointer input in the unscaled window space, so the
+// cursor only reaches a corner of the window and clicks land far from
+// where they're drawn (issue #106).
+//
+// We can't fix this by resizing the live CEF window — under
+// `GDK_GL=disable` the GTK/CEF surface is software-rendered and
+// reallocating it on resize segfaults CEF (see PR #113). So the size has
+// to be known *before* `new BrowserWindow(...)`, which is why the probe
+// here is synchronous: it runs once, inline, at startup.
+//
+// xrandr is the right source (not /sys/class/drm): we want the inner X
+// server's screen size — the same space `_positionOnPrimary` queries —
+// not the physical panel mode, which can differ from gamescope's
+// internal render resolution.
+
+import { spawnSync } from "node:child_process";
+
+export interface ScreenGeometry {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface ScreenSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * Parse an `xrandr --query` dump into the chosen monitor's geometry.
+ * Prefers the line marked `primary`; otherwise the first connected
+ * output with a concrete `<W>x<H>+<X>+<Y>`. Returns null when no
+ * connected output exposes a geometry. Pure — unit-testable directly.
+ */
+export function parseScreenGeometry(xrandr: string): ScreenGeometry | null {
+  // Each monitor line looks roughly:
+  //   "<name> connected [primary] <W>x<H>+<X>+<Y> ..."
+  const geomRe = /(\d+)x(\d+)\+(\d+)\+(\d+)/;
+  let primary: RegExpMatchArray | null = null;
+  let firstConnected: RegExpMatchArray | null = null;
+  for (const line of xrandr.split("\n")) {
+    if (!line.includes(" connected")) continue;
+    const m = line.match(geomRe);
+    if (!m) continue;
+    if (line.includes(" primary ")) {
+      primary = m;
+      break;
+    }
+    if (!firstConnected) firstConnected = m;
+  }
+  const m = primary ?? firstConnected;
+  if (!m) return null;
+  return {
+    w: Number(m[1]),
+    h: Number(m[2]),
+    x: Number(m[3]),
+    y: Number(m[4]),
+  };
+}
+
+/**
+ * Query the gamescope inner-X screen size synchronously via xrandr.
+ * Returns null on any failure (xrandr missing, non-zero exit, or no
+ * connected geometry) so the caller can fall back to a sane default.
+ * Mirrors the env-prefixed invocation `_positionOnPrimary` uses so both
+ * talk to the same display.
+ */
+export function detectGamescopeScreenSizeSync(
+  display: string,
+): ScreenSize | null {
+  try {
+    const res = spawnSync(
+      "env",
+      [`DISPLAY=${display}`, "xrandr", "--current", "--query"],
+      { encoding: "utf8", timeout: 2000 },
+    );
+    if (res.status !== 0 || !res.stdout) return null;
+    const geom = parseScreenGeometry(res.stdout);
+    if (!geom || geom.w <= 0 || geom.h <= 0) return null;
+    return { width: geom.w, height: geom.h };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #106.

## Problem
In Gaming Mode the overlay's **mouse is constrained to ~half the screen** and click targets are badly offset from what's drawn.

**Root cause.** The overlay `BrowserWindow` is born at a hardcoded **1920×1080** (added in #108 so it opens large on a desktop monitor). When that doesn't match the gamescope inner-X resolution, gamescope scales the visual *down* to fit the screen but routes pointer input in the window's **unscaled** coordinate space — so the cursor only reaches a corner of the window and clicks land far from where they're drawn.

## Fix
Detect the gamescope screen size **synchronously at startup** via `xrandr` (the same inner-X space `_positionOnPrimary` already queries) and create the window at that size, so the X11 window maps 1:1 to the visible output. Desktop keeps 1920×1080 (no #108 regression). This also satisfies #108's own "and also gaming mode if applicable" maximise clause.

The size must be known **before** `new BrowserWindow(...)`: under `GDK_GL=disable` the software-rendered CEF surface segfaults on a live resize (see #113), so resizing after the fact isn't an option — hence the synchronous probe and *born-at-size* approach.

## Changes
- **`src/bun/native/screen-size.ts`** (new) — pure `parseScreenGeometry` (extracted from `gamescope-atoms._pickMonitorGeometry`) + `detectGamescopeScreenSizeSync(display)` (sync `xrandr` probe, returns `null` on any failure).
- **`src/bun/index.ts`** — Gaming Mode sizes the window from the detected resolution (falls back to 1280×800 if xrandr can't be read); desktop stays 1920×1080.
- **`src/bun/native/gamescope-atoms.ts`** — `_pickMonitorGeometry` now delegates to the shared `parseScreenGeometry`, so startup sizing and on-show centring parse `xrandr` identically.

## Tests
- `screen-size.test.ts` — 5 new cases (primary preference, first-connected fallback, the gamescope single-output shape, disconnected outputs, no-geometry → `null`).
- `bun test` green: 28 tests (5 new + 23 existing `gamescope-atoms`).
- `tsc --noEmit`: no new errors (identical baseline before/after).

## Verification
Built + installed and tested **on-device in Gaming Mode**: the window is born at the panel's native **1920×1200** (positioned at `0,0`, filling the output), and the mouse now reaches the full screen with on-target clicks — confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)