### PR TITLE
chore: drop macOS host support — Linux-only app (closes #122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ handhelds and desktops running Gamescope. Think **Decky Loader re-imagined in
 one language**: the plugin host, plugin backends, plugin UIs, and the overlay
 itself are all TypeScript on Bun — no Python service, no multi-runtime interop.
 
+**Linux only.** Loadout targets distros with Steam Gaming Mode — **SteamOS**,
+**Bazzite**, and **CachyOS**. There is no macOS or Windows build.
+
 > **Status: early.** This repository is a minimal, freshly-rebuilt version of
 > the project. It currently ships the full platform plus **one example plugin**
 > (`steam-gamescope-ipc`) as a proof-of-concept. The remaining plugins are

--- a/apps/loadout/src/index.ts
+++ b/apps/loadout/src/index.ts
@@ -85,7 +85,7 @@ log.info(`Bun version: ${Bun.version}`);
 log.info(`Project root: ${projectRoot}`);
 log.info(`Port: ${port}`);
 log.info(`Log file: ${LOG_PATH}`);
-log.info(`Platform: ${process.platform} ${process.arch}`);
+log.info(`Arch: ${process.arch}`); // Linux-only app; host platform is always linux
 log.info(`User: ${process.env.USER || process.env.HOME || "unknown"}`);
 log.info(`Process uid: ${process.getuid?.() ?? "?"} (target user: ${targetUser || "none"})`);
 

--- a/docs/os-compatibility.md
+++ b/docs/os-compatibility.md
@@ -1,5 +1,10 @@
 # OS Compatibility
 
+Loadout is a **Linux-only** app — an overlay for distros running Steam's
+Gaming Mode. Supported targets are **SteamOS**, **Bazzite**, and
+**CachyOS**. There is no macOS or Windows build; the notes below cover
+the differences between the supported Linux distros.
+
 ## The Immutability Spectrum
 
 | OS | Filesystem | Notes |
@@ -95,7 +100,7 @@ async function findCEFPort(): Promise<number> {
 | **Bazzite** | `fsync`/`futex2` patched kernel for broader hardware. Deck-specific if on Deck hardware |
 | **CachyOS** | BORE scheduler kernel with custom patches. Not Deck-specific |
 
-## Cross-Platform Distribution
+## Distribution (standalone Linux binary)
 
 The standalone binary (`bun build --compile`) means no runtime dependencies:
 
@@ -124,8 +129,8 @@ Single ~95MB binary. Users don't need Bun, Node, or Python installed.
 ## Development Workflow
 
 - **Desktop Linux** — Cleanest. Run Steam natively, loader connects. QAM only available in Big Picture mode
-- **macOS/Windows** — TypeScript compilation, type checking, unit tests work with Bun. Can't connect to Steam CEF. Push to device via git/rsync
 - **Remote dev on device** — SSH available. VS Code Remote works. Bun fast enough for direct dev
+- **Type-checking off-device** — `bun run typecheck`/unit tests run on any OS with Bun, but the app only builds and runs on Linux, and the overlay needs a Linux box with Steam to test
 
 ## CI Testing
 

--- a/packages/steam-shortcut/src/index.test.ts
+++ b/packages/steam-shortcut/src/index.test.ts
@@ -84,9 +84,8 @@ describe("addNonSteamShortcut", () => {
     expect(idxLaunch).toBeGreaterThan(idxName);
   });
 
-  it("writes a Proton compat tool only when platform=windows on Linux host", async () => {
+  it("writes a Proton compat tool when platform=windows (host is always Linux)", async () => {
     const { addNonSteamShortcut } = await import("./index");
-    const wasLinux = process.platform === "linux";
     await addNonSteamShortcut({
       displayName: "Alba",
       exe: "/games/alba.exe",
@@ -94,12 +93,8 @@ describe("addNonSteamShortcut", () => {
       platform: "windows",
     });
     const idxCompat = calls.findIndex((c) => c.startsWith("compat:"));
-    if (wasLinux) {
-      expect(idxCompat).toBeGreaterThanOrEqual(0);
-      expect(calls[idxCompat]).toContain("proton_experimental");
-    } else {
-      expect(idxCompat).toBe(-1);
-    }
+    expect(idxCompat).toBeGreaterThanOrEqual(0);
+    expect(calls[idxCompat]).toContain("proton_experimental");
   });
 
   it("does not write a compat tool for native linux installs", async () => {

--- a/packages/steam-shortcut/src/index.ts
+++ b/packages/steam-shortcut/src/index.ts
@@ -28,12 +28,11 @@ export interface SteamShortcutSpec {
    *  to dirname(exe). */
   cwd?: string;
   /**
-   * Native OS of `exe`. When `"windows"` on a Linux host the
-   * shortcut pins Proton Experimental as its compat tool so Steam
-   * runs the .exe through Wine. Other values are no-ops on the
-   * compat-tool front.
+   * Native OS of `exe`. When `"windows"` the shortcut pins Proton
+   * Experimental as its compat tool so Steam runs the .exe through
+   * Wine (the host is always Linux). `"linux"` is a no-op.
    */
-  platform?: "windows" | "linux" | "macos";
+  platform?: "windows" | "linux";
   /**
    * User-tag value. Surfaces as a dynamic auto-grouping in Steam's
    * library sidebar. Best-effort — older Steam builds without
@@ -125,11 +124,11 @@ export async function addNonSteamShortcut(
     await sc.apps.setShortcutName(appId, spec.displayName);
     await sc.apps.setShortcutLaunchOptions(appId, spec.args);
 
-    // Windows binary on a Linux host → register Proton as the
-    // compat tool so Steam runs the .exe through Wine. Without
-    // this Steam tries to native-exec the .exe and silently
-    // fails — the "click Launch, nothing happens" symptom.
-    if (spec.platform === "windows" && process.platform === "linux") {
+    // Windows binary → register Proton as the compat tool so Steam
+    // runs the .exe through Wine (the host is always Linux). Without
+    // this Steam tries to native-exec the .exe and silently fails —
+    // the "click Launch, nothing happens" symptom.
+    if (spec.platform === "windows") {
       await bestEffort("specifyCompatTool", () =>
         sc.apps.specifyCompatTool(
           appId,

--- a/plugins/store-bridge/lib/stores/epic/index.ts
+++ b/plugins/store-bridge/lib/stores/epic/index.ts
@@ -440,13 +440,17 @@ class EpicDriverImpl implements StoreDriver {
   }
 }
 
-/** legendary surfaces "Win32"/"Win64"/"Mac"/"Linux"; we squash to our 3-value enum. */
-function normalisePlatform(p?: string): "windows" | "linux" | "macos" | undefined {
+/**
+ * legendary surfaces "Win32"/"Win64"/"Mac"/"Linux"; we squash to the
+ * two platforms the Deck can run — Windows (via Proton) and Linux. macOS
+ * binaries can't run here, so they map to undefined (treated as
+ * unsupported).
+ */
+function normalisePlatform(p?: string): "windows" | "linux" | undefined {
   if (!p) return undefined;
   const lc = p.toLowerCase();
   if (lc.startsWith("win")) return "windows";
   if (lc === "linux") return "linux";
-  if (lc === "mac" || lc === "macos" || lc === "darwin") return "macos";
   return undefined;
 }
 
@@ -463,11 +467,10 @@ function unique<T>(xs: T[]): T[] {
 }
 
 /** Heuristic fallback when legendary's platform field is empty. */
-function guessPlatform(exe?: string): "windows" | "linux" | "macos" | undefined {
+function guessPlatform(exe?: string): "windows" | "linux" | undefined {
   if (!exe) return undefined;
   const lc = exe.toLowerCase();
   if (lc.endsWith(".exe")) return "windows";
-  if (lc.endsWith(".app")) return "macos";
   return "linux";
 }
 

--- a/plugins/store-bridge/lib/types.ts
+++ b/plugins/store-bridge/lib/types.ts
@@ -68,9 +68,10 @@ export interface InstalledGame {
   /** Extra launch-time CLI args reported by the store (Epic
    *  "launch_parameters", e.g. "-window-mode exclusive"). */
   launchParameters?: string;
-  /** Native OS of the executable. Drives whether we set Proton as
-   *  the Steam compat tool when adding the shortcut. */
-  platform?: "windows" | "linux" | "macos";
+  /** Native OS of the executable. `"windows"` drives whether we set
+   *  Proton as the Steam compat tool when adding the shortcut (the
+   *  host is always Linux). */
+  platform?: "windows" | "linux";
   source: InstallSource;
   addedToSteam: boolean;
   steamAppId?: number;


### PR DESCRIPTION
## What

Loadout is a **Linux-only** Steam gaming-mode overlay (SteamOS, Bazzite, CachyOS). This removes macOS host/game-target support outside the recomp plugin and makes the supported-OS messaging explicit.

**Windows game-targets via Proton are kept** — Epic `.exe` games (and recomp's Windows-only games) run via Proton on the Linux host. Only macOS (which can't run on the Deck) and dead Windows-*host* code are removed.

## Changes

- **`packages/steam-shortcut`** — drop `"macos"` from the `platform` union; the Proton compat-tool gate no longer checks the always-true `process.platform === "linux"`, only `spec.platform === "windows"`. Test updated.
- **`plugins/store-bridge`** — drop `"macos"` from the platform type; the Epic driver's `normalisePlatform`/`guessPlatform` now map only `windows | linux` (macOS Epic binaries → `undefined`/unsupported).
- **`apps/loadout/src/index.ts`** — log arch only (host is always Linux).
- **`docs/os-compatibility.md` + `README.md`** — state Linux-only (SteamOS/Bazzite/CachyOS); drop the "Cross-Platform" / macOS-Windows dev framing.

## Scope note

The **recomp-plugin** subset of #122 (its `platform.ts`/`games.json`/types macOS removal) shipped separately on `plugin/recomp` (PR #80), since that branch is mid-review. Together the two PRs fully resolve #122.

## Test

`bun run typecheck` ✅ · `bun run test` (backend 1805 / ui 320, 0 fail) ✅ · `bun run lint` 0 errors. No new prettier debt introduced (touched files were already in the repo's pre-existing non-prettier set).

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)