### PR TITLE
fix(install): fetch SteamOS overlay lib closure in the curl installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ Runtime requirements: an X11/Xwayland display, membership in the `input` group
 (so the overlay can grab evdev devices), and a working Steam install. The CEF
 libraries ship inside the overlay archive.
 
+On **SteamOS** the installer additionally builds a small `libwebkit2gtk-4.1`
+library closure (the overlay's native wrapper dlopens it) from a Fedora
+container via `podman` — shipped in SteamOS Holo 3.7+ — the first time, then
+caches it. This is kept out of the download on purpose so the release stays
+small; Bazzite/CachyOS/Fedora already provide these libraries and skip the step
+entirely.
+
 > If this repository is private, the install command will 404 until it's made
 > public; `install.sh` honours a `GITHUB_TOKEN` env var for authenticated
 > installs.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -426,6 +426,13 @@ phase1() {
     # Download the overlay binary
     download_overlay "$ARCH"
 
+    # SteamOS-only: fetch the webkit2gtk closure the overlay's native wrapper
+    # dlopens at startup. Kept OUT of the release archive on purpose — it's
+    # ~100 MB and only SteamOS needs it (Bazzite/CachyOS/Fedora ship the libs
+    # system-wide), so bundling it would bloat every download. Built locally
+    # via podman instead, then cached. See setup_overlay_deps().
+    setup_overlay_deps
+
     # Download and stage plugins. The loader binary expects every plugin's
     # backend + workspace deps on disk; without this step the public installer
     # leaves $INSTALL_DIR/plugins/ empty and nothing renders. Audit 2026-05 H-002.
@@ -536,6 +543,65 @@ download_overlay() {
         return
     fi
     success "Overlay installed to $OVERLAY_INSTALL_DIR"
+}
+
+# Fetch the runtime libraries the overlay's native wrapper needs but the
+# release archive deliberately omits. Electrobun's libNativeWrapper.so dlopens
+# libwebkit2gtk-4.1 / libjavascriptcoregtk-4.1 / libayatana-appindicator3 at
+# startup. Bazzite, CachyOS and Fedora-ostree ship those in the base image;
+# SteamOS Holo does not. Rather than fatten every download with a ~100 MB
+# closure only SteamOS uses, we build it on the device at install time:
+# fetch-deck-overlay-libs.sh is a near-instant no-op where the system already
+# provides webkit2gtk-4.1, and builds + caches the closure from a Fedora
+# container via podman (shipped in Holo 3.7+) on SteamOS.
+#
+# Non-fatal: if the helper can't be fetched or the build can't run we warn and
+# continue. The binary, plugins and services still install; only the overlay
+# window is blocked until the closure is in place (re-run, or build from clone).
+setup_overlay_deps() {
+    [ -x "$OVERLAY_LAUNCHER" ] || return 0
+
+    # Prefer a sibling copy on disk (running from a clone); otherwise download
+    # it from the repo — the curl|sh path has no checkout. curl_gh/wget_gh add
+    # the GITHUB_TOKEN auth header so this works against a private repo too.
+    DEPS_SCRIPT=""
+    case "$0" in
+        */*)
+            _deps_dir="$(dirname "$0")"
+            [ -f "$_deps_dir/fetch-deck-overlay-libs.sh" ] && \
+                DEPS_SCRIPT="$_deps_dir/fetch-deck-overlay-libs.sh"
+            ;;
+    esac
+
+    _deps_tmp=""
+    if [ -z "$DEPS_SCRIPT" ]; then
+        _deps_tmp="$(mktemp)"
+        DEPS_URL="https://raw.githubusercontent.com/$REPO/main/scripts/fetch-deck-overlay-libs.sh"
+        if command -v curl >/dev/null 2>&1; then
+            curl_gh -fsSL -o "$_deps_tmp" "$DEPS_URL" 2>/dev/null || rm -f "$_deps_tmp"
+        elif command -v wget >/dev/null 2>&1; then
+            wget_gh -q -O "$_deps_tmp" "$DEPS_URL" 2>/dev/null || rm -f "$_deps_tmp"
+        fi
+        if [ ! -s "$_deps_tmp" ]; then
+            rm -f "$_deps_tmp"
+            warn "Could not fetch fetch-deck-overlay-libs.sh from $DEPS_URL."
+            warn "On SteamOS the overlay won't launch until its webkit2gtk closure is present."
+            warn "Build from a clone instead: bun run build-and-install"
+            return 0
+        fi
+        DEPS_SCRIPT="$_deps_tmp"
+    fi
+
+    info "Preparing overlay runtime libraries (no-op unless on SteamOS)..."
+    if sh "$DEPS_SCRIPT" "$OVERLAY_INSTALL_DIR/bin"; then
+        success "Overlay runtime libraries ready."
+    else
+        warn "Overlay dependency setup did not complete (see the message above)."
+        warn "The overlay won't launch until it does. On SteamOS install podman,"
+        warn "then re-run this installer; or build from a clone: bun run build-and-install"
+    fi
+
+    [ -n "$_deps_tmp" ] && rm -f "$_deps_tmp"
 }
 
 # Download and extract the plugin tree built by release.yml. Tarball


### PR DESCRIPTION
## Problem

`curl … install.sh | sh` left the overlay crash-looping on a Steam Deck:

```
Failed to open library ".../bin/libNativeWrapper.so":
libwebkit2gtk-4.1.so.0: cannot open shared object file: No such file or directory
```

Electrobun's native wrapper (`libNativeWrapper.so`) dlopens `libwebkit2gtk-4.1`, `libjavascriptcoregtk-4.1` and `libayatana-appindicator3` at startup. Bazzite/CachyOS/Fedora ship those in the base image; **SteamOS Holo does not.** `build-and-install` worked only because `install-local.sh` runs `fetch-deck-overlay-libs.sh` to build that closure — but the **release/curl path never did**, so every Steam Deck (the primary target) got a non-launching overlay from a release install.

## Fix

Wire the existing `fetch-deck-overlay-libs.sh` into `install.sh` as a post-overlay-download step (`setup_overlay_deps`):

- Finds the helper as a sibling on a clone, else downloads it from the repo (`curl_gh`/`wget_gh` forward `GITHUB_TOKEN`, so private installs work too).
- The helper **self-gates**: a near-instant no-op where `libwebkit2gtk-4.1` is already present (Bazzite/CachyOS/Fedora), building + caching the closure via `podman` (shipped in Holo 3.7+) only on SteamOS.
- **Non-fatal**: binary, plugins and services still install if it can't run; only the overlay window is blocked until the closure is staged.

Deliberately **not** bundled into the release archive — the closure is ~100 MB and only SteamOS needs it, so bundling would bloat every download on every distro. Built locally and cached under `~/.cache/loadout/` instead; nothing extra is stored on GitHub.

## Verification (on a Steam Deck, SteamOS Holo)

- Reproduced the crash loop from a clean `curl … install.sh` install.
- Ran `fetch-deck-overlay-libs.sh` against the release-installed overlay → overlay launches: `systemctl --user is-active loadout-overlay` = `active`, 0 restarts, backend `/up` → `ok`.
- `sh -n scripts/install.sh` passes; helper fetch via raw + token returns HTTP 200 (private-repo curl path works).

Note: a few second-tier webkit deps (ICU 76, flite, …) remain unresolved in `ldd` but are harmless — Loadout renders via CEF, so webkit2gtk only needs to `dlopen` successfully for the wrapper to initialize; its lazy web-rendering deps are never exercised.

## Follow-up (not in this PR)

A CI smoke test that curl-installs in a SteamOS-like container would catch this class of regression before launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)