### PR TITLE
fix(installer): create systemd user dir + guard --user enable on fresh/sessionless installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1025,9 +1025,20 @@ WantedBy=graphical-session.target
 OVERLAYEOF
         success "Overlay service file written to $OVERLAY_SERVICE_FILE"
 
-        systemctl --user daemon-reload
-        systemctl --user enable loadout-overlay
-        success "Overlay service enabled (starts with graphical session)"
+        # Guard the --user calls: on a sessionless install (curl|sh over SSH
+        # with no graphical session and no lingering, or run as root) the
+        # per-user systemd bus is unavailable and these fail. Without `|| true`
+        # `set -e` would abort here — right after the unit was written but
+        # before the user-facing summary — leaving a confusing half-install.
+        # The unit file is on disk regardless, so it'll be picked up on the
+        # next graphical login even if we couldn't reload/enable now.
+        if systemctl --user daemon-reload 2>/dev/null && systemctl --user enable loadout-overlay 2>/dev/null; then
+            success "Overlay service enabled (starts with graphical session)"
+        else
+            warn "Couldn't enable the overlay user service now (no active user session?)."
+            warn "It'll be picked up on your next graphical login; or enable it manually:"
+            warn "  systemctl --user enable --now loadout-overlay"
+        fi
 
         # Start it right now (not just on next login) and pop the window so
         # the user can set their wake button immediately — no reboot, no

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -922,6 +922,11 @@ SERVICEEOF
     # Audit 2026-05 H-001.
     if [ -x "$OVERLAY_LAUNCHER" ]; then
         info "Writing overlay systemd user service file..."
+        # ~/.config/systemd/user doesn't exist yet on a fresh install where
+        # the user has never enabled a systemd --user unit (common on
+        # Bazzite). Without this the `cat >` redirect below fails with
+        # "no such file or directory" and `set -e` aborts the whole install.
+        mkdir -p "$SERVICE_DIR"
         cat > "$OVERLAY_SERVICE_FILE" <<'OVERLAYEOF'
 [Unit]
 Description=Loadout Overlay


### PR DESCRIPTION
## What & why

Fixes the public `curl | sh` installer aborting on fresh **Bazzite** and **CachyOS** installs with:

```
.config/systemd/user/loadout-overlay.service no such directory
```

Two related fixes in `scripts/install.sh`:

1. **Create `~/.config/systemd/user` before writing the overlay unit.** `SERVICE_DIR` was defined but never created. On a fresh install where the user has never enabled a systemd `--user` unit, the directory doesn't exist, so the `cat > "$OVERLAY_SERVICE_FILE"` redirect failed and — under `set -e` — aborted the whole install. Added `mkdir -p "$SERVICE_DIR"` immediately before the write, matching what `install-local.sh` already does. (SteamOS was unaffected only because that directory already exists there.)

2. **Guard the overlay `systemctl --user` calls.** `daemon-reload` / `enable loadout-overlay` were unguarded, unlike every other `--user` call in the script. On a sessionless run (`curl|sh` over SSH without lingering, or as root) the per-user systemd bus is unavailable and they fail — which under `set -e` aborted the installer right after writing the unit but before the summary. Now guarded, with a manual-enable hint; the unit file is on disk regardless, so it's picked up on the next graphical login.

## How it was tested

- `sh -n scripts/install.sh` — passes (POSIX syntax check).
- Traced the `set -e` flow through `setup_service`: confirmed the only prior touches of `SERVICE_DIR` (`rm -f` on the legacy unit, guarded `systemctl --user disable`) are safe on a missing directory, and that the new `mkdir -p` precedes the only write into it.
- Reviewed against sibling `install-local.sh` for consistency (same `mkdir -p "$SERVICE_DIR"` before writing the unit).
- Not yet run end-to-end on a physical Bazzite/CachyOS device — worth a real-device smoke test before release.

## Checklist

- [ ] `bun run typecheck` passes (0 errors) — n/a, shell-only change
- [ ] `bun run lint` passes (0 errors) — n/a, shell-only change
- [ ] `bun run test` passes
- [ ] Added/updated tests for new backend/lib behaviour — n/a, installer script
- [ ] Updated docs / `NOTICE` / `THIRD_PARTY_LICENSES.md` if this wraps or bundles third-party code — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)