### PR TITLE
fix(overlay): scale toasts with the UI scaler + enlarge base size

### DIFF
--- a/apps/loadout-overlay/src/overlay/App.tsx
+++ b/apps/loadout-overlay/src/overlay/App.tsx
@@ -149,21 +149,29 @@ export function App() {
     return () => window.removeEventListener(TOAST_EVENT, onToast);
   }, []);
 
+  // Toasts render here in the parent, OUTSIDE AppInner's zoomed wrapper, so the
+  // UI-scale `zoom` never reached them and they stayed tiny (issue #177). Read
+  // the same `uiScale` config value AppInner uses and scale the toast container
+  // to match, so toasts grow with the rest of the UI.
+  const [uiScale] = useConfigValue<number>("uiScale", loadScale(false));
+
   return (
     <LoadoutProvider>
       <GamepadNavProvider onBack={handleBack}>
         <AppInner />
         <Toaster
           position="top-right"
+          containerStyle={{ zoom: uiScale }}
           toastOptions={{
             duration: 3000,
             style: {
               background: "var(--bg-inset)",
               color: "var(--fg-1)",
               border: "1px solid var(--line)",
-              borderRadius: "10px",
-              fontSize: "13px",
-              padding: "10px 14px",
+              borderRadius: "12px",
+              fontSize: "15px",
+              lineHeight: "1.35",
+              padding: "13px 18px",
               boxShadow: "0 8px 24px rgb(0 0 0 / 0.32)",
             },
             success: {


### PR DESCRIPTION
Closes #177.

Toasts were too small and unaffected by the UI Scale setting.

**Root cause:** the `<Toaster>` is mounted in `App`, *outside* `AppInner`'s `zoom`-scaled wrapper, so the UI scaler never reached it.

**Fix:**
- Read the same `uiScale` config value and apply `zoom: uiScale` to the toast container (`containerStyle`), so toasts scale with the rest of the UI.
- Enlarge the base size for legibility: `fontSize 13→15px`, `padding 10/14→13/18`, `borderRadius 10→12`, added line-height.

Verified on-device across 0.75x–2.0x — toasts now grow/shrink with the slider and are legible at 1.0x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)