### PR TITLE
feat(steamgriddb): art up owned-but-not-installed games

### DIFF
--- a/apps/loadout/src/loader/services/game-library.test.ts
+++ b/apps/loadout/src/loader/services/game-library.test.ts
@@ -13,9 +13,16 @@ import type { GameInfo, GameLibraryChangedEvent } from "@loadout/types";
 // caching and broadcast wiring lives in the loader.
 let mockGames: GameInfo[] = [];
 let scanCalls = 0;
+/** Records the options the service passed to the most recent
+ *  `scanLibrary` call — lets `getFullLibrary` tests assert the owned
+ *  apps are threaded through. */
+let lastScanOpts: { ownedApps?: Array<{ appId: string; name: string }> } | undefined;
 mock.module("@loadout/game-library", () => ({
-  scanLibrary: async () => {
+  scanLibrary: async (
+    opts?: { ownedApps?: Array<{ appId: string; name: string }> },
+  ) => {
     scanCalls += 1;
+    lastScanOpts = opts;
     return mockGames.map((g) => ({ ...g }));
   },
   getCollectionsFromGames: (games: GameInfo[]) => {
@@ -26,6 +33,30 @@ mock.module("@loadout/game-library", () => ({
     return Array.from(counts.entries())
       .map(([id, count]) => ({ id, count }))
       .sort((a, b) => b.count - a.count || a.id.localeCompare(b.id));
+  },
+}));
+
+// Mock the Steam CDP surface `getFullLibrary` uses to read the owned
+// library. `ownedMode` steers each test: "apps" returns owned games,
+// "unreachable" throws SteamClientUnreachableError (Steam closed →
+// installed-only fallback), "error" throws a generic error (should
+// propagate). Mirrors the pattern in protondb-badges/backend.test.ts.
+class SteamClientUnreachableErrorMock extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SteamClientUnreachableError";
+  }
+}
+let ownedMode: "apps" | "unreachable" | "error" = "unreachable";
+let mockOwnedApps: Array<{ appId: string; name: string }> = [];
+mock.module("@loadout/steam-cdp", () => ({
+  SteamClientUnreachableError: SteamClientUnreachableErrorMock,
+  withSteamClient: async (fn: (sc: unknown) => Promise<unknown>) => {
+    if (ownedMode === "unreachable") {
+      throw new SteamClientUnreachableErrorMock("Steam not reachable in test");
+    }
+    if (ownedMode === "error") throw new Error("generic CDP failure");
+    return fn({ apps: { getAllApps: async () => mockOwnedApps } });
   },
 }));
 
@@ -55,6 +86,9 @@ describe("GameLibraryService", () => {
   beforeEach(() => {
     mockGames = [];
     scanCalls = 0;
+    lastScanOpts = undefined;
+    ownedMode = "unreachable";
+    mockOwnedApps = [];
     service = new GameLibraryService();
     events = [];
     service.emit = ({ event, data }) => {
@@ -156,5 +190,91 @@ describe("GameLibraryService", () => {
     a[0].tags.push("hacked");
     const b = await service.getGames();
     expect(b[0].tags).toEqual(["fav"]);
+  });
+
+  describe("getFullLibrary", () => {
+    test("passes the owned apps through to scanLibrary and reports ownedAvailable=true when Steam is reachable", async () => {
+      ownedMode = "apps";
+      mockOwnedApps = [{ appId: "99", name: "Owned Not Installed" }];
+      mockGames = [game("1", "Installed")];
+      const result = await service.getFullLibrary();
+      expect(result.ownedAvailable).toBe(true);
+      expect(lastScanOpts?.ownedApps).toEqual([
+        { appId: "99", name: "Owned Not Installed" },
+      ]);
+      expect(result.games.map((g) => g.appId)).toEqual(["1"]); // mock scan echoes mockGames
+    });
+
+    test("falls back to installed-only with ownedAvailable=false when Steam is unreachable", async () => {
+      ownedMode = "unreachable";
+      mockGames = [game("1", "Installed")];
+      const result = await service.getFullLibrary();
+      expect(result.ownedAvailable).toBe(false);
+      // No owned apps threaded through — scanLibrary called without them.
+      expect(lastScanOpts?.ownedApps).toBeUndefined();
+      expect(result.games).toHaveLength(1);
+    });
+
+    test("rethrows non-unreachable CDP errors", async () => {
+      ownedMode = "error";
+      await expect(service.getFullLibrary()).rejects.toThrow(
+        "generic CDP failure",
+      );
+    });
+
+    test("caches within the same owned-availability, and does not pollute getGames' installed-only cache", async () => {
+      ownedMode = "apps";
+      mockOwnedApps = [{ appId: "99", name: "Owned" }];
+      mockGames = [game("1", "Installed")];
+      await service.getFullLibrary();
+      await service.getFullLibrary();
+      // Second call served from fullCache — no extra scan.
+      expect(scanCalls).toBe(1);
+
+      // getGames keeps its own installed-only cache — separate scan.
+      await service.getGames();
+      expect(scanCalls).toBe(2);
+    });
+
+    test("rebuilds when owned-availability flips (Steam comes up between calls)", async () => {
+      ownedMode = "unreachable";
+      mockGames = [game("1", "Installed")];
+      const first = await service.getFullLibrary();
+      expect(first.ownedAvailable).toBe(false);
+      expect(scanCalls).toBe(1);
+
+      // Steam is now up — the stale installed-only fullCache must not be
+      // reused; a fresh scan runs with the owned apps.
+      ownedMode = "apps";
+      mockOwnedApps = [{ appId: "99", name: "Owned" }];
+      const second = await service.getFullLibrary();
+      expect(second.ownedAvailable).toBe(true);
+      expect(scanCalls).toBe(2);
+      expect(lastScanOpts?.ownedApps).toEqual([{ appId: "99", name: "Owned" }]);
+    });
+
+    test("rescan clears the owned-augmented cache", async () => {
+      ownedMode = "apps";
+      mockOwnedApps = [{ appId: "99", name: "Owned" }];
+      mockGames = [game("1", "Installed")];
+      await service.getFullLibrary();
+      expect(scanCalls).toBe(1);
+
+      await service.rescan(); // scanCalls -> 2, clears fullCache
+      expect(scanCalls).toBe(2);
+
+      await service.getFullLibrary(); // must rebuild -> scanCalls 3
+      expect(scanCalls).toBe(3);
+    });
+
+    test("returns a defensive copy — callers can't mutate the owned cache", async () => {
+      ownedMode = "apps";
+      mockOwnedApps = [{ appId: "99", name: "Owned" }];
+      mockGames = [game("1", "Installed", ["fav"])];
+      const a = await service.getFullLibrary();
+      a.games[0].tags.push("hacked");
+      const b = await service.getFullLibrary();
+      expect(b.games[0].tags).toEqual(["fav"]);
+    });
   });
 });

--- a/apps/loadout/src/loader/services/game-library.ts
+++ b/apps/loadout/src/loader/services/game-library.ts
@@ -9,6 +9,10 @@ import {
   getCollectionsFromGames,
   scanLibrary,
 } from "@loadout/game-library";
+import {
+  SteamClientUnreachableError,
+  withSteamClient,
+} from "@loadout/steam-cdp";
 
 /**
  * `__core:game-library` core service. Replaces the deprecated
@@ -27,6 +31,17 @@ import {
  */
 export class GameLibraryService implements PluginBackend {
   private cache: GameInfo[] | null = null;
+  /**
+   * Separate cache for the owned-augmented library (installed +
+   * shortcuts + owned-but-not-installed). Kept distinct from `cache`
+   * so the classic installed-only `getGames()` every other consumer
+   * relies on is never contaminated with not-installed games.
+   */
+  private fullCache: GameInfo[] | null = null;
+  /** Whether `fullCache` was built with owned games available (Steam
+   *  reachable). Lets us avoid serving a stale installed-only list when
+   *  Steam has since come up, and vice-versa. */
+  private fullCacheOwnedAvailable = false;
   // Audit precedent A-026 in `__core:game-detection`: cache the
   // signature of the last broadcast so a no-op rescan (same games,
   // same order) doesn't trigger a re-render on every subscriber.
@@ -50,12 +65,64 @@ export class GameLibraryService implements PluginBackend {
   }
 
   /**
+   * Return the user's *entire owned* library — installed games and
+   * non-Steam shortcuts (same as `getGames`) PLUS owned-but-not-
+   * installed Steam titles. The extra titles are read from Steam's
+   * in-memory `appStore.allApps` over CDP (`@loadout/steam-cdp`'s
+   * `getAllApps()`), the only source for games that have no
+   * `appmanifest_*.acf` on disk.
+   *
+   * `ownedAvailable` reflects whether that CDP read succeeded: when
+   * Steam isn't running / its library UI hasn't booted the read throws
+   * `SteamClientUnreachableError`, and we transparently fall back to the
+   * installed-only scan so the picker still works — callers use the flag
+   * to nudge the user to start Steam for the full library. Any other
+   * error is rethrown (a genuine failure the caller should surface).
+   *
+   * Cached in `fullCache` (distinct from `getGames`'s installed-only
+   * `cache`); `rescan()` clears both.
+   */
+  async getFullLibrary(): Promise<{
+    games: GameInfo[];
+    ownedAvailable: boolean;
+  }> {
+    let owned: Array<{ appId: string; name: string }> | null = null;
+    try {
+      owned = await withSteamClient((sc) => sc.apps.getAllApps());
+    } catch (err) {
+      if (!(err instanceof SteamClientUnreachableError)) throw err;
+      owned = null; // Steam closed — fall back to installed-only.
+    }
+
+    // Only reuse the cache when it reflects the same owned-availability
+    // as this call, so a first Steam-closed call doesn't pin an
+    // installed-only list for a later Steam-open one (and vice-versa).
+    if (this.fullCache !== null && this.fullCacheOwnedAvailable === (owned !== null)) {
+      return {
+        games: this.fullCache.map((g) => ({ ...g, tags: [...g.tags] })),
+        ownedAvailable: owned !== null,
+      };
+    }
+
+    const games = await scanLibrary({ ownedApps: owned ?? undefined });
+    this.fullCache = games;
+    this.fullCacheOwnedAvailable = owned !== null;
+    return {
+      games: games.map((g) => ({ ...g, tags: [...g.tags] })),
+      ownedAvailable: owned !== null,
+    };
+  }
+
+  /**
    * Force a re-scan. Broadcasts `libraryChanged` if the result differs
    * from the prior cache. Returns the fresh list either way.
    */
   async rescan(): Promise<GameInfo[]> {
     const fresh = await scanLibrary();
     this.cache = fresh;
+    // Owned-augmented library is derived from a live CDP read; drop its
+    // cache so the next `getFullLibrary` rebuilds against fresh state.
+    this.fullCache = null;
     this.broadcastChange();
     return fresh.map((g) => ({ ...g, tags: [...g.tags] }));
   }

--- a/packages/game-library/src/index.test.ts
+++ b/packages/game-library/src/index.test.ts
@@ -232,6 +232,82 @@ describe("scanLibrary", () => {
       "http://example:1234/api/steam-grid/504230/12345/header",
     );
   });
+
+  describe("ownedApps (owned-but-not-installed merge)", () => {
+    test("no ownedApps → output is unchanged (regression guard)", async () => {
+      writeAcf(join(tempRoot, "steamapps"), "504230", "Celeste", 1234567);
+      const withoutOpt = await scanLibrary();
+      const withEmpty = await scanLibrary({ ownedApps: [] });
+      expect(withEmpty).toEqual(withoutOpt);
+      expect(withEmpty).toHaveLength(1);
+    });
+
+    test("synthesizes an entry for an owned app with no manifest", async () => {
+      writeAcf(join(tempRoot, "steamapps"), "504230", "Celeste", 1234567);
+      writeShortcuts(join(tempRoot, "userdata"), "12345", []);
+
+      const games = await scanLibrary({
+        ownedApps: [{ appId: "220", name: "Half-Life 2" }],
+      });
+
+      expect(games).toHaveLength(2);
+      const hl2 = games.find((g) => g.appId === "220");
+      expect(hl2).toBeDefined();
+      expect(hl2?.name).toBe("Half-Life 2");
+      expect(hl2?.source).toBe("steam");
+      // No manifest on disk → not installed.
+      expect(hl2?.sizeOnDisk).toBe(0);
+      // Same art-URL shape as installed Steam apps (local route wins).
+      expect(hl2?.capsuleUrl).toContain("/api/steam-grid/220/12345/capsule");
+      expect(hl2?.cdnCapsuleUrl).toContain(
+        "cdn.cloudflare.steamstatic.com/steam/apps/220/library_600x900.jpg",
+      );
+    });
+
+    test("does NOT overwrite an installed app that is also in the owned list", async () => {
+      writeAcf(join(tempRoot, "steamapps"), "504230", "Celeste", 1234567);
+
+      const games = await scanLibrary({
+        ownedApps: [{ appId: "504230", name: "Celeste (owned label)" }],
+      });
+
+      expect(games).toHaveLength(1);
+      const celeste = games[0];
+      // Installed entry wins: real size + manifest name preserved.
+      expect(celeste.sizeOnDisk).toBe(1234567);
+      expect(celeste.name).toBe("Celeste");
+    });
+
+    test("an owned game that lives in a user collection still gets its tag", async () => {
+      // No manifest for 220 — it's owned-not-installed — but it's in the
+      // user's 'favorite' collection. The synthesis runs before the
+      // collection merge, so the tag should attach.
+      writeShortcuts(join(tempRoot, "userdata"), "12345", []);
+      writeLocalConfigWithCollections(join(tempRoot, "userdata"), "12345", {
+        favorite: { id: "favorite", added: [220] },
+      });
+
+      const games = await scanLibrary({
+        ownedApps: [{ appId: "220", name: "Half-Life 2" }],
+      });
+      const hl2 = games.find((g) => g.appId === "220");
+      expect(hl2?.tags).toEqual(["favorite"]);
+    });
+
+    test("skips malformed owned entries (empty/non-string appId)", async () => {
+      writeAcf(join(tempRoot, "steamapps"), "504230", "Celeste");
+      const games = await scanLibrary({
+        ownedApps: [
+          { appId: "", name: "junk" },
+          // @ts-expect-error — intentionally malformed to exercise the guard
+          { appId: 220, name: "numeric appId" },
+          { appId: "440", name: "Team Fortress 2" },
+        ],
+      });
+      const ids = games.map((g) => g.appId).sort();
+      expect(ids).toEqual(["440", "504230"]);
+    });
+  });
 });
 
 describe("getCollectionsFromGames", () => {

--- a/packages/game-library/src/index.ts
+++ b/packages/game-library/src/index.ts
@@ -37,6 +37,63 @@ const DEFAULT_LOADER_ORIGIN = "http://localhost:33820";
 export interface ScanLibraryOptions {
   /** Origin used to build local `/api/steam-grid/*` URLs. */
   loaderOrigin?: string;
+  /**
+   * The user's full *owned* Steam library — every app in Steam's
+   * in-memory `appStore.allApps`, sourced by the caller via
+   * `@loadout/steam-cdp`'s `getAllApps()`. When provided, owned apps
+   * that have no `appmanifest_*.acf` on disk (never downloaded) are
+   * synthesized into the returned list so consumers like the
+   * SteamGridDB picker can reach them. Installed entries always win —
+   * this only fills gaps. Omit it (the default) to keep the classic
+   * installed-only behaviour every other consumer relies on.
+   */
+  ownedApps?: Array<{ appId: string; name: string }>;
+}
+
+/**
+ * Build the full set of artwork URLs for a Steam app id. Shared by the
+ * installed-manifest scan and the owned-but-not-installed synthesis so
+ * both paths produce byte-identical URLs. When no primary user id is
+ * available (no userdata yet) the local `/api/steam-grid` route can't be
+ * built, so every field falls back to the public CDN.
+ */
+function buildSteamArtUrls(
+  origin: string,
+  appId: string,
+  primaryUserId: string | null,
+): Pick<
+  GameInfo,
+  | "headerUrl"
+  | "capsuleUrl"
+  | "localHeaderUrl"
+  | "localCapsuleUrl"
+  | "cdnHeaderUrl"
+  | "cdnCapsuleUrl"
+> {
+  // `header.jpg` is 460×215 landscape (fallback). `library_600x900.jpg`
+  // is the 600×900 portrait Steam itself shows in the library grid.
+  const cdnHeader = `https://cdn.cloudflare.steamstatic.com/steam/apps/${appId}/header.jpg`;
+  const cdnCapsule = `https://cdn.cloudflare.steamstatic.com/steam/apps/${appId}/library_600x900.jpg`;
+  const localHeader = primaryUserId
+    ? localArtUrl(origin, appId, primaryUserId, "header")
+    : cdnHeader;
+  const localCapsule = primaryUserId
+    ? localArtUrl(origin, appId, primaryUserId, "capsule")
+    : cdnCapsule;
+  // Prefer the loader's local `/api/steam-grid/...` route as the
+  // canonical art URL — its handler probes the user's
+  // `userdata/<id>/config/grid/` first (custom SGDB art wins), falls
+  // back to Steam's downloaded appcache, and only then 302-redirects to
+  // the public CDN. The pure CDN URLs are kept on `cdnHeaderUrl` /
+  // `cdnCapsuleUrl` for the rare plugin that wants the public variant.
+  return {
+    headerUrl: primaryUserId ? localHeader : cdnHeader,
+    capsuleUrl: primaryUserId ? localCapsule : cdnCapsule,
+    localHeaderUrl: localHeader,
+    localCapsuleUrl: localCapsule,
+    cdnHeaderUrl: cdnHeader,
+    cdnCapsuleUrl: cdnCapsule,
+  };
 }
 
 /**
@@ -247,51 +304,46 @@ export async function scanLibrary(
           if (byAppId.has(appId)) continue;
 
           const sizeOnDisk = sizeStr ? parseInt(sizeStr) : 0;
-          // `header.jpg` is 460×215 landscape (fallback). `library_600x900.jpg`
-          // is the 600×900 portrait Steam itself shows in the library
-          // grid — every picker UI wants this for its tiles.
-          const cdnHeader = `https://cdn.cloudflare.steamstatic.com/steam/apps/${appId}/header.jpg`;
-          const cdnCapsule = `https://cdn.cloudflare.steamstatic.com/steam/apps/${appId}/library_600x900.jpg`;
-          const localHeader = primaryUserId
-            ? localArtUrl(origin, appId, primaryUserId, "header")
-            : cdnHeader;
-          const localCapsule = primaryUserId
-            ? localArtUrl(origin, appId, primaryUserId, "capsule")
-            : cdnCapsule;
-
-          // Prefer the loader's local `/api/steam-grid/...` route as
-          // the canonical art URL — its handler probes the user's
-          // `userdata/<id>/config/grid/` first (custom SGDB art wins),
-          // falls back to Steam's downloaded appcache, and only then
-          // 302-redirects to the public CDN when nothing is local.
-          // With `Cache-Control: no-cache` + an mtime-derived ETag,
-          // browsers revalidate on every reload so newly-applied
-          // custom art appears the next time a grid mounts — without
-          // this, plugins that used `headerUrl` would see Steam's
-          // CDN art forever regardless of what the user customised.
-          //
-          // The pure CDN URLs are kept on `cdnHeaderUrl` /
-          // `cdnCapsuleUrl` for the rare plugin that wants the
-          // public, longer-cacheable variant explicitly.
-          //
-          // If we couldn't resolve a primary user id (no userdata yet)
-          // the local route can't be built — fall back to CDN.
+          // Art URLs (local `/api/steam-grid` route + CDN fallbacks) are
+          // built by the shared `buildSteamArtUrls` helper so the
+          // owned-but-not-installed synthesis below stays byte-identical.
           byAppId.set(appId, {
             appId,
             name,
             sizeOnDisk,
-            headerUrl: primaryUserId ? localHeader : cdnHeader,
-            capsuleUrl: primaryUserId ? localCapsule : cdnCapsule,
-            localHeaderUrl: localHeader,
-            localCapsuleUrl: localCapsule,
-            cdnHeaderUrl: cdnHeader,
-            cdnCapsuleUrl: cdnCapsule,
+            ...buildSteamArtUrls(origin, appId, primaryUserId),
             source: "steam",
             tags: [],
           });
         } catch {
           // Skip unreadable manifests
         }
+      }
+    }
+
+    // Owned-but-not-installed games. When the caller passes the full
+    // owned library (from Steam's in-memory `appStore.allApps` via CDP),
+    // synthesize an entry for every owned app we didn't already see on
+    // disk. These have no `appmanifest_*.acf` — so `sizeOnDisk` is 0 —
+    // but they carry the same CDN + local art URLs as installed Steam
+    // apps, so the SGDB picker can art them up. Inserted BEFORE the
+    // collection merge below so a not-installed game that lives in a
+    // user collection (e.g. "favorite") still gets its tag. Installed
+    // entries always win: we only fill gaps, never overwrite the richer
+    // manifest-derived record.
+    if (opts.ownedApps && opts.ownedApps.length > 0) {
+      for (const owned of opts.ownedApps) {
+        if (!owned || typeof owned.appId !== "string" || owned.appId.length === 0)
+          continue;
+        if (byAppId.has(owned.appId)) continue;
+        byAppId.set(owned.appId, {
+          appId: owned.appId,
+          name: owned.name,
+          sizeOnDisk: 0,
+          ...buildSteamArtUrls(origin, owned.appId, primaryUserId),
+          source: "steam",
+          tags: [],
+        });
       }
     }
 

--- a/plugins/steamgriddb/app.spec.tsx
+++ b/plugins/steamgriddb/app.spec.tsx
@@ -61,45 +61,55 @@ beforeEach(() => {
     return Promise.resolve(null);
   });
   gameLibraryCallMock.mockImplementation((method: string) => {
-    if (method === "getGames")
-      return Promise.resolve([
-        {
-          appId: "440",
-          name: "Team Fortress 2",
-          sizeOnDisk: 0,
-          headerUrl: "https://cdn/440/header.jpg",
-          capsuleUrl: "https://cdn/440/capsule.jpg",
-          localHeaderUrl: "/api/steam-grid/440/u/header",
-          localCapsuleUrl: "/api/steam-grid/440/u/capsule",
-          source: "steam",
-          tags: [],
-        },
-        {
-          appId: "730",
-          name: "Counter-Strike 2",
-          sizeOnDisk: 0,
-          headerUrl: "https://cdn/730/header.jpg",
-          capsuleUrl: "https://cdn/730/capsule.jpg",
-          localHeaderUrl: "/api/steam-grid/730/u/header",
-          localCapsuleUrl: "/api/steam-grid/730/u/capsule",
-          source: "steam",
-          tags: [],
-        },
-        {
-          appId: "3735928559",
-          name: "Super Mario 64",
-          sizeOnDisk: 0,
-          headerUrl: "/api/steam-grid/x/u/header",
-          capsuleUrl: "/api/steam-grid/x/u/capsule",
-          localHeaderUrl: "/api/steam-grid/x/u/header",
-          localCapsuleUrl: "/api/steam-grid/x/u/capsule",
-          source: "shortcut",
-          tags: ["Emulation"],
-        },
-      ]);
+    if (method === "getFullLibrary")
+      return Promise.resolve({ games: libraryFixture(), ownedAvailable: true });
     return Promise.resolve(null);
   });
 });
+
+/**
+ * Shared library fixture. TF2 is installed (real `sizeOnDisk`);
+ * Portal 2 is owned-but-not-installed (`sizeOnDisk: 0`, Steam source) so
+ * it exercises the "Not installed" badge; Super Mario 64 is a non-Steam
+ * shortcut (never badged as not-installed).
+ */
+function libraryFixture() {
+  return [
+    {
+      appId: "440",
+      name: "Team Fortress 2",
+      sizeOnDisk: 15_000_000,
+      headerUrl: "https://cdn/440/header.jpg",
+      capsuleUrl: "https://cdn/440/capsule.jpg",
+      localHeaderUrl: "/api/steam-grid/440/u/header",
+      localCapsuleUrl: "/api/steam-grid/440/u/capsule",
+      source: "steam",
+      tags: [],
+    },
+    {
+      appId: "620",
+      name: "Portal 2",
+      sizeOnDisk: 0,
+      headerUrl: "https://cdn/620/header.jpg",
+      capsuleUrl: "https://cdn/620/capsule.jpg",
+      localHeaderUrl: "/api/steam-grid/620/u/header",
+      localCapsuleUrl: "/api/steam-grid/620/u/capsule",
+      source: "steam",
+      tags: [],
+    },
+    {
+      appId: "3735928559",
+      name: "Super Mario 64",
+      sizeOnDisk: 0,
+      headerUrl: "/api/steam-grid/x/u/header",
+      capsuleUrl: "/api/steam-grid/x/u/capsule",
+      localHeaderUrl: "/api/steam-grid/x/u/header",
+      localCapsuleUrl: "/api/steam-grid/x/u/capsule",
+      source: "shortcut",
+      tags: ["Emulation"],
+    },
+  ];
+}
 
 function createContainer(): HTMLElement {
   const container = document.createElement("div");
@@ -197,5 +207,99 @@ describe("steamgriddb plugin", () => {
         "Custom artwork for your library",
       ),
     );
+  });
+
+  it("badges an owned-but-not-installed Steam game as 'Not installed'", async () => {
+    const container = createContainer();
+    const headerSlot = document.createElement("div");
+    document.body.appendChild(headerSlot);
+    const { mount } = await import("./app");
+    mount(container, { headerSlot });
+    // STEAM_ONLY default: TF2 (installed) + Portal 2 (owned/not-installed).
+    await waitFor(() => {
+      expect(container.textContent).toContain("Portal 2");
+    });
+    // Exactly one badge — Portal 2 (sizeOnDisk 0). TF2 is installed
+    // (non-zero size) so it must NOT be badged.
+    const badges = container.textContent?.match(/Not installed/g) ?? [];
+    expect(badges).toHaveLength(1);
+  });
+
+  it("shows the 'start Steam' hint when the owned library is unavailable", async () => {
+    gameLibraryCallMock.mockImplementation((method: string) => {
+      if (method === "getFullLibrary")
+        return Promise.resolve({
+          games: libraryFixture().filter((g) => g.sizeOnDisk > 0),
+          ownedAvailable: false,
+        });
+      return Promise.resolve(null);
+    });
+
+    const container = createContainer();
+    const headerSlot = document.createElement("div");
+    document.body.appendChild(headerSlot);
+    const { mount } = await import("./app");
+    mount(container, { headerSlot });
+    await waitFor(() =>
+      expect(container.textContent).toContain("Showing installed games only"),
+    );
+  });
+
+  it("applies art to a not-installed game with source 'steam'", async () => {
+    sgdbCallMock.mockImplementation((method: string) => {
+      if (method === "hasApiKey") return Promise.resolve(true);
+      if (method === "getGrids")
+        return Promise.resolve([
+          {
+            id: 111,
+            score: 4.2,
+            style: "alternate",
+            width: 600,
+            height: 900,
+            nsfw: false,
+            humor: false,
+            url: "https://sgdb/full/111.png",
+            thumb: "https://sgdb/thumb/111.png",
+            author: { name: "artist", steam64: "0", avatar: "" },
+          },
+        ]);
+      if (method === "applyArt")
+        return Promise.resolve({ success: true, instant: true, paths: [] });
+      return Promise.resolve(null);
+    });
+
+    const container = createContainer();
+    const headerSlot = document.createElement("div");
+    document.body.appendChild(headerSlot);
+    const { mount } = await import("./app");
+    mount(container, { headerSlot });
+
+    // Pick Portal 2 (owned, not installed).
+    await waitFor(() => expect(container.textContent).toContain("Portal 2"));
+    const portalCard = Array.from(
+      container.querySelectorAll("[data-game-card]"),
+    ).find((el) => el.textContent?.includes("Portal 2"));
+    expect(portalCard).toBeTruthy();
+    fireEvent.click(portalCard as HTMLElement);
+
+    // Its grids load — click the first asset tile to apply.
+    await waitFor(() => {
+      expect(container.querySelector('img[alt^="Art by"]')).not.toBeNull();
+    });
+    const assetButton = (
+      container.querySelector('img[alt^="Art by"]') as HTMLElement
+    ).closest("button");
+    fireEvent.click(assetButton as HTMLElement);
+
+    await waitFor(() => {
+      const applyCall = sgdbCallMock.mock.calls.find(
+        (c) => c[0] === "applyArt",
+      );
+      expect(applyCall).toBeTruthy();
+      // applyArt(appId, url, artType, source)
+      expect(applyCall?.[1]).toBe("620");
+      expect(applyCall?.[3]).toBe("grid_p");
+      expect(applyCall?.[4]).toBe("steam");
+    });
   });
 });

--- a/plugins/steamgriddb/app.tsx
+++ b/plugins/steamgriddb/app.tsx
@@ -10,6 +10,7 @@ import {
   FaXmark,
 } from "react-icons/fa6";
 import {
+  Badge,
   Button,
   fuzzySearchGames,
   useCurrentGame,
@@ -169,6 +170,10 @@ function SteamGridDB() {
   const [libraryStatus, setLibraryStatus] = useState<"ok" | string | null>(
     null,
   );
+  /** True when the owned-but-not-installed games were reachable (Steam
+   *  running + library booted). When false, the list is installed-only
+   *  and we nudge the user to open Steam for their full library. */
+  const [ownedAvailable, setOwnedAvailable] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   // Default to Steam-only — most users want SGDB grid art for their
   // Steam library, not Heroic / Lutris / emulator shortcuts (which
@@ -236,15 +241,25 @@ function SteamGridDB() {
     let cancelled = false;
     void (async () => {
       try {
-        const [games, cols] = await Promise.all([
-          gameLibrary.call("getGames") as Promise<GameInfo[]>,
+        // `getFullLibrary` returns installed games + non-Steam shortcuts
+        // PLUS owned-but-not-installed Steam titles (read from Steam's
+        // in-memory library over CDP). `ownedAvailable` is false when
+        // Steam is closed — the list falls back to installed-only and we
+        // surface a hint. Collections still come from the installed-only
+        // `getCollections` (not-installed games carry no manifest tags).
+        const [full, cols] = await Promise.all([
+          gameLibrary.call("getFullLibrary") as Promise<{
+            games: GameInfo[];
+            ownedAvailable: boolean;
+          }>,
           gameLibrary
             .call("getCollections")
             .catch(() => []) as Promise<GameCollection[]>,
         ]);
         if (cancelled) return;
-        const list = Array.isArray(games) ? games : [];
+        const list = Array.isArray(full?.games) ? full.games : [];
         setLibrary(list);
+        setOwnedAvailable(full?.ownedAvailable ?? false);
         setCollections(Array.isArray(cols) ? cols : []);
         setLibraryStatus("ok");
         // Best-effort GC. Failure here just means the prune didn't
@@ -257,7 +272,7 @@ function SteamGridDB() {
           console.warn("[steamgriddb] pruneMatches failed:", err);
         });
       } catch (err) {
-        console.warn("[steamgriddb] game-library getGames failed:", err);
+        console.warn("[steamgriddb] game-library getFullLibrary failed:", err);
         if (cancelled) return;
         setLibraryStatus(err instanceof Error ? err.message : String(err));
       }
@@ -793,6 +808,19 @@ function SteamGridDB() {
                 </div>
               )}
 
+              {/* Steam-closed hint: without a live Steam client we can
+                  only see installed games, so nudge the user to open
+                  Steam for their full owned library. Shown above the
+                  grid so the (still useful) installed list stays
+                  visible below it. */}
+              {libraryStatus === "ok" && !ownedAvailable && (
+                <div className="subsection-desc mb-3">
+                  Showing installed games only. Start Steam and open your
+                  library to art up games you own but haven't downloaded
+                  yet.
+                </div>
+              )}
+
               {visibleGames.length > 0 && (
                 <GameCardGrid>
                   {visibleGames.map((game) => (
@@ -973,6 +1001,12 @@ function SgdbGameTile({
       ? `${game.localHeaderUrl}?v=${refreshToken}`
       : game.headerUrl;
 
+  // A Steam game with no size on disk has no `appmanifest_*.acf` — it's
+  // owned but not downloaded. (Shortcuts are always 0 too, so gate on
+  // source.) Flag it so the user knows the tile isn't installed; art can
+  // still be applied — it lands in the grid folder / Steam's live store.
+  const notInstalled = game.source === "steam" && game.sizeOnDisk === 0;
+
   return (
     <GameCard
       imageUrl={primaryThumb}
@@ -980,6 +1014,13 @@ function SgdbGameTile({
       title={game.name}
       collections={game.tags}
       onPick={onPick}
+      topRightBadge={
+        notInstalled ? (
+          <Badge variant="neutral" size="xs">
+            Not installed
+          </Badge>
+        ) : undefined
+      }
     />
   );
 }


### PR DESCRIPTION
The SGDB picker only listed installed games (appmanifest_*.acf) plus
non-Steam shortcuts, so games a user owns but hasn't downloaded never
appeared and couldn't be given custom artwork — even though the apply
path (SetCustomArtworkForApp + grid-folder write) works for any appId.

Add an opt-in owned-library source:

- @loadout/game-library: `scanLibrary` gains an `ownedApps` option;
  when passed, owned apps with no on-disk manifest are synthesized into
  the list (sizeOnDisk 0, same CDN + local art URLs as installed apps,
  inserted before the collection merge so favorites still get tagged).
  Art-URL building is extracted into a shared `buildSteamArtUrls` helper
  so installed and synthesized entries stay byte-identical.
- __core:game-library service: new `getFullLibrary()` reads the full
  owned library from Steam's in-memory appStore over CDP (getAllApps,
  same pattern protondb-badges uses) and merges via `ownedApps`. Falls
  back to installed-only with `ownedAvailable:false` when Steam is
  closed. Cached separately so the shared installed-only `getGames`
  every other plugin relies on is untouched.
- steamgriddb UI: consume `getFullLibrary`, badge not-installed tiles,
  and show a "start Steam" hint when the owned library is unavailable.

Tests cover the owned merge (synthesis, no-overwrite, collection tag,
malformed-entry guard, no-op regression), the service fallback/caching,
and the plugin badge + apply-with-source path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015XBH4Pu55D76rvfVZTzTQD