### PR TITLE
feat(overlay): add "Save logs" button to Settings (#130)

### DIFF
--- a/apps/loadout-overlay/src/bun/export-logs.test.ts
+++ b/apps/loadout-overlay/src/bun/export-logs.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "bun:test";
+import {
+  buildReport,
+  extractUiLogs,
+  timestampForFilename,
+} from "./export-logs";
+
+describe("timestampForFilename", () => {
+  test("renders a filesystem-safe local timestamp", () => {
+    // 2026-06-20 14:32:07 local time
+    const d = new Date(2026, 5, 20, 14, 32, 7);
+    expect(timestampForFilename(d)).toBe("2026-06-20_14-32-07");
+  });
+
+  test("zero-pads single-digit components", () => {
+    const d = new Date(2026, 0, 3, 4, 5, 6);
+    expect(timestampForFilename(d)).toBe("2026-01-03_04-05-06");
+  });
+});
+
+describe("extractUiLogs", () => {
+  test("returns the uiLogs string when present", () => {
+    expect(extractUiLogs({ uiLogs: "hello" })).toBe("hello");
+  });
+
+  test("returns empty string for malformed payloads", () => {
+    expect(extractUiLogs(undefined)).toBe("");
+    expect(extractUiLogs(null)).toBe("");
+    expect(extractUiLogs("nope")).toBe("");
+    expect(extractUiLogs({ uiLogs: 123 })).toBe("");
+    expect(extractUiLogs({})).toBe("");
+  });
+});
+
+describe("buildReport", () => {
+  const generatedAt = new Date(2026, 5, 20, 14, 32, 7);
+
+  test("includes both sections with their content", () => {
+    const report = buildReport({
+      uiLogs: "[main] booting",
+      serverLogs: "2026-06-20 [INFO] [server] started",
+      generatedAt,
+    });
+    expect(report).toContain("Loadout diagnostic log export");
+    expect(report).toContain("UI LOGS");
+    expect(report).toContain("[main] booting");
+    expect(report).toContain("SERVER LOGS");
+    expect(report).toContain("2026-06-20 [INFO] [server] started");
+    expect(report).toContain(generatedAt.toISOString());
+  });
+
+  test("falls back to placeholders for empty logs", () => {
+    const report = buildReport({ uiLogs: "  ", serverLogs: "", generatedAt });
+    expect(report).toContain("(no UI logs captured this session)");
+    expect(report).toContain("(server log was empty)");
+  });
+});

--- a/apps/loadout-overlay/src/bun/export-logs.ts
+++ b/apps/loadout-overlay/src/bun/export-logs.ts
@@ -1,0 +1,129 @@
+// "Export logs" RPC (issue #130). Collects the overlay UI's captured
+// console output (sent over from the webview) and the backend server's
+// on-disk log file, formats them into one human-readable report, and
+// writes it to the user's Downloads folder with a timestamped filename
+// so they can attach it to a bug report.
+//
+// Extracted from rpc-handlers.ts so the formatting + path logic is
+// unit-testable without booting the overlay or its RPC transport.
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// Matches @loadout/loadout-server's logger LOG_PATH. The overlay doesn't
+// depend on that package, so we recompute the path rather than import it
+// across the app boundary — both derive it from the same convention.
+const SERVER_LOG_PATH = join(
+  homedir(),
+  ".config",
+  "loadout",
+  "logs",
+  "loadout.log",
+);
+
+const HR =
+  "--------------------------------------------------------------------------------";
+
+export interface ExportLogsResult {
+  success: boolean;
+  error?: string;
+  /** Absolute path of the written file, on success. */
+  path?: string;
+}
+
+/** Filesystem-safe local timestamp: `2026-06-20_14-32-07`. Colons and
+ *  dots aren't portable in filenames, so we avoid ISO's separators. */
+export function timestampForFilename(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `_${pad(d.getHours())}-${pad(d.getMinutes())}-${pad(d.getSeconds())}`
+  );
+}
+
+/** Pull the `uiLogs` string out of an untrusted CEF RPC payload. Returns
+ *  "" for any malformed shape so a bad payload still produces a (server-
+ *  only) export rather than throwing across IPC. */
+export function extractUiLogs(params: unknown): string {
+  if (typeof params !== "object" || params === null) return "";
+  const value = (params as { uiLogs?: unknown }).uiLogs;
+  return typeof value === "string" ? value : "";
+}
+
+async function readServerLog(): Promise<string> {
+  try {
+    return await readFile(SERVER_LOG_PATH, "utf8");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return `(could not read server log at ${SERVER_LOG_PATH}: ${msg})`;
+  }
+}
+
+/** Assemble the final report. Sectioned with clear headers so a user (or
+ *  whoever they send it to) can read it top to bottom. */
+export function buildReport(opts: {
+  uiLogs: string;
+  serverLogs: string;
+  generatedAt: Date;
+}): string {
+  const { uiLogs, serverLogs, generatedAt } = opts;
+  const ui = uiLogs.trim() || "(no UI logs captured this session)";
+  const server = serverLogs.trim() || "(server log was empty)";
+
+  return [
+    HR,
+    " Loadout diagnostic log export",
+    ` Generated:  ${generatedAt.toISOString()}`,
+    ` Platform:   ${process.platform} ${process.arch}`,
+    HR,
+    "",
+    "Logs from the Loadout overlay UI and the backend server, collected to",
+    "help diagnose issues. UI logs come first, then the server log file.",
+    "",
+    HR,
+    " UI LOGS  (overlay webview console)",
+    HR,
+    "",
+    ui,
+    "",
+    HR,
+    ` SERVER LOGS  (${SERVER_LOG_PATH})`,
+    HR,
+    "",
+    server,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Write the combined UI + server log report to ~/Downloads with a
+ * timestamped filename. Returns the path on success, or a structured
+ * error. Never throws — the RPC layer turns the envelope into a button
+ * state in Settings.
+ */
+export async function exportLogs(params?: unknown): Promise<ExportLogsResult> {
+  try {
+    const now = new Date();
+    const report = buildReport({
+      uiLogs: extractUiLogs(params),
+      serverLogs: await readServerLog(),
+      generatedAt: now,
+    });
+
+    const downloadsDir = join(homedir(), "Downloads");
+    if (!existsSync(downloadsDir)) {
+      await mkdir(downloadsDir, { recursive: true });
+    }
+
+    const path = join(downloadsDir, `loadout-logs-${timestampForFilename(now)}.txt`);
+    await writeFile(path, report, "utf8");
+    console.log(`[overlay] exported logs to ${path}`);
+    return { success: true, path };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[overlay] exportLogs threw:", err);
+    return { success: false, error: msg };
+  }
+}

--- a/apps/loadout-overlay/src/bun/rpc-handlers.ts
+++ b/apps/loadout-overlay/src/bun/rpc-handlers.ts
@@ -46,6 +46,7 @@ import {
   systemReboot,
   systemShutdown,
 } from "./system-actions";
+import { exportLogs } from "./export-logs";
 
 export interface RpcHandlerDeps {
   /** Triple-flag overlay state — read by getOverlayVisibility, mutated
@@ -114,6 +115,14 @@ export function buildRpcHandlers(deps: RpcHandlerDeps) {
       // systemctl shell-out.
       restartServer: async (): Promise<{ success: boolean; error?: string }> =>
         restartServer(),
+      // Dump the overlay UI's captured console logs (sent over in the
+      // payload) plus the backend server log file into a timestamped
+      // file in the user's Downloads folder. See export-logs.ts. Used
+      // to collect diagnostics from users reporting issues (#130).
+      exportLogs: async (
+        params?: unknown,
+      ): Promise<{ success: boolean; error?: string; path?: string }> =>
+        exportLogs(params),
       // Emergency SIGCONT — finds the "steam" comm PID and resumes it.
       // Exposed as a maintenance button so a user stuck with frozen
       // Steam (e.g. crashed overlay left it TASK_STOPPED, or the

--- a/apps/loadout-overlay/src/overlay/components/Settings.tsx
+++ b/apps/loadout-overlay/src/overlay/components/Settings.tsx
@@ -11,6 +11,7 @@ import {
   forceUnfreezeSteam,
   systemShutdown,
   systemReboot,
+  exportLogs,
   type ControllerShortcuts,
   type ShortcutAction,
 } from "../lib/host";
@@ -256,6 +257,16 @@ function MaintenanceActionRow({ action }: { action: MaintenanceAction }) {
     </div>
   );
 }
+
+const EXPORT_LOGS_ACTION: MaintenanceAction = {
+  title: "Save logs to file",
+  description:
+    "Dumps the UI and server logs into a timestamped file in your Downloads folder — attach it when reporting an issue.",
+  idleLabel: "Save logs",
+  runningLabel: "Saving...",
+  successLabel: "Saved to Downloads",
+  invoke: exportLogs,
+};
 
 const RESTART_SERVER_ACTION: MaintenanceAction = {
   title: "Restart plugin server",
@@ -536,6 +547,7 @@ function SettingsInner({
             <section className="mb-6">
               <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">Maintenance</h3>
               <div className="bg-base-200 rounded-2xl border border-base-300 p-5 space-y-4 divide-y divide-base-300 [&>*]:pt-4 [&>*:first-child]:pt-0">
+                <MaintenanceActionRow action={EXPORT_LOGS_ACTION} />
                 <ClearDataCachesActionRow />
                 <MaintenanceActionRow action={RESTART_SERVER_ACTION} />
                 <MaintenanceActionRow action={RESTART_STEAM_ACTION} />

--- a/apps/loadout-overlay/src/overlay/lib/host.ts
+++ b/apps/loadout-overlay/src/overlay/lib/host.ts
@@ -60,6 +60,27 @@ export async function restartServer(): Promise<{ success: boolean; error?: strin
   return result as { success: boolean; error?: string };
 }
 
+/**
+ * Dump the overlay UI's captured console logs and the backend server
+ * log into a timestamped file in the user's Downloads folder (#130).
+ * The UI logs are collected here from the in-webview ring buffer and
+ * shipped to the Bun host, which combines them with the server log on
+ * disk and writes the file. No-op (returns `{ success: false }`)
+ * outside Electrobun — there's no host to write the file.
+ */
+export async function exportLogs(): Promise<{
+  success: boolean;
+  error?: string;
+  path?: string;
+}> {
+  const { getCapturedLogs } = await import("./logBuffer");
+  const result = await rpcInvoke("exportLogs", { uiLogs: getCapturedLogs() });
+  if (!result || typeof result !== "object") {
+    return { success: false, error: "Host did not respond" };
+  }
+  return result as { success: boolean; error?: string; path?: string };
+}
+
 async function rpcResultOrError(
   cmd: string,
 ): Promise<{ success: boolean; error?: string }> {

--- a/apps/loadout-overlay/src/overlay/lib/logBuffer.ts
+++ b/apps/loadout-overlay/src/overlay/lib/logBuffer.ts
@@ -1,0 +1,102 @@
+// In-memory ring buffer for the overlay webview's console output.
+//
+// The webview's logs only ever go to the CEF dev console — nothing
+// persists them. The Settings "Export logs" action (issue #130) needs
+// the UI side's logs alongside the server log file, so we patch the
+// console methods once at boot to mirror every call into a bounded
+// buffer. The originals still fire, so DevTools / stdout are unchanged.
+//
+// Bounded to MAX_ENTRIES so a long session (or a chatty plugin) can't
+// grow this without limit; oldest entries fall off the front.
+
+const MAX_ENTRIES = 2000;
+
+type LogLevel = "LOG" | "INFO" | "WARN" | "ERROR" | "DEBUG";
+
+interface LogEntry {
+  ts: number;
+  level: LogLevel;
+  text: string;
+}
+
+const buffer: LogEntry[] = [];
+let installed = false;
+
+/** Stringify one console argument for the flat log file. Strings pass
+ *  through; Errors include their stack; everything else is JSON with a
+ *  circular-reference guard, falling back to String() on failure. */
+function serializeArg(arg: unknown): string {
+  if (typeof arg === "string") return arg;
+  if (arg instanceof Error) return arg.stack ?? `${arg.name}: ${arg.message}`;
+  if (arg === undefined) return "undefined";
+  try {
+    const seen = new WeakSet<object>();
+    const json = JSON.stringify(arg, (_key, value) => {
+      if (typeof value === "object" && value !== null) {
+        if (seen.has(value)) return "[Circular]";
+        seen.add(value);
+      }
+      return value;
+    });
+    return json ?? String(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+function record(level: LogLevel, args: unknown[]): void {
+  const text = args.map(serializeArg).join(" ");
+  buffer.push({ ts: Date.now(), level, text });
+  if (buffer.length > MAX_ENTRIES) buffer.shift();
+}
+
+/**
+ * Patch console.{log,info,warn,error,debug} so every call is mirrored
+ * into the buffer. Idempotent — calling twice is a no-op. Call as early
+ * as possible at boot so the most output is captured.
+ */
+export function installLogCapture(): void {
+  if (installed) return;
+  installed = true;
+
+  const levels: Array<["log" | "info" | "warn" | "error" | "debug", LogLevel]> = [
+    ["log", "LOG"],
+    ["info", "INFO"],
+    ["warn", "WARN"],
+    ["error", "ERROR"],
+    ["debug", "DEBUG"],
+  ];
+
+  // Index the console as a loose record so we can swap methods in place;
+  // the typed Console interface marks them as read-only.
+  const con = console as unknown as Record<string, (...args: unknown[]) => void>;
+  for (const [method, level] of levels) {
+    const original = con[method];
+    if (typeof original !== "function") continue;
+    con[method] = (...args: unknown[]) => {
+      try {
+        record(level, args);
+      } catch {
+        // never let capture break the real console call
+      }
+      original.apply(console, args);
+    };
+  }
+}
+
+/**
+ * Render the captured buffer as a flat, timestamped log block. One line
+ * per entry: `2026-06-20T14:32:07.123Z [WARN] message`. Multi-line
+ * entries (stack traces) keep their newlines.
+ */
+export function getCapturedLogs(): string {
+  if (buffer.length === 0) return "(no UI logs captured this session)";
+  return buffer
+    .map((e) => `${new Date(e.ts).toISOString()} [${e.level}] ${e.text}`)
+    .join("\n");
+}
+
+/** Test seam — drop everything captured so far. */
+export function clearCapturedLogs(): void {
+  buffer.length = 0;
+}

--- a/apps/loadout-overlay/src/webview/main.tsx
+++ b/apps/loadout-overlay/src/webview/main.tsx
@@ -15,6 +15,12 @@ import { Electroview } from "electrobun/view";
 import "@overlay/shared-modules";
 import "@overlay/index.css";
 
+// Mirror console output into an in-memory ring buffer so the Settings
+// "Save logs" action can ship the UI's logs alongside the server log
+// (#130). Installed before boot() so the most output is captured.
+import { installLogCapture } from "@overlay/lib/logBuffer";
+installLogCapture();
+
 import { createRoot } from "react-dom/client";
 import { App, navigateOverlay } from "@overlay/App";
 import { applyTheme } from "@overlay/components/Settings";


### PR DESCRIPTION
Adds a Maintenance action in the overlay Settings screen that dumps the
UI and server logs into a timestamped file in the user's Downloads
folder, for collecting diagnostics from users reporting issues.

- logBuffer.ts: patches the webview console at boot into a bounded ring
  buffer so the UI side's logs can be exported (they previously only
  reached the CEF dev console and were never persisted).
- export-logs.ts: Bun-side RPC that combines the captured UI logs with
  the backend server log file (~/.config/loadout/logs/loadout.log) into
  one sectioned, human-readable report and writes it to
  ~/Downloads/loadout-logs-YYYY-MM-DD_HH-MM-SS.txt.
- host.ts exportLogs() ships the captured UI buffer to the host; the
  Settings "Save logs" row reuses the existing MaintenanceActionRow.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WDsxn6axrqzzUDZUW9eAfz