### PR TITLE
fix(overlay): reliable first-run auto-open + correct WM_CLASS

### DIFF
--- a/apps/loadout-overlay/src/bun/native/gamescope-atoms.ts
+++ b/apps/loadout-overlay/src/bun/native/gamescope-atoms.ts
@@ -374,6 +374,50 @@ export class GamescopeAtoms {
   }
 
   /**
+   * Overwrite the window's WM_CLASS. Electrobun's prebuilt native wrapper
+   * hardcodes its template class ("ElectrobunKitchenSink-dev"), which leaks
+   * into X11 WM_CLASS — so our `.desktop` `StartupWMClass=Loadout` never
+   * matches and WMs label/group the overlay as the kitchen-sink demo. We
+   * can't fix it at the source without rebuilding the vendored blob, so we
+   * set WM_CLASS ourselves once the window exists. WM_CLASS is two
+   * NUL-terminated strings: instance ("loadout") then class ("Loadout").
+   */
+  async setWmClass(instance: string, cls: string): Promise<void> {
+    if (!this.windowId) await this.findWindow();
+    if (!this.windowId) return;
+
+    // Fast path: libxcb. WM_CLASS is an XA_STRING holding the two
+    // NUL-terminated parts back to back.
+    if (this.x11) {
+      const idNum = this._windowIdNumFor("own");
+      if (idNum !== null) {
+        this.x11.setString(idNum, "WM_CLASS", `${instance}\0${cls}\0`);
+        this._flush();
+        return;
+      }
+    }
+
+    // Fallback: xdotool, which is already a hard dependency of findWindow
+    // (so it's present whenever we resolved a window id). Sets both
+    // res_name + res_class correctly.
+    try {
+      await run([
+        "env",
+        `DISPLAY=${this.display}`,
+        "xdotool",
+        "set_window",
+        "--classname",
+        instance,
+        "--class",
+        cls,
+        this.windowId,
+      ]);
+    } catch (err) {
+      console.warn("[gamescope-atoms] setWmClass failed:", err);
+    }
+  }
+
+  /**
    * One-time setup — sets atoms that mark this window as a Loadout
    * overlay. Defaults to hidden (opacity 0) so Gamescope doesn't render
    * it until the user toggles.
@@ -391,6 +435,9 @@ export class GamescopeAtoms {
     await this._set("STEAM_OVERLAY", 0);
     await this._set("STEAM_INPUT_FOCUS", 0);
     this._flush();
+    // Overwrite Electrobun's template WM_CLASS so the taskbar/WM labels us
+    // "Loadout" and `.desktop` StartupWMClass=Loadout matches.
+    await this.setWmClass("loadout", "Loadout");
     // Warm the Steam window cache so the first show() doesn't pay a
     // ~40ms cold xdotool/xprop survey. Best-effort: if Steam isn't up
     // yet at boot, show() still falls back to a lazy resolve.

--- a/apps/loadout-overlay/src/webview/main.tsx
+++ b/apps/loadout-overlay/src/webview/main.tsx
@@ -113,7 +113,21 @@ async function boot() {
     // available. Re-apply theme after load in case the on-disk value
     // differed from the mirror (post-reinstall first boot, etc.).
     loadUserConfig()
-      .then(() => applyTheme(getConfigValue<string>("theme", "dark")))
+      .then(() => {
+        applyTheme(getConfigValue<string>("theme", "dark"));
+        // First run (fresh install): the user hasn't completed the welcome
+        // flow or set a wake button, so open the overlay ourselves to show
+        // it. The installer also pokes the loader's /show, but that races
+        // the webview's first (slow) CEF boot and is silently dropped if it
+        // fires before the __overlay subscription below is registered — the
+        // window then stays mapped-hidden. Triggering it here, once the
+        // webview is provably up and config is loaded, guarantees the
+        // welcome screen appears. Gated on welcomeCompleted so it never
+        // auto-opens on normal logins after setup is done.
+        if (!getConfigValue<boolean>("welcomeCompleted", false)) {
+          void showOverlay();
+        }
+      })
       .catch((err) => console.warn("[main] loadUserConfig failed:", err));
     subscribe({
       plugin: "__system",

--- a/apps/loadout/src/loader/index.ts
+++ b/apps/loadout/src/loader/index.ts
@@ -204,6 +204,17 @@ export async function startServer(options: ServerOptions = {}) {
   // --- WebSocket client tracking ---
   const wsClients = new Set<WsClient>();
 
+  // Sticky first-run show. The installer hits /show right after enabling the
+  // overlay unit, which routinely beats the overlay's first (slow) CEF boot —
+  // so the broadcast goes to zero clients and is lost, and the window never
+  // opens on a fresh install. When /show arrives with nobody connected we
+  // remember it and replay once a webview connects.
+  let pendingShow = false;
+
+  function broadcastShow() {
+    broadcast({ type: "event", plugin: "__overlay", event: "show", data: {} });
+  }
+
   function broadcast(msg: RpcEvent) {
     const data = JSON.stringify(msg);
     for (const ws of wsClients) {
@@ -380,7 +391,12 @@ export async function startServer(options: ServerOptions = {}) {
       //     process directly, so it broadcasts to the webview, which calls
       //     the overlay's show() RPC (see App.tsx __overlay listener).
       if (url.pathname === "/show") {
-        broadcast({ type: "event", plugin: "__overlay", event: "show", data: {} });
+        if (wsClients.size > 0) {
+          broadcastShow();
+        } else {
+          // No overlay connected yet — replay on the next connect.
+          pendingShow = true;
+        }
         return new Response("ok");
       }
 
@@ -411,6 +427,14 @@ export async function startServer(options: ServerOptions = {}) {
       open(ws: WsClient) {
         wsClients.add(ws);
         log.debug(`WebSocket client connected (total: ${wsClients.size})`);
+        if (pendingShow) {
+          pendingShow = false;
+          // The socket is open, but the webview registers its
+          // __overlay/show subscription a tick later in its boot() chain.
+          // A short delay lets it attach so the replayed event isn't
+          // dropped a second time.
+          setTimeout(broadcastShow, 500);
+        }
       },
       async message(ws: WsClient, message: string | Buffer) {
         const msg = typeof message === "string" ? message : message.toString();


### PR DESCRIPTION
## Problem

First-install auto-open was racy and often failed. The installer hits the loader's `/show` right after enabling the overlay unit, but `/show` only broadcasts to connected webview clients and returns `"ok"` regardless. On a fresh install the overlay's first CEF boot is slow, so the broadcast lands **before** the webview's `__overlay/show` subscription is registered and is silently dropped — the window stays mapped-hidden while the installer prints "Overlay opened."

Reproduced on a Steam Deck: right after a clean install the overlay window was `IsUnMapped`; it only opened once `/show` was fired again after the webview had connected.

Separately, the overlay's X11 **WM_CLASS was `ElectrobunKitchenSink-dev`** (Electrobun's prebuilt-wrapper template default), so `.desktop`'s `StartupWMClass=Loadout` never matched and WMs labelled/grouped the overlay as the demo app.

## Fixes

1. **Overlay self-opens on first run** (`webview/main.tsx`) — once config is loaded and the webview is provably up, if `welcomeCompleted` is false, call `showOverlay()`. Removes the timing dependency for the case that matters most (first install → Welcome). Gated so it never auto-opens on normal logins.
2. **Sticky `/show`** (`loader/index.ts`) — if `/show` arrives with no overlay connected, store it and replay when a webview connects (small delay so the subscription has attached). Makes the installer's poke reliable on reinstalls too (where `welcomeCompleted` is already true).
3. **Correct WM_CLASS** (`gamescope-atoms.ts`) — set `WM_CLASS` to `"loadout"`/`"Loadout"` via libxcb (xdotool fallback) in `prepare()`, since we can't change the vendored wrapper without rebuilding it.

## Verification (Steam Deck, SteamOS)

- Fresh config → window **self-opens to Welcome at ~4s** with no `/show` fired (`Map State: IsViewable`).
- `welcomeCompleted=true` (Fix 1 disabled) + `/show` fired while the overlay is **down** → window opens on connect via the sticky replay (~6s).
- `xprop WM_CLASS` → `"loadout", "Loadout"`.
- `bun run typecheck` clean; 47 native/overlay-state tests pass; eslint clean on changed files.

> Note: surfaced (and fixed out-of-band) a CEF API-hash crash that was caused by `node_modules` still holding Electrobun 1.16 after `main` was bumped to 1.18.1 — a `bun install` was needed. Not part of this diff, but worth flagging for anyone building from a freshly-pulled tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)