### PR TITLE
feat(recomp): add Mega Man 64: Recompiled

### DIFF
--- a/plugins/recomp/games.json
+++ b/plugins/recomp/games.json
@@ -197,6 +197,30 @@
       "steamGridDbId": 1680
     },
     {
+      "id": "megaman64-recomp",
+      "name": "Mega Man 64",
+      "project": "Mega Man 64: Recompiled",
+      "platform": "n64",
+      "repo": "MegaMan64Recomp/MegaMan64Recompiled",
+      "description": "Native PC port of Mega Man 64 via static recompilation. Widescreen, higher framerates, and mod support.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "MegaMan64Recompiled-*-Windows.zip"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/MegaMan64Recompiled.exe"
+      },
+      "tags": [
+        "mega-man",
+        "n64",
+        "action-adventure",
+        "3d"
+      ],
+      "latestVersion": "v0.9.1",
+      "steamGridDbId": 37399,
+      "_reason": "Windows-only: the upstream Linux build ships as a nested zip->tar.gz the installer doesn't unwrap; the Windows build runs via Proton."
+    },
+    {
       "id": "bmhero-recomp",
       "name": "Bomberman Hero",
       "project": "Bomberman Hero: Recompiled",


### PR DESCRIPTION
Adds **Mega Man 64: Recompiled** (`MegaMan64Recomp/MegaMan64Recompiled`) to the recomp registry — the last of GithubLauncher's curated N64 recomps missing from ours.

Closes #179.

## Entry
| field | value |
|---|---|
| id | `megaman64-recomp` |
| repo | `MegaMan64Recomp/MegaMan64Recompiled` |
| latest | `v0.9.1` (non-prerelease) |
| type | `prebuilt` |
| win asset | `MegaMan64Recompiled-*-Windows.zip` → `MegaMan64Recompiled.exe` (flat zip, verified) |
| SteamGridDB | `37399` |

## Why Windows-only (via Proton)
The upstream **Linux** asset (`…-Linux-X64.zip`) **double-nests** — it's a zip *containing* `MegaMan64Recompiled.tar.gz`, and the recomp pipeline calls `extractArchive` once (`pipeline.ts:594`), so it wouldn't unwrap the inner tarball and the native binary wouldn't be present. The **Windows** zip is flat with the exe, so this entry ships that and runs through Proton on the Deck — same as `quest64-recomp` / `chameleon-twist-recomp`. A `_reason` field documents this in the entry.

A follow-up plugin enhancement (recursive/nested archive extraction) would let us use the native Linux build here — same enhancement that would give Perfect Dark Windows support.

## Verification
- `python3 -m json.tool games.json` passes; 464 games, no duplicate ids.
- Recomp backend + registry tests green.
- Windows zip layout + exe name verified by download/unzip; SteamGridDB id confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)