### PR TITLE
fix(bluetooth): power toggle no longer snaps back to OFF

### DIFF
--- a/plugins/bluetooth/app.spec.tsx
+++ b/plugins/bluetooth/app.spec.tsx
@@ -6,6 +6,7 @@ import * as actualUi from "@loadout/ui";
 import { waitFor } from "../../test/render";
 
 const callMock = mock((_method: string) => Promise.resolve(null));
+const notifyMock = mock((_msg: string, _opts?: unknown) => {});
 const eventHandlers = new Map<string, (data: unknown) => void>();
 
 mock.module("@loadout/ui", () => {
@@ -14,6 +15,7 @@ mock.module("@loadout/ui", () => {
   };
   return {
     ...actualUi,
+    notify: notifyMock,
     // Stripped-down PluginProvider — keeps only the header-slot context
     // so `<PluginHeader>` portal-renders into the supplied slot. Backend
     // and focus context are mocked separately.
@@ -59,6 +61,7 @@ const mockDevices = [
 describe("bluetooth plugin", () => {
   beforeEach(() => {
     callMock.mockReset();
+    notifyMock.mockReset();
     eventHandlers.clear();
     callMock.mockImplementation((_method: string) => {
       if (_method === "getDevices") return Promise.resolve(mockDevices);
@@ -159,6 +162,90 @@ describe("bluetooth plugin", () => {
     mount(container);
     await waitFor(() => {
       expect(eventHandlers.has("deviceChanged")).toBe(true);
+    });
+  });
+
+  it("registers adapterChanged event handler", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { mount } = await import("./app");
+    mount(container);
+    await waitFor(() => {
+      expect(eventHandlers.has("adapterChanged")).toBe(true);
+    });
+  });
+
+  it("updates the power chip when an adapterChanged event fires", async () => {
+    const container = document.createElement("div");
+    const headerSlot = document.createElement("div");
+    document.body.appendChild(container);
+    document.body.appendChild(headerSlot);
+    const { mount } = await import("./app");
+    mount(container, { headerSlot });
+    await waitFor(() => {
+      expect(headerSlot.textContent).toContain("POWERED ON");
+    });
+    // Adapter powered off externally → backend emits adapterChanged.
+    eventHandlers.get("adapterChanged")?.({ ...mockAdapter, powered: false });
+    await waitFor(() => {
+      expect(headerSlot.textContent).toContain("POWERED OFF");
+    });
+  });
+
+  it("reverts the power chip and notifies when togglePower fails", async () => {
+    callMock.mockImplementation((method: string) => {
+      if (method === "getDevices") return Promise.resolve([]);
+      if (method === "getAdapterInfo")
+        return Promise.resolve({ ...mockAdapter, powered: false });
+      if (method === "togglePower") return Promise.reject(new Error("rfkill"));
+      return Promise.resolve(null);
+    });
+    const container = document.createElement("div");
+    const headerSlot = document.createElement("div");
+    document.body.appendChild(container);
+    document.body.appendChild(headerSlot);
+    const { mount } = await import("./app");
+    mount(container, { headerSlot });
+    await waitFor(() => {
+      expect(headerSlot.querySelector('[aria-label="Turn adapter on"]')).not.toBeNull();
+    });
+    headerSlot
+      .querySelector<HTMLButtonElement>('[aria-label="Turn adapter on"]')!
+      .click();
+    await waitFor(() => {
+      // Optimistic ON was reverted back to OFF, and the failure surfaced.
+      expect(headerSlot.textContent).toContain("POWERED OFF");
+      expect(notifyMock).toHaveBeenCalled();
+      expect(notifyMock.mock.calls[0]?.[1]).toMatchObject({ kind: "error" });
+    });
+  });
+
+  it("turns power ON and keeps it on when the adapter confirms", async () => {
+    let powered = false;
+    callMock.mockImplementation((method: string, ...args: unknown[]) => {
+      if (method === "getDevices") return Promise.resolve([]);
+      if (method === "getAdapterInfo")
+        return Promise.resolve({ ...mockAdapter, powered });
+      if (method === "togglePower") {
+        powered = args[0] as boolean;
+        return Promise.resolve("ok");
+      }
+      return Promise.resolve(null);
+    });
+    const container = document.createElement("div");
+    const headerSlot = document.createElement("div");
+    document.body.appendChild(container);
+    document.body.appendChild(headerSlot);
+    const { mount } = await import("./app");
+    mount(container, { headerSlot });
+    await waitFor(() => {
+      expect(headerSlot.querySelector('[aria-label="Turn adapter on"]')).not.toBeNull();
+    });
+    headerSlot
+      .querySelector<HTMLButtonElement>('[aria-label="Turn adapter on"]')!
+      .click();
+    await waitFor(() => {
+      expect(headerSlot.textContent).toContain("POWERED ON");
     });
   });
 });

--- a/plugins/bluetooth/app.tsx
+++ b/plugins/bluetooth/app.tsx
@@ -12,11 +12,20 @@ import {
   Spinner,
   mountComponent,
   mountHeaderStub,
+  notify,
   useBackend,
 } from "@loadout/ui";
 import type { BluetoothDevice, AdapterInfo } from "./lib/parse";
 
 export const icon = FaBluetoothB;
+
+// After `bluetoothctl power on/off` returns, the adapter can take a
+// second or two to actually report the new state via `bluetoothctl
+// show`. Poll a handful of times rather than trusting a single early
+// read (which used to clobber the optimistic value straight back).
+const POWER_POLL_MS = 500;
+const POWER_POLL_TRIES = 6;
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 /** Map device type to a text hint shown next to the name. */
 function deviceTypeLabel(type: BluetoothDevice["type"]): string {
@@ -37,11 +46,32 @@ function BluetoothManager() {
   const [scanning, setScanning] = useState(false);
   const [busyDevices, setBusyDevices] = useState<Set<string>>(new Set());
 
+  // Target power state of an in-flight togglePower, or null when idle.
+  // Used both to ignore contradictory adapterChanged ticks mid-toggle
+  // and to bail the confirm-poll if the user toggles again.
+  const pendingPowerRef = useRef<boolean | null>(null);
+  // Guards the awaited confirm-poll from setState-ing after unmount.
+  const mountedRef = useRef(true);
+
   useEvent({
     event: "deviceChanged",
     handler: (data) => {
       const changed = data as BluetoothDevice;
       setDevices((prev) => prev.map((d) => (d.mac === changed.mac ? changed : d)));
+    },
+  });
+
+  useEvent({
+    event: "adapterChanged",
+    handler: (data) => {
+      const info = data as AdapterInfo;
+      // While a power toggle is settling, ignore backend poll ticks that
+      // disagree with the requested state so a mid-transition read can't
+      // bounce the UI back.
+      if (pendingPowerRef.current !== null && info.powered !== pendingPowerRef.current) {
+        return;
+      }
+      setAdapter(info);
     },
   });
 
@@ -83,6 +113,7 @@ function BluetoothManager() {
   const scanStopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(
     () => () => {
+      mountedRef.current = false;
       for (const id of timersRef.current) clearTimeout(id);
       timersRef.current.clear();
       if (scanStopTimerRef.current !== null) {
@@ -96,10 +127,55 @@ function BluetoothManager() {
   const handleTogglePower = useCallback(async () => {
     if (!adapter) return;
     const next = !adapter.powered;
+    pendingPowerRef.current = next;
     setAdapter((prev) => (prev ? { ...prev, powered: next } : prev));
-    await call("togglePower", next);
-    schedule(refresh, 500);
-  }, [adapter, call, refresh, schedule]);
+
+    try {
+      await call("togglePower", next);
+    } catch (err) {
+      // Command actually failed (e.g. rfkill block) — revert the
+      // optimistic flip and surface it rather than leaving a lie on screen.
+      console.error("[bluetooth] togglePower failed:", err);
+      pendingPowerRef.current = null;
+      setAdapter((prev) => (prev ? { ...prev, powered: !next } : prev));
+      notify(`Couldn't turn Bluetooth ${next ? "on" : "off"}`, { kind: "error" });
+      return;
+    }
+
+    // Poll until the adapter confirms the requested state. Keep the
+    // optimistic value visible meanwhile; a transient "not yet" read
+    // must not flip the UI back.
+    for (let i = 0; i < POWER_POLL_TRIES; i++) {
+      await sleep(POWER_POLL_MS);
+      // Bail if unmounted or the user toggled again (new target wins).
+      if (!mountedRef.current || pendingPowerRef.current !== next) return;
+      let info: AdapterInfo;
+      try {
+        info = (await call("getAdapterInfo")) as AdapterInfo;
+      } catch {
+        continue;
+      }
+      if (!mountedRef.current || pendingPowerRef.current !== next) return;
+      if (info.powered === next) {
+        pendingPowerRef.current = null;
+        setAdapter(info);
+        return;
+      }
+    }
+
+    // Never converged — accept reality and tell the user if it didn't power on.
+    pendingPowerRef.current = null;
+    try {
+      const finalInfo = (await call("getAdapterInfo")) as AdapterInfo;
+      if (!mountedRef.current) return;
+      setAdapter(finalInfo);
+      if (next && !finalInfo.powered) {
+        notify("Bluetooth didn't power on", { kind: "error" });
+      }
+    } catch {
+      /* leave the optimistic value in place */
+    }
+  }, [adapter, call]);
 
   const withBusy = useCallback(
     async (mac: string, fn: () => Promise<void>) => {

--- a/plugins/bluetooth/backend.test.ts
+++ b/plugins/bluetooth/backend.test.ts
@@ -345,6 +345,51 @@ describe("BluetoothBackend", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // _poll — adapter power/discovering watching
+  // ---------------------------------------------------------------------------
+
+  describe("_poll() adapter watching", () => {
+    const showOutput = (powered: boolean, discovering = false) =>
+      [
+        "Controller AA:BB:CC:DD:EE:FF (public)",
+        "\tName: Test Adapter",
+        `\tPowered: ${powered ? "yes" : "no"}`,
+        `\tDiscovering: ${discovering ? "yes" : "no"}`,
+      ].join("\n");
+
+    const poll = () =>
+      (backend as unknown as { _poll(): Promise<void> })._poll();
+
+    it("emits adapterChanged when adapter power flips between polls", async () => {
+      let powered = false;
+      mockRun.mockImplementation((cmd: string[]) => {
+        if (cmd.includes("show")) return Promise.resolve({ stdout: showOutput(powered) });
+        return Promise.resolve({ stdout: "" }); // devices → none
+      });
+
+      await poll(); // baseline read (powered:false) — no emit on first observation
+      expect(emittedEvents.filter((e) => e.event === "adapterChanged")).toHaveLength(0);
+
+      powered = true;
+      await poll(); // transition → emit
+      const evts = emittedEvents.filter((e) => e.event === "adapterChanged");
+      expect(evts).toHaveLength(1);
+      expect((evts[0].data as { powered: boolean }).powered).toBe(true);
+    });
+
+    it("does not emit adapterChanged when the adapter is unchanged", async () => {
+      mockRun.mockImplementation((cmd: string[]) => {
+        if (cmd.includes("show")) return Promise.resolve({ stdout: showOutput(true) });
+        return Promise.resolve({ stdout: "" });
+      });
+
+      await poll();
+      await poll();
+      expect(emittedEvents.filter((e) => e.event === "adapterChanged")).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // startScan / stopScan
   // ---------------------------------------------------------------------------
 

--- a/plugins/bluetooth/backend.ts
+++ b/plugins/bluetooth/backend.ts
@@ -24,6 +24,9 @@ export default class BluetoothBackend implements PluginBackend {
 
   private pollInterval?: Timer;
   private lastDeviceState = new Map<string, boolean>();
+  // Last adapter snapshot the poll loop saw, so it only emits
+  // `adapterChanged` on an actual power/discovering transition.
+  private lastAdapter: AdapterInfo | null = null;
   private scanProcess?: ReturnType<typeof spawn>;
   // Audit F-008: re-entrancy guard. `getDevices()` shells out N+1 times
   // (one `bluetoothctl devices` + one `info <mac>` per paired device).
@@ -35,36 +38,63 @@ export default class BluetoothBackend implements PluginBackend {
   async onLoad(): Promise<void> {
     console.log("[bluetooth] Plugin loaded");
 
-    // Start polling device status every 3 seconds
-    this.pollInterval = setInterval(async () => {
-      if (this.polling) return;
-      this.polling = true;
-      try {
-        const devices = await this.getDevices();
-        const seen = new Set<string>();
-        for (const device of devices) {
-          seen.add(device.mac);
-          const prevConnected = this.lastDeviceState.get(device.mac);
-          if (prevConnected !== undefined && prevConnected !== device.connected) {
-            this.emit?.({
-              event: "deviceChanged",
-              data: device,
-            });
-          }
-          this.lastDeviceState.set(device.mac, device.connected);
-        }
-        // Audit F-008: prune entries for devices that no longer appear
-        // in the paired list (user removed them via bluetoothctl or a
-        // sibling UI). Otherwise lastDeviceState grows monotonically.
-        for (const mac of this.lastDeviceState.keys()) {
-          if (!seen.has(mac)) this.lastDeviceState.delete(mac);
-        }
-      } catch {
-        // Silently ignore poll errors (e.g. adapter off)
-      } finally {
-        this.polling = false;
-      }
+    // Poll device + adapter status every 3 seconds.
+    this.pollInterval = setInterval(() => {
+      this._poll().catch(() => {});
     }, 3000);
+  }
+
+  /**
+   * One poll tick: refresh device connection states and adapter
+   * power/discovering, emitting `deviceChanged` / `adapterChanged` only
+   * on an actual transition. Extracted from the interval so it can be
+   * unit-tested directly. Guarded against overlapping runs.
+   */
+  private async _poll(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      const devices = await this.getDevices();
+      const seen = new Set<string>();
+      for (const device of devices) {
+        seen.add(device.mac);
+        const prevConnected = this.lastDeviceState.get(device.mac);
+        if (prevConnected !== undefined && prevConnected !== device.connected) {
+          this.emit?.({
+            event: "deviceChanged",
+            data: device,
+          });
+        }
+        this.lastDeviceState.set(device.mac, device.connected);
+      }
+      // Audit F-008: prune entries for devices that no longer appear
+      // in the paired list (user removed them via bluetoothctl or a
+      // sibling UI). Otherwise lastDeviceState grows monotonically.
+      for (const mac of this.lastDeviceState.keys()) {
+        if (!seen.has(mac)) this.lastDeviceState.delete(mac);
+      }
+
+      // Watch adapter power + discovering so the UI reflects changes made
+      // elsewhere (and the live scan indicator) without a manual refresh.
+      // Emit only on a real transition; skip the first read (the UI
+      // already fetches getAdapterInfo on mount, so a startup emit is
+      // redundant).
+      const adapter = await this.getAdapterInfo();
+      if (
+        this.lastAdapter === null ||
+        this.lastAdapter.powered !== adapter.powered ||
+        this.lastAdapter.discovering !== adapter.discovering
+      ) {
+        if (this.lastAdapter !== null) {
+          this.emit?.({ event: "adapterChanged", data: adapter });
+        }
+        this.lastAdapter = adapter;
+      }
+    } catch {
+      // Silently ignore poll errors (e.g. adapter off)
+    } finally {
+      this.polling = false;
+    }
   }
 
   async onUnload(): Promise<void> {


### PR DESCRIPTION
## Summary

Turning the Bluetooth adapter **ON** flipped straight back to **OFF**. `handleTogglePower` optimistically set `powered=true`, ran `bluetoothctl power on`, then re-read `bluetoothctl show` once after 500 ms — but on SteamOS the adapter often needs longer than that to report `Powered: yes`, so the stale read clobbered the optimistic state back to OFF.

- **UI**: revert + error toast if the command actually fails; replace the single delayed re-read with a **bounded poll** that keeps the optimistic value until the adapter confirms the requested state (or times out). A `pendingPowerRef` + mounted-guard stop late or contradictory reads from bouncing the toggle.
- **UI**: subscribe to a new `adapterChanged` event so power changes made elsewhere and the scan/discovering indicator stay live.
- **Backend**: extract the 3 s poll body into `_poll()` and also watch adapter power/discovering, emitting `adapterChanged` only on a real transition.

## Test plan

- `bun run typecheck` — 0 errors
- `bun run lint` — 0 errors
- `bun run test:backend` / `bun run test:ui` — green (added: backend `_poll()` emit-on-change; UI revert-on-failure + stays-on-when-confirmed)
- On-device: toggle BT power ON → stays on; toggle off elsewhere → UI reflects; scan indicator updates live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)