### PR TITLE
fix(install): graceful overlay restart to avoid blank CEF webview

### DIFF
--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -229,5 +229,28 @@ for i in $(seq 1 30); do
     sleep 1
 done
 
-systemctl --user restart loadout-overlay
+# Graceful overlay (re)start. A plain `systemctl restart` races CEF: the
+# unit's main process can exit while its CEF helper/zygote children are
+# still tearing down and holding the browser profile under
+# .cache/.../CEF/partitions/default. If the fresh instance launches into
+# that window it fails with "Cannot create profile at path ..." and
+# renders a blank webview. So stop, wait for the whole process tree to
+# actually exit, then start.
+OVERLAY_BIN_DIR="$OVERLAY_INSTALL_DIR/bin"
+systemctl --user stop loadout-overlay 2>/dev/null || true
+echo "Waiting for the overlay to fully exit..."
+for i in $(seq 1 20); do
+    # pgrep -f against the install bin dir catches the launcher, the Bun
+    # main process, and every CEF Helper/zygote child — they all carry
+    # that path in their argv.
+    if ! pgrep -f "$OVERLAY_BIN_DIR" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+# Last resort: anything still clinging after the grace window gets a TERM
+# so the profile lock is guaranteed free before we relaunch.
+pkill -TERM -f "$OVERLAY_BIN_DIR" 2>/dev/null || true
+sleep 0.5
+systemctl --user start loadout-overlay
 echo "Services restarted."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -999,7 +999,19 @@ OVERLAYEOF
         # find the display. Skips cleanly on headless / SSH installs.
         if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
             systemctl --user import-environment DISPLAY WAYLAND_DISPLAY XAUTHORITY 2>/dev/null || true
-            if systemctl --user restart loadout-overlay 2>/dev/null; then
+            # Graceful restart — a plain `restart` can race CEF: the new
+            # instance launches while the old one's helper/zygote children
+            # still hold the browser profile under CEF/partitions/default,
+            # which fails with "Cannot create profile at path ..." and a
+            # blank webview. Stop, wait for the process tree to exit, start.
+            systemctl --user stop loadout-overlay 2>/dev/null || true
+            for _ in 1 2 3 4 5 6 7 8 9 10; do
+                pgrep -f "$OVERLAY_INSTALL_DIR/bin" >/dev/null 2>&1 || break
+                sleep 0.5
+            done
+            pkill -TERM -f "$OVERLAY_INSTALL_DIR/bin" 2>/dev/null || true
+            sleep 0.5
+            if systemctl --user start loadout-overlay 2>/dev/null; then
                 # Give the overlay a moment to come up and connect, then ask
                 # the loader to show it (loopback /show endpoint).
                 show_ok=0


### PR DESCRIPTION
## Problem

A plain `systemctl --user restart loadout-overlay` races CEF. The unit's main process can exit while its CEF **helper/zygote children are still tearing down** and holding the browser profile under `~/.cache/com.loadout.overlay/dev/CEF/partitions/default`. If the fresh instance launches into that window, the renderer comes up **blank** — empty document, no React root:

```
ERROR cef/.../chrome_browser_context.cc] Cannot create profile at path
  .../CEF/partitions/default
```

Hit this live after a back-to-back reinstall: the overlay was a blank screen and only recovered after a manual `systemctl --user restart loadout-overlay` (by which point the old process tree had fully exited).

## Fix

Both installers (`install-local.sh` and the curl-piped `install.sh`) now do a **graceful** restart instead of `restart`:

1. `stop` the overlay,
2. wait for the whole process tree to exit — launcher + Bun main + every CEF `Helper`/zygote child, all matched via `pgrep -f` against the install bin dir in their argv,
3. `pkill -TERM` sweep as a last-resort backstop after the grace window,
4. `start`.

This guarantees the profile lock is free before relaunch.

## Test

- `sh -n` clean on both scripts.
- Ran `build-and-install` on-device: the new "Waiting for the overlay to fully exit..." step runs, and the overlay comes up **non-blank** (verified via CDP: `title: "Loadout Overlay"`, populated React root) on the same reinstall path that previously blanked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)