### PR TITLE
feat(devices): add ONEXPLAYER SUPER X TDP profile

### DIFF
--- a/packages/devices/src/devices.ts
+++ b/packages/devices/src/devices.ts
@@ -98,6 +98,17 @@ const KNOWN_DEVICES: DeviceInfo[] = [
     profiles: { Silent: 15, Balanced: 30, Performance: 50 },
   },
   {
+    // Ryzen AI Max+ 395 (Strix Halo) tablet. 45 W air-cooled default,
+    // 120 W with the external Frost Bay liquid cooler; 90 W is a realistic
+    // AC ceiling between the two. Same APU family as the APEX above.
+    match: "ONEXPLAYER SUPER X",
+    name: "OneXPlayer Super X",
+    minTdp: 5,
+    maxTdp: 90,
+    batteryMaxTdp: 65,
+    profiles: { Silent: 15, Balanced: 45, Performance: 75 },
+  },
+  {
     match: "ONEXPLAYER Mini Pro",
     name: "OneXPlayer Mini Pro",
     minTdp: 5,


### PR DESCRIPTION
Closes #200

## Summary
Adds a device entry for the **OneXPlayer Super X** to `packages/devices/src/devices.ts`, placed before the generic `ONEXPLAYER` catch-all so the specific match wins:

```ts
{
  match: "ONEXPLAYER SUPER X",
  name: "OneXPlayer Super X",
  minTdp: 5,
  maxTdp: 90,
  batteryMaxTdp: 65,
  profiles: { Silent: 15, Balanced: 45, Performance: 75 },
},
```

## ⚠️ The issue's premise was wrong — maxTdp kept at 90, not lowered to ~54
The issue assumed the Super X uses an **AMD Ryzen AI 9 HX 370 (Strix Point)**, whose configurable TDP tops out around **54 W**, implying `maxTdp: 90` was too high.

That's a device mix-up. The HX 370 is in the OneXPlayer **X1 Pro / G1**, not the Super X. The **Super X uses the AMD Ryzen AI Max+ 395 (Strix Halo)** — the same APU family as the OneXFly APEX already in the table (`maxTdp: 80`). So the 54 W ceiling does not apply and `maxTdp` was **kept at 90**, not lowered.

### Reasoning per value
- **maxTdp 90** — the Super X's configurable TDP is **45 W air-cooled by default**, rising to **120 W** only with the separate Frost Bay liquid cooler. 90 W is a realistic AC ceiling between the two: above the air-cooled default (headroom for Frost Bay owners), below the accessory-gated 120 W max, and just above the sibling APEX (`80`, justified by the Super X's larger tablet chassis). The table already sets Performance below max for high-power OneXPlayer devices (APEX: Perf 50 vs max 80), so Perf 75 vs max 90 is consistent.
- **minTdp 5** — matches every other AMD entry.
- **batteryMaxTdp 65** — ≤ maxTdp (invariant holds); mirrors the APEX's ~70% ratio and is supported by the ~83.5 Wh battery.
- **profiles 15 / 45 / 75** — Silent 15 matches the APEX (Strix Halo is inefficient below ~15 W); Balanced 45 anchors to the stock air-cooled TDP; Performance 75 leaves headroom under the cap.

### Match string
`matchDevice` does a case-sensitive `productName.includes(match)`. An on-device report (hhd-dev/hhd#329, tested on CachyOS) gives Board Vendor `ONE-NETBOOK`, Board Name **`ONEXPLAYER SUPER X`** (all caps) — OneXPlayer reports product_name in the same form (cf. the APEX's `ONEXPLAYER APEX`), so `"ONEXPLAYER SUPER X"` is correct. No prior Super X entry existed.

## Validation
- `tsc --noEmit`: passes
- `bun test packages/devices/src/devices.test.ts`: 10 pass / 0 fail
- `eslint`: clean
- (`format:check` flags the file, but this is pre-existing at HEAD across the whole repo — installed prettier is out of sync with the committed config; the addition matches surrounding style exactly.)

## Key sources
- AMD Ryzen AI 9 HX 370 spec page — cTDP 15–54 W (confirms it's a *different* chip)
- ThinkComputers / TechRadar / Tom's Hardware / minixpc — Super X = Ryzen AI Max+ 395, 45 W → 120 W via Frost Bay, ~83.5 Wh battery
- ONEXPLAYER store — ONEXFLY APEX = AI Max+ 395, 5–80 W (matches the existing APEX entry)
- hhd-dev/hhd#329 — on-device DMI strings for the Super X

🤖 Generated with [Claude Code](https://claude.com/claude-code)