### PR TITLE
fix(overlay): clear stuck Guide/dpad state across overlay open/close

### DIFF
--- a/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
@@ -320,6 +320,25 @@ describe("startInputIntercept — grab / release", () => {
     h.shutdown();
   });
 
+  it("re-syncs real hardware state on grab (EVIOCGKEY per grabbed controller)", async () => {
+    // On grab we read the kernel's actual button bitmap (EVIOCGKEY) so a
+    // guide/select release lost across the grab transition can't leave a
+    // stale "held". One read per grabbed controller, none for keyboards.
+    devicesOnSystem = [
+      mkDevice("/dev/input/event5", "Pad", { isController: true }),
+      mkDevice("/dev/input/event6", "KB", { isKeyboard: true }),
+    ];
+    const h = await startInputIntercept({ onWake: () => {}, onAction: () => {} });
+    expect(
+      ffiCalls.filter((c) => c.kind === "ioctl" && c.request === 0x80604518n),
+    ).toHaveLength(0); // no re-sync before grab
+    h.grab();
+    expect(
+      ffiCalls.filter((c) => c.kind === "ioctl" && c.request === 0x80604518n),
+    ).toHaveLength(1); // only the controller fd
+    h.shutdown();
+  });
+
   it("double-grab is a no-op (generation still advances once)", async () => {
     devicesOnSystem = [mkDevice("/dev/input/event5", "Pad", { isController: true })];
     const h = await startInputIntercept({ onWake: () => {}, onAction: () => {} });
@@ -467,6 +486,38 @@ describe("__testing__.processCombo", () => {
     processCombo(s, 0x13a /* BTN_SELECT */, 1, 0);
     processCombo(s, BTN_B, 1, 10);
     expect(processCombo(s, BTN_B, 0, 50)).toBe("GuideB");
+  });
+
+  it("regression: a stuck guideHeld turns a lone B into GuideB; a fresh state does not", () => {
+    // The reported bug: a missed BTN_MODE *release* leaves guideHeld stuck,
+    // so every subsequent lone B is misread as Guide+B → re-toggles overlay.
+    const stuck = newComboState();
+    processCombo(stuck, BTN_MODE, 1, 0); // guide down…
+    // …guide-up event lost across the grab/ungrab transition (never delivered).
+    processCombo(stuck, BTN_B, 1, 10);
+    expect(processCombo(stuck, BTN_B, 0, 20)).toBe("GuideB"); // the bug
+
+    // The fix resets per-device combo state on every grab/release, so the
+    // next cycle starts from a fresh state where lone B is just B.
+    const fresh = newComboState();
+    processCombo(fresh, BTN_B, 1, 10);
+    expect(processCombo(fresh, BTN_B, 0, 20)).toBeNull();
+  });
+});
+
+describe("__testing__.eviocgkey", () => {
+  it("encodes _IOC(_IOC_READ, 'E', 0x18, len)", () => {
+    // dir=READ(2)<<30 | len<<16 | 'E'(0x45)<<8 | 0x18
+    expect(__testing__.eviocgkey(96)).toBe(0x80604518n);
+  });
+});
+
+describe("__testing__.absCodeToAxis", () => {
+  it("maps hat + stick codes and rejects unknowns", () => {
+    expect(__testing__.absCodeToAxis(0x10)).toBe("HatX");
+    expect(__testing__.absCodeToAxis(0x11)).toBe("HatY");
+    expect(__testing__.absCodeToAxis(0x00)).toBe("LeftStickX");
+    expect(__testing__.absCodeToAxis(0x99)).toBeNull();
   });
 });
 

--- a/apps/loadout-overlay/src/bun/native/input-intercept.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.ts
@@ -50,7 +50,11 @@ import {
   enumerateDevices,
   type InputDevice,
 } from "./devices";
-import { NavController, type InputEvent } from "./nav-controller";
+import {
+  NavController,
+  type InputEvent,
+  type GamepadAxis,
+} from "./nav-controller";
 import { trace } from "./trace";
 import {
   startDeviceHotplug,
@@ -367,6 +371,71 @@ function normalizeAxis(code: number, raw: number, cal: Map<number, AxisCal>): nu
   return Math.min(1, Math.max(0, n)) * 2 - 1;
 }
 
+/** Map an EV_ABS code to the NavController axis name, or null if it's an
+ *  axis we don't forward. Shared by toInputEvents (live stream) and the
+ *  grab-time re-sync below. */
+function absCodeToAxis(code: number): GamepadAxis | null {
+  switch (code) {
+    case ABS_X: return "LeftStickX";
+    case ABS_Y: return "LeftStickY";
+    case ABS_RX: return "RightStickX";
+    case ABS_RY: return "RightStickY";
+    case ABS_HAT0X: return "HatX";
+    case ABS_HAT0Y: return "HatY";
+    default: return null;
+  }
+}
+
+// ---- Hardware state re-sync (EVIOCGKEY + EVIOCGABS value) -------------------
+//
+// EVIOCGRAB/EVIOCSMASK only deliver *edge* events; if a button-up or
+// axis-center is lost across a grab/ungrab or mask switch (or dropped over a
+// flaky BT link), the edge-derived held-state desyncs and a control appears
+// stuck "held". On every grab we read the device's ACTUAL current state
+// straight from the kernel so a lost release can never survive the cycle.
+
+/** EVIOCGKEY(len) = _IOC(_IOC_READ, 'E', 0x18, len) — returns a bitmap of the
+ *  current pressed/released state of every key/button on the device. */
+function eviocgkey(len: number): bigint {
+  return (2n << 30n) | (BigInt(len) << 16n) | (0x45n << 8n) | 0x18n;
+}
+
+/** Current pressed-state of the combo modifier buttons, read from the kernel
+ *  key bitmap. Buffer of 96 bytes covers codes 0..767 (well past BTN_MODE). */
+function readModifierState(fd: number): { guide: boolean; select: boolean } {
+  const buf = new Uint8Array(96);
+  const rc = libc.symbols.ioctl(fd, eviocgkey(buf.length), ptr(buf));
+  if (rc < 0) return { guide: false, select: false };
+  const bit = (code: number) => (buf[code >> 3] & (1 << (code & 7))) !== 0;
+  return { guide: bit(BTN_MODE), select: bit(BTN_SELECT) };
+}
+
+/** Current directional-axis positions as InputEvents, so NavController can be
+ *  primed to physical reality on grab. Right-stick (continuous analog scroll)
+ *  is skipped — only the dpad/stick *directions* matter for the stuck-held
+ *  pathology. */
+function readDirectionalAxisState(
+  fd: number,
+  cal: Map<number, AxisCal>,
+): InputEvent[] {
+  const out: InputEvent[] = [];
+  for (const code of NAV_AXIS_CODES) {
+    if (code === ABS_RX || code === ABS_RY) continue;
+    const axis = absCodeToAxis(code);
+    if (!axis) continue;
+    const buf = new Uint8Array(24);
+    const rc = libc.symbols.ioctl(fd, eviocgabs(code), ptr(buf));
+    if (rc !== 0) continue;
+    const raw = new DataView(buf.buffer).getInt32(0, true);
+    out.push({
+      kind: "axis",
+      axis,
+      value: cal.has(code) ? normalizeAxis(code, raw, cal) : raw,
+    });
+  }
+  return out;
+}
+
 // ---- Combo detection (guide+button + ctrl+3/4) -----------------------------
 
 /** How long the combo modifier + button must overlap. Matches
@@ -468,14 +537,7 @@ function toInputEvents(
         null;
       if (btn) out.push({ kind: "button", button: btn, pressed: e.value !== 0 });
     } else if (e.type === EV_ABS) {
-      const axis =
-        e.code === ABS_X ? "LeftStickX" :
-        e.code === ABS_Y ? "LeftStickY" :
-        e.code === ABS_RX ? "RightStickX" :
-        e.code === ABS_RY ? "RightStickY" :
-        e.code === ABS_HAT0X ? "HatX" :
-        e.code === ABS_HAT0Y ? "HatY" :
-        null;
+      const axis = absCodeToAxis(e.code);
       if (axis) {
         out.push({
           kind: "axis",
@@ -705,6 +767,21 @@ export async function startInputIntercept(
   }
   startTimer();
 
+  // Re-sync a freshly-grabbed device's combo + NavController state to the
+  // kernel's ACTUAL current button/axis state. EVIOCGRAB/EVIOCSMASK only
+  // deliver edge events, so a button-up or axis-center lost across the
+  // grab/mask transition would otherwise leave a control stuck "held".
+  function resyncDeviceState(t: TrackedDevice): void {
+    if (t.grabOnly) return;
+    const mods = readModifierState(t.fd);
+    t.combo.guideHeld = mods.guide;
+    t.combo.selectHeld = mods.select;
+    const axisEvents = readDirectionalAxisState(t.fd, t.cal);
+    if (axisEvents.length > 0) {
+      nav.processEvents(`${t.dev.hash}_${generation}`, axisEvents);
+    }
+  }
+
   function doGrab(): void {
     if (intercepting) return;
     intercepting = true;
@@ -712,6 +789,12 @@ export async function startInputIntercept(
     nav.reset();
     for (const t of tracked) {
       if (!t.dev.flags.isController) continue;
+      // Fresh modifier state each cycle: a guide/select/ctrl release missed
+      // last session must not leave guideHeld stuck (→ every B reads as
+      // Guide+B → re-toggles the overlay). resyncDeviceState below then
+      // re-seeds from real hardware.
+      t.combo = newComboState();
+      t.shortcut = newShortcutState();
       if (!t.grabOnly) applyInterceptMasks(t.fd);
       if (!t.grabbed) {
         const intBuf = new Int32Array([1]);
@@ -729,6 +812,7 @@ export async function startInputIntercept(
           );
         }
       }
+      resyncDeviceState(t);
     }
     startTimer();
   }
@@ -749,6 +833,11 @@ export async function startInputIntercept(
         t.grabbed = false;
       }
       if (!t.grabOnly) applyIdleMasks(t.fd, t.dev);
+      // Clear modifier state so it can't carry into the next idle cycle and
+      // fire a phantom Guide+B / Ctrl+4 wake. Idle-mode combo detection
+      // rebuilds guideHeld from fresh BTN_MODE presses.
+      t.combo = newComboState();
+      t.shortcut = newShortcutState();
     }
     nav.reset();
     console.log(
@@ -806,6 +895,7 @@ export async function startInputIntercept(
           `[input-intercept] hotplug grab failed for ${t.path} (rc=${rc})`,
         );
       }
+      resyncDeviceState(t);
     }
   }
 
@@ -880,6 +970,7 @@ export async function startInputIntercept(
             `[input-intercept] reconcile grabbed ${t.path} '${t.dev.name}'${t.grabOnly ? " (virtual, grab-only)" : ""}`,
           );
         }
+        resyncDeviceState(t);
       }
     }
   }
@@ -920,4 +1011,6 @@ export const __testing__ = {
   toInputEvents,
   normalizeAxis,
   eviocgabs,
+  eviocgkey,
+  absCodeToAxis,
 };

--- a/apps/loadout-overlay/src/bun/native/nav-controller.test.ts
+++ b/apps/loadout-overlay/src/bun/native/nav-controller.test.ts
@@ -286,6 +286,28 @@ describe("NavController — reset + multi-controller", () => {
     expect(f.emitted).toEqual(["a"]);
   });
 
+  it("reset() emits x_up for a still-held X so long-press isn't stranded", () => {
+    const f = fxController();
+    f.nav.processEvents("ctrl1", [
+      { kind: "button", button: "X", pressed: true },
+    ]);
+    expect(f.emitted).toEqual(["x"]); // press seen, release pending
+    // Overlay tears down mid-hold (open/close → reset). The release half
+    // must still fire or a frontend long-press handler hangs forever.
+    f.nav.reset();
+    expect(f.emitted).toEqual(["x", "x_up"]);
+  });
+
+  it("reset() does NOT emit a phantom 'b' for a still-held B", () => {
+    const f = fxController();
+    f.nav.processEvents("ctrl1", [
+      { kind: "button", button: "B", pressed: true },
+    ]);
+    f.nav.reset();
+    // Emitting "b" here would inject a spurious Escape into the webview.
+    expect(f.emitted).toEqual([]);
+  });
+
   it("separate controllerIds maintain independent held state", () => {
     const f = fxController();
     // Ctrl1 holds A, ctrl2 is in modifier suppression.

--- a/apps/loadout-overlay/src/bun/native/nav-controller.ts
+++ b/apps/loadout-overlay/src/bun/native/nav-controller.ts
@@ -249,8 +249,19 @@ export class NavController {
 
   /** Reset all per-controller state. Called when the overlay opens or
    *  closes so a half-held button from last session doesn't spam the
-   *  first frame of the new one. */
+   *  first frame of the new one.
+   *
+   *  Before clearing, emit the release half of any still-held press-AND-
+   *  release action so downstream listeners don't get stranded mid-hold. The
+   *  only NavAction with a distinct release is X ("x" press / "x_up" release):
+   *  a frontend long-press handler waiting on x_up would otherwise hang if the
+   *  overlay tore down between the press and release. Directions/A/Y/bumpers
+   *  only have a keydown in the webview map, and B already fires on release,
+   *  so emitting a phantom "b" here would risk a spurious Escape — skip those. */
   reset(): void {
+    for (const st of this.controllers.values()) {
+      if (st.held.has("x")) this.emit("x_up");
+    }
     this.controllers.clear();
   }
 


### PR DESCRIPTION
Closing the overlay and pressing B could re-open it, with the overlay
behaving as if Guide were held (every B toggled it) and the right dpad
were stuck down. Root cause: the evdev path builds modifier/held state
from edge events (press/release deltas) over channels that are torn down
and rebuilt on every open/close (EVIOCGRAB + EVIOCSMASK). A button-up
lost across that transition desynced the state.

NavController.reset() already ran on grab/release, but the per-device
ComboState/ShortcutState (guideHeld/selectHeld/ctrlHeld) were never
reset. A missed BTN_MODE release left guideHeld stuck true, so every
subsequent lone B was detected as Guide+B -> wake -> ToggleOverlay.

Fixes:
- Reset t.combo/t.shortcut to fresh state on every grab and release
  (and on the hotplug/reconcile grab paths), so a missed release can't
  carry into the next cycle.
- Re-sync from real hardware on grab: read the actual button bitmap
  (EVIOCGKEY) to seed guideHeld/selectHeld, and the actual axis values
  (EVIOCGABS value field) to prime NavController directions, so a lost
  release self-heals on the next open regardless of which channel
  dropped it.
- NavController.reset() now emits x_up for a still-held X so a frontend
  long-press handler isn't stranded mid-hold (also benefits the
  InputPlumber path, which shares NavController). B is intentionally not
  emitted to avoid a spurious Escape.

Note: external Bluetooth pads are Steam-managed (not InputPlumber), so
they flow through the evdev path patched here. The on-device controller
uses ip-intercept.ts, which has no persistent modifier state and gates
on `intercepting`, so it needs no change beyond the shared reset.

Tests: stuck-guideHeld regression (lone B must not yield GuideB after a
fresh state), EVIOCGKEY encoding, absCodeToAxis mapping, grab issues
EVIOCGKEY per controller, and reset() x_up/no-phantom-b behavior.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NfaZCUdUEHjYmFtAweaLz8