### PR TITLE
fix(storage): drop redundant detect scan + anchor system-label match

### DIFF
--- a/plugins/storage/backend.test.ts
+++ b/plugins/storage/backend.test.ts
@@ -24,9 +24,6 @@ const driveFixture = {
   inFstab: false,
 };
 const storageStatusImpl = mock(async () => ({ drives: [{ ...driveFixture }] }));
-const detectCandidatesImpl = mock(async () => [
-  { path: "/dev/nvme1n1p1", label: "Games", uuid: "GAME-1", fstype: "ext4", size: 1024 ** 4 },
-]);
 const mountCandidateImpl = mock(async () => ({
   success: true,
   mountpoint: "/run/media/deck/Games",
@@ -37,7 +34,6 @@ const unpersistFstabImpl = mock(async () => ({ success: true }));
 
 mock.module("./lib/storage", () => ({
   getStorageStatus: storageStatusImpl,
-  detectCandidates: detectCandidatesImpl,
   mountCandidate: mountCandidateImpl,
   persistFstab: persistFstabImpl,
   unpersistFstab: unpersistFstabImpl,
@@ -90,7 +86,6 @@ function makeBackend() {
 describe("Storage backend", () => {
   beforeEach(() => {
     storageStatusImpl.mockClear();
-    detectCandidatesImpl.mockClear();
     mountCandidateImpl.mockClear();
     persistFstabImpl.mockClear();
     unpersistFstabImpl.mockClear();
@@ -105,13 +100,12 @@ describe("Storage backend", () => {
     expect(storageStatusImpl).toHaveBeenCalledTimes(1);
   });
 
-  it("detectDrives returns the scan and candidates", async () => {
+  it("detectDrives re-scans and returns the storage status", async () => {
     const { backend } = makeBackend();
 
     const res = await backend.detectDrives();
     expect(res.drives[0]?.uuid).toBe("GAME-1");
-    expect(res.candidates?.[0]?.uuid).toBe("GAME-1");
-    expect(detectCandidatesImpl).toHaveBeenCalledTimes(1);
+    expect(storageStatusImpl).toHaveBeenCalledTimes(1);
   });
 
   it("mountDrive mounts through the lib and emits statusChanged", async () => {

--- a/plugins/storage/backend.ts
+++ b/plugins/storage/backend.ts
@@ -4,13 +4,11 @@ import type { PluginBackend, EmitPayload, PluginLogger } from "@loadout/types";
 import { runFull } from "@loadout/exec";
 import {
   getStorageStatus,
-  detectCandidates,
   mountCandidate,
   persistFstab,
   unpersistFstab,
   type StorageDeps,
   type StorageStatus,
-  type Candidate,
   type MountResult,
 } from "./lib/storage";
 
@@ -88,13 +86,14 @@ export default class StorageBackend implements PluginBackend {
     return getStorageStatus(this.storageDeps);
   }
 
-  /** Re-scan for unmounted/mounted data drives (the "Detect drives" button). */
-  async detectDrives(): Promise<StorageStatus & { candidates?: Candidate[] }> {
-    const [storage, candidates] = await Promise.all([
-      getStorageStatus(this.storageDeps),
-      detectCandidates(this.storageDeps),
-    ]);
-    return { ...storage, candidates };
+  /**
+   * Re-scan for unmounted/mounted data drives (the "Detect drives" button).
+   * `getStorageStatus` already enumerates every managed drive (including the
+   * unmounted ones the UI offers to mount), so a separate candidate scan would
+   * just be a second redundant `lsblk`.
+   */
+  async detectDrives(): Promise<StorageStatus> {
+    return getStorageStatus(this.storageDeps);
   }
 
   /**

--- a/plugins/storage/lib/storage.test.ts
+++ b/plugins/storage/lib/storage.test.ts
@@ -141,6 +141,17 @@ describe("pure filters", () => {
     }
   });
 
+  it("matches system tokens on segment boundaries, not bare substrings", () => {
+    // Data drives whose names merely *contain* a token are NOT system drives.
+    for (const l of ["Homelab", "BootCamp", "Varsity", "Homework", "Bootleg", "Overflow"]) {
+      expect(isSystemLabel(l)).toBe(false);
+    }
+    // …but a token as a whole `-`/`_`-separated segment still flags.
+    for (const l of ["home-A", "boot_b", "var-2", "frzr_root"]) {
+      expect(isSystemLabel(l)).toBe(true);
+    }
+  });
+
   it("isDataPartition rejects non-partitions, missing uuid, non-whitelist fs, system labels", () => {
     const base = { type: "part", fstype: "ext4", uuid: "X", label: "Games" };
     expect(isDataPartition(base)).toBe(true);

--- a/plugins/storage/lib/storage.ts
+++ b/plugins/storage/lib/storage.ts
@@ -64,10 +64,12 @@ export const FSTAB_BACKUP = "/etc/fstab.loadout.bak";
 export const WHITELIST_FS = ["ext4", "btrfs", "xfs", "exfat", "ntfs", "vfat"] as const;
 
 /**
- * Label/mountpoint tokens that mark a partition as system-owned. SteamOS (and
- * friends) suffix these (rootfs-A, var-B, …), so we substring-match
- * case-insensitively. Better to skip a genuinely-named data drive than to ever
- * touch a system partition.
+ * Label tokens that mark a partition as system-owned. SteamOS (and friends)
+ * suffix these with an A/B slot (`rootfs-A`, `var-B`, …), so we match a token
+ * that is either the whole label or a `-`/`_`-separated segment of it — NOT a
+ * bare substring, which would wrongly skip genuinely-named data drives like
+ * `Homelab` (contains "home") or `BootCamp` (contains "boot"). Still biased
+ * toward safety: anything that *is* one of these segments is left untouched.
  */
 export const SYSTEM_LABEL_TOKENS = [
   "rootfs",
@@ -157,8 +159,14 @@ export function isWhitelistedFs(fstype: string | null | undefined): boolean {
 /** True if a label looks like a system partition we must never touch. */
 export function isSystemLabel(label: string | null | undefined): boolean {
   if (!label) return false;
+  const tokens = SYSTEM_LABEL_TOKENS as readonly string[];
   const l = label.toLowerCase();
-  return SYSTEM_LABEL_TOKENS.some((t) => l.includes(t));
+  // Whole-label match first (covers multi-word tokens like `frzr_root`), then
+  // match on the `-`/`_`-separated A/B-slot segments SteamOS uses (`rootfs-A`,
+  // `var-b`) — never a bare substring, which would wrongly skip data drives
+  // named `Homelab` ("home") or `BootCamp` ("boot").
+  if (tokens.includes(l)) return true;
+  return l.split(/[-_]/).some((seg) => tokens.includes(seg));
 }
 
 function toBytes(size: number | string | null | undefined): number {


### PR DESCRIPTION
## What & why

Two follow-ups from the #187 review:

1. **`detectDrives` did a redundant `lsblk`.** It ran both `getStorageStatus` *and* `detectCandidates` (two subprocess scans), but the UI only ever reads `.drives`, and `getStorageStatus` already enumerates the unmounted drives it offers to mount. The extra `candidates` scan was dead work on every "Detect drives" press. Dropped it (and the unused `candidates` return field).

2. **`isSystemLabel` substring-matched the system tokens.** Any label *containing* `home`/`boot`/`var`/… was treated as a system partition, so a genuinely-named data drive like `Homelab` or `BootCamp` was silently skipped and never offered for mounting. Now a token matches only as the whole label or a `-`/`_`-separated segment — still covering SteamOS's `rootfs-A`/`var-B` slots and the multi-word `frzr_root`, but no longer false-skipping data drives.

## Tests

- New boundary-match coverage in `lib/storage.test.ts` (`Homelab`/`BootCamp` → not system; `home-A`/`boot_b`/`frzr_root` → system).
- Updated `backend.test.ts` for the simplified `detectDrives` shape.
- `bun test` (backend + ui, isolated), `tsc --noEmit`, and `eslint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)