### PR TITLE
fix(overlay): fix window move/resize crash via patched native wrapper (electrobun #426)

### DIFF
--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -252,6 +252,16 @@ const overlay = new BrowserWindow({
   title: "Loadout Overlay",
   frame: { x: 0, y: 0, width: OVERLAY_WIDTH, height: OVERLAY_HEIGHT },
   titleBarStyle: "default",
+  // Create the window NON-RESIZABLE. Live drag-resize crashes the overlay:
+  // dragging a corner (or dragging the window between monitors) streams a
+  // storm of geometry changes that reallocate CEF's window surface faster
+  // than it can keep up → SIGSEGV/SIGABRT with non-deterministic crash
+  // sites (heap corruption). A SINGLE atomic geometry change is safe — the
+  // WM "maximise" button never crashed in testing — so we disable user
+  // resize and instead maximise on open (see toggleOverlay). This overrides
+  // Electrobun's hardcoded `Resizable: true` default via the styleMask
+  // spread in BrowserWindow's constructor.
+  styleMask: { Resizable: false },
   transparent: false,
   hidden: !DESKTOP_SMOKE_TEST,
   url: process.env.ELECTROBUN_DEV_URL ?? "views://overlay/index.html",
@@ -507,6 +517,18 @@ function toggleOverlay(source: string) {
     intercept.current?.grab();
     ipIntercept.current?.grab();
     overlay.show();
+    // Fill the screen with a single, safe geometry change. Drag-resize is
+    // disabled (it crashes CEF — see BrowserWindow creation), so maximise
+    // is how the window grows to fit the display. Desktop only: under
+    // gamescope the window is already born at the inner-X resolution and
+    // there's no WM to maximise against.
+    if (!gamescopeMode) {
+      try {
+        overlay.maximize();
+      } catch (e) {
+        console.warn("[overlay] maximize on open failed:", e);
+      }
+    }
     atoms.show().catch((e) => console.warn("[overlay] atoms.show:", e));
     state.isOpen = true;
     broadcastOverlayVisibility();

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -252,16 +252,12 @@ const overlay = new BrowserWindow({
   title: "Loadout Overlay",
   frame: { x: 0, y: 0, width: OVERLAY_WIDTH, height: OVERLAY_HEIGHT },
   titleBarStyle: "default",
-  // Create the window NON-RESIZABLE. Live drag-resize crashes the overlay:
-  // dragging a corner (or dragging the window between monitors) streams a
-  // storm of geometry changes that reallocate CEF's window surface faster
-  // than it can keep up → SIGSEGV/SIGABRT with non-deterministic crash
-  // sites (heap corruption). A SINGLE atomic geometry change is safe — the
-  // WM "maximise" button never crashed in testing — so we disable user
-  // resize and instead maximise on open (see toggleOverlay). This overrides
-  // Electrobun's hardcoded `Resizable: true` default via the styleMask
-  // spread in BrowserWindow's constructor.
-  styleMask: { Resizable: false },
+  // The window is freely resizable. The drag-resize / drag-between-monitors
+  // crash was an Xlib thread-safety bug in Electrobun's native wrapper
+  // (OnPaint painted the OSR buffer on the CEF UI thread while
+  // process_x11_events drained events on the main thread, same Display, no
+  // XInitThreads) — fixed in our patched libNativeWrapper.so (electrobun
+  // #426). See apps/loadout-overlay/vendor/README.md.
   transparent: false,
   hidden: !DESKTOP_SMOKE_TEST,
   url: process.env.ELECTROBUN_DEV_URL ?? "views://overlay/index.html",
@@ -517,18 +513,6 @@ function toggleOverlay(source: string) {
     intercept.current?.grab();
     ipIntercept.current?.grab();
     overlay.show();
-    // Fill the screen with a single, safe geometry change. Drag-resize is
-    // disabled (it crashes CEF — see BrowserWindow creation), so maximise
-    // is how the window grows to fit the display. Desktop only: under
-    // gamescope the window is already born at the inner-X resolution and
-    // there's no WM to maximise against.
-    if (!gamescopeMode) {
-      try {
-        overlay.maximize();
-      } catch (e) {
-        console.warn("[overlay] maximize on open failed:", e);
-      }
-    }
     atoms.show().catch((e) => console.warn("[overlay] atoms.show:", e));
     state.isOpen = true;
     broadcastOverlayVisibility();

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -225,11 +225,14 @@ function sendToWebview<K extends keyof WebviewMessages>(
   }
 }
 
-// Overlay window size, decided once at startup and *born at size* — the
-// window is never resized live, because under `GDK_GL=disable` the
-// software-rendered CEF surface segfaults on reallocation (PR #113).
+// Overlay window size, decided once at startup so the window is *born at
+// the right size*. Live resize is now safe: GDK_GL=disable was removed
+// from the unit (it forced software rendering, and reallocating the
+// software-rendered CEF surface on resize segfaulted — PR #113), so with
+// GL re-enabled the user can drag-resize the desktop window freely.
 //
 // Desktop: 1920×1080 so the overlay opens large on a monitor (issue #108).
+// The window stays resizable, so users on smaller panels can shrink it.
 //
 // Gaming Mode: size to the gamescope inner-X resolution so the X11 window
 // maps 1:1 to the visible output. Born too large (the 1920×1080 default on

--- a/apps/loadout-overlay/src/bun/native/screen-size.ts
+++ b/apps/loadout-overlay/src/bun/native/screen-size.ts
@@ -6,11 +6,13 @@
 // cursor only reaches a corner of the window and clicks land far from
 // where they're drawn (issue #106).
 //
-// We can't fix this by resizing the live CEF window — under
-// `GDK_GL=disable` the GTK/CEF surface is software-rendered and
-// reallocating it on resize segfaults CEF (see PR #113). So the size has
-// to be known *before* `new BrowserWindow(...)`, which is why the probe
-// here is synchronous: it runs once, inline, at startup.
+// We size the window correctly up front rather than resizing it live on
+// show(): the gamescope pointer-mapping fix needs the right size *before*
+// `new BrowserWindow(...)`, which is why the probe here is synchronous —
+// it runs once, inline, at startup. (Historically live resize was also
+// unsafe because `GDK_GL=disable` forced software rendering and
+// reallocating that surface segfaulted CEF — PR #113; that flag has since
+// been removed, so user-driven resize is fine.)
 //
 // xrandr is the right source (not /sys/class/drm): we want the inner X
 // server's screen size — the same space `_positionOnPrimary` queries —

--- a/apps/loadout-overlay/vendor/README.md
+++ b/apps/loadout-overlay/vendor/README.md
@@ -1,10 +1,15 @@
 # Patched Electrobun native wrapper (`libNativeWrapper.so`)
 
 This directory vendors a **patched build of Electrobun's Linux native wrapper**
-that fixes a 100%-CPU busy-loop in the overlay's CEF browser process. The build
-step (`scripts/build.sh`) copies `libNativeWrapper.so` from here over the stock
-one that `electrobun build --release` downloads, so clones and CI releases get
-the fix automatically.
+that fixes two bugs in the overlay's CEF browser process:
+
+1. A **100%-CPU busy-loop** (the original reason this vendor exists).
+2. A **multithreaded-Xlib crash on window move/resize** (upstream electrobun
+   #426) — see "The move/resize crash" below.
+
+The build step (`scripts/build.sh`) copies `libNativeWrapper.so` from here over
+the stock one that `electrobun build --release` downloads, so clones and CI
+releases get both fixes automatically.
 
 ## The bug it fixes
 
@@ -45,6 +50,34 @@ Verified on-device: overlay renders, opens/closes, window maps/unmaps, clean
 shutdown, no regressions.
 
 See `nativeWrapper.cpp.patch` for the exact diff.
+
+## The move/resize crash (electrobun #426)
+
+Dragging the overlay window — resizing from a corner, or moving it between
+monitors — crashed the whole app with `Signal 11` (and sometimes `SIGABRT`),
+with non-deterministic backtraces in JSC's GC. Reproducible in a **pristine
+`electrobun init` CEF app** on 1.16.0 **and** 1.18.1, so it's an upstream bug,
+not ours (filed upstream as #426).
+
+Root cause: **Xlib is driven from two threads with no `XInitThreads()`**.
+`ElectrobunClient::OnPaint` (CEF UI thread) does `XCreateImage` / `XPutImage` /
+`XFlush` on the **same `Display*`** that `process_x11_events` (the main/GTK
+thread) drains events from. Without `XInitThreads()` those concurrent Xlib
+calls corrupt Xlib's internal request heap during a move/resize event storm —
+the corruption then surfaces as a SIGSEGV/SIGABRT in an unrelated thread
+(usually JSC GC), which is why the backtraces looked random.
+
+The fix is two changes in `runCEFEventLoop`/`process_x11_events`:
+
+- **`XInitThreads()`** as the first call in `initializeGTK()` (before
+  `gtk_init` and any `XOpenDisplay`), so Xlib serializes cross-thread calls.
+- **Coalesce `ConfigureNotify`**: a drag emits a storm of them; we collapse the
+  pending burst to the latest geometry (`XCheckTypedWindowEvent`) and fire the
+  JS move/resize callbacks + the CEF `WasResized()`/OSR re-render **at most once
+  per tick**, and only when x/y (move) or w/h (resize) actually changed — a pure
+  move no longer triggers an OSR repaint storm.
+
+Both are in `nativeWrapper.cpp.patch` alongside the CPU-spin fix.
 
 ## Provenance
 

--- a/apps/loadout-overlay/vendor/nativeWrapper.cpp.patch
+++ b/apps/loadout-overlay/vendor/nativeWrapper.cpp.patch
@@ -1,8 +1,6 @@
-diff --git a/package/src/native/linux/nativeWrapper.cpp b/package/src/native/linux/nativeWrapper.cpp
-index 36310d6..87818a6 100644
---- a/package/src/native/linux/nativeWrapper.cpp
-+++ b/package/src/native/linux/nativeWrapper.cpp
-@@ -802,8 +802,7 @@ public:
+--- a/package/src/native/linux/nativeWrapper.cpp	2026-06-20 23:05:57.612319441 +0100
++++ b/package/src/native/linux/nativeWrapper.cpp	2026-06-20 23:07:06.899297213 +0100
+@@ -802,8 +802,7 @@
          // In multi-process mode, return nullptr so render process uses the helper
          return nullptr;
      }
@@ -12,7 +10,7 @@ index 36310d6..87818a6 100644
      void OnContextInitialized() override {
          CefRegisterSchemeHandlerFactory("views", "", new ViewsSchemeHandlerFactory());
      }
-@@ -2046,6 +2045,7 @@ bool initializeCEF() {
+@@ -2046,6 +2045,7 @@
      CefSettings settings;
      settings.no_sandbox = true;
      settings.windowless_rendering_enabled = true;  // Required for OSR/transparent windows
@@ -20,7 +18,94 @@ index 36310d6..87818a6 100644
      settings.log_severity = LOGSEVERITY_ERROR;  // Change to WARNING to see more CEF logs
      // settings.remote_debugging_port = 9222;
      
-@@ -5882,20 +5882,38 @@ gboolean process_x11_events(gpointer data) {
+@@ -5307,6 +5307,17 @@
+     {
+         std::unique_lock<std::mutex> lock(g_gtkInitMutex);
+         if (!g_gtkInitialized) {
++            // loadout fix (electrobun #426): Xlib is driven from multiple
++            // threads — ElectrobunClient::OnPaint (CEF UI thread) does
++            // XCreateImage/XPutImage/XFlush on the SAME Display* that
++            // process_x11_events (main/GTK thread) drains events from. With
++            // no XInitThreads() those concurrent Xlib calls corrupt Xlib's
++            // internal request heap during a move/resize storm → random
++            // SIGSEGV/SIGABRT surfacing in unrelated (JSC GC) threads. This
++            // must run before gtk_init() and any XOpenDisplay(), so it is the
++            // very first call here.
++            XInitThreads();
++
+             // Force X11 backend on Wayland systems
+             setenv("GDK_BACKEND", "x11", 1);
+             
+@@ -5795,35 +5806,49 @@
+                     }
+                     break;
+                     
+-                case ConfigureNotify:
++                case ConfigureNotify: {
+                     // Only process ConfigureNotify events for the actual main window, not CEF child windows
+                     if (event.xconfigure.window != x11win->window) {
+                         break;
+                     }
+-                    
+-                    if (event.xconfigure.width != x11win->width || event.xconfigure.height != x11win->height ||
+-                        event.xconfigure.x != x11win->x || event.xconfigure.y != x11win->y) {
+-                        
+-                        
+-                        x11win->x = event.xconfigure.x;
+-                        x11win->y = event.xconfigure.y;
+-                        x11win->width = event.xconfigure.width;
+-                        x11win->height = event.xconfigure.height;
+-                        
+-                        // Call move callback when position changes
+-                        if (x11win->moveCallback) {
+-                            x11win->moveCallback(x11win->windowId, x11win->x, x11win->y);
+-                        }
+-                        
++
++                    // loadout fix (electrobun #426): a drag or monitor-cross
++                    // emits a STORM of ConfigureNotify events. Firing the JS
++                    // move/resize callbacks and a CEF WasResized()/OnPaint
++                    // re-render for every one floods both the JS worker and
++                    // the OSR pipeline and corrupts the heap. Coalesce the
++                    // whole pending burst down to the LATEST geometry first.
++                    XEvent latest = event;
++                    XEvent peek;
++                    while (XCheckTypedWindowEvent(x11win->display, x11win->window, ConfigureNotify, &peek)) {
++                        latest = peek;
++                    }
++
++                    bool moved   = (latest.xconfigure.x != x11win->x) || (latest.xconfigure.y != x11win->y);
++                    bool resized = (latest.xconfigure.width != x11win->width) || (latest.xconfigure.height != x11win->height);
++
++                    x11win->x = latest.xconfigure.x;
++                    x11win->y = latest.xconfigure.y;
++                    x11win->width = latest.xconfigure.width;
++                    x11win->height = latest.xconfigure.height;
++
++                    // Fire move only when the position actually changed.
++                    if (moved && x11win->moveCallback) {
++                        x11win->moveCallback(x11win->windowId, x11win->x, x11win->y);
++                    }
++
++                    // Fire resize + OSR re-layout only when the SIZE actually
++                    // changed. A pure move (same w/h) must NOT trigger a CEF
++                    // WasResized()/OnPaint storm — that was the move-crash.
++                    if (resized) {
+                         if (x11win->resizeCallback) {
+-                            x11win->resizeCallback(x11win->windowId, x11win->x, x11win->y, 
++                            x11win->resizeCallback(x11win->windowId, x11win->x, x11win->y,
+                                                     x11win->width, x11win->height);
+                         }
+-                        
+-                        // Auto-resize webviews in this window
+                         resizeAutoSizingWebviewsInWindow(x11win->windowId, x11win->width, x11win->height);
+                     }
+                     break;
++                }
+                     
+                 case Expose:
+                     // Handle expose events if needed
+@@ -5882,20 +5907,38 @@
  void runCEFEventLoop() {
      // Initialize GTK on the main thread (this MUST be done here)
      initializeGTK();
@@ -68,7 +153,7 @@ index 36310d6..87818a6 100644
      // Cleanup CEF on shutdown
  
      if (g_cefInitialized) {
-@@ -8938,9 +8956,15 @@ ELECTROBUN_EXPORT void stopEventLoop() {
+@@ -8938,9 +8981,15 @@
      g_shuttingDown.store(true);
      printf("[stopEventLoop] Initiating clean event loop exit\n");
  

--- a/loadout-overlay.service
+++ b/loadout-overlay.service
@@ -26,18 +26,18 @@ ExecStartPre=/bin/sh -c 'for i in $(seq 1 30); do curl -sf "http://localhost:${L
 # src/bun/native/display-detect.ts).
 Environment=HOME=%h
 
-# Disable GDK's GLX path. libNativeWrapper hosts CEF inside a GTK3 window;
-# on the gamescope X server (:0) GTK's GLX probe throws a recurring
-# "X11 Error: GLXBadWindow (code 170)" at startup (the GL surface targets a
-# window that's invalid under gamescope/desktop-mode compositing). CEF
-# renders the actual UI itself, so the GTK host window needs no GL — forcing
-# GDK to its software/cairo path removes the error cleanly with no visual
-# change. Must be set in the unit env: libNativeWrapper opens X in
-# startEventLoop() before our worker thread runs, so JS can't set it in time
-# (same reason DISPLAY is resolved in the ExecStart wrapper below).
-# NOTE: this clears the GLXBadWindow noise only; it does NOT fix the separate
-# CEF/GTK event-loop 100%-CPU spin (tracked elsewhere).
-Environment=GDK_GL=disable
+# NOTE: GDK_GL=disable was removed here. It only silenced a cosmetic
+# "X11 Error: GLXBadWindow (code 170)" GTK GLX-probe warning under
+# gamescope (CEF renders the UI itself, so the GTK host window needs no
+# GL). But forcing GDK to its software/cairo path made the CEF host
+# surface segfault when reallocated on a window resize — so in desktop
+# mode, dragging a resize handle crashed the overlay (the window is
+# created resizable; see BrowserWindow in src/bun/index.ts). Re-enabling
+# GL restores safe live resize. The GLXBadWindow line returns as harmless
+# log noise under gamescope; if it ever needs suppressing again, scope it
+# to gamescope mode only (e.g. export GDK_GL=disable from the ExecStart
+# wrapper when a gamescope display is detected) rather than setting it
+# unconditionally here.
 
 # CEF remote DevTools — attach Chrome to http://localhost:9222 on the
 # device or over SSH tunnel. Port is baked into the build via

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -853,18 +853,18 @@ ExecStartPre=/bin/sh -c 'for i in $(seq 1 30); do curl -sf "http://localhost:${L
 # src/bun/native/display-detect.ts).
 Environment=HOME=%h
 
-# Disable GDK's GLX path. libNativeWrapper hosts CEF inside a GTK3 window;
-# on the gamescope X server (:0) GTK's GLX probe throws a recurring
-# "X11 Error: GLXBadWindow (code 170)" at startup (the GL surface targets a
-# window that's invalid under gamescope/desktop-mode compositing). CEF
-# renders the actual UI itself, so the GTK host window needs no GL — forcing
-# GDK to its software/cairo path removes the error cleanly with no visual
-# change. Must be set in the unit env: libNativeWrapper opens X in
-# startEventLoop() before our worker thread runs, so JS can't set it in time
-# (same reason DISPLAY is resolved in the ExecStart wrapper below).
-# NOTE: this clears the GLXBadWindow noise only; it does NOT fix the separate
-# CEF/GTK event-loop 100%-CPU spin (tracked elsewhere).
-Environment=GDK_GL=disable
+# NOTE: GDK_GL=disable was removed here. It only silenced a cosmetic
+# "X11 Error: GLXBadWindow (code 170)" GTK GLX-probe warning under
+# gamescope (CEF renders the UI itself, so the GTK host window needs no
+# GL). But forcing GDK to its software/cairo path made the CEF host
+# surface segfault when reallocated on a window resize — so in desktop
+# mode, dragging a resize handle crashed the overlay (the window is
+# created resizable; see BrowserWindow in src/bun/index.ts). Re-enabling
+# GL restores safe live resize. The GLXBadWindow line returns as harmless
+# log noise under gamescope; if it ever needs suppressing again, scope it
+# to gamescope mode only (e.g. export GDK_GL=disable from the ExecStart
+# wrapper when a gamescope display is detected) rather than setting it
+# unconditionally here.
 
 # CEF remote DevTools — attach Chrome to http://localhost:9222 on the
 # device or over SSH tunnel. Port is baked into the build via


### PR DESCRIPTION
## Problem
On Linux desktop, the overlay crashed (Signal 11 / occasional SIGABRT, with random JSC-GC backtraces) whenever the window was **resized from a corner** or **dragged between monitors**. It crash-looped via `Restart=on-failure`.

## Root cause — upstream Electrobun bug (#426), not our code
Proven by reproducing the identical crash in a **pristine `electrobun init` CEF app** on both **1.16.0 and 1.18.1** (so upgrading doesn't fix it).

Electrobun's native wrapper drives **Xlib from two threads with no `XInitThreads()`**:
- `ElectrobunClient::OnPaint` (CEF UI thread) does `XCreateImage`/`XPutImage`/`XFlush` on the OSR buffer, on the **same `Display*`** that
- `process_x11_events` (main/GTK thread) drains X events from.

During a move/resize event storm those concurrent Xlib calls corrupt Xlib's internal request heap; the corruption then surfaces as a SIGSEGV/SIGABRT in an unrelated thread (usually JSC GC) — which is why the backtraces looked random and pointed at Bun's GC instead of the real site.

### Ruled out along the way
GL/`GDK_GL`, our libxcb property watcher (`OVERLAY_FORCE_XPROP=1`), CEF software rendering (`disable-gpu:false`), `force-device-scale-factor`, and the wrapper's CPU-spin message-loop patch — none were the cause. Confirmed via coredump symbol resolution that the crashing thread was inside `process_x11_events`.

## Fix
Two changes in the vendored `libNativeWrapper.so` (+ `nativeWrapper.cpp.patch`, built natively against CEF 145.0.23 — matches the bundled `libcef.so`):
1. **`XInitThreads()`** as the first call in `initializeGTK()` (before `gtk_init` / any `XOpenDisplay`) — serializes cross-thread Xlib access.
2. **Coalesce `ConfigureNotify`** — collapse a drag's event storm to the latest geometry (`XCheckTypedWindowEvent`) and fire the JS move/resize callbacks + CEF `WasResized()`/OSR re-render **at most once per tick**, only on an actual x/y (move) or w/h (resize) change. A pure move no longer triggers an OSR repaint storm.

Reverts the earlier interim non-resizable + maximise-on-open mitigation — **the window is freely resizable again.**

## Validation
On-device (dual monitor, 430-DPI handheld panel + 157-DPI 4K TV): aggressive corner-resize and repeated cross-monitor dragging **no longer crash**; the overlay's main process stays up (`NRestarts=0`). Confirmed both with a minimal hello-world and the full overlay (gamescope atoms + input intercept running).

## Files
- `apps/loadout-overlay/vendor/libNativeWrapper.so` — rebuilt patched wrapper.
- `apps/loadout-overlay/vendor/nativeWrapper.cpp.patch` + `README.md` — updated (CPU-spin + #426).
- `apps/loadout-overlay/src/bun/index.ts` — revert interim mitigation (free resize).

## Note
Also includes the earlier `GDK_GL=disable` removal (re-enables GTK host GL). That was an early hypothesis and is **not** part of the crash fix; it's harmless but brings back the cosmetic `GLXBadWindow` log line under gamescope. Say the word if you'd rather I restore `GDK_GL=disable` to keep gamescope logs quiet.

## Follow-up
Upstream PR to blackboardsh/electrobun #426 (apply the same two changes to `srsholmes/electrobun`) — that issue is currently undiagnosed, so this root-cause + fix would close it.