### PR TITLE
feat(apex): auto-recover gamepad on wake (rebased onto main, picks up #161 re-grab fix)

### DIFF
--- a/plugins/apex/app.spec.tsx
+++ b/plugins/apex/app.spec.tsx
@@ -143,6 +143,46 @@ describe("apex plugin", () => {
     });
   });
 
+  it("shows the auto-recover-on-wake control and toggles it", async () => {
+    const container = document.createElement("div");
+    const { mount } = await import("./app");
+    mount(container);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Recover automatically on wake");
+    });
+
+    // The auto-recover toggle is the first checkbox — it lives in the
+    // gamepad-recovery card, ahead of the driver-blacklist card.
+    const autoToggle = container.querySelector(
+      'input[type="checkbox"]',
+    ) as HTMLInputElement;
+    expect(autoToggle.checked).toBe(false);
+
+    fireEvent.click(autoToggle);
+    await waitFor(() => {
+      expect(callMock).toHaveBeenCalledWith("setAutoRecoverOnWake", true);
+    });
+  });
+
+  it("reflects a persisted auto-recover-on-wake setting as checked", async () => {
+    callMock.mockImplementation((method: string) => {
+      if (method === "getStatus")
+        return Promise.resolve({ ...healthyStatus, autoRecoverOnWake: true, listenerRunning: true });
+      return Promise.resolve({ success: true });
+    });
+    const container = document.createElement("div");
+    const { mount } = await import("./app");
+    mount(container);
+
+    await waitFor(() => {
+      const autoToggle = container.querySelector(
+        'input[type="checkbox"]',
+      ) as HTMLInputElement;
+      expect(autoToggle?.checked).toBe(true);
+    });
+  });
+
   it("shows the driver-blacklist control and toggles it", async () => {
     const container = document.createElement("div");
     const { mount } = await import("./app");

--- a/plugins/apex/app.tsx
+++ b/plugins/apex/app.tsx
@@ -32,6 +32,8 @@ interface StatusResult {
   status?: XhciStatus;
   hidOxp?: HidOxpStatus;
   fingerprint?: FingerprintStatus;
+  autoRecoverOnWake?: boolean;
+  listenerRunning?: boolean;
 }
 
 interface FingerprintResult {
@@ -56,6 +58,7 @@ function Apex() {
 
   const [data, setData] = useState<StatusResult | null>(null);
   const [busy, setBusy] = useState(false);
+  const [autoWakeBusy, setAutoWakeBusy] = useState(false);
   const [blacklistBusy, setBlacklistBusy] = useState(false);
   const [fpBusy, setFpBusy] = useState(false);
 
@@ -91,6 +94,25 @@ function Apex() {
       setBusy(false);
     }
   }, [call, refresh]);
+
+  const handleToggleAutoWake = useCallback(
+    async (next: boolean) => {
+      setAutoWakeBusy(true);
+      try {
+        const res = (await call("setAutoRecoverOnWake", next)) as {
+          success: boolean;
+          error?: string;
+        };
+        if (!res.success) {
+          notify(res.error ?? "Couldn't update the setting.", { kind: "error" });
+        }
+      } finally {
+        setAutoWakeBusy(false);
+        await refresh();
+      }
+    },
+    [call, refresh],
+  );
 
   const handleToggleBlacklist = useCallback(
     async (next: boolean) => {
@@ -223,6 +245,23 @@ function Apex() {
             <div className="text-xs text-base-content/55 leading-relaxed">
               Safe to run any time — if the controller is already working it does nothing, so
               there's no harm in pressing it.
+            </div>
+
+            <div className="flex justify-between items-start gap-4 pt-4 mt-1 border-t border-base-300">
+              <div className="flex flex-col gap-1 min-w-0">
+                <span className="text-sm text-base-content font-medium">
+                  Recover automatically on wake
+                </span>
+                <span className="text-xs text-base-content/55 leading-relaxed">
+                  Run this recovery whenever the device wakes from sleep, so you never have to
+                  press the button. Only rebinds if the gamepad is actually missing.
+                </span>
+              </div>
+              <Toggle
+                checked={!!data.autoRecoverOnWake}
+                disabled={autoWakeBusy}
+                onChange={handleToggleAutoWake}
+              />
             </div>
           </div>
         </div>

--- a/plugins/apex/backend.test.ts
+++ b/plugins/apex/backend.test.ts
@@ -64,6 +64,28 @@ mock.module("./lib/fingerprint", () => ({
   revert: revertFingerprintImpl,
 }));
 
+// In-memory plugin storage so settings persist within a test without touching
+// the real ~/.config/loadout file.
+let storage: Record<string, unknown> = {};
+mock.module("@loadout/plugin-storage", () => ({
+  readPluginStorage: async () => ({ ...storage }),
+  writePluginStorage: async (_id: string, next: Record<string, unknown>) => {
+    storage = { ...next };
+  },
+}));
+
+// Capture the resume callback and hand back a stop spy so we can assert the
+// listener is started/stopped without a real dbus-monitor.
+let capturedOnResume: (() => void) | null = null;
+const stopSpy = mock(() => {});
+const startWakeListenerImpl = mock((_deps: unknown, onResume: () => void) => {
+  capturedOnResume = onResume;
+  return { stop: stopSpy };
+});
+mock.module("./lib/wake-listener", () => ({
+  startWakeListener: startWakeListenerImpl,
+}));
+
 import ApexBackend from "./backend";
 
 function makeBackend() {
@@ -83,6 +105,10 @@ describe("Apex backend", () => {
     fingerprintStatusImpl.mockClear();
     applyFingerprintImpl.mockClear();
     revertFingerprintImpl.mockClear();
+    storage = {};
+    capturedOnResume = null;
+    stopSpy.mockClear();
+    startWakeListenerImpl.mockClear();
   });
 
   it("marks itself unsupported on non-Apex hardware", async () => {
@@ -182,5 +208,92 @@ describe("Apex backend", () => {
 
     release();
     await first;
+  });
+
+  // ---------- auto-recover-on-wake ----------
+
+  it("enabling auto-recover-on-wake persists the setting and starts the listener", async () => {
+    const { backend, events } = makeBackend();
+    await backend.onLoad();
+    expect(startWakeListenerImpl).not.toHaveBeenCalled();
+
+    const res = await backend.setAutoRecoverOnWake(true);
+    expect(res.success).toBe(true);
+    expect(storage.autoRecoverOnWake).toBe(true);
+    expect(startWakeListenerImpl).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([{ event: "statusChanged", data: undefined }]);
+
+    const status = await backend.getStatus();
+    expect(status.autoRecoverOnWake).toBe(true);
+    expect(status.listenerRunning).toBe(true);
+  });
+
+  it("disabling auto-recover-on-wake stops the listener and clears the flag", async () => {
+    const { backend } = makeBackend();
+    await backend.onLoad();
+    await backend.setAutoRecoverOnWake(true);
+
+    const res = await backend.setAutoRecoverOnWake(false);
+    expect(res.success).toBe(true);
+    expect(storage.autoRecoverOnWake).toBe(false);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+
+    const status = await backend.getStatus();
+    expect(status.autoRecoverOnWake).toBe(false);
+    expect(status.listenerRunning).toBe(false);
+  });
+
+  it("restores the wake listener on load when previously enabled", async () => {
+    storage = { autoRecoverOnWake: true };
+    const { backend } = makeBackend();
+    await backend.onLoad();
+
+    expect(startWakeListenerImpl).toHaveBeenCalledTimes(1);
+    expect((await backend.getStatus()).listenerRunning).toBe(true);
+  });
+
+  it("does not start the listener on load when disabled", async () => {
+    storage = { autoRecoverOnWake: false };
+    const { backend } = makeBackend();
+    await backend.onLoad();
+
+    expect(startWakeListenerImpl).not.toHaveBeenCalled();
+    expect((await backend.getStatus()).listenerRunning).toBe(false);
+  });
+
+  it("stops the wake listener on unload", async () => {
+    storage = { autoRecoverOnWake: true };
+    const { backend } = makeBackend();
+    await backend.onLoad();
+    expect(stopSpy).not.toHaveBeenCalled();
+
+    await backend.onUnload();
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect((await backend.getStatus()).listenerRunning).toBe(false);
+  });
+
+  it("runs the guarded recovery when a resume fires", async () => {
+    storage = { autoRecoverOnWake: true };
+    const { backend } = makeBackend();
+    await backend.onLoad();
+    expect(capturedOnResume).not.toBeNull();
+
+    // The resume handler waits RESUME_SETTLE_MS before recovering; the timer
+    // is the only thing between the signal and recover(), so the call is
+    // observable shortly after the settle window.
+    capturedOnResume!();
+    await new Promise((r) => setTimeout(r, 2_100));
+    expect(recoverImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses to enable auto-recover-on-wake on non-Apex hardware", async () => {
+    isApexResult = false;
+    const { backend } = makeBackend();
+    await backend.onLoad();
+
+    const res = await backend.setAutoRecoverOnWake(true);
+    expect(res.unsupported).toBe(true);
+    expect(res.success).toBe(false);
+    expect(startWakeListenerImpl).not.toHaveBeenCalled();
   });
 });

--- a/plugins/apex/backend.ts
+++ b/plugins/apex/backend.ts
@@ -1,6 +1,7 @@
 import { access, readFile, writeFile, rm } from "node:fs/promises";
 import type { PluginBackend, EmitPayload, PluginLogger, CallPlugin } from "@loadout/types";
-import { runFull } from "@loadout/exec";
+import { runFull, runStreaming } from "@loadout/exec";
+import { readPluginStorage, writePluginStorage } from "@loadout/plugin-storage";
 import { isApex } from "@loadout/devices";
 import {
   getStatus as computeStatus,
@@ -23,6 +24,23 @@ import {
   type FingerprintStatus,
   type FingerprintResult,
 } from "./lib/fingerprint";
+import { startWakeListener, type StopHandle } from "./lib/wake-listener";
+
+const PLUGIN_ID = "apex";
+
+/** Persisted per-plugin settings (in ~/.config/loadout/plugins/apex.json). */
+interface ApexSettings {
+  /** Run the gamepad recovery automatically whenever the device resumes. */
+  autoRecoverOnWake?: boolean;
+}
+
+/**
+ * How long to wait after a resume before checking the gamepad. The kernel
+ * re-enumerates USB during resume; checking too early can read the pad as
+ * briefly-absent and trigger a needless rebind. recover() then polls, so
+ * this only needs to clear the initial settle.
+ */
+const RESUME_SETTLE_MS = 2_000;
 
 /**
  * Apex — OneXPlayer Apex device fixes.
@@ -45,6 +63,10 @@ export default class ApexBackend implements PluginBackend {
   private unsupported = false;
   /** Serialises recover() so a double-tap can't run two rebinds at once. */
   private recovering = false;
+  /** Live handle to the resume listener when auto-recover-on-wake is on. */
+  private wakeStop: StopHandle | null = null;
+  /** Pending post-resume settle timer, so stop()/unload can cancel it. */
+  private resumeTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Hardware-access dependencies handed to the pure xhci orchestration.
   // Wired to the real exec / fs / timers here; swapped for fakes in tests.
@@ -158,9 +180,19 @@ export default class ApexBackend implements PluginBackend {
     this.unsupported = !(await isApex());
     if (this.unsupported) {
       this.log?.info("[apex] Non-Apex hardware — plugin inert (recovery disabled).");
-    } else {
-      this.log?.info("[apex] OneXPlayer Apex detected — recovery available.");
+      return;
     }
+    this.log?.info("[apex] OneXPlayer Apex detected — recovery available.");
+
+    // Restore the auto-recover-on-wake listener if it was left enabled.
+    const settings = await readPluginStorage<ApexSettings>(PLUGIN_ID);
+    if (settings.autoRecoverOnWake) {
+      this.startWake();
+    }
+  }
+
+  async onUnload(): Promise<void> {
+    this.stopWake();
   }
 
   // ---------- RPC ----------
@@ -171,14 +203,24 @@ export default class ApexBackend implements PluginBackend {
     status?: XhciStatus;
     hidOxp?: HidOxpStatus;
     fingerprint?: FingerprintStatus;
+    autoRecoverOnWake?: boolean;
+    listenerRunning?: boolean;
   }> {
     if (this.unsupported) return { unsupported: true };
-    const [status, hidOxp, fingerprint] = await Promise.all([
+    const [status, hidOxp, fingerprint, settings] = await Promise.all([
       computeStatus(this.deps),
       getHidOxpStatus(this.hidOxpDeps),
       fingerprintStatus(this.fpDeps),
+      readPluginStorage<ApexSettings>(PLUGIN_ID),
     ]);
-    return { unsupported: false, status, hidOxp, fingerprint };
+    return {
+      unsupported: false,
+      status,
+      hidOxp,
+      fingerprint,
+      autoRecoverOnWake: !!settings.autoRecoverOnWake,
+      listenerRunning: this.wakeStop !== null,
+    };
   }
 
   /**
@@ -219,6 +261,32 @@ export default class ApexBackend implements PluginBackend {
     }
   }
 
+  /**
+   * Enable/disable running the recovery automatically on resume. Persists
+   * the choice and starts/stops the logind wake listener to match.
+   */
+  async setAutoRecoverOnWake(
+    enabled: boolean,
+  ): Promise<{ success: boolean; unsupported?: boolean; error?: string }> {
+    if (this.unsupported) {
+      return { success: false, unsupported: true, error: "Not running on Apex hardware." };
+    }
+    try {
+      const existing = await readPluginStorage<ApexSettings>(PLUGIN_ID);
+      await writePluginStorage<ApexSettings>(PLUGIN_ID, {
+        ...existing,
+        autoRecoverOnWake: enabled,
+      });
+      if (enabled) this.startWake();
+      else this.stopWake();
+      this.emit?.({ event: "statusChanged", data: undefined });
+      return { success: true };
+    } catch (e) {
+      this.log?.warn(`[apex] setAutoRecoverOnWake failed: ${e}`);
+      return { success: false, error: String(e) };
+    }
+  }
+
   /** Run the rebind recovery. Returns a structured result for the UI. */
   async recover(): Promise<RecoverResult & { unsupported?: boolean }> {
     if (this.unsupported) {
@@ -248,6 +316,79 @@ export default class ApexBackend implements PluginBackend {
       return result;
     } finally {
       this.recovering = false;
+    }
+  }
+
+  // ---------- auto-recover-on-wake ----------
+
+  /** Start the logind resume listener (idempotent). */
+  private startWake(): void {
+    if (this.wakeStop) return;
+    this.wakeStop = startWakeListener(
+      {
+        spawn: ({ cmd, onLine, onSpawn }) => {
+          // Long-lived; resolves only when the monitor is killed on stop().
+          // enforceCommandPolicy runs synchronously inside runStreaming, so
+          // the `dbus-monitor` permission is checked within this scope.
+          void runStreaming(cmd, {
+            onLine,
+            onSpawn: (proc) => onSpawn({ kill: () => proc.kill() }),
+          })
+            .catch((e) => this.log?.warn(`[apex] wake listener exited: ${e}`))
+            // The monitor died (crash, kill, or policy reject). Drop the
+            // handle so getStatus().listenerRunning reflects reality instead
+            // of reporting a dead listener as healthy.
+            .finally(() => {
+              this.wakeStop = null;
+            });
+        },
+        log: (m) => this.log?.info(`[apex] ${m}`),
+      },
+      () => void this.onResume(),
+    );
+    this.log?.info("[apex] auto-recover-on-wake enabled — listening for resume.");
+  }
+
+  /** Stop the resume listener (idempotent). */
+  private stopWake(): void {
+    // Cancel any in-flight settle so a teardown mid-resume can't fire a
+    // rebind after the plugin (or the listener) has been torn down.
+    if (this.resumeTimer) {
+      clearTimeout(this.resumeTimer);
+      this.resumeTimer = null;
+    }
+    if (!this.wakeStop) return;
+    this.wakeStop.stop();
+    this.wakeStop = null;
+    this.log?.info("[apex] auto-recover-on-wake disabled.");
+  }
+
+  /**
+   * Fired on resume. Waits for the bus to settle, then runs the guarded
+   * recovery — a no-op if the gamepad survived the sleep, a rebind if not.
+   * The settle is cancellable (resumeTimer) so a stop during the wait aborts
+   * cleanly without rebinding.
+   */
+  private async onResume(): Promise<void> {
+    const settled = await new Promise<boolean>((resolve) => {
+      this.resumeTimer = setTimeout(() => {
+        this.resumeTimer = null;
+        resolve(true);
+      }, RESUME_SETTLE_MS);
+    });
+    // Listener was stopped during the settle window — abort the rebind.
+    if (!settled || !this.wakeStop) return;
+    try {
+      const res = await this.recover();
+      if (res.alreadyHealthy) {
+        this.log?.info("[apex] wake: gamepad healthy — no rebind needed.");
+      } else if (res.success) {
+        this.log?.info(`[apex] wake: recovered gamepad (rebound ${res.controller}).`);
+      } else {
+        this.log?.warn(`[apex] wake: recovery failed — ${res.error ?? "unknown"}.`);
+      }
+    } catch (e) {
+      this.log?.warn(`[apex] wake recovery threw: ${e}`);
     }
   }
 }

--- a/plugins/apex/lib/wake-listener.test.ts
+++ b/plugins/apex/lib/wake-listener.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "bun:test";
+import {
+  makePrepareForSleepParser,
+  startWakeListener,
+  DBUS_MONITOR_CMD,
+  type WakeDeps,
+  type WakeProc,
+} from "./wake-listener";
+
+/**
+ * Wake-listener tests. The dbus-monitor subprocess is injected, so these
+ * are pure unit tests of the PrepareForSleep parser and the start/stop
+ * orchestration — no D-Bus, no root.
+ */
+
+// A realistic dbus-monitor signal header for PrepareForSleep.
+const HEADER =
+  "signal time=123.4 sender=:1.3 -> destination=(null destination) serial=42 " +
+  "path=/org/freedesktop/login1; interface=org.freedesktop.login1.Manager; member=PrepareForSleep";
+
+describe("makePrepareForSleepParser", () => {
+  it("returns resume on header followed by boolean false", () => {
+    const parse = makePrepareForSleepParser();
+    expect(parse(HEADER)).toBeNull();
+    expect(parse("   boolean false")).toBe("resume");
+  });
+
+  it("returns suspend on header followed by boolean true", () => {
+    const parse = makePrepareForSleepParser();
+    expect(parse(HEADER)).toBeNull();
+    expect(parse("   boolean true")).toBe("suspend");
+  });
+
+  it("tolerates a blank line between header and the boolean arg", () => {
+    const parse = makePrepareForSleepParser();
+    parse(HEADER);
+    expect(parse("")).toBeNull();
+    expect(parse("   boolean false")).toBe("resume");
+  });
+
+  it("ignores a boolean line that wasn't preceded by a PrepareForSleep header", () => {
+    const parse = makePrepareForSleepParser();
+    expect(parse("   boolean false")).toBeNull();
+  });
+
+  it("re-arms for each subsequent signal (suspend then resume)", () => {
+    const parse = makePrepareForSleepParser();
+    parse(HEADER);
+    expect(parse("   boolean true")).toBe("suspend");
+    parse(HEADER);
+    expect(parse("   boolean false")).toBe("resume");
+  });
+});
+
+/** A fake monitor that records its command and lets the test feed lines. */
+function makeFakeDeps(): {
+  deps: WakeDeps;
+  emit: (line: string) => void;
+  killed: () => number;
+  cmd: () => string[] | null;
+} {
+  let onLine: ((line: string) => void) | null = null;
+  let kills = 0;
+  let cmd: string[] | null = null;
+  const deps: WakeDeps = {
+    spawn: (args) => {
+      cmd = args.cmd;
+      onLine = args.onLine;
+      const proc: WakeProc = { kill: () => void kills++ };
+      args.onSpawn(proc);
+    },
+  };
+  return {
+    deps,
+    emit: (line) => onLine?.(line),
+    killed: () => kills,
+    cmd: () => cmd,
+  };
+}
+
+describe("startWakeListener", () => {
+  it("spawns the filtered system-bus PrepareForSleep monitor", () => {
+    const f = makeFakeDeps();
+    startWakeListener(f.deps, () => {});
+    expect(f.cmd()).toEqual([...DBUS_MONITOR_CMD]);
+  });
+
+  it("fires onResume once per resume, never on suspend", () => {
+    const f = makeFakeDeps();
+    let resumes = 0;
+    startWakeListener(f.deps, () => void resumes++);
+
+    f.emit(HEADER);
+    f.emit("   boolean true"); // suspend — no callback
+    expect(resumes).toBe(0);
+
+    f.emit(HEADER);
+    f.emit("   boolean false"); // resume
+    expect(resumes).toBe(1);
+  });
+
+  it("stop() kills the monitor process", () => {
+    const f = makeFakeDeps();
+    const handle = startWakeListener(f.deps, () => {});
+    expect(f.killed()).toBe(0);
+    handle.stop();
+    expect(f.killed()).toBe(1);
+  });
+
+  it("stop() before the process spawns still kills it once it arrives", () => {
+    // Defer onSpawn to model the async spawn racing behind a fast stop().
+    let deliver: (() => void) | null = null;
+    let kills = 0;
+    const deps: WakeDeps = {
+      spawn: (args) => {
+        deliver = () => args.onSpawn({ kill: () => void kills++ });
+      },
+    };
+    const handle = startWakeListener(deps, () => {});
+    handle.stop(); // stop before the process is delivered
+    deliver?.(); // now the process arrives
+    expect(kills).toBe(1);
+  });
+});

--- a/plugins/apex/lib/wake-listener.ts
+++ b/plugins/apex/lib/wake-listener.ts
@@ -1,0 +1,109 @@
+/**
+ * Wake listener — fires a callback when the system resumes from sleep.
+ *
+ * Tails logind's `PrepareForSleep` D-Bus signal via `dbus-monitor` on the
+ * system bus. The signal carries a boolean: `true` is emitted just before
+ * suspend, `false` once the system has resumed. We only care about resume
+ * (`false`): that's when the Apex's xHCI controller may have died and the
+ * internal gamepad needs recovering.
+ *
+ * logind is present identically on SteamOS, Bazzite and CachyOS, so this is
+ * the portable cross-distro wake hook — there's no systemd-sleep script to
+ * install, nothing to clean up on disable, and it survives suspend because
+ * the backend that owns it runs as a root system service.
+ *
+ * The subprocess and the line parsing are dependency-injected (`WakeDeps`)
+ * so the orchestration is unit-testable without a real D-Bus.
+ */
+
+/** The minimal handle we need on the spawned monitor: a way to kill it. */
+export interface WakeProc {
+  kill: () => void;
+}
+
+export interface WakeDeps {
+  /**
+   * Start the streaming monitor. Wired to `@loadout/exec`'s `runStreaming`
+   * in prod: it should deliver each output line to `onLine` and hand the
+   * spawned process to `onSpawn` so we can kill it on stop.
+   */
+  spawn: (args: {
+    cmd: string[];
+    onLine: (line: string) => void;
+    onSpawn: (proc: WakeProc) => void;
+  }) => void;
+  /** Optional progress sink. */
+  log?: (message: string) => void;
+}
+
+/** Watch only the PrepareForSleep signal on the system bus. */
+export const DBUS_MONITOR_CMD = [
+  "dbus-monitor",
+  "--system",
+  "type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'",
+] as const;
+
+export interface StopHandle {
+  stop: () => void;
+}
+
+/**
+ * Stateful parser for `dbus-monitor` output. dbus-monitor prints a signal
+ * header line followed by the argument on the next line, e.g.:
+ *
+ *   signal time=… interface=org.freedesktop.login1.Manager … member=PrepareForSleep
+ *      boolean false
+ *
+ * We arm on a header line whose member is `PrepareForSleep`, then read the
+ * following `boolean <true|false>` line. `false` = resume, `true` = suspend.
+ * Returns `"resume"`, `"suspend"`, or `null` for any line that isn't the
+ * boolean we're waiting on. The monitor is filtered to PrepareForSleep, so
+ * no other signal headers interleave.
+ */
+export function makePrepareForSleepParser(): (line: string) => "resume" | "suspend" | null {
+  let armed = false;
+  return (line: string) => {
+    if (line.includes("member=PrepareForSleep")) {
+      armed = true;
+      return null;
+    }
+    if (!armed) return null;
+    const m = /boolean\s+(true|false)/.exec(line);
+    if (!m) return null; // blank/whitespace line between header and arg — keep waiting
+    armed = false;
+    return m[1] === "false" ? "resume" : "suspend";
+  };
+}
+
+/**
+ * Start listening for resume events. Calls `onResume` once per resume.
+ * Returns a handle whose `stop()` kills the monitor (and pre-empts a kill
+ * if `stop()` races ahead of the async spawn).
+ */
+export function startWakeListener(deps: WakeDeps, onResume: () => void): StopHandle {
+  const parse = makePrepareForSleepParser();
+  let proc: WakeProc | null = null;
+  let stopped = false;
+
+  deps.spawn({
+    cmd: [...DBUS_MONITOR_CMD],
+    onSpawn: (p) => {
+      proc = p;
+      if (stopped) p.kill(); // stop() arrived before the process existed
+    },
+    onLine: (line) => {
+      if (parse(line) === "resume") {
+        deps.log?.("resume detected — running gamepad recovery");
+        onResume();
+      }
+    },
+  });
+
+  return {
+    stop: () => {
+      stopped = true;
+      proc?.kill();
+      proc = null;
+    },
+  };
+}

--- a/plugins/apex/package.json
+++ b/plugins/apex/package.json
@@ -12,7 +12,7 @@
   "plugin": {
     "id": "apex",
     "name": "Apex",
-    "description": "OneXPlayer Apex device fixes: recover the internal gamepad when its xHCI controller dies on resume (or blacklist the hid-oxp driver to prevent the drop-out), and block the fingerprint reader from waking the device on a light touch.",
+    "description": "OneXPlayer Apex device fixes: recover the internal gamepad when its xHCI controller dies on resume — manually or automatically on every wake (or blacklist the hid-oxp driver to prevent the drop-out), and block the fingerprint reader from waking the device on a light touch.",
     "permissions": {
       "commands": [
         "tee",


### PR DESCRIPTION
## Rebased onto main — blockers cleared

This re-introduces the **auto-recover-on-wake** toggle + logind `PrepareForSleep` listener that #164 removed. It has now been **rebased onto current `main`** and reconstructed as a single clean commit (no revert/reapply/duplicate-blacklist noise), so it is `MERGEABLE` against main.

### Why the original was reverted (#160)
The on-wake rebind hotplugs the pad on a fresh USB node, but InputPlumber kept its grab on the old node and read the rebound pad as a duplicate/dead controller — the **"pad works in the overlay/menus but is dead in Steam's main UI"** state. That, fired automatically on every wake, is why #160 was pulled.

### How this version fixes it
Because it now sits on top of `main`, `onResume()` → `this.recover()` → `runRecover(this.deps)` runs through main's recover path, which already carries the **#161 InputPlumber-delegation fix**: after a successful rebind it delegates to the input-plumber plugin's `restartInputPlumber`, re-grabbing the pad cleanly **and preserving the QAM→F16 wake profile** across the restart. Verified live on-device — the journal shows `restarting InputPlumber to re-grab the recovered pad` → `wake: recovered gamepad`.

### Pre-revival conditions (from the original PR body) — now met
- [x] **Rebased onto current `main`** so the recovery path picks up the #161 fix.
- [x] **Duplicate-target issue addressed**: the auto path delegates through `restartInputPlumber`; it can no longer land in the half-working state.

### Hardening over the original re-add
- The post-resume settle timer is tracked and cancelled on stop/unload, so a teardown mid-resume can't fire a rebind after the listener is gone.
- The streaming `dbus-monitor`'s exit nulls the wake handle, so `getStatus().listenerRunning` reflects reality instead of reporting a dead listener as healthy.
- **Adds the wake-path test coverage the original lacked**: enable/disable persist+start/stop, `onLoad` restore, `onUnload` teardown, resume→recover, non-Apex guard, plus a UI toggle test.

Gates green: typecheck · eslint · check-plugin-specs · apex tests (24/24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)