### PR TITLE
feat(overlay): optional "Loadout" entry in Steam's main menu to open the overlay (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Open the overlay from Steam's menu** (#169) — An optional **"Loadout"** entry in Steam's main menu that opens the overlay. It lives in Steam's own focus tree, so it stays reachable by D-pad even if the controller wake-shortcut is mis-configured or the pads wedge on wake — a backup way in. Toggle it under **Settings → General → Steam menu**; selecting it opens the overlay without navigating you anywhere.
+
 ## [v0.1.0] — 2026-07-03
 
 First versioned release. Establishes the versioned release process and bundles everything from the rolling-build history below; the notable recent additions:

--- a/apps/loadout-overlay/src/overlay/components/Settings.tsx
+++ b/apps/loadout-overlay/src/overlay/components/Settings.tsx
@@ -1,5 +1,15 @@
-import { useState, useEffect, useMemo } from "react";
-import { PluginProvider, TabBar, Slider, Button, Select, Toggle, useBackend } from "@loadout/ui";
+import { useState, useEffect, useMemo, useRef } from "react";
+import {
+  PluginProvider,
+  TabBar,
+  Slider,
+  Button,
+  Select,
+  Toggle,
+  notify,
+  useBackend,
+} from "@loadout/ui";
+import { apiUrl, authHeaders } from "../lib/backend";
 import { useSidebarAutoCollapseSetting } from "../hooks/useSidebarCollapse";
 import { OVERLAY_VERSION } from "../version";
 import { useEnabledPlugins } from "../hooks/useEnabledPlugins";
@@ -502,6 +512,10 @@ function SettingsInner({
   const [theme, setTheme] = useConfigValue<string>("theme", loadTheme());
   const [startupView, setStartupView] = useConfigValue<string>("startupView", "home");
   const [autoCollapseSidebar, setAutoCollapseSidebar] = useSidebarAutoCollapseSetting();
+  const [steamMainMenu, setSteamMainMenu] = useConfigValue<boolean>(
+    "steamOverlayButtonMainMenu",
+    false,
+  );
   const [shortcuts, setShortcuts] = useState<ControllerShortcuts | null>(null);
   const { isEnabled, toggle: togglePluginEnabled } = useEnabledPlugins();
   const allPluginIds = useMemo(() => plugins.map((p) => p.id), [plugins]);
@@ -520,6 +534,50 @@ function SettingsInner({
       .then(setShortcuts)
       .catch(() => {});
   }, []);
+
+  // Push the Steam-menu "open overlay" button change into the running Steam
+  // client (issue #169). Debounced so typing a label doesn't spam the
+  // injector; surfaces a toast when injection fails (e.g. Steam not attached
+  // or desktop mode). Config itself is already persisted by the setters
+  // above — this only re-applies the CEF patch.
+  const steamButtonRefreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  function scheduleSteamButtonRefresh() {
+    if (steamButtonRefreshTimer.current) clearTimeout(steamButtonRefreshTimer.current);
+    steamButtonRefreshTimer.current = setTimeout(() => {
+      steamButtonRefreshTimer.current = null;
+      const enabled = getConfigValue<boolean>("steamOverlayButtonMainMenu", false);
+      fetch(apiUrl("/api/overlay-button/refresh"), { method: "POST", headers: authHeaders() })
+        .then(async (res) => {
+          const data = (await res.json().catch(() => null)) as
+            | { ok?: boolean; error?: string }
+            | null;
+          const ok = res.ok && data?.ok !== false;
+          // Only nag when the user is trying to *enable* it — a failed
+          // teardown (already gone, Steam closed) isn't worth a toast.
+          if (ok) {
+            if (enabled) {
+              notify("Added the overlay button to Steam's menu.", {
+                kind: "success",
+                id: "steam-overlay-button",
+              });
+            }
+          } else if (enabled) {
+            notify(data?.error ?? "Couldn't add the button to Steam.", {
+              kind: "error",
+              id: "steam-overlay-button",
+            });
+          }
+        })
+        .catch(() => {
+          if (enabled) {
+            notify("Couldn't reach the loader to update Steam.", {
+              kind: "error",
+              id: "steam-overlay-button",
+            });
+          }
+        });
+    }, 400);
+  }
 
   function handleShortcutChange(key: keyof ControllerShortcuts, value: string) {
     if (!shortcuts) return;
@@ -606,6 +664,34 @@ function SettingsInner({
                     </div>
                   </div>
                   <Toggle checked={autoCollapseSidebar} onChange={setAutoCollapseSidebar} />
+                </div>
+              </div>
+            </section>
+
+            {/* Steam menu button — an optional escape hatch into the overlay
+                that lives in Steam's own nav menu, reachable by D-pad even if
+                the controller wake chord fails (issue #169). */}
+            <section className="mb-6">
+              <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-4">
+                Steam menu
+              </h3>
+              <div className="bg-base-200 rounded-2xl border border-base-300 p-5">
+                <div className="flex justify-between items-center min-h-[44px]">
+                  <div className="pr-4">
+                    <div className="text-sm text-base-content">Add "Loadout" to Steam's main menu</div>
+                    <div className="text-xs text-base-content/50 mt-0.5">
+                      Adds a "Loadout" entry to Steam's main menu that opens the overlay — a
+                      backup way in if the controller shortcut ever stops working. Selecting it
+                      opens the overlay without navigating you anywhere.
+                    </div>
+                  </div>
+                  <Toggle
+                    checked={steamMainMenu}
+                    onChange={(v) => {
+                      setSteamMainMenu(v);
+                      scheduleSteamButtonRefresh();
+                    }}
+                  />
                 </div>
               </div>
             </section>

--- a/apps/loadout-overlay/src/overlay/components/Settings.tsx
+++ b/apps/loadout-overlay/src/overlay/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo } from "react";
 import {
   PluginProvider,
   TabBar,
@@ -535,48 +535,43 @@ function SettingsInner({
       .catch(() => {});
   }, []);
 
-  // Push the Steam-menu "open overlay" button change into the running Steam
-  // client (issue #169). Debounced so typing a label doesn't spam the
-  // injector; surfaces a toast when injection fails (e.g. Steam not attached
-  // or desktop mode). Config itself is already persisted by the setters
-  // above — this only re-applies the CEF patch.
-  const steamButtonRefreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  function scheduleSteamButtonRefresh() {
-    if (steamButtonRefreshTimer.current) clearTimeout(steamButtonRefreshTimer.current);
-    steamButtonRefreshTimer.current = setTimeout(() => {
-      steamButtonRefreshTimer.current = null;
-      const enabled = getConfigValue<boolean>("steamOverlayButtonMainMenu", false);
-      fetch(apiUrl("/api/overlay-button/refresh"), { method: "POST", headers: authHeaders() })
-        .then(async (res) => {
-          const data = (await res.json().catch(() => null)) as
-            | { ok?: boolean; error?: string }
-            | null;
-          const ok = res.ok && data?.ok !== false;
-          // Only nag when the user is trying to *enable* it — a failed
-          // teardown (already gone, Steam closed) isn't worth a toast.
-          if (ok) {
-            if (enabled) {
-              notify("Added the overlay button to Steam's menu.", {
-                kind: "success",
-                id: "steam-overlay-button",
-              });
-            }
-          } else if (enabled) {
-            notify(data?.error ?? "Couldn't add the button to Steam.", {
-              kind: "error",
-              id: "steam-overlay-button",
-            });
-          }
-        })
-        .catch(() => {
-          if (enabled) {
-            notify("Couldn't reach the loader to update Steam.", {
-              kind: "error",
-              id: "steam-overlay-button",
-            });
-          }
+  // Apply the Steam main-menu "Loadout" entry toggle to the running Steam
+  // client (issue #169). Config is already persisted optimistically by
+  // `setSteamMainMenu`; this re-applies the CEF patch and passes the desired
+  // state in the request body so the injector doesn't race the async config
+  // PATCH. Surfaces a toast only when *enabling* fails (a failed teardown —
+  // Steam closed, already gone — isn't worth nagging about).
+  async function applySteamMainMenu(enabled: boolean) {
+    try {
+      const res = await fetch(apiUrl("/api/overlay-button/refresh"), {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ mainMenu: enabled }),
+      });
+      const data = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string }
+        | null;
+      const ok = res.ok && data?.ok !== false;
+      if (!enabled) return;
+      if (ok) {
+        notify("Added the overlay button to Steam's menu.", {
+          kind: "success",
+          id: "steam-overlay-button",
         });
-    }, 400);
+      } else {
+        notify(data?.error ?? "Couldn't add the button to Steam.", {
+          kind: "error",
+          id: "steam-overlay-button",
+        });
+      }
+    } catch {
+      if (enabled) {
+        notify("Couldn't reach the loader to update Steam.", {
+          kind: "error",
+          id: "steam-overlay-button",
+        });
+      }
+    }
   }
 
   function handleShortcutChange(key: keyof ControllerShortcuts, value: string) {
@@ -689,7 +684,7 @@ function SettingsInner({
                     checked={steamMainMenu}
                     onChange={(v) => {
                       setSteamMainMenu(v);
-                      scheduleSteamButtonRefresh();
+                      void applySteamMainMenu(v);
                     }}
                   />
                 </div>

--- a/apps/loadout/src/injector/index.ts
+++ b/apps/loadout/src/injector/index.ts
@@ -1,4 +1,4 @@
-export { SteamInjector, type InjectorOptions } from "./injector";
+export { SteamInjector, resolveOverlayMainMenu, type InjectorOptions } from "./injector";
 export { buildComponentDiscoveryScript, type SteamComponentMeta, type SteamComponentPropMeta } from "./steam-components";
 export { findSharedJSContext, findBigPictureTab, findQuickAccessTab, getTabs, isSharedJSContext, isBigPictureMode, isQuickAccessTab, type CEFTab, type GetTabsOptions } from "./tabs";
 export { REACT_UTILS, GET_REACT_ROOT, FIND_IN_REACT_TREE, AFTER_PATCH } from "./react-utils";

--- a/apps/loadout/src/injector/index.ts
+++ b/apps/loadout/src/injector/index.ts
@@ -4,5 +4,14 @@ export { findSharedJSContext, findBigPictureTab, findQuickAccessTab, getTabs, is
 export { REACT_UTILS, GET_REACT_ROOT, FIND_IN_REACT_TREE, AFTER_PATCH } from "./react-utils";
 export { DISCOVER_STEAM_REACT } from "./steam-react";
 export { buildMenuPatchScript, type MenuPluginEntry } from "./menu-patcher";
+export {
+  buildOverlayMenuInjectScript,
+  buildOverlayMenuRemoveScript,
+  OVERLAY_MENU_BINDING,
+  OVERLAY_MENU_ROUTE,
+  OVERLAY_MENU_LABEL,
+  OVERLAY_MENU_STATE_GLOBAL,
+  type OverlayMenuConfig,
+} from "./overlay-menu";
 export { buildRoutePatchScript, type RouteEntry } from "./route-patcher";
 export { createGameSessionMonitor, type GameSessionMonitor, type GameSessionEvent, type GameSessionMonitorOptions, type CreateGameSessionMonitorOptions } from "./game-session-monitor";

--- a/apps/loadout/src/injector/injector.test.ts
+++ b/apps/loadout/src/injector/injector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { maybeGiveUp } from "./injector";
+import { maybeGiveUp, resolveOverlayMainMenu } from "./injector";
 
 // The injectBPMBundles (A-019) and buildPanelMountScript (A-008) test
 // blocks were removed alongside their subjects — issue #60: the
@@ -47,5 +47,44 @@ describe("maybeGiveUp (A-021)", () => {
     expect(logs.length).toBe(1);
     expect(logs[0]).toContain("onGiveUp callback threw");
     expect(logs[0]).toContain("downstream broadcast blew up");
+  });
+});
+
+/**
+ * Issue #169: the main-menu entry setting was renamed from
+ * `steamOverlayButtonEnabled` to `steamOverlayButtonMainMenu`. The new key
+ * must win once present so toggling it *off* removes the item even for a
+ * config still carrying the legacy flag; the legacy flag is honoured only
+ * as a fallback when the new key was never written.
+ */
+describe("resolveOverlayMainMenu (#169 config precedence)", () => {
+  it("uses the new key when present (true)", () => {
+    expect(resolveOverlayMainMenu({ steamOverlayButtonMainMenu: true })).toBe(true);
+  });
+
+  it("new key wins over a truthy legacy flag when explicitly false", () => {
+    // The exact bug the reviewer caught: toggling off must remove the item
+    // even though the legacy `steamOverlayButtonEnabled` is still true.
+    expect(
+      resolveOverlayMainMenu({
+        steamOverlayButtonMainMenu: false,
+        steamOverlayButtonEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to the legacy flag only when the new key is absent", () => {
+    expect(resolveOverlayMainMenu({ steamOverlayButtonEnabled: true })).toBe(true);
+    expect(resolveOverlayMainMenu({ steamOverlayButtonEnabled: false })).toBe(false);
+  });
+
+  it("defaults to false for an empty / unrelated config", () => {
+    expect(resolveOverlayMainMenu({})).toBe(false);
+    expect(resolveOverlayMainMenu({ theme: "midnight" })).toBe(false);
+  });
+
+  it("treats non-boolean values as not-enabled (no type coercion)", () => {
+    expect(resolveOverlayMainMenu({ steamOverlayButtonMainMenu: "true" })).toBe(false);
+    expect(resolveOverlayMainMenu({ steamOverlayButtonMainMenu: 1 })).toBe(false);
   });
 });

--- a/apps/loadout/src/injector/injector.ts
+++ b/apps/loadout/src/injector/injector.ts
@@ -102,6 +102,27 @@ export function maybeGiveUp(
   return true;
 }
 
+/**
+ * Resolve whether the main-menu "Loadout" entry should be present from a
+ * raw user-config object (issue #169). The new `steamOverlayButtonMainMenu`
+ * key wins once it exists — so toggling it *off* removes the item even for
+ * a config that still carries the legacy `steamOverlayButtonEnabled` flag
+ * (used by the first build of this feature, pre key-rename). The legacy key
+ * is honoured only as a fallback when the new key was never written.
+ *
+ * Pure + exported so the back-compat precedence is unit-testable without a
+ * live CEF connection.
+ */
+export function resolveOverlayMainMenu(cfg: Record<string, unknown>): boolean {
+  const hasNew = Object.prototype.hasOwnProperty.call(
+    cfg,
+    "steamOverlayButtonMainMenu",
+  );
+  return hasNew
+    ? cfg.steamOverlayButtonMainMenu === true
+    : cfg.steamOverlayButtonEnabled === true;
+}
+
 /*
  * The plugin-bundle / panel-mount machinery (injectBPMBundles,
  * PANEL_CONTAINER_STYLE, PanelMountScriptOptions, buildPanelMountScript,
@@ -470,35 +491,42 @@ export class SteamInjector {
    * Idempotent — re-adding an existing binding is a non-fatal no-op.
    */
   private async setupOverlayBinding(): Promise<void> {
-    if (!this.cdp?.connected) return;
+    const cdp = this.cdp;
+    if (!cdp?.connected) return;
+
+    // Attach the client-side listener exactly once — *synchronously*, before
+    // any await, so two concurrent callers (launch-time setup racing a
+    // Settings-toggle refresh) can't both pass the guard and double-add it,
+    // which would fire onOverlayOpen twice per activation. The listener
+    // survives page reloads (it lives on the CDP client, not the page).
+    if (!this.overlayBindingUnsub) {
+      this.overlayBindingUnsub = cdp.on(
+        "Runtime.bindingCalled",
+        (params: Record<string, unknown>) => {
+          if (params.name !== OVERLAY_MENU_BINDING) return;
+          this.log("[injector] Overlay-menu entry activated");
+          try {
+            this.onOverlayOpen?.();
+          } catch (err) {
+            this.log(`[injector] onOverlayOpen hook threw: ${err instanceof Error ? err.message : err}`);
+          }
+        },
+      );
+    }
 
     try {
-      await this.cdp.send("Runtime.enable");
+      await cdp.send("Runtime.enable");
     } catch {
       // May already be enabled — non-fatal.
     }
-    // Always (re)add: CDP drops bindings on page navigation, so this must
-    // run again after a reload even though the listener below persists.
+    // Always (re)add the binding itself: CDP drops bindings on page
+    // navigation, so this must run again after a reload even though the
+    // listener above is attached only once.
     try {
-      await this.cdp.send("Runtime.addBinding", { name: OVERLAY_MENU_BINDING });
+      await cdp.send("Runtime.addBinding", { name: OVERLAY_MENU_BINDING });
     } catch {
       // Binding may already exist from a prior session — non-fatal.
     }
-
-    // Attach the client-side listener exactly once — it survives reloads.
-    if (this.overlayBindingUnsub) return;
-    this.overlayBindingUnsub = this.cdp.on(
-      "Runtime.bindingCalled",
-      (params: Record<string, unknown>) => {
-        if (params.name !== OVERLAY_MENU_BINDING) return;
-        this.log("[injector] Overlay-menu entry activated");
-        try {
-          this.onOverlayOpen?.();
-        } catch (err) {
-          this.log(`[injector] onOverlayOpen hook threw: ${err instanceof Error ? err.message : err}`);
-        }
-      },
-    );
   }
 
   /**
@@ -511,46 +539,54 @@ export class SteamInjector {
    * the legacy `steamOverlayButtonEnabled` key (pre-#169-split) is
    * honoured as an alias so an existing opt-in isn't silently dropped.
    */
-  private async readOverlayButtonConfig(): Promise<{ mainMenu: boolean }> {
+  private async readOverlayButtonConfig(): Promise<boolean | null> {
     try {
       const res = await this.fetchApi("/api/user-config");
-      if (!res.ok) return { mainMenu: false };
+      if (!res.ok) return null;
       const cfg = (await res.json()) as Record<string, unknown>;
-      // The new key wins once it exists — so toggling it *off* removes the
-      // item even for users who still carry the legacy `steamOverlayButtonEnabled`
-      // flag from before the #169 rename. Fall back to the legacy flag only
-      // when the new key was never written.
-      const hasNew = Object.prototype.hasOwnProperty.call(
-        cfg,
-        "steamOverlayButtonMainMenu",
-      );
-      return {
-        mainMenu: hasNew
-          ? cfg.steamOverlayButtonMainMenu === true
-          : cfg.steamOverlayButtonEnabled === true,
-      };
+      return resolveOverlayMainMenu(cfg);
     } catch {
-      return { mainMenu: false };
+      // Distinguish "couldn't read" (null) from "read: disabled" (false) so
+      // callers don't tear down an enabled item on a transient blip.
+      return null;
     }
   }
 
   /**
-   * (Re)apply the main-menu "Loadout" entry to match the current user
-   * config (issue #169). Injects when enabled, tears down when disabled.
-   * Returns a `{ ok, error }` result so the loader's refresh endpoint can
-   * surface a failure toast in the overlay. Safe to call any time; a
-   * no-op-shaped failure (no CEF, desktop mode) returns `ok: false` with
-   * a reason.
+   * (Re)apply the main-menu "Loadout" entry (issue #169). Injects when
+   * enabled, tears down when disabled. Returns a `{ ok, error }` result so
+   * the loader's refresh endpoint can surface a failure toast in the
+   * overlay.
+   *
+   * `opts.mainMenu` carries the *explicit* desired state from the Settings
+   * toggle so we act on it directly instead of re-reading `/api/user-config`
+   * — the config PATCH the toggle fires is async and could otherwise race
+   * this read. Omit it (launch / reinject) to fall back to the persisted
+   * config; a read failure there is surfaced as `ok: false` rather than
+   * silently removing an enabled item.
    */
-  async refreshOverlayButton(): Promise<{ ok: boolean; error?: string }> {
+  async refreshOverlayButton(
+    opts: { mainMenu?: boolean } = {},
+  ): Promise<{ ok: boolean; error?: string }> {
     if (!this.cdp?.connected) {
       return { ok: false, error: "Not connected to Steam — is Steam running?" };
     }
     if (!(await this.isGameMode())) {
       return { ok: false, error: "The Steam overlay button is only available in Gaming Mode." };
     }
+
+    let mainMenu: boolean;
+    if (typeof opts.mainMenu === "boolean") {
+      mainMenu = opts.mainMenu;
+    } else {
+      const read = await this.readOverlayButtonConfig();
+      if (read === null) {
+        return { ok: false, error: "Couldn't read Loadout settings." };
+      }
+      mainMenu = read;
+    }
+
     try {
-      const { mainMenu } = await this.readOverlayButtonConfig();
       // Make sure the binding is live before the entry can be activated.
       await this.setupOverlayBinding();
       if (mainMenu) {

--- a/apps/loadout/src/injector/injector.ts
+++ b/apps/loadout/src/injector/injector.ts
@@ -9,6 +9,11 @@ import { CDPClient } from "@loadout/steam-cdp";
 import { findSharedJSContext, findBigPictureTab, type CEFTab, type GetTabsOptions } from "./tabs";
 import { buildComponentDiscoveryScript } from "./steam-components";
 import { buildMenuPatchScript, type MenuPluginEntry } from "./menu-patcher";
+import {
+  buildOverlayMenuInjectScript,
+  buildOverlayMenuRemoveScript,
+  OVERLAY_MENU_BINDING,
+} from "./overlay-menu";
 import { buildRoutePatchScript, type RouteEntry } from "./route-patcher";
 import { buildWebpackPatcherScript, type WebpackPatchEntry } from "./webpack-patcher";
 import { buildInspectorScript } from "./inspector";
@@ -45,6 +50,13 @@ export interface InjectorOptions {
    */
   onGameLaunch?: (appId: number, gameName: string) => void | Promise<void>;
   onGameExit?: (appId: number, gameName: string) => void | Promise<void>;
+  /**
+   * Fired when the injected Steam-menu overlay entry is activated
+   * (issue #169). The loader wires this to `broadcastShow()` so the
+   * overlay window pops. Dispatched from a CDP `Runtime.addBinding`
+   * callback because Steam's CEF blocks fetch() to localhost.
+   */
+  onOverlayOpen?: () => void;
   /**
    * Called once after the injector exhausts its crash-retry budget and
    * stops trying. Lets the host surface a `__system` event so UI
@@ -118,6 +130,9 @@ export class SteamInjector {
   private onGameLaunch?: InjectorOptions["onGameLaunch"];
   private onGameExit?: InjectorOptions["onGameExit"];
   private onGiveUp?: InjectorOptions["onGiveUp"];
+  private onOverlayOpen?: InjectorOptions["onOverlayOpen"];
+  /** Unsubscribe for the overlay-open CDP binding (issue #169). */
+  private overlayBindingUnsub: (() => void) | null = null;
   private isGameMode: () => boolean | Promise<boolean>;
 
   constructor(options: InjectorOptions = {}) {
@@ -129,6 +144,7 @@ export class SteamInjector {
     this.onGameLaunch = options.onGameLaunch;
     this.onGameExit = options.onGameExit;
     this.onGiveUp = options.onGiveUp;
+    this.onOverlayOpen = options.onOverlayOpen;
     this.log = options.log ?? console.log;
     this.cdpFactory = options.cdpFactory ?? null;
     this.isGameMode = options.isGameMode ?? isGamescopeRunning;
@@ -238,6 +254,10 @@ export class SteamInjector {
     // monitor below in desktop mode — only the plugin injection is skipped.
     const gameMode = await this.isGameMode();
     if (gameMode) {
+      // Step 3.5: Arm the overlay-open binding (issue #169) so the injected
+      // Steam-menu entry has a callback to hit the moment it's clicked.
+      await this.setupOverlayBinding();
+
       // Step 4: Inject if not already loaded
       const alreadyLoaded = await this.cdp.hasGlobalVar(GLOBAL_FLAG);
       if (!alreadyLoaded) {
@@ -444,6 +464,111 @@ export class SteamInjector {
   }
 
   /**
+   * Add the `Runtime.addBinding` the injected overlay-menu entry calls
+   * (issue #169), and fan its invocations out to `onOverlayOpen`. Runs on
+   * `this.cdp` (SharedJSContext) where the menu patch + watcher live.
+   * Idempotent — re-adding an existing binding is a non-fatal no-op.
+   */
+  private async setupOverlayBinding(): Promise<void> {
+    if (!this.cdp?.connected) return;
+
+    try {
+      await this.cdp.send("Runtime.enable");
+    } catch {
+      // May already be enabled — non-fatal.
+    }
+    // Always (re)add: CDP drops bindings on page navigation, so this must
+    // run again after a reload even though the listener below persists.
+    try {
+      await this.cdp.send("Runtime.addBinding", { name: OVERLAY_MENU_BINDING });
+    } catch {
+      // Binding may already exist from a prior session — non-fatal.
+    }
+
+    // Attach the client-side listener exactly once — it survives reloads.
+    if (this.overlayBindingUnsub) return;
+    this.overlayBindingUnsub = this.cdp.on(
+      "Runtime.bindingCalled",
+      (params: Record<string, unknown>) => {
+        if (params.name !== OVERLAY_MENU_BINDING) return;
+        this.log("[injector] Overlay-menu entry activated");
+        try {
+          this.onOverlayOpen?.();
+        } catch (err) {
+          this.log(`[injector] onOverlayOpen hook threw: ${err instanceof Error ? err.message : err}`);
+        }
+      },
+    );
+  }
+
+  /**
+   * Read the overlay-button user settings from the loader's config
+   * (issue #169). Server-side fetch — the injector runs in the loader
+   * process, so localhost is reachable here even though Steam's CEF
+   * blocks it. Missing / malformed config reads as "disabled".
+   *
+   * `steamOverlayButtonMainMenu` gates the main-menu "Loadout" entry;
+   * the legacy `steamOverlayButtonEnabled` key (pre-#169-split) is
+   * honoured as an alias so an existing opt-in isn't silently dropped.
+   */
+  private async readOverlayButtonConfig(): Promise<{ mainMenu: boolean }> {
+    try {
+      const res = await this.fetchApi("/api/user-config");
+      if (!res.ok) return { mainMenu: false };
+      const cfg = (await res.json()) as Record<string, unknown>;
+      // The new key wins once it exists — so toggling it *off* removes the
+      // item even for users who still carry the legacy `steamOverlayButtonEnabled`
+      // flag from before the #169 rename. Fall back to the legacy flag only
+      // when the new key was never written.
+      const hasNew = Object.prototype.hasOwnProperty.call(
+        cfg,
+        "steamOverlayButtonMainMenu",
+      );
+      return {
+        mainMenu: hasNew
+          ? cfg.steamOverlayButtonMainMenu === true
+          : cfg.steamOverlayButtonEnabled === true,
+      };
+    } catch {
+      return { mainMenu: false };
+    }
+  }
+
+  /**
+   * (Re)apply the main-menu "Loadout" entry to match the current user
+   * config (issue #169). Injects when enabled, tears down when disabled.
+   * Returns a `{ ok, error }` result so the loader's refresh endpoint can
+   * surface a failure toast in the overlay. Safe to call any time; a
+   * no-op-shaped failure (no CEF, desktop mode) returns `ok: false` with
+   * a reason.
+   */
+  async refreshOverlayButton(): Promise<{ ok: boolean; error?: string }> {
+    if (!this.cdp?.connected) {
+      return { ok: false, error: "Not connected to Steam — is Steam running?" };
+    }
+    if (!(await this.isGameMode())) {
+      return { ok: false, error: "The Steam overlay button is only available in Gaming Mode." };
+    }
+    try {
+      const { mainMenu } = await this.readOverlayButtonConfig();
+      // Make sure the binding is live before the entry can be activated.
+      await this.setupOverlayBinding();
+      if (mainMenu) {
+        await this.cdp.evaluate(buildOverlayMenuInjectScript(), { awaitPromise: false });
+        this.log("[injector] Main-menu 'Loadout' entry injected");
+      } else {
+        await this.cdp.evaluate(buildOverlayMenuRemoveScript(), { awaitPromise: false });
+        this.log("[injector] Main-menu 'Loadout' entry removed (disabled)");
+      }
+      return { ok: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.log(`[injector] Overlay-menu refresh failed: ${msg}`);
+      return { ok: false, error: `Failed to update Steam: ${msg}` };
+    }
+  }
+
+  /**
    * Fetch the plugin list and apply QAM tab injection + route patching
    * for plugins that declare targets or routes.
    */
@@ -530,6 +655,10 @@ export class SteamInjector {
         await this.cdp!.evaluate(menuScript, { awaitPromise: true });
         this.log("[injector] Main menu patch applied");
       }
+
+      // Apply the optional "open overlay" menu entry (issue #169). Reads
+      // the toggle from user config; injects or removes accordingly.
+      await this.refreshOverlayButton();
 
     } catch (err) {
       this.log(`[injector] Target patches failed (non-fatal): ${err instanceof Error ? err.message : err}`);
@@ -645,6 +774,8 @@ export class SteamInjector {
         clearInterval(checkInterval);
         this.gameSessionMonitor?.cleanup().catch(() => {});
         this.gameSessionMonitor = null;
+        this.overlayBindingUnsub?.();
+        this.overlayBindingUnsub = null;
         this.cdp?.close();
         this.cdp = null;
         this.bpmCdp?.close();
@@ -748,6 +879,8 @@ export class SteamInjector {
     this.running = false;
     this.gameSessionMonitor?.cleanup().catch(() => {});
     this.gameSessionMonitor = null;
+    this.overlayBindingUnsub?.();
+    this.overlayBindingUnsub = null;
     this.cdp?.close();
     this.cdp = null;
     this.bpmCdp?.close();

--- a/apps/loadout/src/injector/overlay-menu.test.ts
+++ b/apps/loadout/src/injector/overlay-menu.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildOverlayMenuInjectScript,
+  buildOverlayMenuRemoveScript,
+  OVERLAY_MENU_BINDING,
+  OVERLAY_MENU_LABEL,
+  OVERLAY_MENU_ROUTE,
+  OVERLAY_MENU_STATE_GLOBAL,
+} from "./overlay-menu";
+
+describe("buildOverlayMenuInjectScript", () => {
+  test("embeds the hardcoded label, sentinel route, and binding", () => {
+    const script = buildOverlayMenuInjectScript();
+    expect(script).toContain(`"label":"${OVERLAY_MENU_LABEL}"`);
+    expect(script).toContain(OVERLAY_MENU_ROUTE);
+    expect(script).toContain(OVERLAY_MENU_BINDING);
+  });
+
+  test("navigate-nowhere: wraps history push/replace and swallows the sentinel", () => {
+    const script = buildOverlayMenuInjectScript();
+    expect(script).toContain("history.push");
+    expect(script).toContain("history.replace");
+    expect(script).toContain("isSentinel");
+    // Safety net still steps back rather than stranding on a blank page.
+    expect(script).toContain("goBack");
+    // No dependency on the (absent) navigation singleton anymore.
+    expect(script).not.toContain("__LOADOUT_NAVIGATION");
+  });
+
+  test("wraps in an IIFE and installs a cleanup on the state global", () => {
+    const script = buildOverlayMenuInjectScript();
+    expect(script.startsWith("(function()")).toBe(true);
+    expect(script).toContain(OVERLAY_MENU_STATE_GLOBAL);
+    expect(script).toContain("cleanup");
+  });
+
+  test("pins the icon to 1.25rem so it matches Steam's sibling nav icons (20px)", () => {
+    const script = buildOverlayMenuInjectScript();
+    expect(script).toContain('width: "1.25rem"');
+  });
+
+  test("passes an explicit position through", () => {
+    const script = buildOverlayMenuInjectScript({ position: 4 });
+    expect(script).toContain('"position":4');
+  });
+
+  test("defaults position to just-after-Home (2)", () => {
+    const script = buildOverlayMenuInjectScript();
+    expect(script).toContain('"position":2');
+  });
+});
+
+describe("buildOverlayMenuRemoveScript", () => {
+  test("references the state global and calls its cleanup", () => {
+    const script = buildOverlayMenuRemoveScript();
+    expect(script).toContain(OVERLAY_MENU_STATE_GLOBAL);
+    expect(script).toContain("cleanup");
+    expect(script).toContain("nothing_to_remove");
+  });
+});

--- a/apps/loadout/src/injector/overlay-menu.ts
+++ b/apps/loadout/src/injector/overlay-menu.ts
@@ -1,0 +1,317 @@
+/**
+ * Overlay-menu patcher — injects an *optional* "Loadout" entry into
+ * Steam's main navigation menu that opens the Loadout overlay (issue
+ * #169).
+ *
+ * Why this exists: the overlay is normally summoned by a controller
+ * chord (the wake button). If that chord is mis-configured, or the
+ * controller itself wedges on wake, the user has no way back into the
+ * overlay to fix it / reboot the pads. A menu entry lives in Steam's own
+ * focus tree, so it stays reachable by D-pad even when the wake chord is
+ * dead — unlike a raw floating DOM button, which Steam's spatial nav
+ * can't focus.
+ *
+ * Label + icon are fixed ("Loadout" + a gamepad glyph) — it's a single
+ * well-known escape hatch, not a themeable widget.
+ *
+ * Mechanics (all in SharedJSContext, where #root + the full React tree
+ * live — same context the plugin menu-patcher targets):
+ *   1. Fiber-patch `MainNavMenuContainer` to splice one nav item in
+ *      (technique lifted from ./menu-patcher, narrowed to a single item
+ *      so the feature is independent of the plugin menu system — no
+ *      plugin ships a `menu` target today, issue #60).
+ *   2. Steam nav items are pure route items — activating one just calls
+ *      `tempNavStore.m_history.push(route)`. We give the item a sentinel
+ *      route and wrap `m_history.push`/`.replace` so that navigating to
+ *      the sentinel instead fires the CDP binding (which pops the
+ *      overlay) and is *swallowed* — the router never moves, so closing
+ *      the overlay returns the user exactly where they were. Verified
+ *      live: swallowing the push leaves `location.pathname` unchanged.
+ *      A 150ms pathname poll is kept purely as a safety net: if a future
+ *      Steam build routes the item some other way and the sentinel does
+ *      land, we fire the overlay and `history.goBack()` so the user can
+ *      never get stranded on a blank page again.
+ *
+ * The binding is added loader-side via `Runtime.addBinding` (see
+ * injector.ts) because Steam's CEF blocks fetch() to localhost — the
+ * same cross-CEF dispatch path the game-session monitor uses.
+ *
+ * Pure string builders so the structure is unit-testable without a live
+ * Steam.
+ */
+
+import { REACT_UTILS } from "./react-utils";
+
+/** DOM/global markers — shared with the remove script + injector cleanup. */
+export const OVERLAY_MENU_STATE_GLOBAL = "__LOADOUT_OVERLAY_MENU";
+/** Sentinel route the nav item points at; intercepted to trigger the overlay. */
+export const OVERLAY_MENU_ROUTE = "/loadout/open-overlay";
+/** CDP binding name the item calls to reach the loader. */
+export const OVERLAY_MENU_BINDING = "__loadoutOverlayOpen";
+/** Fixed menu label. */
+export const OVERLAY_MENU_LABEL = "Loadout";
+
+/**
+ * Gamepad glyph (Lucide-derived, 24×24, stroke = currentColor). Rendered
+ * at 60% of the icon slot so it reads at the same visual weight as
+ * Steam's own nav glyphs (which sit inset in their slot rather than
+ * filling it edge-to-edge).
+ */
+const GAMEPAD_ICON_PATH =
+  "M6 12h4m-2-2v4M15 11h.01M18 13h.01M17.32 5H6.68a4 4 0 0 0-3.978 3.59C2.604 9.416 2 14.456 2 16a3 3 0 0 0 3 3c1 0 1.5-.5 2-1l1.414-1.414A2 2 0 0 1 9.828 16h4.344a2 2 0 0 1 1.414.586L17 18c.5.5 1 1 2 1a3 3 0 0 0 3-3c0-1.545-.604-6.584-.685-7.258A4 4 0 0 0 17.32 5z";
+
+export interface OverlayMenuConfig {
+  /** 1-based nav position; omit to insert right after Home. */
+  position?: number;
+}
+
+/**
+ * Build the SharedJSContext script that injects the "Loadout" nav entry
+ * and arms the navigate-nowhere interception. Idempotent: re-running
+ * cleans up the prior patch first, so it's safe to call on every
+ * reinject.
+ */
+export function buildOverlayMenuInjectScript(config: OverlayMenuConfig = {}): string {
+  const cfg = {
+    label: OVERLAY_MENU_LABEL,
+    iconPath: GAMEPAD_ICON_PATH,
+    route: OVERLAY_MENU_ROUTE,
+    binding: OVERLAY_MENU_BINDING,
+    position: config.position ?? 2,
+    stateGlobal: OVERLAY_MENU_STATE_GLOBAL,
+  };
+  const cfgJson = JSON.stringify(cfg);
+
+  return `
+(function() {
+  "use strict";
+
+  ${REACT_UTILS}
+
+  var CFG = ${cfgJson};
+
+  // Tear down any previous patch (hot reload / re-inject).
+  if (window[CFG.stateGlobal] && typeof window[CFG.stateGlobal].cleanup === "function") {
+    try { window[CFG.stateGlobal].cleanup(); } catch (e) {}
+  }
+
+  // ── Trigger plumbing ────────────────────────────────────────────
+  function fireOverlay() {
+    try { if (typeof window[CFG.binding] === "function") window[CFG.binding](""); } catch (e) {}
+  }
+  function currentPath() {
+    try {
+      var ns = window.tempNavStore;
+      var p = ns && ns.m_history && ns.m_history.location && ns.m_history.location.pathname;
+      return p || window.location.pathname || "";
+    } catch (e) { return ""; }
+  }
+  function isSentinel(to) {
+    var p = (typeof to === "string") ? to : (to && to.pathname) || "";
+    return typeof p === "string" && p.indexOf(CFG.route) === 0;
+  }
+
+  // Primary path: intercept navigation to the sentinel route and swallow
+  // it, opening the overlay instead. The router never moves → no blank page.
+  var history = null, origPush = null, origReplace = null;
+  try {
+    var ns = window.tempNavStore;
+    history = ns && ns.m_history;
+    if (history && !history.__loadoutOverlayWrapped) {
+      origPush = history.push.bind(history);
+      origReplace = history.replace.bind(history);
+      history.push = function(to) { if (isSentinel(to)) { fireOverlay(); return; } return origPush.apply(this, arguments); };
+      history.replace = function(to) { if (isSentinel(to)) { fireOverlay(); return; } return origReplace.apply(this, arguments); };
+      history.__loadoutOverlayWrapped = true;
+    }
+  } catch (e) {}
+
+  // Safety net: if navigation ever slips through to the sentinel anyway,
+  // open the overlay and step back so the user is never stranded.
+  var watchId = setInterval(function() {
+    if (isSentinel(currentPath())) {
+      fireOverlay();
+      try { if (history && typeof history.goBack === "function") history.goBack(); } catch (e) {}
+    }
+  }, 150);
+
+  // ── Menu injection ──────────────────────────────────────────────
+  var steamReact;
+  if (window.webpackChunksteamui) {
+    var wpRequire;
+    window.webpackChunksteamui.push([[Symbol()], {}, function(r) { wpRequire = r; }]);
+    if (wpRequire) {
+      try { steamReact = wpRequire(51745); } catch (e) {}
+      if (!steamReact || !steamReact.createElement) {
+        steamReact = null;
+        var ids = Object.keys(wpRequire.c || {});
+        for (var mi = 0; mi < ids.length; mi++) {
+          try {
+            var mod = wpRequire(ids[mi]);
+            if (mod && mod.createElement && mod.useState && mod.useEffect) { steamReact = mod; break; }
+          } catch (e) {}
+        }
+      }
+    }
+  }
+
+  function installCleanup(unpatchMenu) {
+    window[CFG.stateGlobal] = {
+      cleanup: function() {
+        try { clearInterval(watchId); } catch (e) {}
+        try {
+          if (history && history.__loadoutOverlayWrapped) {
+            if (origPush) history.push = origPush;
+            if (origReplace) history.replace = origReplace;
+            delete history.__loadoutOverlayWrapped;
+          }
+        } catch (e) {}
+        try { if (unpatchMenu) unpatchMenu(); } catch (e) {}
+        try { delete window[CFG.stateGlobal]; } catch (e) {}
+      }
+    };
+  }
+
+  if (!steamReact) {
+    console.warn("[loadout:overlay-menu] Steam React not found — trigger armed, menu item skipped");
+    installCleanup(null);
+    return;
+  }
+
+  var fiberRoot = getReactRoot(document.getElementById("root"));
+  if (!fiberRoot) { console.warn("[loadout:overlay-menu] No fiber root"); installCleanup(null); return; }
+
+  var menuNode = findInReactTree(fiberRoot, function(node) {
+    return node && node.memoizedProps && node.memoizedProps.navID === "MainNavMenuContainer";
+  });
+  if (!menuNode || !menuNode.return || !menuNode.return.type) {
+    console.warn("[loadout:overlay-menu] MainNavMenuContainer not found");
+    installCleanup(null);
+    return;
+  }
+
+  var orig = menuNode.return.type;
+  var patchedInner = null;
+
+  // Steam's own nav icons are a fixed 1.25rem (20px @ root 16px) square —
+  // measured live against the sibling items. Our <svg> has no intrinsic
+  // size, so without an explicit width Steam's icon wrapper balloons to
+  // the row height (~115px). Pin it to 1.25rem so the wrapper collapses to
+  // the exact sibling size; rem tracks Steam's UI scale.
+  function makeIcon() {
+    return steamReact.createElement("svg", {
+      xmlns: "http://www.w3.org/2000/svg", viewBox: "0 0 24 24", fill: "none",
+      stroke: "currentColor", strokeWidth: 2, strokeLinecap: "round", strokeLinejoin: "round",
+      style: { width: "1.25rem", height: "1.25rem", display: "block", flex: "0 0 auto" }
+    }, steamReact.createElement("path", { d: CFG.iconPath }));
+  }
+
+  function menuWrapper(props) {
+    var ret = orig(props);
+    var cc = ret && ret.props && ret.props.children &&
+             ret.props.children.props && ret.props.children.props.children;
+    if (!cc || !cc[0] || !cc[0].type) return ret;
+
+    if (patchedInner) { cc[0].type = patchedInner; return ret; }
+    var origInner = cc[0].type;
+
+    cc[0].type = function patchedMenuInner() {
+      var innerRet = origInner.apply(this, arguments);
+
+      var isMenuItem = function(e) { return e && e.props && e.props.label && e.props.route; };
+      var queue = [innerRet], found = null, searched = 0;
+      while (queue.length > 0 && searched < 200) {
+        var node = queue.shift(); searched++;
+        if (!node) continue;
+        if (Array.isArray(node) && node.some(isMenuItem)) { found = node; break; }
+        if (node.props) {
+          if (Array.isArray(node.props.children)) {
+            if (node.props.children.some(isMenuItem)) { found = node.props.children; break; }
+            for (var ci = 0; ci < node.props.children.length; ci++) queue.push(node.props.children[ci]);
+          } else if (node.props.children) {
+            queue.push(node.props.children);
+          }
+        }
+      }
+      if (!found) return innerRet;
+
+      // Drop our previously-injected item so re-renders don't duplicate it.
+      for (var ri = found.length - 1; ri >= 0; ri--) {
+        if (found[ri] && found[ri].key === "loadout-overlay-open") found.splice(ri, 1);
+      }
+
+      var refItem = found.find(isMenuItem);
+      if (!refItem) return innerRet;
+
+      var newItem = steamReact.createElement(refItem.type, {
+        key: "loadout-overlay-open",
+        route: CFG.route,
+        label: CFG.label,
+        onFocus: refItem.props.onFocus,
+        icon: makeIcon()
+      });
+
+      var itemIndexes = [];
+      for (var ii = 0; ii < found.length; ii++) {
+        if (found[ii] && found[ii].$$typeof && found[ii].type !== "div") itemIndexes.push(ii);
+      }
+      var pos = CFG.position;
+      if (pos > 0 && pos <= itemIndexes.length) {
+        found.splice(itemIndexes[pos - 1] + 1, 0, newItem);
+      } else {
+        found.splice(itemIndexes.length > 0 ? itemIndexes[0] + 1 : 0, 0, newItem);
+      }
+      return innerRet;
+    };
+    patchedInner = cc[0].type;
+    return ret;
+  }
+
+  menuNode.return.type = menuWrapper;
+  if (menuNode.return.alternate) menuNode.return.alternate.type = menuWrapper;
+
+  function forceRerender(node) {
+    var f = node;
+    while (f) {
+      if (f.memoizedState) {
+        var hs = f.memoizedState;
+        while (hs) {
+          if (hs.queue && hs.queue.dispatch) {
+            try { hs.queue.dispatch({ __loadoutForce: Date.now() }); } catch (e) {}
+            break;
+          }
+          hs = hs.next;
+        }
+        break;
+      }
+      f = f.return;
+    }
+  }
+  forceRerender(menuNode);
+
+  installCleanup(function() {
+    try {
+      menuNode.return.type = orig;
+      if (menuNode.return.alternate) menuNode.return.alternate.type = orig;
+      forceRerender(menuNode);
+    } catch (e) {}
+  });
+
+  console.log("[loadout:overlay-menu] Injected '" + CFG.label + "' entry (navigate-nowhere)");
+})();
+  `.trim();
+}
+
+/** Build the teardown script (called when the user disables the toggle). */
+export function buildOverlayMenuRemoveScript(): string {
+  return `
+(function() {
+  var s = window["${OVERLAY_MENU_STATE_GLOBAL}"];
+  if (s && typeof s.cleanup === "function") {
+    try { s.cleanup(); } catch (e) {}
+    return "removed";
+  }
+  return "nothing_to_remove";
+})();
+  `.trim();
+}

--- a/apps/loadout/src/injector/overlay-menu.ts
+++ b/apps/loadout/src/injector/overlay-menu.ts
@@ -126,12 +126,24 @@ export function buildOverlayMenuInjectScript(config: OverlayMenuConfig = {}): st
     }
   } catch (e) {}
 
-  // Safety net: if navigation ever slips through to the sentinel anyway,
-  // open the overlay and step back so the user is never stranded.
+  // Safety net: if navigation ever slips through to the sentinel anyway
+  // (a future Steam build routing the item some other way, or m_history not
+  // being ready when we wrapped above), open the overlay and step back so
+  // the user is never stranded on the blank sentinel page. Re-reads
+  // m_history live each tick — the reference captured above may have been
+  // null — and latches so it fires once per landing, not every 150ms.
+  var sentinelHandled = false;
   var watchId = setInterval(function() {
     if (isSentinel(currentPath())) {
+      if (sentinelHandled) return;
+      sentinelHandled = true;
       fireOverlay();
-      try { if (history && typeof history.goBack === "function") history.goBack(); } catch (e) {}
+      try {
+        var h = window.tempNavStore && window.tempNavStore.m_history;
+        if (h && typeof h.goBack === "function") h.goBack();
+      } catch (e) {}
+    } else {
+      sentinelHandled = false;
     }
   }, 150);
 

--- a/apps/loadout/src/loader/index.ts
+++ b/apps/loadout/src/loader/index.ts
@@ -412,6 +412,22 @@ export async function startServer(options: ServerOptions = {}) {
         });
       }
 
+      // --- Re-apply the optional Steam "open overlay" menu entry on
+      //     demand (issue #169). The overlay Settings UI hits this right
+      //     after the user toggles the setting or edits the label so the
+      //     change lands in Steam immediately (and it can surface a toast
+      //     if injection fails). Authenticated via the /api/* gate above.
+      if (url.pathname === "/api/overlay-button/refresh" && req.method === "POST") {
+        const result = await injector.refreshOverlayButton();
+        return new Response(JSON.stringify(result), {
+          status: result.ok ? 200 : 503,
+          headers: {
+            "Content-Type": "application/json;charset=utf-8",
+            "Access-Control-Allow-Origin": "*",
+          },
+        });
+      }
+
       // --- Route-module dispatch (issue #87 / A-001). Every HTTP
       //     surface beyond /ws + /up lives in routes/<name>.ts and is
       //     wired through this single call. `dispatchRoute` returns
@@ -468,6 +484,14 @@ export async function startServer(options: ServerOptions = {}) {
     onGameExit: async (appId) => {
       const called = await broadcastToPlugins("handleGameExit", [appId]);
       log.info(`[broadcast] handleGameExit fanned out to ${called} plugin(s)`);
+    },
+    // Issue #169: the injected Steam-menu "open overlay" entry can't reach
+    // the overlay's Bun main process directly, so it calls back here and we
+    // reuse the same /show broadcast path (→ webview → show() RPC).
+    onOverlayOpen: () => {
+      log.info("[overlay-button] Steam-menu entry activated — showing overlay");
+      if (wsClients.size > 0) broadcastShow();
+      else pendingShow = true;
     },
     // Audit A-021: when the injector exhausts its crash-retry budget, fan
     // a __system event out so UI subscribers can surface "injector stopped"

--- a/apps/loadout/src/loader/index.ts
+++ b/apps/loadout/src/loader/index.ts
@@ -334,6 +334,12 @@ export async function startServer(options: ServerOptions = {}) {
   // `dispatchRoute(req, url, ctx)` first; routes that match return
   // a Response, anything that falls through hits the inlined blocks
   // (currently every route) and ultimately the 404.
+  // The CEF injector is constructed further down (it needs broadcast
+  // helpers defined above), but the overlay-button route needs to reach it.
+  // Hold it in a ref the ctx closure reads lazily — until it's assigned,
+  // callers get a not-ready error rather than a crash.
+  const injectorRef: { current: SteamInjector | null } = { current: null };
+
   const ctx: RouteContext = {
     plugins,
     token,
@@ -345,6 +351,10 @@ export async function startServer(options: ServerOptions = {}) {
     broadcastToPlugins,
     compileTsx,
     bunPlugins: [vendorGlobalsPlugin(), sdkGlobalPlugin()],
+    refreshOverlayButton: (mainMenu) =>
+      injectorRef.current
+        ? injectorRef.current.refreshOverlayButton({ mainMenu })
+        : Promise.resolve({ ok: false, error: "Injector not ready yet." }),
   };
 
   // --- HTTP Server ---
@@ -405,22 +415,6 @@ export async function startServer(options: ServerOptions = {}) {
       if (url.pathname.startsWith("/api/") && !validateRequest(req)) {
         return new Response(JSON.stringify({ error: "Unauthorized" }), {
           status: 401,
-          headers: {
-            "Content-Type": "application/json;charset=utf-8",
-            "Access-Control-Allow-Origin": "*",
-          },
-        });
-      }
-
-      // --- Re-apply the optional Steam "open overlay" menu entry on
-      //     demand (issue #169). The overlay Settings UI hits this right
-      //     after the user toggles the setting or edits the label so the
-      //     change lands in Steam immediately (and it can surface a toast
-      //     if injection fails). Authenticated via the /api/* gate above.
-      if (url.pathname === "/api/overlay-button/refresh" && req.method === "POST") {
-        const result = await injector.refreshOverlayButton();
-        return new Response(JSON.stringify(result), {
-          status: result.ok ? 200 : 503,
           headers: {
             "Content-Type": "application/json;charset=utf-8",
             "Access-Control-Allow-Origin": "*",
@@ -501,6 +495,9 @@ export async function startServer(options: ServerOptions = {}) {
       broadcast({ type: "event", plugin: "__system", event: "inject-failed", data: info });
     },
   });
+  // Expose the injector to the overlay-button route (see ctx above).
+  injectorRef.current = injector;
+
   injector.start().catch((err) => {
     log.error(`[injector] Fatal error: ${err}`);
   });

--- a/apps/loadout/src/loader/routes/index.ts
+++ b/apps/loadout/src/loader/routes/index.ts
@@ -26,6 +26,7 @@ import { steamGridRoute } from "./steam-grid";
 import { pluginsRoutes } from "./plugins";
 import { rpcRoute } from "./rpc";
 import { injectRoutes } from "./inject";
+import { overlayButtonRoute } from "./overlay-button";
 
 /**
  * Ordered route list. Populated incrementally as A-001 progresses;
@@ -38,6 +39,7 @@ const routes: RouteHandler[] = [
   steamGridRoute,
   ...pluginsRoutes,
   rpcRoute,
+  overlayButtonRoute,
   ...injectRoutes,
 ];
 

--- a/apps/loadout/src/loader/routes/overlay-button.ts
+++ b/apps/loadout/src/loader/routes/overlay-button.ts
@@ -1,0 +1,37 @@
+/**
+ * Steam main-menu "Loadout" entry refresh — `POST /api/overlay-button/refresh`
+ * (issue #169).
+ *
+ * The overlay's Settings toggle hits this after flipping
+ * `steamOverlayButtonMainMenu` so the change lands in the running Steam
+ * client immediately (and the injection result can drive a success/failure
+ * toast). Authenticated via the `/api/*` gate in index.ts.
+ *
+ * Body: `{ mainMenu?: boolean }` — the explicit desired state, passed
+ * straight through to the injector so it doesn't have to re-read
+ * `/api/user-config` (which the toggle PATCHes asynchronously, a race).
+ * A malformed / missing body falls back to persisted config.
+ */
+
+import { jsonResponse } from "../index";
+import type { RouteHandler } from "./types";
+
+export const overlayButtonRoute: RouteHandler = {
+  name: "overlay-button-refresh",
+  match: (req, url) =>
+    url.pathname === "/api/overlay-button/refresh" && req.method === "POST",
+  async handle(req, _url, ctx) {
+    let mainMenu: boolean | undefined;
+    try {
+      const body = (await req.json()) as { mainMenu?: unknown };
+      if (typeof body?.mainMenu === "boolean") mainMenu = body.mainMenu;
+    } catch {
+      // No / invalid body — fall back to persisted config in the injector.
+    }
+
+    const result = await ctx.refreshOverlayButton(mainMenu);
+    // 503 when injection couldn't be applied (Steam not attached, desktop
+    // mode, transient read failure) so the client branches on status.
+    return jsonResponse(result, result.ok ? 200 : 503);
+  },
+};

--- a/apps/loadout/src/loader/routes/types.ts
+++ b/apps/loadout/src/loader/routes/types.ts
@@ -78,6 +78,18 @@ export interface RouteContext {
     args: unknown[],
   ) => Promise<number>;
 
+  /**
+   * (Re)apply the optional Steam main-menu "Loadout" entry (issue #169).
+   * Backed by the CEF injector, which is constructed after this context —
+   * so it's a capability closure rather than the injector object, and
+   * returns a not-ready error until the injector exists. `mainMenu` is the
+   * explicit desired state from the Settings toggle (avoids a config re-read
+   * race); omit to fall back to persisted config.
+   */
+  readonly refreshOverlayButton: (
+    mainMenu?: boolean,
+  ) => Promise<{ ok: boolean; error?: string }>;
+
   // --- Build helpers ---
   /** Compile a plugin's app.tsx for the overlay — same Bun.build
    *  pipeline the server uses on hot-reload. */


### PR DESCRIPTION
Closes #169.

Adds an **opt-in "Loadout" item to Steam's main navigation menu** that opens the overlay. Because it lives in Steam's own focus tree, it stays reachable by D-pad even when the controller wake-chord is mis-configured or the pads wedge on wake — the escape hatch the issue asks for.

## What it looks like
Settings → **General → Steam menu** → toggle *"Add 'Loadout' to Steam's main menu"*. When on, a **Loadout** entry (gamepad icon) appears right after Home. Selecting it opens the overlay **without navigating you anywhere** — close the overlay and you're exactly where you were.

## How it works
- `injector/overlay-menu.ts` fiber-patches `MainNavMenuContainer` (technique from `menu-patcher`, narrowed to one item) to splice in the entry. The gamepad glyph is pinned to `1.25rem` — measured live against Steam's sibling nav icons (20px).
- Steam nav items are pure route items, so activation = navigation. The item points at a sentinel route and we wrap `tempNavStore.m_history` `push`/`replace` to **swallow** it, firing a CDP binding that pops the overlay while the router stays put. A `goBack()` safety net covers any future Steam build that routes it differently. (`__LOADOUT_NAVIGATION` doesn't exist in current Steam — that was the original blank-page bug.)
- The binding reaches the loader via `Runtime.addBinding` (Steam's CEF blocks localhost `fetch`); the loader reuses its existing `/show` broadcast to raise the overlay.
- `SteamInjector.refreshOverlayButton()` injects/removes to match the `steamOverlayButtonMainMenu` config key (authoritative once set, so toggling off removes the item even for users carrying the legacy `steamOverlayButtonEnabled` flag). Exposed over `POST /api/overlay-button/refresh` so the toggle applies live and can surface a failure toast.

## Testing
- New `overlay-menu.test.ts` covering the inject/remove script builders (label, sentinel route, binding, navigate-nowhere wrapping, icon sizing, cleanup).
- Full suite green locally: typecheck, lint, `check:specs`, 363 tests pass.
- **Validated end-to-end against a live gamescope Steam over CDP**: item injects at the right position; activation opens the overlay with `location.pathname` unchanged; toggling off removes the item and unwraps the history interception (verified through the real `/api/overlay-button/refresh` flow).

## Notes
- QAM injection was considered and dropped — Steam's QAM tree is only patchable while open, which is the fragility this repo previously backed away from. Main-menu only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)