### PR TITLE
fix(overlay): defer external-pad grab until Guide released (fixes stuck-Guide in Steam)

### DIFF
--- a/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, mock } from "bun:test";
-import { toArrayBuffer } from "bun:ffi";
+import { toArrayBuffer, type Pointer } from "bun:ffi";
 import type { InputDevice } from "./devices";
 
 // ---- Mocks -----------------------------------------------------------------
@@ -75,7 +75,9 @@ mock.module("./ffi", () => ({
           guideHeldFds.has(fd) &&
           typeof valuePtr === "number"
         ) {
-          const bitmap = new Uint8Array(toArrayBuffer(valuePtr, 0, 96));
+          const bitmap = new Uint8Array(
+            toArrayBuffer(valuePtr as Pointer, 0, 96),
+          );
           bitmap[BTN_MODE_CODE >> 3] |= 1 << (BTN_MODE_CODE & 7);
         }
         const rc = ioctlFailFds.has(fd) ? -1 : 0;
@@ -394,6 +396,50 @@ describe("startInputIntercept — grab / release", () => {
       (c) => c.kind === "ioctl" && c.request === 0x40044590n && c.argKind === "pointer",
     );
     expect(grabs).toHaveLength(1);
+    h.shutdown();
+  });
+
+  it("release cancels a still-deferred grab — the pad is never grabbed", async () => {
+    devicesOnSystem = [mkDevice("/dev/input/event5", "Pad", { isController: true })];
+    const h = await startInputIntercept({ onWake: () => {}, onAction: () => {} });
+    const padFd = (
+      ffiCalls.find((c) => c.kind === "open" && c.path === "/dev/input/event5") as
+        | { rc: number }
+        | undefined
+    )?.rc as number;
+    guideHeldFds.add(padFd);
+    h.grab(); // deferred (Guide held)
+    h.release(); // closes before Guide ever released → must cancel the defer
+    guideHeldFds.delete(padFd); // even though Guide is now "up"…
+    await new Promise((r) => setTimeout(r, 70)); // …no late grab may fire
+    const grabs = ffiCalls.filter(
+      (c) => c.kind === "ioctl" && c.request === 0x40044590n && c.argKind === "pointer",
+    );
+    expect(grabs).toHaveLength(0);
+    h.shutdown();
+  });
+
+  it("with two pads, defers only the Guide-held one and grabs the other now", async () => {
+    devicesOnSystem = [
+      mkDevice("/dev/input/event5", "Held", { isController: true }),
+      mkDevice("/dev/input/event6", "Free", { isController: true }),
+    ];
+    const h = await startInputIntercept({ onWake: () => {}, onAction: () => {} });
+    const heldFd = (
+      ffiCalls.find((c) => c.kind === "open" && c.path === "/dev/input/event5") as
+        | { rc: number }
+        | undefined
+    )?.rc as number;
+    guideHeldFds.add(heldFd); // only the first pad has Guide held
+    const grabs = () =>
+      ffiCalls.filter(
+        (c) => c.kind === "ioctl" && c.request === 0x40044590n && c.argKind === "pointer",
+      );
+    h.grab();
+    expect(grabs()).toHaveLength(1); // free pad grabbed immediately, held one deferred
+    guideHeldFds.delete(heldFd);
+    await new Promise((r) => setTimeout(r, 70));
+    expect(grabs().length).toBeGreaterThanOrEqual(2); // held pad grabbed after release
     h.shutdown();
   });
 

--- a/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, mock } from "bun:test";
+import { toArrayBuffer } from "bun:ffi";
 import type { InputDevice } from "./devices";
 
 // ---- Mocks -----------------------------------------------------------------
@@ -37,6 +38,11 @@ let nextFd = 100;
 /** Queued events per FD: each entry is a batch delivered on the next read. */
 const pendingReads = new Map<number, Uint8Array[]>();
 let ioctlFailFds = new Set<number>();
+// FDs for which EVIOCGKEY should report BTN_MODE (Guide) currently held, so
+// the deferred-grab path (doGrab → defer until Guide released) can be tested.
+const guideHeldFds = new Set<number>();
+const EVIOCGKEY_96 = 0x80604518n;
+const BTN_MODE_CODE = 0x13c;
 
 function enqueueRead(fd: number, data: Uint8Array): void {
   const list = pendingReads.get(fd) ?? [];
@@ -62,6 +68,16 @@ mock.module("./ffi", () => ({
         else if (typeof valuePtr === "number" && valuePtr !== 0)
           argKind = "pointer";
         else if (typeof valuePtr === "object") argKind = "pointer";
+        // Simulate the kernel filling the EVIOCGKEY button bitmap so tests can
+        // assert the Guide-held deferral. Only when this fd is flagged held.
+        if (
+          request === EVIOCGKEY_96 &&
+          guideHeldFds.has(fd) &&
+          typeof valuePtr === "number"
+        ) {
+          const bitmap = new Uint8Array(toArrayBuffer(valuePtr, 0, 96));
+          bitmap[BTN_MODE_CODE >> 3] |= 1 << (BTN_MODE_CODE & 7);
+        }
         const rc = ioctlFailFds.has(fd) ? -1 : 0;
         ffiCalls.push({
           kind: "ioctl",
@@ -183,6 +199,7 @@ beforeEach(() => {
   nextFd = 100;
   pendingReads.clear();
   ioctlFailFds = new Set();
+  guideHeldFds.clear();
   devicesOnSystem = [];
 });
 
@@ -336,6 +353,47 @@ describe("startInputIntercept — grab / release", () => {
     expect(
       ffiCalls.filter((c) => c.kind === "ioctl" && c.request === 0x80604518n),
     ).toHaveLength(1); // only the controller fd
+    h.shutdown();
+  });
+
+  it("defers EVIOCGRAB while Guide is held, then grabs once it's released", async () => {
+    // The overlay opens on Guide+B. Grabbing while Guide is still physically
+    // held would swallow the user's Guide-release, leaving Steam stuck in
+    // "Guide held" after close. So doGrab defers the EVIOCGRAB until BTN_MODE
+    // reads released, and pollOnce engages it then.
+    devicesOnSystem = [mkDevice("/dev/input/event5", "Pad", { isController: true })];
+    const h = await startInputIntercept({ onWake: () => {}, onAction: () => {} });
+    const padFd = (
+      ffiCalls.find((c) => c.kind === "open" && c.path === "/dev/input/event5") as
+        | { rc: number }
+        | undefined
+    )?.rc as number;
+    const grabs = () =>
+      ffiCalls.filter(
+        (c) =>
+          c.kind === "ioctl" &&
+          c.request === 0x40044590n /* EVIOCGRAB */ &&
+          c.argKind === "pointer",
+      );
+
+    guideHeldFds.add(padFd); // Guide currently held
+    h.grab();
+    expect(grabs()).toHaveLength(0); // deferred — no grab yet
+
+    guideHeldFds.delete(padFd); // Guide released
+    await new Promise((r) => setTimeout(r, 70)); // > POLL_ACTIVE_MS (25ms)
+    expect(grabs().length).toBeGreaterThanOrEqual(1); // pollOnce grabbed it
+    h.shutdown();
+  });
+
+  it("grabs immediately when Guide is NOT held at grab time", async () => {
+    devicesOnSystem = [mkDevice("/dev/input/event5", "Pad", { isController: true })];
+    const h = await startInputIntercept({ onWake: () => {}, onAction: () => {} });
+    h.grab(); // guideHeldFds empty → BTN_MODE reads released
+    const grabs = ffiCalls.filter(
+      (c) => c.kind === "ioctl" && c.request === 0x40044590n && c.argKind === "pointer",
+    );
+    expect(grabs).toHaveLength(1);
     h.shutdown();
   });
 

--- a/apps/loadout-overlay/src/bun/native/input-intercept.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.ts
@@ -724,8 +724,17 @@ export async function startInputIntercept(
     // deadline. See doGrab for the stuck-Guide rationale.
     if (intercepting && pendingGrabs.size > 0) {
       for (const [t, deadline] of [...pendingGrabs]) {
-        if (!readModifierState(t.fd).guide || now >= deadline) {
+        const released = !readModifierState(t.fd).guide;
+        if (released || now >= deadline) {
           pendingGrabs.delete(t);
+          if (!released) {
+            // Deadline hit with Guide still held — grab anyway so we can't be
+            // left ungrabbed forever, but this re-introduces the stuck-Guide
+            // we were avoiding. Log it so a field report can be tied to this.
+            console.warn(
+              `[input-intercept] forcing deferred grab of ${t.path} after ${DEFER_GRAB_TIMEOUT_MS}ms (Guide still held)`,
+            );
+          }
           grabDevice(t);
         }
       }
@@ -741,6 +750,14 @@ export async function startInputIntercept(
       // never run wake detection on them. readRawEvents above already drained
       // the fd so its buffer can't back up — just skip the rest.
       if (t.grabOnly) continue;
+
+      // A device with a still-deferred grab isn't ours yet — the app
+      // underneath is reading it (that's the whole point of deferring, so it
+      // sees the Guide release). Don't run wake detection on it (a second
+      // Guide+B would otherwise re-toggle the overlay we just opened) and
+      // don't forward its events to nav (it'd double with the app). We still
+      // drained its fd above so its buffer can't back up.
+      if (pendingGrabs.has(t)) continue;
 
       // Wake detection runs in every mode on every device.
       for (const e of events) {
@@ -831,6 +848,40 @@ export async function startInputIntercept(
     resyncDeviceState(t, mods);
   }
 
+  /**
+   * Grab `t` now, or — for a physical pad whose Guide (BTN_MODE) is still
+   * held — DEFER the EVIOCGRAB until Guide releases (pollOnce engages it).
+   *
+   * The overlay opens on Guide+B; if we grab while Guide is held, the user's
+   * Guide-RELEASE lands on us (grabbed) and never reaches the app underneath,
+   * leaving Steam stuck in "Guide held" after we close — every button then
+   * reads as a Guide chord (X→keyboard, L2→zoom, R2→screenshot, stick→volume),
+   * looking like a dead controller. While deferred the app still reads the
+   * (ungrabbed) device, so it observes the release.
+   *
+   * Shared by all three grab sites (doGrab, hotplug, reconcile) so they behave
+   * identically. Caller must have applied intercept masks for non-grab-only
+   * devices first. Grab-only virtual mirrors don't carry the user-held
+   * modifier (resyncDeviceState no-ops on them) so they grab immediately.
+   */
+  function grabOrDefer(t: TrackedDevice): void {
+    if (t.grabOnly || t.grabbed) {
+      grabDevice(t);
+      return;
+    }
+    // Read the kernel button bitmap once: it decides the deferral and (when
+    // we grab now) seeds resyncDeviceState, so EVIOCGKEY is read once per grab.
+    const mods = readModifierState(t.fd);
+    if (mods.guide) {
+      pendingGrabs.set(t, performance.now() + DEFER_GRAB_TIMEOUT_MS);
+      console.log(
+        `[input-intercept] deferring grab of ${t.path} '${t.dev.name}' until Guide released`,
+      );
+      return;
+    }
+    grabDevice(t, mods);
+  }
+
   function doGrab(): void {
     if (intercepting) return;
     intercepting = true;
@@ -841,37 +892,12 @@ export async function startInputIntercept(
       if (!t.dev.flags.isController) continue;
       // Fresh modifier state each cycle: a guide/select/ctrl release missed
       // last session must not leave guideHeld stuck (→ every B reads as
-      // Guide+B → re-toggles the overlay). resyncDeviceState below then
-      // re-seeds from real hardware.
+      // Guide+B → re-toggles the overlay). resyncDeviceState (in grabOrDefer)
+      // then re-seeds from real hardware.
       t.combo = newComboState();
       t.shortcut = newShortcutState();
-      // grab-only virtual mirrors don't carry the user-held modifier and
-      // resyncDeviceState no-ops on them, so just grab immediately.
-      if (t.grabOnly) {
-        grabDevice(t);
-        continue;
-      }
-      applyInterceptMasks(t.fd);
-      // Read the kernel button bitmap once: it both decides the deferral
-      // below and seeds resyncDeviceState (passed into grabDevice), so we
-      // never read EVIOCGKEY twice for the same grab.
-      const mods = readModifierState(t.fd);
-      // Defer the EVIOCGRAB while the toggle modifier (Guide/BTN_MODE) is
-      // still physically held. The overlay opens on Guide+B; if we grab now,
-      // the user's Guide-RELEASE lands on us (grabbed) and never reaches the
-      // app underneath, leaving Steam stuck in "Guide held" after we close —
-      // every button then reads as a Guide chord (X→keyboard, L2→zoom,
-      // R2→screenshot, stick→volume), looking like a dead controller. While
-      // we hold off, the app still reads the (ungrabbed) device, so it
-      // observes the release; pollOnce grabs the instant Guide goes up.
-      if (!t.grabbed && mods.guide) {
-        pendingGrabs.set(t, performance.now() + DEFER_GRAB_TIMEOUT_MS);
-        console.log(
-          `[input-intercept] deferring grab of ${t.path} '${t.dev.name}' until Guide released`,
-        );
-        continue;
-      }
-      grabDevice(t, mods);
+      if (!t.grabOnly) applyInterceptMasks(t.fd);
+      grabOrDefer(t);
     }
     startTimer();
   }
@@ -945,19 +971,7 @@ export async function startInputIntercept(
     // Keyboards / qam don't get grabbed.
     if (intercepting && t.dev.flags.isController) {
       if (!t.grabOnly) applyInterceptMasks(t.fd);
-      const intBuf = new Int32Array([1]);
-      const rc = libc.symbols.ioctl(t.fd, EVIOCGRAB, ptr(intBuf));
-      if (rc === 0) {
-        t.grabbed = true;
-        console.log(
-          `[input-intercept] hotplug grabbed ${t.path} '${t.dev.name}'${t.grabOnly ? " (virtual, grab-only)" : ""}`,
-        );
-      } else {
-        console.warn(
-          `[input-intercept] hotplug grab failed for ${t.path} (rc=${rc})`,
-        );
-      }
-      resyncDeviceState(t);
+      grabOrDefer(t);
     }
   }
 
@@ -965,6 +979,9 @@ export async function startInputIntercept(
     const idx = tracked.findIndex((t) => t.path === eventPath);
     if (idx < 0) return;
     const [t] = tracked.splice(idx, 1);
+    // Drop any deferred-grab entry before closing the fd: a stale entry would
+    // make pollOnce ioctl a closed (possibly OS-reused) fd next tick.
+    pendingGrabs.delete(t);
     if (t.grabbed) {
       libc.symbols.ioctl(t.fd, EVIOCGRAB, null);
       t.grabbed = false;
@@ -1024,15 +1041,7 @@ export async function startInputIntercept(
       const t = openAndTrack(dev);
       if (t && intercepting && t.dev.flags.isController) {
         if (!t.grabOnly) applyInterceptMasks(t.fd);
-        const intBuf = new Int32Array([1]);
-        const rc = libc.symbols.ioctl(t.fd, EVIOCGRAB, ptr(intBuf));
-        if (rc === 0) {
-          t.grabbed = true;
-          console.log(
-            `[input-intercept] reconcile grabbed ${t.path} '${t.dev.name}'${t.grabOnly ? " (virtual, grab-only)" : ""}`,
-          );
-        }
-        resyncDeviceState(t);
+        grabOrDefer(t);
       }
     }
   }

--- a/apps/loadout-overlay/src/bun/native/input-intercept.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.ts
@@ -138,6 +138,11 @@ export type WakeEvent =
  *  100ms while idle — both sides are cheap and within frame-time. */
 const POLL_ACTIVE_MS = 25;
 const POLL_IDLE_MS = 100;
+// Safety cap for the deferred-grab path (see doGrab). If the toggle modifier
+// (Guide) somehow never reports released — a flaky pad, EVIOCGKEY lying — we
+// grab anyway after this long so the overlay can't be left ungrabbed (Steam
+// navigating underneath) indefinitely. Well past a normal Guide tap+release.
+const DEFER_GRAB_TIMEOUT_MS = 2000;
 
 /** Buffer = 64 events per device per tick. Way bigger than any realistic
  *  25 ms burst; small enough that per-device allocation stays negligible. */
@@ -689,6 +694,11 @@ export async function startInputIntercept(
   let intercepting = false;
   let generation = 0;
 
+  // Controllers whose EVIOCGRAB was deferred because the Guide modifier was
+  // still held at grab time (see doGrab). Maps device -> deadline (perf.now
+  // ms); pollOnce grabs each the instant Guide releases, or at the deadline.
+  const pendingGrabs = new Map<TrackedDevice, number>();
+
   const nav = new NavController({
     emit: (a) => {
       opts.onAction(a);
@@ -708,6 +718,18 @@ export async function startInputIntercept(
     hotplug?.poll();
 
     const now = performance.now();
+
+    // Engage any deferred grabs whose Guide modifier has now been released
+    // (so Steam has observed the release), or that have waited past the
+    // deadline. See doGrab for the stuck-Guide rationale.
+    if (intercepting && pendingGrabs.size > 0) {
+      for (const [t, deadline] of [...pendingGrabs]) {
+        if (!readModifierState(t.fd).guide || now >= deadline) {
+          pendingGrabs.delete(t);
+          grabDevice(t);
+        }
+      }
+    }
 
     for (const t of tracked) {
       const events = readRawEvents(t.fd, buf, view);
@@ -771,15 +793,42 @@ export async function startInputIntercept(
   // kernel's ACTUAL current button/axis state. EVIOCGRAB/EVIOCSMASK only
   // deliver edge events, so a button-up or axis-center lost across the
   // grab/mask transition would otherwise leave a control stuck "held".
-  function resyncDeviceState(t: TrackedDevice): void {
+  function resyncDeviceState(
+    t: TrackedDevice,
+    mods?: { guide: boolean; select: boolean },
+  ): void {
     if (t.grabOnly) return;
-    const mods = readModifierState(t.fd);
-    t.combo.guideHeld = mods.guide;
-    t.combo.selectHeld = mods.select;
+    const m = mods ?? readModifierState(t.fd);
+    t.combo.guideHeld = m.guide;
+    t.combo.selectHeld = m.select;
     const axisEvents = readDirectionalAxisState(t.fd, t.cal);
     if (axisEvents.length > 0) {
       nav.processEvents(`${t.dev.hash}_${generation}`, axisEvents);
     }
+  }
+
+  /** EVIOCGRAB one tracked device + re-sync its state. Idempotent on
+   *  already-grabbed devices. Shared by the immediate path and the
+   *  deferred-grab path (pollOnce). */
+  function grabDevice(
+    t: TrackedDevice,
+    mods?: { guide: boolean; select: boolean },
+  ): void {
+    if (!t.grabbed) {
+      const intBuf = new Int32Array([1]);
+      const rc = libc.symbols.ioctl(t.fd, EVIOCGRAB, ptr(intBuf));
+      if (rc === 0) {
+        t.grabbed = true;
+        console.log(
+          `[input-intercept] grabbed ${t.path} '${t.dev.name}'${t.grabOnly ? " (virtual, grab-only)" : ""}`,
+        );
+      } else {
+        // EBUSY is normal if another app (old overlay instance,
+        // steamcompmgr) has it — log and move on.
+        console.warn(`[input-intercept] grab failed for ${t.path} (rc=${rc})`);
+      }
+    }
+    resyncDeviceState(t, mods);
   }
 
   function doGrab(): void {
@@ -787,6 +836,7 @@ export async function startInputIntercept(
     intercepting = true;
     generation += 1;
     nav.reset();
+    pendingGrabs.clear();
     for (const t of tracked) {
       if (!t.dev.flags.isController) continue;
       // Fresh modifier state each cycle: a guide/select/ctrl release missed
@@ -795,24 +845,33 @@ export async function startInputIntercept(
       // re-seeds from real hardware.
       t.combo = newComboState();
       t.shortcut = newShortcutState();
-      if (!t.grabOnly) applyInterceptMasks(t.fd);
-      if (!t.grabbed) {
-        const intBuf = new Int32Array([1]);
-        const rc = libc.symbols.ioctl(t.fd, EVIOCGRAB, ptr(intBuf));
-        if (rc === 0) {
-          t.grabbed = true;
-          console.log(
-            `[input-intercept] grabbed ${t.path} '${t.dev.name}'${t.grabOnly ? " (virtual, grab-only)" : ""}`,
-          );
-        } else {
-          // EBUSY is normal if another app (old overlay instance,
-          // steamcompmgr) has it — log and move on.
-          console.warn(
-            `[input-intercept] grab failed for ${t.path} (rc=${rc})`,
-          );
-        }
+      // grab-only virtual mirrors don't carry the user-held modifier and
+      // resyncDeviceState no-ops on them, so just grab immediately.
+      if (t.grabOnly) {
+        grabDevice(t);
+        continue;
       }
-      resyncDeviceState(t);
+      applyInterceptMasks(t.fd);
+      // Read the kernel button bitmap once: it both decides the deferral
+      // below and seeds resyncDeviceState (passed into grabDevice), so we
+      // never read EVIOCGKEY twice for the same grab.
+      const mods = readModifierState(t.fd);
+      // Defer the EVIOCGRAB while the toggle modifier (Guide/BTN_MODE) is
+      // still physically held. The overlay opens on Guide+B; if we grab now,
+      // the user's Guide-RELEASE lands on us (grabbed) and never reaches the
+      // app underneath, leaving Steam stuck in "Guide held" after we close —
+      // every button then reads as a Guide chord (X→keyboard, L2→zoom,
+      // R2→screenshot, stick→volume), looking like a dead controller. While
+      // we hold off, the app still reads the (ungrabbed) device, so it
+      // observes the release; pollOnce grabs the instant Guide goes up.
+      if (!t.grabbed && mods.guide) {
+        pendingGrabs.set(t, performance.now() + DEFER_GRAB_TIMEOUT_MS);
+        console.log(
+          `[input-intercept] deferring grab of ${t.path} '${t.dev.name}' until Guide released`,
+        );
+        continue;
+      }
+      grabDevice(t, mods);
     }
     startTimer();
   }
@@ -820,6 +879,9 @@ export async function startInputIntercept(
   function doRelease(): void {
     if (!intercepting) return;
     intercepting = false;
+    // Cancel any grab still deferred (overlay closed before Guide released).
+    // Those devices were never grabbed, so the loop below leaves them be.
+    pendingGrabs.clear();
     for (const t of tracked) {
       if (!t.dev.flags.isController) continue;
       if (t.grabbed) {


### PR DESCRIPTION
## Problem

External controllers went unresponsive after closing the overlay — every input behaved as a **Guide chord**: X → on-screen keyboard, L2 → zoom, R2 → screenshot, left stick → volume. It looked like a dead/defocused pad, recoverable only by pressing Guide (opening a Steam menu) or reopening one. The on-device pad was never affected.

## Root cause

The overlay opens on **Guide+B** and immediately `EVIOCGRAB`s the physical pad **while Guide is still held**. The user's subsequent Guide **release** lands on the overlay (which holds the grab) and never reaches Steam, so **Steam stays stuck believing Guide is held** — hence every later button reads as a Guide chord.

The on-device pad is immune because it rides InputPlumber's `deck-uhid` virtual target rather than a raw evdev grab.

This is the **Steam-side twin of the overlay-internal stuck-`guideHeld`** that PR #139 fixed — #139 only cleared *our own* combo state, never Steam's.

### Ruled out along the way (all by direct on-device test)
- Steam-freeze (`DECK_OVERLAY_SUSPEND_STEAM=0` → still broke)
- `hid-oxp` blacklist / apex PRs #160/#161/#164 (removed + `hid_oxp` loaded → still broke)
- `InterceptMode` (correctly `0` after close)
- gamescope focus atoms (identical in working vs broken states)
- A recent Steam/SteamOS update (plausible trigger for *exposure*, but the bug is the grab swallowing the modifier release)

## Fix

In `input-intercept.ts` `doGrab()`: if `BTN_MODE` (Guide) is currently held, **defer** the `EVIOCGRAB` for that physical pad and grab it from `pollOnce` the instant Guide reads released (or after a 2s safety cap). While deferred, the app underneath still reads the ungrabbed device, so it **observes the Guide release** — no stuck modifier on close. Grab-only virtual mirrors are unaffected (grabbed immediately). The `EVIOCGKEY` bitmap is read once and threaded into `resyncDeviceState`, so the grab path still does a single key-state read.

## Tests

- Extended the ffi mock to simulate `BTN_MODE` held (`EVIOCGKEY` via `toArrayBuffer`).
- New regression tests: held → deferred (no grab), released → grabbed on next poll, not-held → immediate grab.
- Full bun suite otherwise unchanged (one pre-existing unrelated cross-test mock failure remains on `main`).

## Verification

Built + installed on-device (OneXPlayer APEX, SteamOS beta). Confirmed working: open overlay via Guide+B with an external Xbox pad, navigate, close — pad behaves normally in both Big Picture and in-game (no volume/zoom/stuck-Guide). Journal shows `deferring grab … until Guide released` on open, then `grabbed …` on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)