### PR TITLE
Open the overlay for first-run setup + local release script

### DIFF
--- a/apps/loadout-overlay/src/webview/main.tsx
+++ b/apps/loadout-overlay/src/webview/main.tsx
@@ -22,6 +22,7 @@ import { initBackend } from "@overlay/lib/backend";
 import { getConfigValue, loadUserConfig } from "@overlay/lib/userConfig";
 import { runStartupInits } from "@overlay/lib/pluginInit";
 import { ensureConnected, subscribe } from "@loadout/ui/ws-client";
+import { showOverlay } from "@overlay/lib/host";
 import {
   onOverlayAction,
   onOverlayOpenPlugin,
@@ -115,6 +116,18 @@ async function boot() {
         if (isReloadEvent(data) && (data.plugin === "__overlay" || data.plugin === "__sdk")) {
           location.reload();
         }
+      },
+    });
+
+    // Pop the overlay on demand: the loader broadcasts this when something
+    // hits its GET/POST /show endpoint (the installer's first-run setup,
+    // or a desktop launcher). The loader can't reach the overlay's Bun
+    // main process directly, so it routes through here → the show() RPC.
+    subscribe({
+      plugin: "__overlay",
+      event: "show",
+      handler: () => {
+        void showOverlay();
       },
     });
     runStartupInits().catch((err) => {

--- a/apps/loadout/src/loader/index.ts
+++ b/apps/loadout/src/loader/index.ts
@@ -373,6 +373,17 @@ export async function startServer(options: ServerOptions = {}) {
         return new Response("ok");
       }
 
+      // --- Show the overlay on demand (loopback-only, unauthenticated
+      //     like /up). Lets the installer — or a desktop launcher — pop
+      //     the overlay window for first-run wake-button setup without a
+      //     session token. The loader can't reach the overlay main
+      //     process directly, so it broadcasts to the webview, which calls
+      //     the overlay's show() RPC (see App.tsx __overlay listener).
+      if (url.pathname === "/show") {
+        broadcast({ type: "event", plugin: "__overlay", event: "show", data: {} });
+        return new Response("ok");
+      }
+
       // --- API (all /api/* routes require authentication) ---
 
       if (url.pathname.startsWith("/api/") && !validateRequest(req)) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -925,6 +925,36 @@ OVERLAYEOF
         systemctl --user daemon-reload
         systemctl --user enable loadout-overlay
         success "Overlay service enabled (starts with graphical session)"
+
+        # Start it right now (not just on next login) and pop the window so
+        # the user can set their wake button immediately — no reboot, no
+        # Steam restart needed for this (that's only for Gaming Mode focus).
+        # Needs a graphical session; import its env so the user manager can
+        # find the display. Skips cleanly on headless / SSH installs.
+        if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
+            systemctl --user import-environment DISPLAY WAYLAND_DISPLAY XAUTHORITY 2>/dev/null || true
+            if systemctl --user restart loadout-overlay 2>/dev/null; then
+                # Give the overlay a moment to come up and connect, then ask
+                # the loader to show it (loopback /show endpoint).
+                show_ok=0
+                for _ in 1 2 3 4 5 6 7 8 9 10; do
+                    if curl -fsS "http://localhost:$OVERLAY_PORT/show" >/dev/null 2>&1; then
+                        show_ok=1
+                        break
+                    fi
+                    sleep 1
+                done
+                if [ "$show_ok" = "1" ]; then
+                    success "Overlay opened — set your wake button, then close it."
+                else
+                    info "Overlay started; open it from your apps menu to set a wake button."
+                fi
+            else
+                warn "Couldn't start the overlay now; it'll start with your next graphical session."
+            fi
+        else
+            info "No graphical session detected — the overlay starts on your next login."
+        fi
     fi
 
     echo ""

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Build + publish a Loadout "rolling" GitHub release from this machine,
+# using the gh CLI. A local-operator mirror of .github/workflows/release.yml
+# for when you'd rather cut a release by hand than run the Actions workflow.
+#
+# Produces the exact assets scripts/install.sh expects, for the host arch:
+#   loadout-<arch>                  the compiled loader binary
+#   loadout-overlay-<arch>.tar.xz   the Electrobun/CEF overlay tree
+#   loadout-plugins-<arch>.tar.xz   plugins/ + one hoisted node_modules/
+#   SHA256SUMS                      checksums install.sh verifies against
+#
+# It replaces the single rolling release tagged `rolling` (marked
+# GitHub-"latest"), so `releases/latest` — which install.sh fetches —
+# always points at the newest build.
+#
+# Prereqs: bun, gh (authenticated: `gh auth login`), xz, tar, sha256sum.
+#
+# Usage:
+#   sh scripts/release-local.sh            # build + publish
+#   sh scripts/release-local.sh --dry-run  # build + package, skip the upload
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO="srsholmes/loadout"
+TAG="rolling"
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+case "$(uname -m)" in
+    x86_64) ARCH="x86_64" ;;
+    aarch64) ARCH="aarch64" ;;
+    *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+OUT="$ROOT/dist/release"
+OVERLAY_TREE="$ROOT/apps/loadout-overlay/build/dev-linux-x64/loadout-overlay-dev"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing required tool: $1" >&2; exit 1; }; }
+need bun; need tar; need xz; need sha256sum
+[ "$DRY_RUN" = "1" ] || need gh
+
+echo "==> Building (bun run build) ..."
+( cd "$ROOT" && bun run build )
+
+if [ ! -f "$ROOT/dist/loadout" ]; then
+    echo "build did not produce dist/loadout" >&2; exit 1
+fi
+if [ ! -d "$OVERLAY_TREE" ]; then
+    echo "overlay tree not found at $OVERLAY_TREE (electrobun build may have failed)" >&2; exit 1
+fi
+
+rm -rf "$OUT"; mkdir -p "$OUT"
+
+echo "==> Packaging assets for $ARCH ..."
+# 1. Loader binary.
+cp "$ROOT/dist/loadout" "$OUT/loadout-${ARCH}"
+
+# 2. Overlay tree (strip-components=1 on the install side expects the
+#    top-level loadout-overlay-dev/ dir).
+tar -C "$(dirname "$OVERLAY_TREE")" -cJf "$OUT/loadout-overlay-${ARCH}.tar.xz" loadout-overlay-dev
+
+# 3. Plugins + hoisted node_modules.
+STAGE="$(mktemp -d)"
+sh "$ROOT/scripts/prepare-plugins.sh" "$STAGE"
+tar -C "$STAGE" -cJf "$OUT/loadout-plugins-${ARCH}.tar.xz" plugins node_modules
+rm -rf "$STAGE"
+
+# 4. Checksums (computed from inside $OUT so the file lists bare names,
+#    which is what install.sh greps for).
+( cd "$OUT" && sha256sum \
+    "loadout-${ARCH}" \
+    "loadout-overlay-${ARCH}.tar.xz" \
+    "loadout-plugins-${ARCH}.tar.xz" \
+    > SHA256SUMS )
+
+echo "==> Assets:"
+( cd "$OUT" && ls -lh loadout-${ARCH} loadout-overlay-${ARCH}.tar.xz loadout-plugins-${ARCH}.tar.xz SHA256SUMS )
+
+if [ "$DRY_RUN" = "1" ]; then
+    echo "==> --dry-run: skipping upload. Assets are in $OUT"
+    exit 0
+fi
+
+echo "==> Publishing release '$TAG' to $REPO ..."
+ASSETS="$OUT/loadout-${ARCH} $OUT/loadout-overlay-${ARCH}.tar.xz $OUT/loadout-plugins-${ARCH}.tar.xz $OUT/SHA256SUMS"
+NOTES="Rolling build from $(git -C "$ROOT" rev-parse --short HEAD). Install: curl -fsSL https://raw.githubusercontent.com/$REPO/main/scripts/install.sh | sh"
+
+if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+    # Re-upload the per-arch assets (and SHA256SUMS) over the existing
+    # rolling release. --clobber replaces same-named assets so re-running
+    # for the same arch is idempotent; other arches' assets are untouched.
+    # shellcheck disable=SC2086
+    gh release upload "$TAG" $ASSETS --clobber --repo "$REPO"
+    gh release edit "$TAG" --latest --repo "$REPO" >/dev/null
+else
+    # shellcheck disable=SC2086
+    gh release create "$TAG" $ASSETS \
+        --repo "$REPO" \
+        --title "Rolling build (latest main)" \
+        --notes "$NOTES" \
+        --latest
+fi
+
+echo "==> Done. install.sh will pull this via releases/latest."


### PR DESCRIPTION
Makes a fresh `curl | sh` install end with the overlay **open on the desktop**, so the user can set their wake button straight away — no reboot, no Steam restart. Also adds a local release script so we can cut the first GitHub release by hand.

## Overlay first-run open
The overlay only shows on a wake event (F16 / Deck button), which a first-time user hasn't bound yet. This wires an on-demand show:

- **Loader** — new **`/show`** endpoint: loopback-only, unauthenticated like `/up` (no session token needed). It `broadcast()`s a `__overlay`/`show` event to webview clients.
- **Webview** (`main.tsx`) — subscribes to `__overlay`/`show` and calls the existing `showOverlay()` host RPC (the overlay's Bun main already exposes `show`/`hide`/`toggle`). The loader can't reach the overlay process directly, so it routes through the webview.
- **`install.sh`** — after install, starts the overlay user service immediately (importing the session `DISPLAY`/`WAYLAND_DISPLAY`/`XAUTHORITY`), waits for it to come up, then `curl`s `/show`. Skips cleanly on headless/SSH. Messaging clarifies the Steam restart is only needed for Gaming-Mode focus.

## Local release script
`scripts/release-local.sh` mirrors `.github/workflows/release.yml` but runs from a dev machine via `gh`, producing the four assets `install.sh` expects for the host arch and publishing/refreshing the rolling release (`--latest`):
`loadout-<arch>`, `loadout-overlay-<arch>.tar.xz`, `loadout-plugins-<arch>.tar.xz`, `SHA256SUMS`. `--dry-run` builds + packages without uploading.

## Test plan
- `bun run typecheck` — clean
- `bun run test:backend` (2030) / `bun run test:ui` (327) — green
- ⚠️ **Needs on-device verification:** the CEF `show()` under a desktop X session can't be exercised in CI — confirm the window actually pops after `install.sh` on a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)