### PR TITLE
fix(store-bridge): trust release-assets.githubusercontent.com for downloads

### DIFF
--- a/plugins/store-bridge/lib/github-release.test.ts
+++ b/plugins/store-bridge/lib/github-release.test.ts
@@ -107,6 +107,37 @@ describe("downloadFile", () => {
     expect(requests[1]?.url).toContain("objects.githubusercontent.com");
   });
 
+  it("walks the github.com → release-assets.githubusercontent.com redirect", async () => {
+    // GitHub migrated release-asset downloads from
+    // objects.githubusercontent.com to release-assets.githubusercontent.com
+    // in 2025. The walker must trust the new host or every self-install
+    // download fails closed at hop 1.
+    stubFetch((url) => {
+      if (url.startsWith("https://github.com/")) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: {
+              location: "https://release-assets.githubusercontent.com/blob/abc",
+            },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(new Uint8Array([0xde, 0xad, 0xbe, 0xef]), {
+          status: 200,
+          headers: { "content-length": "4" },
+        }),
+      );
+    });
+    await downloadFile(
+      "https://github.com/x/y/releases/download/v1/legendary",
+      join(dir, "ra.bin"),
+    );
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.url).toContain("release-assets.githubusercontent.com");
+  });
+
   it("refuses to follow a redirect to a non-allow-listed host", async () => {
     // 302 from github.com pointing at an attacker host — the manual
     // walker must reject BEFORE issuing the second fetch, so the

--- a/plugins/store-bridge/lib/github-release.ts
+++ b/plugins/store-bridge/lib/github-release.ts
@@ -33,15 +33,18 @@ export async function githubToken(): Promise<string | undefined> {
 /**
  * Allow-list of hostnames the GitHub-release download walker will
  * follow. Real release-asset URLs redirect from `github.com` →
- * `objects.githubusercontent.com` (and sometimes `*.githubusercontent.com`
- * /`codeload.github.com` for source archives). We re-check the host
- * on EVERY hop of the redirect chain, not just the final URL, so a
- * malicious release that 302s through an attacker host can't have
- * its body fetched before the final-host check fires.
+ * `release-assets.githubusercontent.com` (GitHub migrated asset
+ * downloads here in 2025; older links still hit
+ * `objects.githubusercontent.com`), and `codeload.github.com` serves
+ * source archives. We re-check the host on EVERY hop of the redirect
+ * chain, not just the final URL, so a malicious release that 302s
+ * through an attacker host can't have its body fetched before the
+ * final-host check fires.
  */
 const TRUSTED_GITHUB_HOSTS = [
   "github.com",
   "objects.githubusercontent.com",
+  "release-assets.githubusercontent.com",
   "codeload.github.com",
 ];
 

--- a/plugins/store-bridge/package.json
+++ b/plugins/store-bridge/package.json
@@ -25,6 +25,7 @@
         "api.github.com",
         "github.com",
         "objects.githubusercontent.com",
+        "release-assets.githubusercontent.com",
         "cdn1.epicgames.com",
         "cdn2.unrealengine.com",
         "cdn2.steamgriddb.com",


### PR DESCRIPTION
## What

GitHub migrated release-asset downloads from `objects.githubusercontent.com` to `release-assets.githubusercontent.com` in 2025. The store-bridge download walker re-checks the host on **every** hop of the redirect chain, so any host not in the allow-list makes the download fail closed at the first redirect — breaking self-install downloads (e.g. legendary).

## Change

- Add `release-assets.githubusercontent.com` to `TRUSTED_GITHUB_HOSTS` in `github-release.ts`
- Add the same host to the plugin manifest network allow-list in `package.json`
- Add a test covering the `github.com → release-assets.githubusercontent.com` redirect

## Test

`bun test plugins/store-bridge/lib/github-release.test.ts` → 13 pass / 0 fail (the non-allow-listed-host rejection test still passes, so the security check is intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)