### PR TITLE
docs(readme): add FAQ (overlay open, first-time setup, SteamGridDB key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,28 @@ entirely.
 
 </details>
 
+## FAQ
+
+**How do I open the overlay?**
+From Gaming Mode, trigger your configured wake shortcut on the controller. If
+you're on a keyboard (or your controller shortcut isn't working yet),
+**`Ctrl+4`** toggles the overlay open and closed at any time — handy as a
+fallback during first-time setup.
+
+**What should I do the first time I launch it?**
+First-time setup is much smoother with a **keyboard attached**. You'll be
+entering a few values (like a SteamGridDB API key) and configuring shortcuts,
+and typing those on a keyboard is far quicker than the on-screen keyboard. Once
+you're set up, day-to-day use is fully controller- and d-pad-friendly.
+
+**Do I need a SteamGridDB API key?**
+It's **highly encouraged.** The [SteamGridDB](plugins/steamgriddb/README.md)
+plugin — and the custom artwork that other plugins pull in (box art, heroes,
+logos) — needs a free API key to fetch art. Grab one from
+[steamgriddb.com/profile/preferences/api](https://www.steamgriddb.com/profile/preferences/api)
+and paste it into the SteamGridDB plugin's settings; you only enter it once and
+it persists across reinstalls.
+
 ## How it works
 
 - **TypeScript end to end.** The plugin host, every plugin backend, every

--- a/README.md
+++ b/README.md
@@ -150,6 +150,55 @@ logos) — needs a free API key to fetch art. Grab one from
 and paste it into the SteamGridDB plugin's settings; you only enter it once and
 it persists across reinstalls.
 
+**Can I open the overlay with a controller instead?**
+Yes — that's the main way. In **Settings → Controller** you can bind the overlay
+to **Guide + B** or **Guide + X**. (Guide + A and Guide + Y are deliberately left
+alone — Steam and InputPlumber reserve them for the QAM and Steam menu.) `Ctrl+4`
+on a keyboard always works too, as a fallback.
+
+**How do I update to a new version?**
+Re-run the same install command — it's idempotent. It checks for a newer binary
+and overlay, refreshes the bundled plugins, and leaves your config untouched:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/srsholmes/loadout/main/scripts/install.sh | sh
+```
+
+**How do I install or manage plugins?**
+All 20-plus plugins ship **bundled** with the release — there's nothing extra to
+download. Enable or disable individual plugins from **Settings → Plugins**.
+
+**My controller seems dead in Steam — what's going on?**
+While the overlay is *open*, it exclusively grabs your controller so your inputs
+drive the overlay and don't leak through to the game underneath. That's by
+design — close the overlay and the controller returns to Steam immediately. If a
+pad stays unresponsive while the overlay is *hidden*, make sure you're on the
+latest version.
+
+**Where do my settings live? Do they survive a reinstall?**
+Everything — theme, UI scale, favourites, home layout, controller shortcuts, and
+per-plugin state — lives in `~/.config/loadout/config.json` (honouring
+`$XDG_CONFIG_HOME`) and survives reinstalls and CEF profile wipes.
+
+**Something's not working — where are the logs?**
+Backend logs are at `~/.config/loadout/logs/loadout.log`, or follow them live:
+
+```sh
+journalctl -u loadout -f               # backend (system service)
+journalctl --user -u loadout-overlay -f   # overlay (user service)
+```
+
+**How do I report a bug or get help?**
+[Open an issue](https://github.com/srsholmes/loadout/issues) with your handheld,
+distro, and steps to reproduce — and if you're on an untested device, I'd love
+to hear from you.
+
+**How do I uninstall?**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/srsholmes/loadout/main/scripts/uninstall.sh | sh
+```
+
 ## How it works
 
 - **TypeScript end to end.** The plugin host, every plugin backend, every


### PR DESCRIPTION
Now that the repo is public, adds a user-facing **FAQ** section to the README (right after Install) covering common onboarding and troubleshooting questions:

- **How do I open the overlay?** — `Ctrl+4` toggles it; controller bindings (Guide+B / Guide+X) via Settings → Controller.
- **First-time setup** — smoother with a keyboard attached.
- **SteamGridDB API key** — highly encouraged; free key powers the artwork, entered once and persisted.
- **Updating** — re-run the idempotent installer.
- **Plugins** — all bundled with the release; enable/disable in Settings → Plugins.
- **"Controller seems dead in Steam"** — the overlay grabs input only while open, by design.
- **Config location & persistence** — `~/.config/loadout/config.json`, survives reinstalls.
- **Logs** — `~/.config/loadout/logs/loadout.log` + journalctl one-liners.
- **Reporting bugs / uninstalling.**

All claims verified against the source:
- `Ctrl+4` / `Ctrl+3` hardcoded overlay toggles — `apps/loadout-overlay/src/bun/lib/wake-routing.ts`, `src/bun/native/input-intercept.ts`.
- Controller combos (Guide+B/X bindable; Guide+A/Y reserved) — `apps/loadout-overlay/src/overlay/components/Settings.tsx`.
- SGDB API key URL — `plugins/steamgriddb/backend.ts`.
- Log path — `apps/loadout/src/loader/logger.ts`.
- Update/uninstall flow — `scripts/install.sh`, `scripts/uninstall.sh`, README Install section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)