### PR TITLE
feat(release): versioned, manually-triggered release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         Thanks for the report! Please confirm the bug reproduces on the
-        latest rolling build before filing.
+        latest release before filing.
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libarchive-tools
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Typecheck
         run: bun run typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,29 @@
 name: Release
 
-# Manual-only release workflow. Builds the Loadout binary + Electrobun
-# overlay tree and replaces a single rolling GitHub Release tagged `rolling`,
-# marked as the GitHub-latest.
+# Versioned release workflow. Builds the Loadout binary + Electrobun overlay
+# tree + plugin bundle for a `vX.Y.Z` tag and publishes a versioned GitHub
+# Release (marked "latest", so the curl installer resolves to it). Old versions
+# stay downloadable by tag.
 #
-# Auto-trigger on push-to-main was removed (audit 2026-05 Q-001 / owner
-# decision): releases ship before CI gates, and a hotfix off a stale base
-# or a force-push would sail through unchecked. Until release.yml runs
-# `needs: ci`, the safer default is to require explicit operator intent.
+# Triggered by pushing a `v*.*.*` tag — which the local `scripts/release.sh`
+# (`bun run release <major|minor|patch>`) does after bumping versions, updating
+# the CHANGELOG, committing and tagging. You can also re-run a tag manually from
+# the Actions tab via workflow_dispatch with the `tag` input.
 #
-# Workflow: land changes on main, run CI, then trigger this manually from
-# the Actions tab (or via `gh workflow run release.yml`).
+# The old auto-trigger-on-push concern (audit 2026-05 Q-001: releasing before CI
+# gates) is handled here by the `gate` job — typecheck/lint/spec/test must pass
+# before anything publishes, and the tag is cut by an explicit operator action.
 
 on:
+  push:
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing vX.Y.Z tag to (re)build and publish"
+        required: true
+        type: string
 
 permissions:
   contents: write  # required by softprops/action-gh-release@v2 to create the release
@@ -23,8 +33,36 @@ concurrency:
   cancel-in-progress: false  # don't kill a half-uploaded release
 
 jobs:
+  gate:
+    name: Pre-release checks (typecheck, lint, specs, tests)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Spec coverage
+        run: bun run check:specs
+
+      - name: Tests
+        run: bun run test
+
   build-and-release:
-    name: Build x86_64 + publish rolling release
+    name: Build x86_64 + publish versioned release
+    needs: gate
     # TODO(arm): add a matrix entry for aarch64 once we have hardware to test on.
     runs-on: ubuntu-latest
 
@@ -32,7 +70,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          fetch-depth: 0  # so scripts/build.sh can read git short SHA for dev-<sha> versioning
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0  # so scripts/build.sh can `git describe --tags` the version
+
+      - name: Resolve + verify release tag
+        id: tag
+        run: |
+          set -eu
+          TAG="${{ inputs.tag || github.ref_name }}"
+          case "$TAG" in
+            v[0-9]*.[0-9]*.[0-9]*) : ;;
+            *) echo "::error::Refusing to release '$TAG' — expected a vX.Y.Z tag."; exit 1 ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Releasing $TAG"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
@@ -64,12 +115,10 @@ jobs:
 
           # 3. Plugin tree — stage every plugin alongside a single hoisted
           #    node_modules/ (react/react-dom/scheduler/react-icons +
-          #    @loadout/*). One copy shared by all 29 plugins instead
-          #    of per-plugin duplication that ballooned the tarball to
-          #    ~250 MB compressed. inject-builder.ts resolves deps from
-          #    the hoisted location at runtime. Without this, curl|sh
-          #    installs end up with an empty plugins/ dir and nothing
-          #    renders (audit 2026-05 H-002).
+          #    @loadout/*). One copy shared by all plugins instead of
+          #    per-plugin duplication that ballooned the tarball. Without
+          #    this, curl|sh installs end up with an empty plugins/ dir and
+          #    nothing renders (audit 2026-05 H-002).
           PLUGIN_STAGE_DIR="$RUNNER_TEMP/staged-install-root"
           bash scripts/prepare-plugins.sh "$PLUGIN_STAGE_DIR"
           tar -C "$PLUGIN_STAGE_DIR" -cJf loadout-plugins-x86_64.tar.xz plugins node_modules
@@ -87,22 +136,22 @@ jobs:
             loadout-plugins-x86_64.tar.xz \
             SHA256SUMS
 
-      - name: Publish rolling release
+      - name: Publish versioned release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
-          tag_name: rolling
-          name: Rolling build (latest main)
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
           body: |
-            Rolling release built from `main` at commit ${{ github.sha }}.
+            Loadout ${{ steps.tag.outputs.tag }}.
 
-            **Latest commit:** ${{ github.event.head_commit.message }}
-
-            Install with:
+            Install (or update) with:
             ```sh
             curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/install.sh | sh
             ```
+            Pin this version: `LOADOUT_VERSION=${{ steps.tag.outputs.tag }} curl -fsSL … | sh`
 
-            Each push to `main` overwrites this release. For pinned versions, see tagged releases (when available).
+            Full notes: [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md)
+          generate_release_notes: true
           prerelease: false
           make_latest: "true"
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Spec coverage
         run: bun run check:specs
 
+      # bsdtar (libarchive) backs the recomp plugin's archive tests, which call
+      # it directly; the ubuntu runner doesn't ship it by default. Mirrors ci.yml.
+      - name: Install system test deps (bsdtar)
+        run: sudo apt-get update && sudo apt-get install -y libarchive-tools
+
       - name: Tests
         run: bun run test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,10 +83,12 @@ jobs:
         run: |
           set -eu
           TAG="${{ inputs.tag || github.ref_name }}"
-          case "$TAG" in
-            v[0-9]*.[0-9]*.[0-9]*) : ;;
-            *) echo "::error::Refusing to release '$TAG' — expected a vX.Y.Z tag."; exit 1 ;;
-          esac
+          # Strict semver check — the tag-push glob (v*.*.*) is loose (its dots
+          # match any char), so validate properly here before publishing.
+          if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Refusing to release '$TAG' — expected a vX.Y.Z tag."
+            exit 1
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Releasing $TAG"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,13 @@ bun run format        # prettier
 Keep PRs focused, match the style of the surrounding code, and add tests for
 new backend/lib behaviour.
 
+## Releases
+
+Releases are versioned (`vX.Y.Z`) and cut manually with `bun run release
+<minor|patch>`, which bumps versions, updates the CHANGELOG, tags, and lets CI
+build and publish. Loose semver pre-1.0: features → minor, fixes → patch. See
+[docs/releasing.md](docs/releasing.md).
+
 ## Licensing
 
 By contributing, you agree your contributions are licensed under the

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ your Epic library, install a recompiled N64 classic — then get straight back t
 playing. Twenty-plus plugins, one slick d-pad-friendly UI.
 
 **Works in both Gaming Mode and Desktop Mode.** In Steam's Gaming Mode it runs
-as an *in-game overlay* layered over your game; on the desktop it runs as a
-*standalone app* in its own window. Loadout detects which mode you're in and
+as an _in-game overlay_ layered over your game; on the desktop it runs as a
+_standalone app_ in its own window. Loadout detects which mode you're in and
 adapts automatically.
 
 [**Install →**](#install) · [Plugins](#plugins) · [Supported devices](#supported-devices--testing) · [Build from source](#build-from-source)
@@ -57,7 +57,7 @@ you're in (it looks for Gamescope) and adapts:
   desktop — no game underneath to freeze, controller input still grabbed so it
   stays d-pad-friendly.
 
-A handful of plugins that reach *into* Steam's Big Picture UI (badges, CSS
+A handful of plugins that reach _into_ Steam's Big Picture UI (badges, CSS
 theming) are Gaming-Mode-only by nature; everything else works in either mode.
 
 ## In Gaming Mode
@@ -82,19 +82,19 @@ with community CSS themes:
 **Loadout is Linux-only by design** — it targets distros that ship Steam Gaming
 Mode. No Windows or macOS build.
 
-| OS | Status |
-|---|---|
+| OS                       | Status       |
+| ------------------------ | ------------ |
 | **SteamOS** (Steam Deck) | ✅ Supported |
-| **Bazzite** | ✅ Supported |
-| **CachyOS** | ✅ Supported |
+| **Bazzite**              | ✅ Supported |
+| **CachyOS**              | ✅ Supported |
 
 **Hardware tested so far:**
 
-| Device | Status |
-|---|---|
-| OneXPlayer APEX | ✅ Daily-driven |
-| Steam Deck | ✅ Tested |
-| OneXPlayer F1 Pro | ✅ Tested |
+| Device            | Status          |
+| ----------------- | --------------- |
+| OneXPlayer APEX   | ✅ Daily-driven |
+| Steam Deck        | ✅ Tested       |
+| OneXPlayer F1 Pro | ✅ Tested       |
 
 > 🙋 **Got a different handheld?** ROG Ally, Legion Go, OneXPlayer, GPD, AYANEO,
 > AOKZOE — I'd love your help. **I'm actively looking for testers on other
@@ -184,11 +184,19 @@ on a keyboard always works too, as a fallback.
 
 ### How do I update to a new version?
 
-Re-run the same install command — it's idempotent. It checks for a newer binary
-and overlay, refreshes the bundled plugins, and leaves your config untouched:
+Re-run the same install command — it's idempotent. It pulls the latest release,
+checks for a newer binary and overlay, refreshes the bundled plugins, and leaves
+your config untouched:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/srsholmes/loadout/main/scripts/install.sh | sh
+```
+
+To install or roll back to a **specific version**, set `LOADOUT_VERSION` to a
+[release tag](https://github.com/srsholmes/loadout/releases):
+
+```sh
+LOADOUT_VERSION=v0.1.0 curl -fsSL https://raw.githubusercontent.com/srsholmes/loadout/main/scripts/install.sh | sh
 ```
 
 ### How do I install or manage plugins?
@@ -198,10 +206,10 @@ download. Enable or disable individual plugins from **Settings → Plugins**.
 
 ### My controller seems dead in Steam — what's going on?
 
-While the overlay is *open*, it exclusively grabs your controller so your inputs
+While the overlay is _open_, it exclusively grabs your controller so your inputs
 drive the overlay and don't leak through to the game underneath. That's by
 design — close the overlay and the controller returns to Steam immediately. If a
-pad stays unresponsive while the overlay is *hidden*, make sure you're on the
+pad stays unresponsive while the overlay is _hidden_, make sure you're on the
 latest version.
 
 ### Where do my settings live? Do they survive a reinstall?
@@ -239,7 +247,7 @@ curl -fsSL https://raw.githubusercontent.com/srsholmes/loadout/main/scripts/unin
 - **Our own overlay surface.** A standalone CEF window layered over Gamescope
   via X11 atoms — not an injected panel, so Steam redesigns don't break it. The
   same window runs as the Desktop Mode app.
-- **Injection only when you want it.** Plugins *can* reach into Big Picture via
+- **Injection only when you want it.** Plugins _can_ reach into Big Picture via
   CEF's remote-debug protocol (badges, theming) — but it's opt-in, not the
   default path.
 - **Batteries-included SDK.** `@loadout/ui` gives plugin authors typed RPC,
@@ -434,14 +442,14 @@ loadout/
 
 ## Scripts
 
-| Command | Description |
-|---|---|
-| `bun run dev:overlay` | Loader dev server + Electrobun overlay with hot reload |
-| `bun run build` | Compile loader binary + Electrobun overlay tree |
-| `bun run build-and-install` | `build` + install into `~/.local/share/` and enable services |
-| `bun run typecheck` | `tsc --noEmit` |
-| `bun run test` | Backend + UI tests |
-| `bun run lint` / `bun run format` | ESLint 9 flat config / Prettier |
+| Command                           | Description                                                  |
+| --------------------------------- | ------------------------------------------------------------ |
+| `bun run dev:overlay`             | Loader dev server + Electrobun overlay with hot reload       |
+| `bun run build`                   | Compile loader binary + Electrobun overlay tree              |
+| `bun run build-and-install`       | `build` + install into `~/.local/share/` and enable services |
+| `bun run typecheck`               | `tsc --noEmit`                                               |
+| `bun run test`                    | Backend + UI tests                                           |
+| `bun run lint` / `bun run format` | ESLint 9 flat config / Prettier                              |
 
 > **CI:** every pull request and every push to `main` runs the full
 > typecheck / lint / test suite ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)).
@@ -464,14 +472,17 @@ shortcuts, per-plugin state — live in `~/.config/loadout/config.json`
 
 ## Documentation
 
-| Document | Description |
-|---|---|
-| [Architecture](docs/architecture.md) | Loader architecture, plugin structure, startup sequence |
-| [Plugin Development](docs/plugin-development.md) | Plugin structure, backend/frontend APIs, examples |
-| [Steam UI Injection](docs/steam-ui-injection.md) | Injectable surfaces, SteamClient API, Gamescope notes |
-| [Overlay / Gamescope](docs/overlay-gamescope-integration.md) | X11 atoms, input grab, display detection |
-| [Gamepad Navigation](docs/gamepad-navigation-guide.md) | Spatial navigation, focus management |
-| [OS Compatibility](docs/os-compatibility.md) | SteamOS, Bazzite, CachyOS specifics |
+| Document                                                     | Description                                             |
+| ------------------------------------------------------------ | ------------------------------------------------------- |
+| [Architecture](docs/architecture.md)                         | Loader architecture, plugin structure, startup sequence |
+| [Plugin Development](docs/plugin-development.md)             | Plugin structure, backend/frontend APIs, examples       |
+| [Steam UI Injection](docs/steam-ui-injection.md)             | Injectable surfaces, SteamClient API, Gamescope notes   |
+| [Overlay / Gamescope](docs/overlay-gamescope-integration.md) | X11 atoms, input grab, display detection                |
+| [Gamepad Navigation](docs/gamepad-navigation-guide.md)       | Spatial navigation, focus management                    |
+| [OS Compatibility](docs/os-compatibility.md)                 | SteamOS, Bazzite, CachyOS specifics                     |
+| [Releasing](docs/releasing.md)                               | Versioning policy + how releases are cut                |
+
+See [CHANGELOG.md](CHANGELOG.md) for the release history.
 
 ## Thanks & acknowledgements
 

--- a/apps/loadout-overlay/src/overlay/components/Settings.tsx
+++ b/apps/loadout-overlay/src/overlay/components/Settings.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { PluginProvider, TabBar, Slider, Button, Select, Toggle, useBackend } from "@loadout/ui";
 import { useSidebarAutoCollapseSetting } from "../hooks/useSidebarCollapse";
+import { OVERLAY_VERSION } from "../version";
 import { useEnabledPlugins } from "../hooks/useEnabledPlugins";
 import { useConfigValue, getConfigValue, setConfigValue } from "../lib/userConfig";
 import {
@@ -33,25 +34,90 @@ interface SettingsProps {
   onShowWelcome?: () => void;
 }
 
-const VERSION = "0.1.0-alpha";
+const VERSION = OVERLAY_VERSION;
 
 /** Loadout's four signature themes. Each swaps the full token set
  *  (surfaces, ink, accent, status colors) — there is no "dark vs light"
  *  toggle independent of theme. `colors` is a 3-dot preview swatch. */
 export const LOADOUT_THEMES = [
-  { id: "midnight", name: "Midnight",    desc: "Deep, quiet dark — default",   colors: ["#2d2a3e", "#7c5bff", "#f4f0ff"] },
-  { id: "paper",    name: "Paper",       desc: "Clean light theme",            colors: ["#ffffff", "#4c2ee8", "#1a1530"] },
-  { id: "synth",    name: "Synth",       desc: "Magenta + cyan retro",         colors: ["#221830", "#ff3de0", "#3df0ff"] },
-  { id: "terminal", name: "Terminal",    desc: "Green on black, mono-first",   colors: ["#0e1712", "#58ff80", "#c7ffd3"] },
-  { id: "nord",     name: "Nord",        desc: "Cool slate, muted pastels",    colors: ["#2e3440", "#88c0d0", "#eceff4"] },
-  { id: "dracula",  name: "Dracula",     desc: "Classic purple + pink",        colors: ["#282a36", "#bd93f9", "#ff79c6"] },
-  { id: "gruvbox",  name: "Gruvbox",     desc: "Warm retro tan + olive",       colors: ["#282828", "#fe8019", "#ebdbb2"] },
-  { id: "tokyo",    name: "Tokyo Night", desc: "Deep indigo + cyan",           colors: ["#1a1b26", "#7dcfff", "#bb9af7"] },
-  { id: "one-dark", name: "One Dark", desc: "Atom's iconic industry-standard dark", colors: ["#282c34", "#61afef", "#abb2bf"] },
-  { id: "monokai-pro", name: "Monokai Pro", desc: "Vibrant pink + lime — the classic", colors: ["#2d2a2e", "#ff6188", "#ffd866"] },
-  { id: "catppuccin-mocha", name: "Catppuccin Mocha", desc: "Pastel dark — community favorite", colors: ["#1e1e2e", "#cba6f7", "#cdd6f4"] },
-  { id: "rose-pine", name: "Rosé Pine", desc: "All-natural pine + faux-fur rose", colors: ["#191724", "#c4a7e7", "#e0def4"] },
-  { id: "solarized-dark", name: "Solarized Dark", desc: "Ethan Schoonover's classic muted", colors: ["#002b36", "#268bd2", "#839496"] },
+  {
+    id: "midnight",
+    name: "Midnight",
+    desc: "Deep, quiet dark — default",
+    colors: ["#2d2a3e", "#7c5bff", "#f4f0ff"],
+  },
+  {
+    id: "paper",
+    name: "Paper",
+    desc: "Clean light theme",
+    colors: ["#ffffff", "#4c2ee8", "#1a1530"],
+  },
+  {
+    id: "synth",
+    name: "Synth",
+    desc: "Magenta + cyan retro",
+    colors: ["#221830", "#ff3de0", "#3df0ff"],
+  },
+  {
+    id: "terminal",
+    name: "Terminal",
+    desc: "Green on black, mono-first",
+    colors: ["#0e1712", "#58ff80", "#c7ffd3"],
+  },
+  {
+    id: "nord",
+    name: "Nord",
+    desc: "Cool slate, muted pastels",
+    colors: ["#2e3440", "#88c0d0", "#eceff4"],
+  },
+  {
+    id: "dracula",
+    name: "Dracula",
+    desc: "Classic purple + pink",
+    colors: ["#282a36", "#bd93f9", "#ff79c6"],
+  },
+  {
+    id: "gruvbox",
+    name: "Gruvbox",
+    desc: "Warm retro tan + olive",
+    colors: ["#282828", "#fe8019", "#ebdbb2"],
+  },
+  {
+    id: "tokyo",
+    name: "Tokyo Night",
+    desc: "Deep indigo + cyan",
+    colors: ["#1a1b26", "#7dcfff", "#bb9af7"],
+  },
+  {
+    id: "one-dark",
+    name: "One Dark",
+    desc: "Atom's iconic industry-standard dark",
+    colors: ["#282c34", "#61afef", "#abb2bf"],
+  },
+  {
+    id: "monokai-pro",
+    name: "Monokai Pro",
+    desc: "Vibrant pink + lime — the classic",
+    colors: ["#2d2a2e", "#ff6188", "#ffd866"],
+  },
+  {
+    id: "catppuccin-mocha",
+    name: "Catppuccin Mocha",
+    desc: "Pastel dark — community favorite",
+    colors: ["#1e1e2e", "#cba6f7", "#cdd6f4"],
+  },
+  {
+    id: "rose-pine",
+    name: "Rosé Pine",
+    desc: "All-natural pine + faux-fur rose",
+    colors: ["#191724", "#c4a7e7", "#e0def4"],
+  },
+  {
+    id: "solarized-dark",
+    name: "Solarized Dark",
+    desc: "Ethan Schoonover's classic muted",
+    colors: ["#002b36", "#268bd2", "#839496"],
+  },
 ] as const;
 
 const THEME_IDS = LOADOUT_THEMES.map((t) => t.id) as readonly string[];
@@ -97,19 +163,25 @@ const BUTTON_LABELS: { key: keyof ControllerShortcuts; label: string }[] = [
 
 function actionToString(action: ShortcutAction): string {
   switch (action.type) {
-    case "None":           return "none";
-    case "ToggleOverlay":  return "toggle_overlay";
-    case "OpenPlugin":     return `plugin:${action.value ?? ""}`;
-    case "OpenSettings":   return "open_settings";
-    case "OpenHome":       return "open_home";
-    case "ToggleKeyboard": return "toggle_keyboard";
+    case "None":
+      return "none";
+    case "ToggleOverlay":
+      return "toggle_overlay";
+    case "OpenPlugin":
+      return `plugin:${action.value ?? ""}`;
+    case "OpenSettings":
+      return "open_settings";
+    case "OpenHome":
+      return "open_home";
+    case "ToggleKeyboard":
+      return "toggle_keyboard";
   }
 }
 
 function stringToAction(s: string): ShortcutAction {
-  if (s === "toggle_overlay")  return { type: "ToggleOverlay" };
-  if (s === "open_settings")   return { type: "OpenSettings" };
-  if (s === "open_home")       return { type: "OpenHome" };
+  if (s === "toggle_overlay") return { type: "ToggleOverlay" };
+  if (s === "open_settings") return { type: "OpenSettings" };
+  if (s === "open_home") return { type: "OpenHome" };
   if (s === "toggle_keyboard") return { type: "ToggleKeyboard" };
   if (s.startsWith("plugin:")) return { type: "OpenPlugin", value: s.slice(7) };
   return { type: "None" };
@@ -153,7 +225,15 @@ function ThemeSwatch({
         </div>
         {active && (
           <div className="w-5 h-5 rounded-full bg-primary text-primary-content flex items-center justify-center shrink-0 ml-2">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round" className="w-3 h-3">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={3}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-3 h-3"
+            >
               <polyline points="20 6 9 17 4 12" />
             </svg>
           </div>
@@ -225,16 +305,22 @@ function MaintenanceActionRow({ action }: { action: MaintenanceAction }) {
   }
 
   const label =
-    status === "arming" ? "Click again to confirm"
-    : status === "running" ? action.runningLabel
-    : status === "success" ? action.successLabel
-    : status === "error" ? "Failed"
-    : action.idleLabel;
+    status === "arming"
+      ? "Click again to confirm"
+      : status === "running"
+        ? action.runningLabel
+        : status === "success"
+          ? action.successLabel
+          : status === "error"
+            ? "Failed"
+            : action.idleLabel;
 
   const variant =
-    status === "arming" || status === "error" ? "danger"
-    : status === "success" ? "primary"
-    : "default";
+    status === "arming" || status === "error"
+      ? "danger"
+      : status === "success"
+        ? "primary"
+        : "default";
 
   return (
     <div className="flex justify-between items-center min-h-[44px]">
@@ -247,11 +333,7 @@ function MaintenanceActionRow({ action }: { action: MaintenanceAction }) {
           )}
         </div>
       </div>
-      <Button
-        onClick={handleClick}
-        disabled={status === "running"}
-        variant={variant}
-      >
+      <Button onClick={handleClick} disabled={status === "running"} variant={variant}>
         {label}
       </Button>
     </div>
@@ -279,7 +361,8 @@ const RESTART_SERVER_ACTION: MaintenanceAction = {
 
 const RESTART_STEAM_ACTION: MaintenanceAction = {
   title: "Restart Steam",
-  description: "Restarts the Steam process without rebooting. Use this if Steam crashed or froze after applying a CSS theme.",
+  description:
+    "Restarts the Steam process without rebooting. Use this if Steam crashed or froze after applying a CSS theme.",
   idleLabel: "Restart Steam",
   runningLabel: "Restarting...",
   successLabel: "Restarted",
@@ -288,7 +371,8 @@ const RESTART_STEAM_ACTION: MaintenanceAction = {
 
 const UNFREEZE_STEAM_ACTION: MaintenanceAction = {
   title: "Unfreeze Steam",
-  description: "Sends SIGCONT to the Steam process. Use this if Steam's menu is visible but buttons don't respond after closing the overlay.",
+  description:
+    "Sends SIGCONT to the Steam process. Use this if Steam's menu is visible but buttons don't respond after closing the overlay.",
   idleLabel: "Unfreeze Steam",
   runningLabel: "Unfreezing...",
   successLabel: "Unfrozen",
@@ -312,7 +396,6 @@ const REBOOT_ACTION: MaintenanceAction = {
   successLabel: "Restarting",
   invoke: systemReboot,
 };
-
 
 /**
  * "Clear all data caches" — fans `clearExternalCache` out via
@@ -433,7 +516,9 @@ function SettingsInner({
   }, [theme]);
 
   useEffect(() => {
-    getControllerShortcuts().then(setShortcuts).catch(() => {});
+    getControllerShortcuts()
+      .then(setShortcuts)
+      .catch(() => {});
   }, []);
 
   function handleShortcutChange(key: keyof ControllerShortcuts, value: string) {
@@ -456,19 +541,17 @@ function SettingsInner({
           <>
             {/* Appearance */}
             <section className="mb-6">
-              <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">Appearance</h3>
+              <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">
+                Appearance
+              </h3>
               <div className="bg-base-200 rounded-2xl border border-base-300 p-5">
                 <div className="flex justify-between items-center mb-3">
                   <span className="text-sm text-base-content">UI Scale</span>
-                  <span className="text-sm font-mono text-primary font-bold">{scale.toFixed(2)}x</span>
+                  <span className="text-sm font-mono text-primary font-bold">
+                    {scale.toFixed(2)}x
+                  </span>
                 </div>
-                <Slider
-                  min={0.75}
-                  max={2}
-                  step={0.05}
-                  value={scale}
-                  onChange={onScaleChange}
-                />
+                <Slider min={0.75} max={2} step={0.05} value={scale} onChange={onScaleChange} />
                 <div className="flex justify-between text-xs text-base-content/30 mt-1.5">
                   <span>0.75x</span>
                   <span>1.0x</span>
@@ -479,7 +562,9 @@ function SettingsInner({
 
             {/* Homepage */}
             <section className="mb-6">
-              <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">Homepage</h3>
+              <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">
+                Homepage
+              </h3>
               <div className="bg-base-200 rounded-2xl border border-base-300 p-5 space-y-4 divide-y divide-base-300 [&>*]:pt-4 [&>*:first-child]:pt-0">
                 <div className="flex justify-between items-center min-h-[44px]">
                   <span className="text-sm text-base-content">On startup</span>
@@ -509,7 +594,9 @@ function SettingsInner({
 
             {/* Sidebar */}
             <section className="mb-6">
-              <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">Sidebar</h3>
+              <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">
+                Sidebar
+              </h3>
               <div className="bg-base-200 rounded-2xl border border-base-300 p-5">
                 <div className="flex justify-between items-center min-h-[44px]">
                   <div className="pr-4">
@@ -526,7 +613,9 @@ function SettingsInner({
             {/* Theme — four Loadout themes with big preview swatch cards */}
             <section className="mb-6">
               <div className="flex items-baseline justify-between mb-4">
-                <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40">Theme</h3>
+                <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40">
+                  Theme
+                </h3>
                 <span className="chip chip-accent">
                   {LOADOUT_THEMES.find((t) => t.id === theme)?.name ?? "Midnight"}
                 </span>
@@ -545,7 +634,9 @@ function SettingsInner({
 
             {/* Maintenance */}
             <section className="mb-6">
-              <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">Maintenance</h3>
+              <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">
+                Maintenance
+              </h3>
               <div className="bg-base-200 rounded-2xl border border-base-300 p-5 space-y-4 divide-y divide-base-300 [&>*]:pt-4 [&>*:first-child]:pt-0">
                 <MaintenanceActionRow action={EXPORT_LOGS_ACTION} />
                 <ClearDataCachesActionRow />
@@ -559,11 +650,15 @@ function SettingsInner({
 
             {/* About */}
             <section>
-              <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">About</h3>
+              <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">
+                About
+              </h3>
               <div className="bg-base-200 rounded-2xl border border-base-300 p-5">
                 <div className="flex justify-between items-center min-h-[44px]">
                   <span className="text-sm text-base-content">Version</span>
-                  <code className="text-sm text-primary bg-primary/10 px-3 py-1 rounded-lg font-mono">{VERSION}</code>
+                  <code className="text-sm text-primary bg-primary/10 px-3 py-1 rounded-lg font-mono">
+                    {VERSION}
+                  </code>
                 </div>
               </div>
             </section>
@@ -644,9 +739,7 @@ function SettingsInner({
                     plugins={plugins}
                   />
                 ))}
-              {!shortcuts && (
-                <div className="text-sm text-base-content/40">Loading...</div>
-              )}
+              {!shortcuts && <div className="text-sm text-base-content/40">Loading...</div>}
             </div>
           </section>
         )}

--- a/apps/loadout-overlay/src/overlay/components/Sidebar.tsx
+++ b/apps/loadout-overlay/src/overlay/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { PluginInfo } from "../hooks/usePlugins";
 import { usePluginIcons } from "../hooks/usePluginIcons";
+import { OVERLAY_VERSION } from "../version";
 import { useFavorites } from "../hooks/useFavorites";
 import type { MouseEvent as ReactMouseEvent } from "react";
 import { useFocusable, FocusContext, Focusable, setFocus } from "./GamepadNav";
@@ -61,7 +62,8 @@ export function Sidebar({
 
   const { favorites, toggle: toggleFavorite } = useFavorites();
   const currentGame = useCurrentGame();
-  const homeLabel = currentGame?.gameName?.trim() || (currentGame ? `App ${currentGame.appId}` : "Home");
+  const homeLabel =
+    currentGame?.gameName?.trim() || (currentGame ? `App ${currentGame.appId}` : "Home");
   const homeTooltip = currentGame ? `Now playing: ${homeLabel}` : "Home";
   const homeCapsuleSrc = currentGame ? steamArtworkUrls(currentGame.appId).capsule : null;
 
@@ -94,10 +96,7 @@ export function Sidebar({
   }, [plugins, favorites]);
 
   // Flat list used for the active-indicator lookup and icon loading.
-  const flatPlugins = useMemo(
-    () => sections.flatMap((s) => s.items),
-    [sections],
-  );
+  const flatPlugins = useMemo(() => sections.flatMap((s) => s.items), [sections]);
   const pluginIcons = usePluginIcons(flatPlugins);
 
   const listRef = useRef<HTMLDivElement>(null);
@@ -140,7 +139,16 @@ export function Sidebar({
               tabIndex={-1}
               className="btn btn-square btn-ghost btn-sm shrink-0 is-drawer-close:tooltip is-drawer-close:tooltip-right"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" strokeLinejoin="round" strokeLinecap="round" strokeWidth={2} fill="none" stroke="currentColor" className="inline-block size-4">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                strokeWidth={2}
+                fill="none"
+                stroke="currentColor"
+                className="inline-block size-4"
+              >
                 <path d="M4 4m0 2a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2z" />
                 <path d="M9 4v16" />
                 <path d="M14 10l2 2l-2 2" />
@@ -153,7 +161,7 @@ export function Sidebar({
             </div>
             <div className="flex flex-col leading-tight min-w-0">
               <span className="text-sm font-bold truncate">Loadout</span>
-              <span className="text-[10px] text-base-content/40">v0.1.0-alpha</span>
+              <span className="text-[10px] text-base-content/40">v{OVERLAY_VERSION}</span>
             </div>
           </div>
         </div>
@@ -179,8 +187,19 @@ export function Sidebar({
                   homeCapsuleSrc ? (
                     <HomeCapsuleIcon src={homeCapsuleSrc} alt={homeLabel} />
                   ) : (
-                    <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+                      />
                     </svg>
                   )
                 }
@@ -290,7 +309,6 @@ export function Sidebar({
             />
           </Focusable>
         </div>
-
       </div>
     </FocusContext.Provider>
   );
@@ -337,9 +355,7 @@ function SidebarRow({
       >
         {icon}
       </div>
-      <span className="is-drawer-close:hidden text-sm font-medium truncate flex-1">
-        {label}
-      </span>
+      <span className="is-drawer-close:hidden text-sm font-medium truncate flex-1">{label}</span>
     </button>
   );
 }
@@ -357,7 +373,14 @@ function HomeCapsuleIcon({ src, alt }: { src: string; alt: string }) {
   }, [src]);
   if (failed) {
     return (
-      <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="w-4 h-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
         <path strokeLinecap="round" strokeLinejoin="round" d="M5 3l14 9-14 9V3z" />
       </svg>
     );

--- a/apps/loadout-overlay/src/overlay/utils/error-reporter.ts
+++ b/apps/loadout-overlay/src/overlay/utils/error-reporter.ts
@@ -7,6 +7,7 @@
  */
 
 import { authHeaders } from "../lib/backend";
+import { OVERLAY_VERSION } from "../version";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -31,7 +32,7 @@ export interface ErrorReport {
 // Constants
 // ---------------------------------------------------------------------------
 
-const VERSION = "0.1.0-alpha";
+const VERSION = OVERLAY_VERSION;
 
 // ---------------------------------------------------------------------------
 // Report creation
@@ -40,11 +41,7 @@ const VERSION = "0.1.0-alpha";
 /**
  * Build a structured error report from an Error and plugin metadata.
  */
-export function createErrorReport(
-  pluginId: string,
-  pluginName: string,
-  error: Error,
-): ErrorReport {
+export function createErrorReport(pluginId: string, pluginName: string, error: Error): ErrorReport {
   return {
     pluginName,
     pluginId,
@@ -179,9 +176,7 @@ export function installGlobalErrorHandlers(): () => void {
     const report = createErrorReport(
       "global",
       "Uncaught Error",
-      event.error instanceof Error
-        ? event.error
-        : new Error(event.message || "Unknown error"),
+      event.error instanceof Error ? event.error : new Error(event.message || "Unknown error"),
     );
     notifyListeners(report);
   }

--- a/apps/loadout-overlay/src/overlay/version.ts
+++ b/apps/loadout-overlay/src/overlay/version.ts
@@ -1,0 +1,10 @@
+/**
+ * Product version for the overlay UI.
+ *
+ * Baked in at build time by `vite.config.ts` as `__OVERLAY_VERSION__` (read from
+ * this app's package.json). Guarded with `typeof` so it falls back to "dev"
+ * outside a Vite build — e.g. under `bun test`, where the define isn't applied.
+ * Mirrors the backend's `__LOADOUT_VERSION__` guard in apps/loadout/src/index.ts.
+ */
+export const OVERLAY_VERSION: string =
+  typeof __OVERLAY_VERSION__ !== "undefined" ? __OVERLAY_VERSION__ : "dev";

--- a/apps/loadout-overlay/src/overlay/vite-env.d.ts
+++ b/apps/loadout-overlay/src/overlay/vite-env.d.ts
@@ -3,4 +3,4 @@
 /** Product version, injected at build time by `vite.config.ts` from
  *  `apps/loadout-overlay/package.json`. Single source for every UI version
  *  display (Settings → About, sidebar badge, error reports). */
-declare const __OVERLAY_VERSION__: string;
+declare const __OVERLAY_VERSION__: string | undefined;

--- a/apps/loadout-overlay/src/overlay/vite-env.d.ts
+++ b/apps/loadout-overlay/src/overlay/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+/** Product version, injected at build time by `vite.config.ts` from
+ *  `apps/loadout-overlay/package.json`. Single source for every UI version
+ *  display (Settings → About, sidebar badge, error reports). */
+declare const __OVERLAY_VERSION__: string;

--- a/apps/loadout-overlay/vite.config.ts
+++ b/apps/loadout-overlay/vite.config.ts
@@ -2,8 +2,17 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
+import { readFileSync } from "node:fs";
 
 const BACKEND_URL = "http://localhost:33820";
+
+// Single source of truth for the UI-visible product version. Read from this
+// app's package.json and baked in as `__OVERLAY_VERSION__` so Settings, the
+// sidebar badge, and error reports all track one number — bump the package.json
+// (the release script does) and every display follows.
+const OVERLAY_VERSION = (
+  JSON.parse(readFileSync(path.resolve(__dirname, "package.json"), "utf8")) as { version: string }
+).version;
 
 import type { Plugin } from "vite";
 
@@ -20,6 +29,9 @@ function stripCrossorigin(): Plugin {
 
 export default defineConfig({
   plugins: [react(), tailwindcss(), stripCrossorigin()],
+  define: {
+    __OVERLAY_VERSION__: JSON.stringify(OVERLAY_VERSION),
+  },
   root: "src/webview",
   resolve: {
     alias: {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,79 @@
+# Releasing
+
+Loadout ships **versioned, manually-triggered releases**. A release is a git tag
+`vX.Y.Z` that CI builds into a GitHub Release (binary + overlay + plugins +
+checksums), marked "latest" so the installer resolves to it. Every version stays
+downloadable by tag.
+
+## Versioning (loose semver, pre-1.0)
+
+- **New feature → minor** (`0.1.0` → `0.2.0`)
+- **Bug fix / small change → patch** (`0.2.0` → `0.2.1`)
+- **No major bump before 1.0.** `bun run release major` is intentionally
+  disabled; pass an explicit version if you ever truly mean it.
+
+Only the **product** versions are bumped — the repo root and the two shipped apps
+(`apps/loadout`, `apps/loadout-overlay`). Internal `packages/*` and `plugins/*`
+keep their own versions (private, unpublished, not user-visible).
+
+## Cutting a release
+
+From a clean, up-to-date `main`:
+
+```sh
+bun run release minor    # or: patch  |  or an explicit X.Y.Z
+```
+
+The script (`scripts/release.sh`) then:
+
+1. **Preflight** — on `main`, clean tree, `gh` authenticated, in sync with
+   `origin/main`.
+2. **CI-green gate** — the newest `ci.yml` run for `main`'s HEAD must be green
+   (`--no-ci-check` to override).
+3. **CHANGELOG gate** — if `CHANGELOG.md` has no `## [vX.Y.Z]` section it
+   **stops** and prints the merged PRs / commits since the last tag so you can
+   write the entry, then re-run (`--skip-changelog` to override).
+4. Bumps the three product `package.json` versions.
+5. Commits `chore(release): vX.Y.Z`, tags it, and pushes `main` + the tag.
+6. The tag push triggers `.github/workflows/release.yml`, which **re-runs
+   typecheck/lint/specs/tests as a gate**, builds, and publishes the versioned
+   release. The script watches that run and prints the release URL.
+
+Preview without changing anything:
+
+```sh
+bun run release patch --dry-run
+```
+
+## How the version reaches the build
+
+- **Binary:** `scripts/build.sh` runs `git describe --tags --exact-match`, so a
+  build at tag `v0.2.0` reports `loadout 0.2.0` — no manual edit needed.
+- **Overlay UI:** `apps/loadout-overlay/vite.config.ts` bakes
+  `__OVERLAY_VERSION__` from that app's `package.json`; Settings → About, the
+  sidebar badge, and error reports all read it. That's why the release script
+  bumps the overlay `package.json` before tagging.
+
+## Installing a specific version
+
+The installer takes the newest release by default. To pin/downgrade:
+
+```sh
+LOADOUT_VERSION=v0.1.0 curl -fsSL https://raw.githubusercontent.com/srsholmes/loadout/main/scripts/install.sh | sh
+```
+
+## Emergency / offline release
+
+If CI is unavailable, mirror it locally (checkout the tag first so the binary
+versions correctly):
+
+```sh
+git checkout v0.2.0
+sh scripts/release-local.sh v0.2.0        # add --dry-run to build without publishing
+```
+
+## Notes
+
+- The old single **`rolling`** release is retired in favour of versioned tags.
+- GitHub auto-generates release notes from merged PRs; `CHANGELOG.md` is the
+  curated, human-facing history.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "install-local": "sh scripts/install-local.sh",
     "build-and-install": "sh scripts/build.sh && sh scripts/install-local.sh",
     "restart": "sh scripts/restart-loadout.sh",
+    "release": "sh scripts/release.sh",
     "typecheck": "tsc --noEmit",
     "test": "bun run test:backend && bun run test:ui",
     "test:backend": "bun test test.ts --isolate",

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -6,6 +6,10 @@
  * `plugins/*` are deliberately left at their own versions (private, unpublished,
  * not user-visible) — see docs/releasing.md.
  *
+ * Edits only the top-level `"version"` field in place (a targeted text replace),
+ * leaving all other bytes untouched — so it never reformats the file or fights
+ * Prettier (e.g. the root package.json's multi-line `workspaces` array).
+ *
  * Called by scripts/release.sh; runnable directly:
  *   bun scripts/bump-version.ts <X.Y.Z>
  */
@@ -21,16 +25,20 @@ if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const TARGETS = ["package.json", "apps/loadout/package.json", "apps/loadout-overlay/package.json"];
 
+// The top-level version field. package.json lists it near the top, before any
+// nested object, and none of these files have another `"version"` key, so the
+// first match is always the product version.
+const VERSION_RE = /"version":\s*"([^"]*)"/;
+
 for (const rel of TARGETS) {
   const path = resolve(ROOT, rel);
-  const pkg = JSON.parse(await Bun.file(path).text()) as {
-    version?: string;
-    [k: string]: unknown;
-  };
-  const prev = pkg.version ?? "(none)";
-  pkg.version = version;
-  // 2-space indent + trailing newline to match the repo's existing package.json
-  // formatting (and Prettier).
-  await Bun.write(path, `${JSON.stringify(pkg, null, 2)}\n`);
+  const text = await Bun.file(path).text();
+  const m = text.match(VERSION_RE);
+  if (!m) {
+    console.error(`  ${rel}: no "version" field found — aborting`);
+    process.exit(1);
+  }
+  const prev = m[1];
+  await Bun.write(path, text.replace(VERSION_RE, `"version": "${version}"`));
   console.log(`  ${rel}: ${prev} -> ${version}`);
 }

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env bun
+/**
+ * Set the product-level package.json versions to an exact version.
+ *
+ * "Product" = the repo root + the two shipped apps. Internal `packages/*` and
+ * `plugins/*` are deliberately left at their own versions (private, unpublished,
+ * not user-visible) — see docs/releasing.md.
+ *
+ * Called by scripts/release.sh; runnable directly:
+ *   bun scripts/bump-version.ts <X.Y.Z>
+ */
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+  console.error(`usage: bun scripts/bump-version.ts <X.Y.Z> (got: ${version ?? "nothing"})`);
+  process.exit(1);
+}
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const TARGETS = ["package.json", "apps/loadout/package.json", "apps/loadout-overlay/package.json"];
+
+for (const rel of TARGETS) {
+  const path = resolve(ROOT, rel);
+  const pkg = JSON.parse(await Bun.file(path).text()) as {
+    version?: string;
+    [k: string]: unknown;
+  };
+  const prev = pkg.version ?? "(none)";
+  pkg.version = version;
+  // 2-space indent + trailing newline to match the repo's existing package.json
+  // formatting (and Prettier).
+  await Bun.write(path, `${JSON.stringify(pkg, null, 2)}\n`);
+  console.log(`  ${rel}: ${prev} -> ${version}`);
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -324,6 +324,15 @@ phase1() {
         fi
     fi
 
+    # A pinned version that doesn't resolve (typo, or a tag with no published
+    # release) leaves RELEASE_JSON empty. Fail loudly here instead of falling
+    # through to the "latest"-literal URL below, which 404s with a misleading
+    # error and hides the real problem.
+    if [ -n "$LOADOUT_VERSION" ] && [ -z "${RELEASE_JSON:-}" ]; then
+        error "Pinned release $LOADOUT_VERSION not found (no such tag, or it has no published release). See https://github.com/$REPO/releases"
+        exit 1
+    fi
+
     if [ -z "$DOWNLOAD_URL" ]; then
         if [ -n "$GITHUB_TOKEN" ]; then
             error "Could not resolve a release asset URL. Check that GITHUB_TOKEN has Contents: read on $REPO and that a release with tag 'main' exists."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -91,6 +91,12 @@ error() {
 # CLI is logged in.
 GITHUB_TOKEN="${GITHUB_TOKEN:-}"
 
+# Pin a specific release instead of the newest one. Set LOADOUT_VERSION to a
+# release tag (e.g. v0.1.0) to install/downgrade to that exact version; unset,
+# the installer resolves the GitHub "latest" release. The tag flows through to
+# the binary, overlay, plugin, and SHA256SUMS asset URLs automatically.
+LOADOUT_VERSION="${LOADOUT_VERSION:-}"
+
 # curl/wget wrappers that add an Authorization header when GITHUB_TOKEN is
 # set. Pass-through otherwise — public repos keep working with no token.
 curl_gh() {
@@ -292,7 +298,13 @@ phase1() {
 
     # --- Download or locate binary ---
 
-    RELEASE_URL="https://api.github.com/repos/$REPO/releases/latest"
+    # LOADOUT_VERSION pins a specific tag; otherwise take the newest release.
+    if [ -n "$LOADOUT_VERSION" ]; then
+        info "Pinned to release $LOADOUT_VERSION"
+        RELEASE_URL="https://api.github.com/repos/$REPO/releases/tags/$LOADOUT_VERSION"
+    else
+        RELEASE_URL="https://api.github.com/repos/$REPO/releases/latest"
+    fi
 
     DOWNLOAD_URL=""
     DOWNLOAD_ACCEPT_HEADER=""

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
-# Build + publish a Loadout "rolling" GitHub release from this machine,
-# using the gh CLI. A local-operator mirror of .github/workflows/release.yml
-# for when you'd rather cut a release by hand than run the Actions workflow.
+# Build + publish a Loadout versioned GitHub release from this machine, using
+# the gh CLI. An emergency/offline mirror of .github/workflows/release.yml for
+# when CI is unavailable and you must cut a release by hand.
+#
+# The normal path is `bun run release <minor|patch>` (scripts/release.sh), which
+# tags and lets CI build. Use this only as a fallback — and check out the tag
+# first (`git checkout vX.Y.Z`) so the binary reports the right version.
 #
 # Produces the exact assets scripts/install.sh expects, for the host arch:
 #   loadout-<arch>                  the compiled loader binary
@@ -9,23 +13,29 @@
 #   loadout-plugins-<arch>.tar.xz   plugins/ + one hoisted node_modules/
 #   SHA256SUMS                      checksums install.sh verifies against
 #
-# It replaces the single rolling release tagged `rolling` (marked
-# GitHub-"latest"), so `releases/latest` — which install.sh fetches —
-# always points at the newest build.
+# Publishes a release tagged vX.Y.Z, marked GitHub-"latest" so `releases/latest`
+# — which install.sh fetches — points at it.
 #
 # Prereqs: bun, gh (authenticated: `gh auth login`), xz, tar, sha256sum.
 #
 # Usage:
-#   sh scripts/release-local.sh            # build + publish
-#   sh scripts/release-local.sh --dry-run  # build + package, skip the upload
+#   sh scripts/release-local.sh vX.Y.Z            # build + publish the tag
+#   sh scripts/release-local.sh vX.Y.Z --dry-run  # build + package, skip upload
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO="srsholmes/loadout"
-TAG="rolling"
+TAG=""
 DRY_RUN=0
-[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        v[0-9]*.[0-9]*.[0-9]*) TAG="$arg" ;;
+        *) echo "usage: sh scripts/release-local.sh vX.Y.Z [--dry-run]" >&2; exit 1 ;;
+    esac
+done
+[ -n "$TAG" ] || { echo "missing release tag (vX.Y.Z). usage: sh scripts/release-local.sh vX.Y.Z [--dry-run]" >&2; exit 1; }
 
 case "$(uname -m)" in
     x86_64) ARCH="x86_64" ;;
@@ -84,12 +94,13 @@ fi
 
 echo "==> Publishing release '$TAG' to $REPO ..."
 ASSETS="$OUT/loadout-${ARCH} $OUT/loadout-overlay-${ARCH}.tar.xz $OUT/loadout-plugins-${ARCH}.tar.xz $OUT/SHA256SUMS"
-NOTES="Rolling build from $(git -C "$ROOT" rev-parse --short HEAD). Install: curl -fsSL https://raw.githubusercontent.com/$REPO/main/scripts/install.sh | sh"
+NOTES="Loadout $TAG. Install: curl -fsSL https://raw.githubusercontent.com/$REPO/main/scripts/install.sh | sh
+Pin this version: LOADOUT_VERSION=$TAG curl -fsSL https://raw.githubusercontent.com/$REPO/main/scripts/install.sh | sh"
 
 if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
     # Re-upload the per-arch assets (and SHA256SUMS) over the existing
-    # rolling release. --clobber replaces same-named assets so re-running
-    # for the same arch is idempotent; other arches' assets are untouched.
+    # release. --clobber replaces same-named assets so re-running for the
+    # same arch is idempotent; other arches' assets are untouched.
     # shellcheck disable=SC2086
     gh release upload "$TAG" $ASSETS --clobber --repo "$REPO"
     gh release edit "$TAG" --latest --repo "$REPO" >/dev/null
@@ -97,7 +108,7 @@ else
     # shellcheck disable=SC2086
     gh release create "$TAG" $ASSETS \
         --repo "$REPO" \
-        --title "Rolling build (latest main)" \
+        --title "$TAG" \
         --notes "$NOTES" \
         --latest
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,176 @@
+#!/bin/sh
+# Cut a versioned Loadout release.
+#
+# Bumps the product version, updates the CHANGELOG (via a gate — see below),
+# commits, tags `vX.Y.Z`, and pushes. The tag push triggers
+# .github/workflows/release.yml, which builds the tag in clean CI and publishes
+# a versioned GitHub Release (marked "latest", so the curl installer resolves to
+# it). Old versions stay downloadable by tag.
+#
+# Semver (pre-1.0, loose): features -> minor, fixes -> patch. No major until 1.0.
+#
+# Usage:
+#   sh scripts/release.sh <major|minor|patch|X.Y.Z> [flags]
+#   bun run release minor
+#
+# Flags:
+#   --dry-run          Show what would happen; make no commits/tags/pushes.
+#                      Preflight problems (dirty tree, behind origin) become
+#                      warnings instead of errors so it's a safe preview.
+#   --skip-changelog   Skip the CHANGELOG-entry gate (rare no-notes release).
+#   --no-ci-check      Skip the "main CI is green" gate.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO="srsholmes/loadout"
+
+# --- output helpers (match scripts/build.sh) ---
+if [ -t 1 ]; then
+    GREEN='\033[0;32m'; BLUE='\033[0;34m'; YELLOW='\033[1;33m'
+    RED='\033[0;31m'; BOLD='\033[1m'; NC='\033[0m'
+else
+    GREEN=''; BLUE=''; YELLOW=''; RED=''; BOLD=''; NC=''
+fi
+info()    { printf "${BLUE}[release]${NC} %s\n" "$1"; }
+success() { printf "${GREEN}[ok]${NC} %s\n" "$1"; }
+warn()    { printf "${YELLOW}[warn]${NC} %s\n" "$1"; }
+error()   { printf "${RED}[error]${NC} %s\n" "$1" >&2; }
+die()     { error "$1"; exit 1; }
+
+# --- args ---
+BUMP=""
+DRY_RUN=0
+SKIP_CHANGELOG=0
+NO_CI_CHECK=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        --skip-changelog) SKIP_CHANGELOG=1 ;;
+        --no-ci-check) NO_CI_CHECK=1 ;;
+        -h|--help)
+            sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        -*) die "unknown flag: $arg" ;;
+        *) [ -z "$BUMP" ] && BUMP="$arg" || die "unexpected argument: $arg" ;;
+    esac
+done
+[ -n "$BUMP" ] || die "missing bump: major|minor|patch|X.Y.Z (see --help)"
+
+# preflight problems are fatal for a real run, warnings for --dry-run
+preflight_fail() { [ "$DRY_RUN" = "1" ] && warn "$1" || die "$1"; }
+
+# --- tools ---
+for t in git gh bun; do command -v "$t" >/dev/null 2>&1 || die "missing required tool: $t"; done
+
+# --- preflight: branch, tree, remote, auth ---
+BRANCH="$(git -C "$ROOT" rev-parse --abbrev-ref HEAD)"
+[ "$BRANCH" = "main" ] || preflight_fail "not on main (on '$BRANCH'). Releases are cut from main."
+[ -z "$(git -C "$ROOT" status --porcelain)" ] || preflight_fail "working tree is dirty. Commit or stash first."
+gh auth status >/dev/null 2>&1 || preflight_fail "gh is not authenticated (run: gh auth login)."
+
+git -C "$ROOT" fetch --quiet origin main 2>/dev/null || warn "could not fetch origin/main"
+LOCAL="$(git -C "$ROOT" rev-parse HEAD)"
+REMOTE="$(git -C "$ROOT" rev-parse origin/main 2>/dev/null || echo "")"
+if [ -n "$REMOTE" ] && [ "$LOCAL" != "$REMOTE" ]; then
+    preflight_fail "local main ($(echo "$LOCAL" | cut -c1-9)) != origin/main ($(echo "$REMOTE" | cut -c1-9)). Pull/push first."
+fi
+
+# --- compute versions ---
+CUR="$(grep '"version"' "$ROOT/package.json" | head -1 | sed 's/.*"version": *"//;s/".*//')"
+[ -n "$CUR" ] || die "could not read current version from package.json"
+MAJOR="${CUR%%.*}"; REST="${CUR#*.}"; MINOR="${REST%%.*}"; PATCH="${REST#*.}"; PATCH="${PATCH%%-*}"
+
+case "$BUMP" in
+    major) die "major bumps are disabled pre-1.0 — pass an explicit version (e.g. 1.0.0) if you truly mean it." ;;
+    minor) NEW="$MAJOR.$((MINOR + 1)).0" ;;
+    patch) NEW="$MAJOR.$MINOR.$((PATCH + 1))" ;;
+    [0-9]*.[0-9]*.[0-9]*) NEW="$BUMP" ;;
+    *) die "invalid bump '$BUMP' — use major|minor|patch|X.Y.Z" ;;
+esac
+echo "$NEW" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || die "computed version '$NEW' is not X.Y.Z"
+TAG="v$NEW"
+
+git -C "$ROOT" rev-parse "$TAG" >/dev/null 2>&1 && die "tag $TAG already exists."
+
+info "current version: ${BOLD}$CUR${NC}"
+info "new version:     ${BOLD}$NEW${NC}  (tag $TAG)"
+
+# --- CI-green gate: newest ci.yml run for this exact commit must be success ---
+if [ "$NO_CI_CHECK" = "1" ]; then
+    warn "skipping CI-green gate (--no-ci-check)"
+else
+    CI="$(gh run list --repo "$REPO" --branch main --workflow ci.yml --limit 15 \
+        --json headSha,status,conclusion \
+        --jq '[.[] | select(.headSha=="'"$LOCAL"'")][0] | (.status + "/" + (.conclusion // ""))' 2>/dev/null || true)"
+    case "$CI" in
+        completed/success) success "CI is green for $(echo "$LOCAL" | cut -c1-9)" ;;
+        "" ) preflight_fail "no CI run found for main HEAD $(echo "$LOCAL" | cut -c1-9) yet — wait for CI, or pass --no-ci-check." ;;
+        completed/*) preflight_fail "CI for main HEAD is ${CI#completed/} (not success). Fix main first, or pass --no-ci-check." ;;
+        *) preflight_fail "CI for main HEAD is still running ($CI). Wait for it, or pass --no-ci-check." ;;
+    esac
+fi
+
+# --- CHANGELOG gate (the AI/human prompt) ---
+DATE="$(date -u +%Y-%m-%d)"
+if [ "$SKIP_CHANGELOG" = "1" ]; then
+    warn "skipping CHANGELOG gate (--skip-changelog)"
+elif grep -qF "## [$TAG]" "$ROOT/CHANGELOG.md" 2>/dev/null; then
+    success "CHANGELOG.md has a section for $TAG"
+else
+    LAST_TAG="$(git -C "$ROOT" describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+    printf '\n'
+    error "CHANGELOG.md has no \"## [$TAG]\" section."
+    printf "${BOLD}Add this section to the top of CHANGELOG.md, then re-run \`bun run release $BUMP\`:${NC}\n\n"
+    printf "  ## [%s] — %s\n\n" "$TAG" "$DATE"
+    printf "  ### Added / Changed / Fixed\n"
+    printf "  - ...\n\n"
+    printf "${BOLD}Source material — changes since %s:${NC}\n" "${LAST_TAG:-the start (first versioned release)}"
+    if [ -n "$LAST_TAG" ]; then
+        git -C "$ROOT" log --no-merges --pretty='  - %s' "$LAST_TAG..HEAD"
+        SINCE="$(git -C "$ROOT" log -1 --format=%cs "$LAST_TAG")"
+        printf "\n${BOLD}Merged PRs since %s:${NC}\n" "$SINCE"
+        gh pr list --repo "$REPO" --state merged --limit 100 \
+            --json number,title,mergedAt \
+            --jq 'sort_by(.mergedAt) | .[] | select(.mergedAt[0:10] >= "'"$SINCE"'") | "  #\(.number) \(.title)"' 2>/dev/null || true
+    else
+        git -C "$ROOT" log --no-merges -20 --pretty='  - %s'
+        printf "  (first versioned release — see the existing CHANGELOG for the full history)\n"
+    fi
+    printf "\n${BOLD}Reminder:${NC} features -> minor, fixes -> patch. Group entries under Added / Changed / Fixed.\n\n"
+    exit 1
+fi
+
+# --- dry run stops here ---
+if [ "$DRY_RUN" = "1" ]; then
+    printf '\n'
+    info "--dry-run: would do the following (no changes made):"
+    printf "  1. bump root + apps/loadout + apps/loadout-overlay package.json -> %s\n" "$NEW"
+    printf "  2. commit \"chore(release): %s\" (package.json x3 + CHANGELOG.md)\n" "$TAG"
+    printf "  3. tag %s and push main + tag\n" "$TAG"
+    printf "  4. tag push triggers release.yml -> versioned release\n"
+    exit 0
+fi
+
+# --- bump, commit, tag, push ---
+info "bumping product versions..."
+bun "$SCRIPT_DIR/bump-version.ts" "$NEW"
+
+git -C "$ROOT" add package.json apps/loadout/package.json apps/loadout-overlay/package.json CHANGELOG.md
+git -C "$ROOT" commit -q -m "chore(release): $TAG"
+git -C "$ROOT" tag -a "$TAG" -m "$TAG"
+success "committed and tagged $TAG"
+
+info "pushing main + tag..."
+git -C "$ROOT" push --quiet origin main --follow-tags
+success "pushed. release.yml will build $TAG."
+
+# --- watch the release run (best-effort) ---
+sleep 8
+RUN_ID="$(gh run list --repo "$REPO" --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
+if [ -n "$RUN_ID" ]; then
+    info "watching release run $RUN_ID..."
+    gh run watch "$RUN_ID" --repo "$REPO" --exit-status --interval 15 || warn "release run did not succeed — check the Actions tab."
+fi
+RELEASE_URL="https://github.com/$REPO/releases/tag/$TAG"
+success "done. Release: $RELEASE_URL"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,11 +43,13 @@ BUMP=""
 DRY_RUN=0
 SKIP_CHANGELOG=0
 NO_CI_CHECK=0
+FORCE=0
 for arg in "$@"; do
     case "$arg" in
         --dry-run) DRY_RUN=1 ;;
         --skip-changelog) SKIP_CHANGELOG=1 ;;
         --no-ci-check) NO_CI_CHECK=1 ;;
+        --force) FORCE=1 ;;
         -h|--help)
             sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
             exit 0 ;;
@@ -93,6 +95,19 @@ TAG="v$NEW"
 
 git -C "$ROOT" rev-parse "$TAG" >/dev/null 2>&1 && die "tag $TAG already exists."
 
+# Guard against a downgrade: an explicit version lower than the current one
+# would still publish with make_latest, silently downgrading every installer.
+# (minor/patch keywords always increase, so this only bites explicit X.Y.Z.)
+# NEW == CUR is allowed — that's the first release when package.json already
+# carries the target version; the tag-exists check above blocks true re-releases.
+if [ "$NEW" != "$CUR" ]; then
+    HIGHEST="$(printf '%s\n%s\n' "$CUR" "$NEW" | sort -V | tail -1)"
+    if [ "$HIGHEST" = "$CUR" ]; then
+        [ "$FORCE" = "1" ] || die "refusing to release $NEW — lower than current $CUR (pass --force to override)."
+        warn "releasing $NEW below current $CUR (--force)."
+    fi
+fi
+
 info "current version: ${BOLD}$CUR${NC}"
 info "new version:     ${BOLD}$NEW${NC}  (tag $TAG)"
 
@@ -102,7 +117,7 @@ if [ "$NO_CI_CHECK" = "1" ]; then
 else
     CI="$(gh run list --repo "$REPO" --branch main --workflow ci.yml --limit 15 \
         --json headSha,status,conclusion \
-        --jq '[.[] | select(.headSha=="'"$LOCAL"'")][0] | (.status + "/" + (.conclusion // ""))' 2>/dev/null || true)"
+        --jq '[.[] | select(.headSha=="'"$LOCAL"'")][0] | if . == null then "" else .status + "/" + (.conclusion // "") end' 2>/dev/null || true)"
     case "$CI" in
         completed/success) success "CI is green for $(echo "$LOCAL" | cut -c1-9)" ;;
         "" ) preflight_fail "no CI run found for main HEAD $(echo "$LOCAL" | cut -c1-9) yet — wait for CI, or pass --no-ci-check." ;;
@@ -138,7 +153,10 @@ else
         printf "  (first versioned release — see the existing CHANGELOG for the full history)\n"
     fi
     printf "\n${BOLD}Reminder:${NC} features -> minor, fixes -> patch. Group entries under Added / Changed / Fixed.\n\n"
-    exit 1
+    # In --dry-run this is a preview: surface the requirement but don't hard-fail,
+    # so the rest of the plan still prints. A real run stops here.
+    [ "$DRY_RUN" = "1" ] || exit 1
+    warn "--dry-run: CHANGELOG section missing (a real run would stop here)."
 fi
 
 # --- dry run stops here ---
@@ -166,11 +184,23 @@ git -C "$ROOT" push --quiet origin main --follow-tags
 success "pushed. release.yml will build $TAG."
 
 # --- watch the release run (best-effort) ---
-sleep 8
-RUN_ID="$(gh run list --repo "$REPO" --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
+# Poll for the run whose head branch is THIS tag, rather than grabbing the
+# newest release run — otherwise a slow-to-register run lets us watch a prior
+# (already-succeeded) one and report a false success.
+RUN_ID=""
+i=0
+while [ "$i" -lt 6 ]; do
+    RUN_ID="$(gh run list --repo "$REPO" --workflow release.yml --limit 15 \
+        --json databaseId,headBranch \
+        --jq '[.[] | select(.headBranch=="'"$TAG"'")][0].databaseId' 2>/dev/null || true)"
+    [ -n "$RUN_ID" ] && break
+    i=$((i + 1))
+    sleep 5
+done
 if [ -n "$RUN_ID" ]; then
     info "watching release run $RUN_ID..."
     gh run watch "$RUN_ID" --repo "$REPO" --exit-status --interval 15 || warn "release run did not succeed — check the Actions tab."
+else
+    warn "couldn't find the release run for $TAG yet — check the Actions tab."
 fi
-RELEASE_URL="https://github.com/$REPO/releases/tag/$TAG"
-success "done. Release: $RELEASE_URL"
+success "done. Release: https://github.com/$REPO/releases/tag/$TAG"


### PR DESCRIPTION
fixes https://github.com/srsholmes/loadout/issues/174 
## What & why

Replaces the single overwriting **`rolling`** release with **versioned `vX.Y.Z`** releases, so users can download or pin any version and there's a real per-version history. Releases stay **manually triggered** (by the maintainer or AI, on request) — the trigger is a tag push, and CI builds it.

## How it works

`bun run release <minor|patch|X.Y.Z>` → `scripts/release.sh`:
1. Preflight (on main, clean tree, `gh` auth, in sync with origin).
2. **CI-green gate** — main HEAD's `ci.yml` run must be green.
3. **CHANGELOG gate** — halts if there's no `## [vX.Y.Z]` section, printing the merged PRs + commits since the last tag as source material, so the entry gets written before release (`--skip-changelog` to override).
4. Bumps product versions, commits `chore(release): vX.Y.Z`, tags, pushes.
5. The tag push triggers `release.yml`, which re-runs typecheck/lint/specs/tests as a **gate job**, builds, and publishes a versioned release (auto-generated notes + `make_latest`). The script watches the run.

## Details

- **Overlay UI version single-sourced** from `apps/loadout-overlay/package.json` via a `__OVERLAY_VERSION__` Vite define (guarded `typeof` fallback so `bun test` doesn't throw), replacing three hardcoded `"0.1.0-alpha"` strings.
- **Binary version** already derives from `git describe --tags` in `build.sh` — no change needed.
- **Installer**: `LOADOUT_VERSION=vX.Y.Z curl … | sh` pins a version; default resolves the newest via `releases/latest`.
- `release-local.sh` retargeted to versioned tags (emergency/offline mirror).
- `docs/releasing.md` + README/CONTRIBUTING pointers.

Semver (pre-1.0, loose): **features → minor, fixes → patch**; major disabled until 1.0.

## Not in this PR (follow-ups after merge)

- Cut the first real release: `bun run release 0.1.0` on `main` (writes the `## [v0.1.0]` CHANGELOG heading when the gate prompts).
- **After** that release is live and marked latest, retire the old `rolling` release + tag.

## Verification

- `bun run typecheck`, `bun run lint` (0 errors), `bun run test` (2220 backend + 363 UI, 0 fail).
- Vite-built the webview and confirmed `0.1.0` bakes into the bundle from the define.
- Shell syntax-checked all scripts; `bump-version.ts` validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)