### PR TITLE
feat(protondb-badges): library-source picker + open game in Steam → ProtonDB

### DIFF
--- a/packages/steam-cdp/src/steam-client.ts
+++ b/packages/steam-cdp/src/steam-client.ts
@@ -652,6 +652,53 @@ class AppsApi {
     }
     return result.data ?? null;
   }
+
+  /**
+   * Read the user's full *owned* Steam library — every app in
+   * `window.appStore.allApps`, not just the installed titles that
+   * `@loadout/steam-paths` can see on disk. This is the only source
+   * for owned-but-not-installed games (they have no
+   * `appmanifest_*.acf`).
+   *
+   * `appStore.allApps` is an array of MobX app-overview objects; we
+   * project each to a plain `{ appId, name }` inside the page so the
+   * structured-clone over CDP stays cheap and never trips on a
+   * non-cloneable MobX field. `app_type === 1` is Steam's "game" enum
+   * — it filters out tools, demos, soundtracks, videos, and config
+   * apps so the grid only shows real games.
+   *
+   * Throws `SteamClientUnreachableError` if `appStore` hasn't booted
+   * (Steam still starting, or the library UI never opened this
+   * session).
+   */
+  async getAllApps(): Promise<Array<{ appId: string; name: string }>> {
+    const expr = `(() => {
+      const store = window.appStore;
+      if (!store || !Array.isArray(store.allApps)) return { tag: "no-store" };
+      const apps = store.allApps
+        .filter((a) => a && a.app_type === 1)
+        .map((a) => ({
+          appId: String(a.appid),
+          name: a.display_name || String(a.appid),
+        }));
+      return { tag: "ok", apps };
+    })()`;
+    const result = (await this.client._evaluateAsync(expr)) as {
+      tag: string;
+      apps?: Array<{ appId: string; name: string }>;
+    };
+    if (result?.tag === "no-store") {
+      throw new SteamClientUnreachableError(
+        "window.appStore.allApps is not available on the SharedJSContext tab — is Steam's library UI booted?",
+      );
+    }
+    if (result?.tag !== "ok" || !Array.isArray(result.apps)) {
+      throw new Error(
+        `appStore.allApps read returned unexpected value: ${JSON.stringify(result)}`,
+      );
+    }
+    return result.apps;
+  }
 }
 
 // ─── URL namespace ────────────────────────────────────────────────────
@@ -685,6 +732,32 @@ class UrlApi {
     if (result !== "ok") {
       throw new Error(
         `SteamClient.URL.ExecuteSteamURL returned unexpected value: ${JSON.stringify(result)}`,
+      );
+    }
+  }
+
+  /**
+   * Open a web URL inside Steam's own in-client browser via
+   * `window.open(url, "_blank")` evaluated in the SharedJSContext tab.
+   *
+   * This is the exact path the injected ProtonDB badge takes when the
+   * user clicks it on a Steam library / store page — so driving it
+   * from here reproduces that behaviour (the page opens in Steam's
+   * built-in browser overlay) rather than spawning a desktop browser.
+   *
+   * Unlike `executeSteamURL`, `window.open` is always present, so
+   * there's no `no-api` branch; we only surface the standard
+   * unreachable error from the underlying connect/evaluate.
+   */
+  async openWebUrl(url: string): Promise<void> {
+    const expr = `(() => {
+      window.open(${JSON.stringify(url)}, "_blank");
+      return "ok";
+    })()`;
+    const result = await this.client._evaluateAsync(expr);
+    if (result !== "ok") {
+      throw new Error(
+        `window.open returned unexpected value: ${JSON.stringify(result)}`,
       );
     }
   }

--- a/plugins/protondb-badges/app.spec.tsx
+++ b/plugins/protondb-badges/app.spec.tsx
@@ -9,6 +9,9 @@ const callMock = mock((_method: string, ..._args: unknown[]) =>
   Promise.resolve(null as unknown),
 );
 const eventHandlers = new Map<string, (data: unknown) => void>();
+// Spy for the host shim the tile-click handler invokes to close the
+// overlay before driving Steam. Wired into the @loadout/ui mock below.
+const hideOverlayMock = mock(() => Promise.resolve());
 
 const { PluginHeaderSlotProvider } = actualUi as unknown as {
   PluginHeaderSlotProvider: (props: {
@@ -34,10 +37,12 @@ mock.module("@loadout/ui", () => ({
     ready: true,
   }),
   useCurrentGame: () => null,
+  hideOverlay: hideOverlayMock,
 }));
 
 beforeEach(() => {
   callMock.mockReset();
+  hideOverlayMock.mockClear();
   eventHandlers.clear();
   callMock.mockImplementation((method: string) => {
     if (method === "getSettings")
@@ -55,6 +60,12 @@ beforeEach(() => {
       return Promise.resolve([
         { appId: "440", name: "Team Fortress 2" },
         { appId: "730", name: "Counter-Strike 2" },
+      ]);
+    if (method === "listAllGames")
+      return Promise.resolve([
+        { appId: "440", name: "Team Fortress 2" },
+        { appId: "730", name: "Counter-Strike 2" },
+        { appId: "570", name: "Dota 2" },
       ]);
     return Promise.resolve(null);
   });
@@ -131,5 +142,80 @@ describe("protondb-badges plugin", () => {
     await waitFor(() =>
       expect(container.textContent).toContain("Clear ProtonDB Cache"),
     );
+  });
+
+  it("defaults the library-source dropdown to Installed games", async () => {
+    const container = createContainer();
+    const headerSlot = document.createElement("div");
+    document.body.appendChild(headerSlot);
+    const { mount } = await import("./app");
+    mount(container, { headerSlot });
+    await waitFor(() =>
+      expect(headerSlot.textContent).toContain("Installed games"),
+    );
+    // The installed list is the source by default; the all-library RPC
+    // must not be hit until the user switches.
+    const calledMethods = callMock.mock.calls.map((c) => c[0]);
+    expect(calledMethods).toContain("listInstalledGames");
+    expect(calledMethods).not.toContain("listAllGames");
+  });
+
+  it("switching the dropdown to All games fetches the full library", async () => {
+    const container = createContainer();
+    const headerSlot = document.createElement("div");
+    document.body.appendChild(headerSlot);
+    const { mount } = await import("./app");
+    mount(container, { headerSlot });
+
+    // Open the dropdown (trigger button lives in the portaled header).
+    const trigger = await waitFor(() => {
+      const btn = headerSlot.querySelector(
+        'button[aria-haspopup="listbox"]',
+      ) as HTMLButtonElement | null;
+      expect(btn).not.toBeNull();
+      return btn!;
+    });
+    fireEvent.click(trigger);
+
+    // Click the "All games" option.
+    const allOption = await waitFor(() => {
+      const opt = Array.from(
+        headerSlot.querySelectorAll('[role="option"]'),
+      ).find((el) => el.textContent?.includes("All games")) as
+        | HTMLElement
+        | undefined;
+      expect(opt).toBeDefined();
+      return opt!;
+    });
+    fireEvent.click(allOption);
+
+    await waitFor(() => {
+      const calledMethods = callMock.mock.calls.map((c) => c[0]);
+      expect(calledMethods).toContain("listAllGames");
+    });
+  });
+
+  it("clicking a game hides the overlay and opens it in Steam → ProtonDB", async () => {
+    const container = createContainer();
+    const headerSlot = document.createElement("div");
+    document.body.appendChild(headerSlot);
+    const { mount } = await import("./app");
+    mount(container, { headerSlot });
+
+    const tile = await waitFor(() => {
+      const btn = Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Team Fortress 2"),
+      ) as HTMLButtonElement | undefined;
+      expect(btn).toBeDefined();
+      return btn!;
+    });
+    fireEvent.click(tile);
+
+    await waitFor(() => {
+      expect(hideOverlayMock).toHaveBeenCalled();
+      const openCall = callMock.mock.calls.find((c) => c[0] === "openProtonDb");
+      expect(openCall).toBeDefined();
+      expect(openCall?.[1]).toEqual({ appId: "440" });
+    });
   });
 });

--- a/plugins/protondb-badges/app.tsx
+++ b/plugins/protondb-badges/app.tsx
@@ -5,12 +5,14 @@ import {
   fuzzySearchGames,
   GameCard,
   HeaderBackButton,
+  hideOverlay,
   IconButton,
   mountComponent,
   mountHeaderStub,
   PluginHeader,
   SearchField,
   SegmentedItem,
+  Select,
   Spinner,
   Toggle,
   useBackend,
@@ -65,6 +67,16 @@ interface BareInstalledGame {
   appId: string;
   name: string;
 }
+
+/** Which slice of the Steam library the grid shows. "installed" reads
+ *  `appmanifest_*.acf` off disk (fast, offline); "all" reads the full
+ *  owned library from `appStore.allApps` over CDP (needs Steam up). */
+type LibrarySource = "installed" | "all";
+
+const LIBRARY_SOURCE_OPTIONS: { value: LibrarySource; label: string }[] = [
+  { value: "installed", label: "Installed games" },
+  { value: "all", label: "All games" },
+];
 
 // --- Tier config ---
 
@@ -165,6 +177,13 @@ function ProtonDBBadges() {
   const [settings, setSettings] = useState<ProtonDBSettings | null>(null);
   const [status, setStatus] = useState<StatusInfo>({ connected: false, tabs: 0 });
   const [installed, setInstalled] = useState<GridGame[] | null>(null);
+  /** Which library slice the grid shows. Defaults to "installed" —
+   *  the plugin's original behaviour (disk-read appmanifests). */
+  const [librarySource, setLibrarySource] = useState<LibrarySource>("installed");
+  /** Set when the "All games" CDP read fails (Steam unreachable) so the
+   *  grid can show an actionable empty state instead of a bare "no
+   *  games". Cleared whenever a fetch starts. */
+  const [loadError, setLoadError] = useState<string | null>(null);
   /** Toggles between library grid and inline settings card. */
   const [showConfig, setShowConfig] = useState(false);
   /** Header search query — filters the grid in place. */
@@ -176,8 +195,20 @@ function ProtonDBBadges() {
   useEffect(() => {
     void call("getSettings").then((s) => setSettings(s as ProtonDBSettings));
     void call("getStatus").then((s) => setStatus(s as StatusInfo));
-    void call("listInstalledGames")
+  }, [call]);
+
+  // Load the grid's games for the selected source. "installed" reads
+  // appmanifests off disk; "all" pulls the full owned library from
+  // Steam over CDP (and can fail if Steam isn't reachable — surface
+  // that as `loadError` rather than a silent empty grid).
+  useEffect(() => {
+    let alive = true;
+    setInstalled(null);
+    setLoadError(null);
+    const rpc = librarySource === "all" ? "listAllGames" : "listInstalledGames";
+    call(rpc)
       .then((games) => {
+        if (!alive) return;
         const list = Array.isArray(games)
           ? (games as BareInstalledGame[])
           : [];
@@ -192,8 +223,34 @@ function ProtonDBBadges() {
           })),
         );
       })
-      .catch(() => setInstalled([]));
-  }, [call]);
+      .catch((err) => {
+        if (!alive) return;
+        setInstalled([]);
+        if (librarySource === "all") {
+          setLoadError(
+            "Couldn't read your full Steam library. Make sure Steam is running, then try again.",
+          );
+        }
+        console.warn(`[protondb-badges] ${rpc} failed:`, err);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [call, librarySource]);
+
+  // Open the game in Steam and land on its ProtonDB page — the same
+  // destination the injected library badge reaches. Hide the overlay
+  // first so the Steam UI / ProtonDB page isn't obscured, then drive
+  // Steam from the backend over CDP.
+  const handleOpenGame = useCallback(
+    (appId: string) => {
+      void hideOverlay().catch(() => {});
+      void call("openProtonDb", { appId }).catch((err) => {
+        console.warn("[protondb-badges] openProtonDb failed:", err);
+      });
+    },
+    [call],
+  );
 
   useEvent({
     event: "stateChanged",
@@ -292,7 +349,12 @@ function ProtonDBBadges() {
   const subtitle = (() => {
     if (showConfig) return "Plugin preferences";
     if (installed === null) return "Reading Steam library…";
-    if (installed.length === 0) return "No installed Steam games found";
+    if (loadError) return "Steam library unavailable";
+    if (installed.length === 0) {
+      return librarySource === "all"
+        ? "No Steam games found"
+        : "No installed Steam games found";
+    }
     const total = installed.length;
     const shown = visibleGames?.length ?? total;
     const filteringCopy =
@@ -322,6 +384,14 @@ function ProtonDBBadges() {
         </div>
 
         <div className="flex items-center gap-2 shrink-0">
+          {!showConfig && (
+            <Select<LibrarySource>
+              value={librarySource}
+              options={LIBRARY_SOURCE_OPTIONS}
+              onChange={setLibrarySource}
+              size="sm"
+            />
+          )}
           {!showConfig && (
             <SearchField
               value={searchQuery}
@@ -392,9 +462,13 @@ function ProtonDBBadges() {
           {visibleGames && visibleGames.length === 0 ? (
             <div className="card">
               <div className="text-center py-10 text-[var(--fg-3)]">
-                {searchQuery.trim()
-                  ? `No installed games match "${searchQuery.trim()}".`
-                  : "No installed Steam games found. Install something via Steam first."}
+                {loadError
+                  ? loadError
+                  : searchQuery.trim()
+                    ? `No games match "${searchQuery.trim()}".`
+                    : librarySource === "all"
+                      ? "No Steam games found in your library."
+                      : "No installed Steam games found. Install something via Steam first."}
               </div>
             </div>
           ) : (
@@ -412,6 +486,7 @@ function ProtonDBBadges() {
                     String(currentGame.appId) === game.appId
                   }
                   onTier={reportTier}
+                  onPick={() => handleOpenGame(game.appId)}
                 />
               ))}
             </div>
@@ -434,10 +509,12 @@ function ProtonDBGameCard({
   game,
   isCurrent,
   onTier,
+  onPick,
 }: {
   game: GridGame;
   isCurrent: boolean;
   onTier: (appId: string, tier: TierKey | "pending" | null) => void;
+  onPick: () => void;
 }) {
   const { call } = useBackend("protondb-badges");
   const [report, setReport] = useState<ProtonDBReport | null>(null);
@@ -533,6 +610,7 @@ function ProtonDBGameCard({
       }
       highlighted={isCurrent}
       rootRef={handleRootRef}
+      onPick={onPick}
     />
   );
 }

--- a/plugins/protondb-badges/backend.test.ts
+++ b/plugins/protondb-badges/backend.test.ts
@@ -5,6 +5,35 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as pluginStorage from "@loadout/plugin-storage";
 
+// ── steam-cdp mock ──────────────────────────────────────────────────
+// The backend reaches into Steam over CDP for `listAllGames` (reads
+// appStore.allApps) and `openProtonDb` (navigates Steam + opens the
+// ProtonDB page). Mock the module so these paths are deterministic and
+// don't touch a real Steam debug port. `mock.module` is scoped to this
+// file's run; the suite runs in isolation (no cross-file bleed).
+class SteamClientUnreachableErrorMock extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SteamClientUnreachableError";
+  }
+}
+
+// Per-test handle so individual cases can stub behaviour.
+const steamCdpMock = {
+  /** Replaced per-test; receives the fake SteamClient surface. */
+  withSteamClient: mock(
+    async (_fn: (sc: unknown) => Promise<unknown>): Promise<unknown> => {
+      throw new SteamClientUnreachableErrorMock("Steam not reachable in test");
+    },
+  ),
+};
+
+mock.module("@loadout/steam-cdp", () => ({
+  withSteamClient: (fn: (sc: unknown) => Promise<unknown>) =>
+    steamCdpMock.withSteamClient(fn),
+  SteamClientUnreachableError: SteamClientUnreachableErrorMock,
+}));
+
 import ProtonDBBadgesBackend from "./backend";
 
 // ── Module-level fetch mock ─────────────────────────────────────────
@@ -36,6 +65,13 @@ describe("ProtonDBBadgesBackend", () => {
     process.env.XDG_CACHE_HOME = tmpCacheRoot;
 
     globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    // Default: Steam unreachable. Cases that need a connected client
+    // override `steamCdpMock.withSteamClient` themselves.
+    steamCdpMock.withSteamClient.mockReset();
+    steamCdpMock.withSteamClient.mockImplementation(async () => {
+      throw new SteamClientUnreachableErrorMock("Steam not reachable in test");
+    });
 
     // spyOn instead of mock.module — the backend imports from
     // @loadout/plugin-storage as a namespace, so a spy patches the
@@ -521,6 +557,67 @@ describe("ProtonDBBadgesBackend", () => {
     it("getCurrentRouteAppId returns null before any route is observed", async () => {
       const appId = await backend.getCurrentRouteAppId();
       expect(appId).toBeNull();
+    });
+  });
+
+  describe("listAllGames", () => {
+    it("reads, maps, and alphabetically sorts appStore.allApps over CDP", async () => {
+      const getAllApps = mock(async () => [
+        { appId: "730", name: "Counter-Strike 2" },
+        { appId: "440", name: "Team Fortress 2" },
+        { appId: "570", name: "Dota 2" },
+      ]);
+      steamCdpMock.withSteamClient.mockImplementation(
+        async (fn: (sc: unknown) => Promise<unknown>) =>
+          fn({ apps: { getAllApps } }),
+      );
+
+      const games = await backend.listAllGames();
+      expect(getAllApps).toHaveBeenCalledTimes(1);
+      expect(games).toEqual([
+        { appId: "730", name: "Counter-Strike 2" },
+        { appId: "570", name: "Dota 2" },
+        { appId: "440", name: "Team Fortress 2" },
+      ]);
+    });
+
+    it("propagates SteamClientUnreachableError when Steam is down", async () => {
+      // Default beforeEach impl already throws unreachable.
+      await expect(backend.listAllGames()).rejects.toBeInstanceOf(
+        SteamClientUnreachableErrorMock,
+      );
+    });
+  });
+
+  describe("openProtonDb", () => {
+    it("navigates Steam to the game then opens its ProtonDB page", async () => {
+      const executeSteamURL = mock(async (_url: string) => {});
+      const openWebUrl = mock(async (_url: string) => {});
+      steamCdpMock.withSteamClient.mockImplementation(
+        async (fn: (sc: unknown) => Promise<unknown>) =>
+          fn({ url: { executeSteamURL, openWebUrl } }),
+      );
+
+      await backend.openProtonDb({ appId: "620" });
+      expect(executeSteamURL).toHaveBeenCalledWith(
+        "steam://nav/games/details/620",
+      );
+      expect(openWebUrl).toHaveBeenCalledWith(
+        "https://www.protondb.com/app/620",
+      );
+    });
+
+    it("rejects on an empty appId", async () => {
+      await expect(backend.openProtonDb({ appId: "" })).rejects.toThrow(
+        /non-empty string/,
+      );
+      expect(steamCdpMock.withSteamClient).not.toHaveBeenCalled();
+    });
+
+    it("propagates SteamClientUnreachableError when Steam is down", async () => {
+      await expect(
+        backend.openProtonDb({ appId: "620" }),
+      ).rejects.toBeInstanceOf(SteamClientUnreachableErrorMock);
     });
   });
 });

--- a/plugins/protondb-badges/backend.ts
+++ b/plugins/protondb-badges/backend.ts
@@ -5,6 +5,10 @@ import {
 } from "@loadout/steam-paths";
 import { SteamCefBadgeInjector } from "@loadout/steam-cef-badges";
 import {
+  SteamClientUnreachableError,
+  withSteamClient,
+} from "@loadout/steam-cdp";
+import {
   readPluginStorage,
   writePluginStorage,
 } from "@loadout/plugin-storage";
@@ -243,6 +247,65 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
    */
   async listInstalledGames(): Promise<InstalledGame[]> {
     return listInstalledGames();
+  }
+
+  /**
+   * Enumerate the user's *entire owned* Steam library (not just the
+   * installed titles) by reading `window.appStore.allApps` from Steam's
+   * SharedJSContext tab over CDP. Unlike `listInstalledGames`, this
+   * reaches owned-but-not-installed games — there's no
+   * `appmanifest_*.acf` on disk for those, so the CDP read is the only
+   * source.
+   *
+   * Returns the same `{ appId, name }` shape as `listInstalledGames`,
+   * sorted alphabetically by name so the grid order is stable. Throws
+   * `SteamClientUnreachableError` (surfaced to the overlay) when Steam
+   * isn't reachable on its CDP port — the overlay then falls back to
+   * the installed list.
+   */
+  async listAllGames(): Promise<InstalledGame[]> {
+    const apps = await withSteamClient((sc) => sc.apps.getAllApps());
+    return apps
+      .map((a) => ({ appId: a.appId, name: a.name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /**
+   * Open a game in the Steam UI and navigate to its ProtonDB page —
+   * the same destination the injected library/store badge reaches when
+   * clicked. Invoked from the overlay grid after the overlay hides
+   * itself, so the user lands on the Steam app's details page with the
+   * ProtonDB site open in Steam's in-client browser.
+   *
+   * Two steps through one serialised `withSteamClient` session:
+   *   1. `steam://nav/games/details/<appId>` — focuses the game's
+   *      details page in the Steam UI.
+   *   2. `window.open("https://www.protondb.com/app/<appId>")` — opens
+   *      ProtonDB in Steam's built-in browser, mirroring the badge's
+   *      own `window.open` exactly.
+   */
+  async openProtonDb({ appId }: { appId: string }): Promise<void> {
+    if (typeof appId !== "string" || appId.length === 0) {
+      throw new Error("openProtonDb: appId must be a non-empty string");
+    }
+    try {
+      await withSteamClient(async (sc) => {
+        await sc.url.executeSteamURL(`steam://nav/games/details/${appId}`);
+        await sc.url.openWebUrl(`https://www.protondb.com/app/${appId}`);
+      });
+    } catch (err) {
+      if (err instanceof SteamClientUnreachableError) {
+        console.warn(
+          `[protondb-badges] openProtonDb: Steam unreachable for ${appId}: ${err.message}`,
+        );
+      } else {
+        console.error(
+          `[protondb-badges] openProtonDb failed for ${appId}:`,
+          err,
+        );
+      }
+      throw err;
+    }
   }
 
   async searchGames(query: string): Promise<SteamSearchResult[]> {


### PR DESCRIPTION
## Summary

Two additions to the ProtonDB Badges overlay grid:

1. **Library-source dropdown** beside the existing game filter — a `Select` with **Installed games** (default, unchanged disk-read behaviour) and **All games** (the user's full owned Steam library). Switching re-populates the grid.
2. **Tile click → open in Steam, then ProtonDB.** Clicking a game now closes the overlay (`hideOverlay`) and drives the Steam UI to the game's details page, then opens its ProtonDB page in Steam's in-client browser — the same destination clicking the injected library/store badge reaches.

## How the "open in Steam → ProtonDB" navigation is wired (key design decision)

The injected badge (in `backend.ts`) runs *inside Steam's CEF* and does `window.open("https://www.protondb.com/app/" + appId)`. The overlay runs in a *different* CEF context, so it can't call that directly. Instead:

- The overlay tile's `onPick` calls `hideOverlay()` then a new backend RPC `openProtonDb({ appId })`.
- `openProtonDb` runs one serialised `withSteamClient` session that (a) `executeSteamURL("steam://nav/games/details/<appId>")` to focus the game in the Steam UI, then (b) `openWebUrl("https://www.protondb.com/app/<appId>")` — a new `UrlApi.openWebUrl` helper in `@loadout/steam-cdp` that evals `window.open(url, "_blank")` in Steam's SharedJSContext tab, **reproducing the badge's exact behaviour** (ProtonDB opens in Steam's built-in browser, not a desktop browser).

This reuses the existing `withSteamClient` / `executeSteamURL` plumbing already used by quick-links/store-bridge, and keeps SteamClient's "one typed method per Steam API call" convention.

## "All games" source

There was no existing RPC for the full owned library (every prior path reads installed `appmanifest_*.acf`). Added `AppsApi.getAllApps()` to `@loadout/steam-cdp`, which reads `window.appStore.allApps` over CDP, filters to `app_type === 1` (games), and projects to `{ appId, name }`. Backend `listAllGames` wraps it (sorted, alphabetical). Failures (Steam unreachable) surface as an actionable empty state in the grid; "Installed" stays fast/offline.

## Test plan

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (57 pre-existing `any` warnings)
- `bun run test:backend` — 2035 pass (incl. new `listAllGames` + `openProtonDb` cases: success, empty-appId guard, Steam-unreachable propagation)
- `bun run test:ui` — 330 pass (incl. new cases: dropdown defaults to Installed without hitting `listAllGames`; switching to All games fetches the full library; clicking a tile hides the overlay and calls `openProtonDb` with the appId)

🤖 Generated with [Claude Code](https://claude.com/claude-code)