### PR TITLE
feat(apex): auto-recover gamepad on wake

### DIFF
--- a/plugins/apex/app.tsx
+++ b/plugins/apex/app.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { FaGamepad, FaTriangleExclamation, FaCircleCheck, FaRotate } from "react-icons/fa6";
-import { Alert, Button, Spinner, mountComponent, notify, useBackend } from "@loadout/ui";
+import { Alert, Button, Spinner, Toggle, mountComponent, notify, useBackend } from "@loadout/ui";
 
 export const icon = FaGamepad;
 
@@ -16,6 +16,8 @@ interface XhciStatus {
 interface StatusResult {
   unsupported: boolean;
   status?: XhciStatus;
+  autoRecoverOnWake?: boolean;
+  listenerRunning?: boolean;
 }
 
 interface RecoverResult {
@@ -33,6 +35,7 @@ function Apex() {
 
   const [data, setData] = useState<StatusResult | null>(null);
   const [busy, setBusy] = useState(false);
+  const [autoWakeBusy, setAutoWakeBusy] = useState(false);
 
   const refresh = useCallback(async () => {
     setData((await call("getStatus")) as StatusResult);
@@ -66,6 +69,25 @@ function Apex() {
       setBusy(false);
     }
   }, [call, refresh]);
+
+  const handleToggleAutoWake = useCallback(
+    async (next: boolean) => {
+      setAutoWakeBusy(true);
+      try {
+        const res = (await call("setAutoRecoverOnWake", next)) as {
+          success: boolean;
+          error?: string;
+        };
+        if (!res.success) {
+          notify(res.error ?? "Couldn't update the setting.", { kind: "error" });
+        }
+      } finally {
+        setAutoWakeBusy(false);
+        await refresh();
+      }
+    },
+    [call, refresh],
+  );
 
   if (!data) {
     return (
@@ -144,6 +166,23 @@ function Apex() {
             <div className="text-xs text-base-content/55 leading-relaxed">
               Safe to run any time — if the controller is already working it does nothing, so
               there's no harm in pressing it.
+            </div>
+
+            <div className="flex justify-between items-start gap-4 pt-4 mt-1 border-t border-base-300">
+              <div className="flex flex-col gap-1 min-w-0">
+                <span className="text-sm text-base-content font-medium">
+                  Recover automatically on wake
+                </span>
+                <span className="text-xs text-base-content/55 leading-relaxed">
+                  Run this recovery whenever the device wakes from sleep, so you never have to
+                  press the button. Only rebinds if the gamepad is actually missing.
+                </span>
+              </div>
+              <Toggle
+                checked={!!data.autoRecoverOnWake}
+                disabled={autoWakeBusy}
+                onChange={handleToggleAutoWake}
+              />
             </div>
           </div>
         </div>

--- a/plugins/apex/backend.ts
+++ b/plugins/apex/backend.ts
@@ -1,6 +1,7 @@
 import { access } from "node:fs/promises";
 import type { PluginBackend, EmitPayload, PluginLogger } from "@loadout/types";
-import { runFull } from "@loadout/exec";
+import { runFull, runStreaming } from "@loadout/exec";
+import { readPluginStorage, writePluginStorage } from "@loadout/plugin-storage";
 import { isApex } from "./lib/dmi";
 import {
   getStatus as computeStatus,
@@ -9,6 +10,23 @@ import {
   type XhciStatus,
   type RecoverResult,
 } from "./lib/xhci";
+import { startWakeListener, type StopHandle } from "./lib/wake-listener";
+
+const PLUGIN_ID = "apex";
+
+/** Persisted per-plugin settings (in ~/.config/loadout/plugins/apex.json). */
+interface ApexSettings {
+  /** Run the gamepad recovery automatically whenever the device resumes. */
+  autoRecoverOnWake?: boolean;
+}
+
+/**
+ * How long to wait after a resume before checking the gamepad. The kernel
+ * re-enumerates USB during resume; checking too early can read the pad as
+ * briefly-absent and trigger a needless rebind. recover() then polls, so
+ * this only needs to clear the initial settle.
+ */
+const RESUME_SETTLE_MS = 2_000;
 
 /**
  * Apex — OneXPlayer Apex device fixes.
@@ -30,6 +48,8 @@ export default class ApexBackend implements PluginBackend {
   private unsupported = false;
   /** Serialises recover() so a double-tap can't run two rebinds at once. */
   private recovering = false;
+  /** Live handle to the resume listener when auto-recover-on-wake is on. */
+  private wakeStop: StopHandle | null = null;
 
   // Hardware-access dependencies handed to the pure xhci orchestration.
   // Wired to the real exec / fs / timers here; swapped for fakes in tests.
@@ -53,17 +73,64 @@ export default class ApexBackend implements PluginBackend {
     this.unsupported = !(await isApex());
     if (this.unsupported) {
       this.log?.info("[apex] Non-Apex hardware — plugin inert (recovery disabled).");
-    } else {
-      this.log?.info("[apex] OneXPlayer Apex detected — recovery available.");
+      return;
     }
+    this.log?.info("[apex] OneXPlayer Apex detected — recovery available.");
+
+    // Restore the auto-recover-on-wake listener if it was left enabled.
+    const settings = await readPluginStorage<ApexSettings>(PLUGIN_ID);
+    if (settings.autoRecoverOnWake) {
+      this.startWake();
+    }
+  }
+
+  async onUnload(): Promise<void> {
+    this.stopWake();
   }
 
   // ---------- RPC ----------
 
   /** Snapshot the controller/gamepad state for the UI. */
-  async getStatus(): Promise<{ unsupported: boolean; status?: XhciStatus }> {
+  async getStatus(): Promise<{
+    unsupported: boolean;
+    status?: XhciStatus;
+    autoRecoverOnWake?: boolean;
+    listenerRunning?: boolean;
+  }> {
     if (this.unsupported) return { unsupported: true };
-    return { unsupported: false, status: await computeStatus(this.deps) };
+    const settings = await readPluginStorage<ApexSettings>(PLUGIN_ID);
+    return {
+      unsupported: false,
+      status: await computeStatus(this.deps),
+      autoRecoverOnWake: !!settings.autoRecoverOnWake,
+      listenerRunning: this.wakeStop !== null,
+    };
+  }
+
+  /**
+   * Enable/disable running the recovery automatically on resume. Persists
+   * the choice and starts/stops the logind wake listener to match.
+   */
+  async setAutoRecoverOnWake(
+    enabled: boolean,
+  ): Promise<{ success: boolean; unsupported?: boolean; error?: string }> {
+    if (this.unsupported) {
+      return { success: false, unsupported: true, error: "Not running on Apex hardware." };
+    }
+    try {
+      const existing = await readPluginStorage<ApexSettings>(PLUGIN_ID);
+      await writePluginStorage<ApexSettings>(PLUGIN_ID, {
+        ...existing,
+        autoRecoverOnWake: enabled,
+      });
+      if (enabled) this.startWake();
+      else this.stopWake();
+      this.emit?.({ event: "statusChanged", data: undefined });
+      return { success: true };
+    } catch (e) {
+      this.log?.warn(`[apex] setAutoRecoverOnWake failed: ${e}`);
+      return { success: false, error: String(e) };
+    }
   }
 
   /** Run the rebind recovery. Returns a structured result for the UI. */
@@ -95,6 +162,57 @@ export default class ApexBackend implements PluginBackend {
       return result;
     } finally {
       this.recovering = false;
+    }
+  }
+
+  // ---------- auto-recover-on-wake ----------
+
+  /** Start the logind resume listener (idempotent). */
+  private startWake(): void {
+    if (this.wakeStop) return;
+    this.wakeStop = startWakeListener(
+      {
+        spawn: ({ cmd, onLine, onSpawn }) => {
+          // Long-lived; resolves only when the monitor is killed on stop().
+          // enforceCommandPolicy runs synchronously inside runStreaming, so
+          // the `dbus-monitor` permission is checked within this scope.
+          void runStreaming(cmd, {
+            onLine,
+            onSpawn: (proc) => onSpawn({ kill: () => proc.kill() }),
+          }).catch((e) => this.log?.warn(`[apex] wake listener exited: ${e}`));
+        },
+        log: (m) => this.log?.info(`[apex] ${m}`),
+      },
+      () => void this.onResume(),
+    );
+    this.log?.info("[apex] auto-recover-on-wake enabled — listening for resume.");
+  }
+
+  /** Stop the resume listener (idempotent). */
+  private stopWake(): void {
+    if (!this.wakeStop) return;
+    this.wakeStop.stop();
+    this.wakeStop = null;
+    this.log?.info("[apex] auto-recover-on-wake disabled.");
+  }
+
+  /**
+   * Fired on resume. Waits for the bus to settle, then runs the guarded
+   * recovery — a no-op if the gamepad survived the sleep, a rebind if not.
+   */
+  private async onResume(): Promise<void> {
+    await new Promise((r) => setTimeout(r, RESUME_SETTLE_MS));
+    try {
+      const res = await this.recover();
+      if (res.alreadyHealthy) {
+        this.log?.info("[apex] wake: gamepad healthy — no rebind needed.");
+      } else if (res.success) {
+        this.log?.info(`[apex] wake: recovered gamepad (rebound ${res.controller}).`);
+      } else {
+        this.log?.warn(`[apex] wake: recovery failed — ${res.error ?? "unknown"}.`);
+      }
+    } catch (e) {
+      this.log?.warn(`[apex] wake recovery threw: ${e}`);
     }
   }
 }

--- a/plugins/apex/lib/wake-listener.test.ts
+++ b/plugins/apex/lib/wake-listener.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "bun:test";
+import {
+  makePrepareForSleepParser,
+  startWakeListener,
+  DBUS_MONITOR_CMD,
+  type WakeDeps,
+  type WakeProc,
+} from "./wake-listener";
+
+/**
+ * Wake-listener tests. The dbus-monitor subprocess is injected, so these
+ * are pure unit tests of the PrepareForSleep parser and the start/stop
+ * orchestration — no D-Bus, no root.
+ */
+
+// A realistic dbus-monitor signal header for PrepareForSleep.
+const HEADER =
+  "signal time=123.4 sender=:1.3 -> destination=(null destination) serial=42 " +
+  "path=/org/freedesktop/login1; interface=org.freedesktop.login1.Manager; member=PrepareForSleep";
+
+describe("makePrepareForSleepParser", () => {
+  it("returns resume on header followed by boolean false", () => {
+    const parse = makePrepareForSleepParser();
+    expect(parse(HEADER)).toBeNull();
+    expect(parse("   boolean false")).toBe("resume");
+  });
+
+  it("returns suspend on header followed by boolean true", () => {
+    const parse = makePrepareForSleepParser();
+    expect(parse(HEADER)).toBeNull();
+    expect(parse("   boolean true")).toBe("suspend");
+  });
+
+  it("tolerates a blank line between header and the boolean arg", () => {
+    const parse = makePrepareForSleepParser();
+    parse(HEADER);
+    expect(parse("")).toBeNull();
+    expect(parse("   boolean false")).toBe("resume");
+  });
+
+  it("ignores a boolean line that wasn't preceded by a PrepareForSleep header", () => {
+    const parse = makePrepareForSleepParser();
+    expect(parse("   boolean false")).toBeNull();
+  });
+
+  it("re-arms for each subsequent signal (suspend then resume)", () => {
+    const parse = makePrepareForSleepParser();
+    parse(HEADER);
+    expect(parse("   boolean true")).toBe("suspend");
+    parse(HEADER);
+    expect(parse("   boolean false")).toBe("resume");
+  });
+});
+
+/** A fake monitor that records its command and lets the test feed lines. */
+function makeFakeDeps(): {
+  deps: WakeDeps;
+  emit: (line: string) => void;
+  killed: () => number;
+  cmd: () => string[] | null;
+} {
+  let onLine: ((line: string) => void) | null = null;
+  let kills = 0;
+  let cmd: string[] | null = null;
+  const deps: WakeDeps = {
+    spawn: (args) => {
+      cmd = args.cmd;
+      onLine = args.onLine;
+      const proc: WakeProc = { kill: () => void kills++ };
+      args.onSpawn(proc);
+    },
+  };
+  return {
+    deps,
+    emit: (line) => onLine?.(line),
+    killed: () => kills,
+    cmd: () => cmd,
+  };
+}
+
+describe("startWakeListener", () => {
+  it("spawns the filtered system-bus PrepareForSleep monitor", () => {
+    const f = makeFakeDeps();
+    startWakeListener(f.deps, () => {});
+    expect(f.cmd()).toEqual([...DBUS_MONITOR_CMD]);
+  });
+
+  it("fires onResume once per resume, never on suspend", () => {
+    const f = makeFakeDeps();
+    let resumes = 0;
+    startWakeListener(f.deps, () => void resumes++);
+
+    f.emit(HEADER);
+    f.emit("   boolean true"); // suspend — no callback
+    expect(resumes).toBe(0);
+
+    f.emit(HEADER);
+    f.emit("   boolean false"); // resume
+    expect(resumes).toBe(1);
+  });
+
+  it("stop() kills the monitor process", () => {
+    const f = makeFakeDeps();
+    const handle = startWakeListener(f.deps, () => {});
+    expect(f.killed()).toBe(0);
+    handle.stop();
+    expect(f.killed()).toBe(1);
+  });
+
+  it("stop() before the process spawns still kills it once it arrives", () => {
+    // Defer onSpawn to model the async spawn racing behind a fast stop().
+    let deliver: (() => void) | null = null;
+    let kills = 0;
+    const deps: WakeDeps = {
+      spawn: (args) => {
+        deliver = () => args.onSpawn({ kill: () => void kills++ });
+      },
+    };
+    const handle = startWakeListener(deps, () => {});
+    handle.stop(); // stop before the process is delivered
+    deliver?.(); // now the process arrives
+    expect(kills).toBe(1);
+  });
+});

--- a/plugins/apex/lib/wake-listener.ts
+++ b/plugins/apex/lib/wake-listener.ts
@@ -1,0 +1,109 @@
+/**
+ * Wake listener — fires a callback when the system resumes from sleep.
+ *
+ * Tails logind's `PrepareForSleep` D-Bus signal via `dbus-monitor` on the
+ * system bus. The signal carries a boolean: `true` is emitted just before
+ * suspend, `false` once the system has resumed. We only care about resume
+ * (`false`): that's when the Apex's xHCI controller may have died and the
+ * internal gamepad needs recovering.
+ *
+ * logind is present identically on SteamOS, Bazzite and CachyOS, so this is
+ * the portable cross-distro wake hook — there's no systemd-sleep script to
+ * install, nothing to clean up on disable, and it survives suspend because
+ * the backend that owns it runs as a root system service.
+ *
+ * The subprocess and the line parsing are dependency-injected (`WakeDeps`)
+ * so the orchestration is unit-testable without a real D-Bus.
+ */
+
+/** The minimal handle we need on the spawned monitor: a way to kill it. */
+export interface WakeProc {
+  kill: () => void;
+}
+
+export interface WakeDeps {
+  /**
+   * Start the streaming monitor. Wired to `@loadout/exec`'s `runStreaming`
+   * in prod: it should deliver each output line to `onLine` and hand the
+   * spawned process to `onSpawn` so we can kill it on stop.
+   */
+  spawn: (args: {
+    cmd: string[];
+    onLine: (line: string) => void;
+    onSpawn: (proc: WakeProc) => void;
+  }) => void;
+  /** Optional progress sink. */
+  log?: (message: string) => void;
+}
+
+/** Watch only the PrepareForSleep signal on the system bus. */
+export const DBUS_MONITOR_CMD = [
+  "dbus-monitor",
+  "--system",
+  "type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'",
+] as const;
+
+export interface StopHandle {
+  stop: () => void;
+}
+
+/**
+ * Stateful parser for `dbus-monitor` output. dbus-monitor prints a signal
+ * header line followed by the argument on the next line, e.g.:
+ *
+ *   signal time=… interface=org.freedesktop.login1.Manager … member=PrepareForSleep
+ *      boolean false
+ *
+ * We arm on a header line whose member is `PrepareForSleep`, then read the
+ * following `boolean <true|false>` line. `false` = resume, `true` = suspend.
+ * Returns `"resume"`, `"suspend"`, or `null` for any line that isn't the
+ * boolean we're waiting on. The monitor is filtered to PrepareForSleep, so
+ * no other signal headers interleave.
+ */
+export function makePrepareForSleepParser(): (line: string) => "resume" | "suspend" | null {
+  let armed = false;
+  return (line: string) => {
+    if (line.includes("member=PrepareForSleep")) {
+      armed = true;
+      return null;
+    }
+    if (!armed) return null;
+    const m = /boolean\s+(true|false)/.exec(line);
+    if (!m) return null; // blank/whitespace line between header and arg — keep waiting
+    armed = false;
+    return m[1] === "false" ? "resume" : "suspend";
+  };
+}
+
+/**
+ * Start listening for resume events. Calls `onResume` once per resume.
+ * Returns a handle whose `stop()` kills the monitor (and pre-empts a kill
+ * if `stop()` races ahead of the async spawn).
+ */
+export function startWakeListener(deps: WakeDeps, onResume: () => void): StopHandle {
+  const parse = makePrepareForSleepParser();
+  let proc: WakeProc | null = null;
+  let stopped = false;
+
+  deps.spawn({
+    cmd: [...DBUS_MONITOR_CMD],
+    onSpawn: (p) => {
+      proc = p;
+      if (stopped) p.kill(); // stop() arrived before the process existed
+    },
+    onLine: (line) => {
+      if (parse(line) === "resume") {
+        deps.log?.("resume detected — running gamepad recovery");
+        onResume();
+      }
+    },
+  });
+
+  return {
+    stop: () => {
+      stopped = true;
+      proc?.kill();
+      proc = null;
+    },
+  };
+}

--- a/plugins/apex/package.json
+++ b/plugins/apex/package.json
@@ -16,7 +16,8 @@
       "commands": [
         "tee",
         "lsusb",
-        "dmesg"
+        "dmesg",
+        "dbus-monitor"
       ]
     },
     "category": "Device",


### PR DESCRIPTION
## What

Adds an opt-in **"Recover automatically on wake"** toggle to the Apex plugin. When on, the existing xHCI gamepad recovery runs automatically every time the device resumes from sleep — so users no longer have to open the panel and press **Recover gamepad** by hand after each wake.

Motivated by Discord reports of the internal gamepad dying on resume and users restarting 10+ times per session.

## How

- The Apex backend runs as root and survives suspend, so it hosts the wake hook directly — no `systemd-sleep` script is installed (nothing to clean up, no SteamOS read-only `/etc` dance).
- It tails **logind's `PrepareForSleep` D-Bus signal** via `dbus-monitor` (`@loadout/exec` `runStreaming`). On resume (`boolean false`) it calls the **existing guarded `recover()`**, which:
  - no-ops when the gamepad is already enumerating (`alreadyHealthy`), and
  - only rebinds `0000:65:00.4` when the pad actually dropped off the bus.
- A 2s settle delay after resume avoids reading a mid-enumeration pad as "missing".

## Cross-distro

logind + `dbus-monitor` + the sysfs rebind are identical on **SteamOS, Bazzite, and CachyOS**, so this works on all three. The existing DMI gate keeps the whole plugin Apex-only.

## Changes

- `lib/wake-listener.ts` (new) — dependency-injected `PrepareForSleep` listener + a pure, unit-tested line parser.
- `backend.ts` — persisted `autoRecoverOnWake` setting (`~/.config/loadout/plugins/apex.json`), listener lifecycle (`onLoad` restore / `onUnload` stop), `setAutoRecoverOnWake` RPC, extra status fields.
- `app.tsx` — the toggle (manual button kept as-is).
- `package.json` — allow the `dbus-monitor` command.
- `lib/wake-listener.test.ts` (new) — parser + start/stop orchestration.

## Test

- `bun test plugins/apex/...test.ts --isolate` → 32/32 pass (9 new). Lint + typecheck clean.
- Manual: enable the toggle, sleep/resume; on wake the pad recovers without the button; a healthy wake logs `gamepad healthy — no rebind needed`; toggle persists across reboot.

> Note: the **fingerprint-wake block** is a separate follow-up PR (it drags in per-distro kernel-arg handling). This PR is just the auto-recover-on-wake option. The intermittent amdgpu/Strix-Halo resume hang is tracked separately in #156 and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
