### PR TITLE
fix(input-plumber): stop the Restart button from bricking InputPlumber

### DIFF
--- a/plugins/input-plumber/app.spec.tsx
+++ b/plugins/input-plumber/app.spec.tsx
@@ -258,6 +258,7 @@ describe("input-plumber plugin", () => {
       if (method === "getWakeStatus") return Promise.resolve(wake);
       if (method === "setWakeButton") return Promise.resolve({ ok: true });
       if (method === "clearWakeButton") return Promise.resolve({ ok: true });
+      if (method === "restartInputPlumber") return Promise.resolve({ ok: true });
       if (method === "prepareWake") return Promise.resolve(wake);
       return Promise.resolve(null);
     });
@@ -349,6 +350,44 @@ describe("input-plumber plugin", () => {
         b.textContent?.trim() === "Set wake button",
       ) as HTMLButtonElement;
       expect(reSetBtn.disabled).toBe(false);
+    });
+  });
+
+  it("restart button confirms the controller is back, then enters a cooldown", async () => {
+    // restartInputPlumber → ok, and getWakeStatus reports a composite device,
+    // so the confirm poll succeeds on the first attempt (no delay).
+    rpcWithWake(wakeActive);
+    const container = document.createElement("div");
+    const { mount } = await import("./app");
+    mount(container);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Restart InputPlumber");
+    });
+
+    const restartBtn = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Restart InputPlumber"),
+    )!;
+    fireEvent.click(restartBtn);
+
+    await waitFor(() => {
+      expect(callMock).toHaveBeenCalledWith("restartInputPlumber");
+    });
+
+    // Reports confirmed detection — not a bare "should be back" — because a
+    // composite device re-appeared via getWakeStatus.
+    await waitFor(() => {
+      expect(container.textContent).toContain("controller detected");
+    });
+
+    // The button is now in cooldown: disabled and showing a countdown, so the
+    // user can't immediately re-fire it.
+    await waitFor(() => {
+      const btn = Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Restart InputPlumber"),
+      ) as HTMLButtonElement;
+      expect(btn.textContent).toContain("s)");
+      expect(btn.disabled).toBe(true);
     });
   });
 

--- a/plugins/input-plumber/app.tsx
+++ b/plugins/input-plumber/app.tsx
@@ -29,6 +29,17 @@ import type {
 
 const CAPTURE_TIMEOUT_MS = 10_000;
 
+// Restart-recovery pacing. The backend already resets systemd's start-limit
+// before each restart, so a fast click can't brick IP anymore — but we still
+// hold the button down until we've *confirmed* the controller came back, then
+// keep it disabled for a short cooldown. Together these stop the "looks dead so
+// I'll click again" loop that piled up restarts in the first place: the user
+// can't re-fire while we're still checking, and there's a beat afterwards to
+// see whether it worked before trying again.
+const RESTART_CONFIRM_ATTEMPTS = 6;
+const RESTART_CONFIRM_DELAY_MS = 1000;
+const RESTART_COOLDOWN_S = 5;
+
 export const icon = FaPlug;
 
 // Hard cap on retained install-log lines. Chatty installs (pacman/dnf
@@ -340,6 +351,7 @@ function WakeButtonSection() {
   const [info, setInfo] = useState<string | null>(null);
   const [legacyAck, setLegacyAck] = useState(false);
   const [restarting, setRestarting] = useState(false);
+  const [restartCooldown, setRestartCooldown] = useState(0);
 
   // Mounted-ref guard so awaited callbacks don't `setState` after the user
   // navigates away mid-capture (10s windows are long enough to leave on).
@@ -374,6 +386,18 @@ function WakeButtonSection() {
     }, 1000);
     return () => clearInterval(tick);
   }, [capturing]);
+
+  // Post-restart cooldown ticker — keeps the Restart button disabled for a few
+  // seconds after a restart resolves so a frustrated user can't immediately
+  // re-fire it (which is how a single dead controller turned into a restart
+  // storm).
+  useEffect(() => {
+    if (restartCooldown <= 0) return;
+    const tick = setInterval(() => {
+      setRestartCooldown((c) => (c > 0 ? c - 1 : 0));
+    }, 1000);
+    return () => clearInterval(tick);
+  }, [restartCooldown]);
 
   const startCapture = useCallback(async () => {
     safeSet(setError, null);
@@ -417,21 +441,52 @@ function WakeButtonSection() {
   // Recovery: restart the InputPlumber daemon (rebuilds composite devices) and
   // re-load the wake profile. Slower than the other ops (daemon restart + a few
   // retries for re-enumeration), so it has its own busy state + spinner.
+  //
+  // Confirm-before-re-enable: the daemon coming back ≠ the controller being
+  // usable, so after the restart we poll getWakeStatus until a composite device
+  // re-appears (or we give up), and only then report success. The button stays
+  // disabled (`restarting`) for the whole poll, then a cooldown, so the user
+  // can't stack restarts while the controller is still re-enumerating — the
+  // exact pile-up that tripped systemd's start-limit and bricked IP.
   const restartIp = useCallback(async () => {
     safeSet(setRestarting, true);
     safeSet(setError, null);
     safeSet(setInfo, null);
     try {
       const r = (await call("restartInputPlumber")) as WakeOpResult;
-      if (r.ok) safeSet(setInfo, "InputPlumber restarted — controllers should be back.");
-      else safeSet(setError, r.error ?? "Restart failed.");
-      await refresh();
+      if (!r.ok) {
+        safeSet(setError, r.error ?? "Restart failed.");
+        return;
+      }
+      // Poll until the controller re-appears, refreshing the UI as we go.
+      let back = false;
+      for (let attempt = 0; attempt < RESTART_CONFIRM_ATTEMPTS; attempt++) {
+        const s = (await call("getWakeStatus")) as WakeStatus;
+        if (mountedRef.current) setWake(s);
+        if (s.ipActive && s.devices.length > 0) {
+          back = true;
+          break;
+        }
+        if (attempt < RESTART_CONFIRM_ATTEMPTS - 1) {
+          await new Promise((res) => setTimeout(res, RESTART_CONFIRM_DELAY_MS));
+        }
+      }
+      if (back) {
+        safeSet(setInfo, "InputPlumber restarted — controller detected.");
+      } else {
+        safeSet(
+          setError,
+          "InputPlumber restarted, but no controller showed up. Try re-plugging it, then restart again.",
+        );
+      }
     } catch (e) {
       safeSet(setError, e instanceof Error ? e.message : String(e));
     } finally {
       safeSet(setRestarting, false);
+      // Brief cooldown before the button can fire again, even after success.
+      safeSet(setRestartCooldown, RESTART_COOLDOWN_S);
     }
-  }, [call, refresh, safeSet]);
+  }, [call, safeSet]);
 
   const cardWrap = (body: React.ReactNode) => (
     <div className="card mt-3.5">
@@ -583,12 +638,17 @@ function WakeButtonSection() {
         </div>
         <FocusButton
           onClick={() => void restartIp()}
-          disabled={busy || capturing || restarting}
+          disabled={busy || capturing || restarting || restartCooldown > 0}
           variant="ghost"
         >
           {restarting ? (
             <>
               <Spinner size={14} /> <span className="ml-1.5">Restarting…</span>
+            </>
+          ) : restartCooldown > 0 ? (
+            <>
+              <FaArrowsRotate className="w-3 h-3 mr-1" /> Restart InputPlumber (
+              {restartCooldown}s)
             </>
           ) : (
             <>

--- a/plugins/input-plumber/lib/wake-trigger.test.ts
+++ b/plugins/input-plumber/lib/wake-trigger.test.ts
@@ -16,6 +16,7 @@ import {
   clearWakeButton,
   captureWakeButton,
   reloadPersistedProfile,
+  restartInputPlumber,
 } from "./wake-trigger";
 import { PROFILE_PATH } from "./profile";
 
@@ -232,6 +233,27 @@ describe("wake-trigger orchestration", () => {
     expect(r.ok).toBe(true);
     expect(writtenFiles.get(PROFILE_PATH)).toContain("button: RightPaddle1");
     expect(calls.find((c) => has(c, "LoadProfilePath"))).toBeDefined();
+  });
+
+  it("restartInputPlumber resets the start-limit before restarting (so rapid presses can't brick IP)", async () => {
+    const { stub, calls } = makeSpawnStub(happyPathExpectations());
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawnSpy = spyOn(Bun, "spawn").mockImplementation(stub as any);
+
+    const r = await restartInputPlumber();
+    expect(r.ok).toBe(true);
+
+    const resetIdx = calls.findIndex(
+      (c) => c[0] === "systemctl" && has(c, "reset-failed") && has(c, "inputplumber"),
+    );
+    const restartIdx = calls.findIndex(
+      (c) => c[0] === "systemctl" && has(c, "restart") && has(c, "inputplumber"),
+    );
+    expect(resetIdx).toBeGreaterThanOrEqual(0);
+    expect(restartIdx).toBeGreaterThanOrEqual(0);
+    // reset-failed must precede the restart, else a start-limit-hit state stays
+    // stuck and the recovery button can't recover.
+    expect(resetIdx).toBeLessThan(restartIdx);
   });
 
   it("captureWakeButton restores the previous binding when the catch-all load fails", async () => {

--- a/plugins/input-plumber/lib/wake-trigger.ts
+++ b/plugins/input-plumber/lib/wake-trigger.ts
@@ -533,6 +533,15 @@ const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
  * wake button would silently fail to reload right after the restart.
  */
 export async function restartInputPlumber(): Promise<WakeOpResult> {
+  // Clear systemd's restart bookkeeping before every restart. This is the one
+  // change that makes the button safe AND able to recover. (a) It resets the
+  // start-limit counter (StartLimitBurst=5 / 10s), so repeated presses — which
+  // happen naturally when the controller is still dead and the user clicks
+  // again — can never trip "start-limit-hit" and brick IP. (b) If IP is already
+  // in a failed state (e.g. a prior burst already tripped the limit), a plain
+  // `restart` keeps failing; reset-failed first lets the button dig IP back out.
+  // Best-effort: a non-zero exit just means there was nothing to reset.
+  await exec(["systemctl", "reset-failed", "inputplumber"]);
   const r = await exec(["systemctl", "restart", "inputplumber"]);
   if (!r.ok) {
     return { ok: false, error: `Failed to restart InputPlumber: ${r.err || "unknown error"}` };


### PR DESCRIPTION
## What happened

A real field incident on my handheld: controller didn't present to Steam on launch, so I opened the plugin and hit **Restart InputPlumber** to fix it — and it had a meltdown. The controller went *fully* dead and the button could no longer recover it.

From the journal, the recovery button fired `systemctl restart inputplumber` ~5 times inside one second:

```
16:35:16.481 [plugin:input-plumber] Restarting InputPlumber (user-requested recovery)…
16:35:16.998 [plugin:input-plumber] Restarting InputPlumber (user-requested recovery)…
...
inputplumber.service: Start request repeated too quickly.
inputplumber.service: Failed with result 'start-limit-hit'.
```

## Root cause

1. When no wake button is bound, `restartInputPlumber()` returns in ~500ms (the profile-reload retry no-ops), so the button re-enabled almost instantly. With the controller still dead, clicking again is the natural thing to do → 5 restarts in InputPlumber's 10s window → systemd's `StartLimitBurst=5` trips → `failed (start-limit-hit)`.
2. Once failed, every `systemctl restart` returns `start-limit-hit`, so the recovery button can't recover anything. IP's failed shutdown also left the source evdev/js nodes at `chmod 000` → controller fully dead.

## Fix (two layers)

**Backend (`wake-trigger.ts`)** — run `systemctl reset-failed inputplumber` before every `restart`. One change, two wins:
- Resets the burst counter on each press → rapid clicks can never trip the start-limit again.
- Clears an already-failed state → the button can dig IP out of the bricked case.

**Frontend (`app.tsx`)** — confirm-before-re-enable + cooldown:
- After the restart, poll `getWakeStatus` until a composite device actually re-appears before reporting success (*"controller detected"* vs the old always-optimistic *"controllers should be back"*; honest *"no controller showed up — try re-plugging"* otherwise).
- Hold the button disabled through the poll **plus a 5s cooldown** with a visible countdown (`Restart InputPlumber (5s)`), breaking the "looks dead so I'll click again" loop at the UX layer.

## Tests
- `wake-trigger.test.ts`: asserts `reset-failed` is ordered before `restart`.
- `app.spec.tsx`: asserts the restart surfaces the confirmed-detection message and the button enters a disabled cooldown.

## Verification
- `bun test` (backend + UI suites): pass
- `tsc --noEmit`: clean
- `eslint` on changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)