### PR TITLE
fix(overlay): persist controller shortcuts across restarts

### DIFF
--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -52,6 +52,7 @@ import {
 import { trace } from "./native/trace";
 import { createOverlayState } from "./lib/overlay-state";
 import { routeWake } from "./lib/wake-routing";
+import { loadPersistedShortcuts } from "./lib/persisted-shortcuts";
 
 // ---- State ------------------------------------------------------------------
 // PendingFlags + the flag-lifecycle helpers live in lib/overlay-state.ts so
@@ -67,8 +68,10 @@ const DESKTOP_SMOKE_TEST = process.env.DECK_OVERLAY_DESKTOP_DEV === "1";
 
 const state = createOverlayState(DESKTOP_SMOKE_TEST);
 
-// TODO(stage-2): persist to disk (XDG config) like the Rust version does —
-// currently this resets on every process restart.
+// These are the fallback defaults. The persisted user config is loaded from
+// disk in the startup IIFE below (loadPersistedShortcuts) and overwrites
+// `current` before the input loop starts — so a saved binding survives a
+// process restart instead of reverting until the user re-edits it.
 //
 // Guide+A and Guide+Y are reserved by Steam / InputPlumber on Bazzite
 // (QAM and guide menu respectively). Even if a saved user config has them
@@ -591,6 +594,17 @@ function onWake(event: WakeEvent): void {
 // external IP-managed pad IS present, IP's DBus stream drives nav and the
 // virtual pad is a mirror we only grab — so we DON'T read it (would double).
 void (async () => {
+  // Seed the wake-routing engine from the persisted config BEFORE either
+  // intercept starts — no wake event can arrive until they do, so the ref
+  // is guaranteed populated before routeWake() first reads it. Falls back
+  // to the hardcoded default (already in `shortcuts.current`) when there's
+  // no saved config or it's malformed.
+  const persisted = await loadPersistedShortcuts();
+  if (persisted) {
+    shortcuts.current = persisted;
+    console.log("[overlay] seeded controller shortcuts from config", persisted);
+  }
+
   let ipHandle: IpInterceptHandle | null = null;
   try {
     ipHandle = await startIpIntercept({

--- a/apps/loadout-overlay/src/bun/lib/persisted-shortcuts.test.ts
+++ b/apps/loadout-overlay/src/bun/lib/persisted-shortcuts.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { configPath, parsePersistedShortcuts } from "./persisted-shortcuts";
+import type { ControllerShortcuts } from "../../webview/lib/electrobun";
+
+// A full, valid controllerShortcuts block as the backend writes it into
+// config.json.
+const VALID_SHORTCUTS: ControllerShortcuts = {
+  guide_a: { type: "None" },
+  guide_b: { type: "ToggleOverlay" },
+  guide_x: { type: "OpenPlugin", value: "fan-control" },
+  guide_y: { type: "None" },
+};
+
+function configWith(shortcuts: unknown): string {
+  return JSON.stringify({ theme: "tokyo", controllerShortcuts: shortcuts });
+}
+
+describe("parsePersistedShortcuts", () => {
+  it("returns the validated shortcuts from a well-formed config", () => {
+    const out = parsePersistedShortcuts(configWith(VALID_SHORTCUTS));
+    expect(out).toEqual(VALID_SHORTCUTS);
+  });
+
+  it("returns null when the config has no controllerShortcuts key", () => {
+    expect(parsePersistedShortcuts(JSON.stringify({ theme: "tokyo" }))).toBeNull();
+  });
+
+  it("returns null for unparseable JSON", () => {
+    expect(parsePersistedShortcuts("{ not json")).toBeNull();
+  });
+
+  it("returns null when the JSON is not an object", () => {
+    expect(parsePersistedShortcuts("42")).toBeNull();
+    expect(parsePersistedShortcuts('"hello"')).toBeNull();
+    expect(parsePersistedShortcuts("null")).toBeNull();
+  });
+
+  it("returns null when a required slot is missing", () => {
+    const { guide_y, ...missingSlot } = VALID_SHORTCUTS;
+    expect(parsePersistedShortcuts(configWith(missingSlot))).toBeNull();
+  });
+
+  it("returns null when a slot has an unknown action type", () => {
+    const bad = { ...VALID_SHORTCUTS, guide_b: { type: "LaunchNukes" } };
+    expect(parsePersistedShortcuts(configWith(bad))).toBeNull();
+  });
+
+  it("returns null when a slot is not an object", () => {
+    const bad = { ...VALID_SHORTCUTS, guide_x: "ToggleOverlay" };
+    expect(parsePersistedShortcuts(configWith(bad))).toBeNull();
+  });
+
+  it("returns null when controllerShortcuts is an array", () => {
+    expect(parsePersistedShortcuts(configWith([]))).toBeNull();
+  });
+});
+
+describe("configPath", () => {
+  const original = process.env.XDG_CONFIG_HOME;
+  afterEach(() => {
+    if (original === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = original;
+  });
+
+  it("honors $XDG_CONFIG_HOME when set", () => {
+    process.env.XDG_CONFIG_HOME = "/custom/xdg";
+    expect(configPath()).toBe("/custom/xdg/loadout/config.json");
+  });
+
+  it("falls back to ~/.config when $XDG_CONFIG_HOME is empty", () => {
+    process.env.XDG_CONFIG_HOME = "";
+    expect(configPath()).toMatch(/\/\.config\/loadout\/config\.json$/);
+  });
+});

--- a/apps/loadout-overlay/src/bun/lib/persisted-shortcuts.ts
+++ b/apps/loadout-overlay/src/bun/lib/persisted-shortcuts.ts
@@ -1,0 +1,70 @@
+// Seeds the wake-routing engine's ControllerShortcuts from the persisted
+// user config at startup.
+//
+// The overlay's Bun process holds the authoritative in-memory `shortcuts`
+// ref that routeWake() consults. Before this module existed it booted to a
+// hardcoded default and only picked up the user's saved bindings when the
+// Settings UI pushed them over the setControllerShortcuts RPC — so every
+// process restart silently reverted the bindings until the user re-edited
+// them (index.ts stage-2 TODO). We now read the same config file the
+// backend writes (`~/.config/loadout/config.json`, honoring
+// $XDG_CONFIG_HOME) so a saved binding survives restarts.
+//
+// Reading the file directly (rather than the backend's /api/user-config)
+// keeps this dependency-free: no loader port, no auth token, and it works
+// even if the backend is still coming up when the overlay boots. The
+// backend writes atomically, so a torn read isn't a concern.
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { validateControllerShortcuts } from "../rpc-validation";
+import type { ControllerShortcuts } from "../../webview/lib/electrobun";
+
+/** Config key under which the backend persists controller shortcuts.
+ *  Must match host.ts's CONFIG_KEY. */
+const CONFIG_KEY = "controllerShortcuts";
+
+/**
+ * Resolve `~/.config/loadout/config.json`, honoring $XDG_CONFIG_HOME.
+ * Mirrors apps/loadout/src/loader/user-config.ts so both ends agree on the
+ * path.
+ */
+export function configPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".config");
+  return join(base, "loadout", "config.json");
+}
+
+/**
+ * Extract + validate the persisted ControllerShortcuts from raw config JSON.
+ * Pure (exposed for tests). Returns null when the file is unparseable, has
+ * no `controllerShortcuts` key, or the value is structurally invalid — the
+ * caller keeps its hardcoded default in every one of those cases.
+ */
+export function parsePersistedShortcuts(raw: string): ControllerShortcuts | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const value = (parsed as Record<string, unknown>)[CONFIG_KEY];
+  if (value === undefined) return null;
+  return validateControllerShortcuts(value);
+}
+
+/**
+ * Load persisted controller shortcuts from disk. Returns null on any
+ * failure (missing file, unreadable, malformed) so the caller falls back to
+ * its default without special-casing errno.
+ */
+export async function loadPersistedShortcuts(): Promise<ControllerShortcuts | null> {
+  try {
+    const raw = await readFile(configPath(), "utf8");
+    return parsePersistedShortcuts(raw);
+  } catch {
+    return null;
+  }
+}

--- a/apps/loadout-overlay/src/bun/rpc-validation.ts
+++ b/apps/loadout-overlay/src/bun/rpc-validation.ts
@@ -39,6 +39,18 @@ function isValidControllerShortcuts(value: unknown): value is ControllerShortcut
 }
 
 /**
+ * Validate a bare {@link ControllerShortcuts} value (not wrapped in an RPC
+ * params envelope). Returns the typed shortcuts on success, or null if the
+ * shape is malformed. Used when seeding the wake-routing engine from the
+ * persisted config file at startup.
+ */
+export function validateControllerShortcuts(
+  value: unknown,
+): ControllerShortcuts | null {
+  return isValidControllerShortcuts(value) ? value : null;
+}
+
+/**
  * Validate the params passed to the `setControllerShortcuts` RPC handler.
  * Returns the typed shortcuts on success, or null if the payload is
  * malformed (caller logs + ignores). Fixes audit B-001 — previously the


### PR DESCRIPTION
## Problem

A controller shortcut bound to **Toggle Overlay** reverts after a restart, and only re-binding in Settings brings it back. In practice: a keyboard button set to open the overlay starts opening Steam's on-screen keyboard again after every reboot.

Two compounding bugs:

1. **Engine never reads the saved config at boot.** The overlay's wake-routing engine (`bun/index.ts`) held its `ControllerShortcuts` only in memory, initialized to a hardcoded default. It only picked up the user's saved bindings when the webview pushed them via the `setControllerShortcuts` RPC (i.e. when Settings was opened and a value edited). Every process restart reverted to the default. This was a long-standing `stage-2` TODO carried in verbatim from the steam-loader migration (#2) — the old Rust version persisted; the Electrobun/TS port never did.

2. **Startup round-trip actively clobbers the saved value.** `App.tsx`'s boot-time "sync persisted shortcuts to backend" calls `getControllerShortcuts()` — which returns the *engine's* value (the un-seeded default at boot) — and writes it back to `config.json`, overwriting the user's real binding with the default on every start.

## Fix

Seed `shortcuts.current` from the persisted config (`~/.config/loadout/config.json`, honoring `$XDG_CONFIG_HOME` — the same file the backend writes) in the startup IIFE, **before either input intercept begins**, so no wake event can arrive before the ref is populated. Falls back to the existing hardcoded default when there's no saved config or it's malformed.

This also neutralizes bug #2: `getControllerShortcuts()` now returns the real saved value, so the `App.tsx` round-trip becomes a no-op instead of a clobber.

Reads the file directly (not via `/api/user-config`) to stay dependency-free — no loader port, no auth token, and it works even if the backend is still coming up. Backend writes are atomic, so a torn read isn't a concern.

## Changes

- `lib/persisted-shortcuts.ts` (new) — pure `parsePersistedShortcuts(raw)` + `loadPersistedShortcuts()` disk wrapper, mirroring the `devices.ts` pure/wrapper split.
- `lib/persisted-shortcuts.test.ts` (new) — 10 unit tests: valid config, missing key, malformed JSON, non-object, missing slot, unknown action type, non-object slot, array; plus `$XDG_CONFIG_HOME` path resolution.
- `bun/index.ts` — import + seed at startup; replaced the stale `stage-2` TODO comment.
- `rpc-validation.ts` — export `validateControllerShortcuts` (bare-value validator) for reuse.

## Testing

- `bun test` for the new + existing bun-side suites pass (the 13 pre-existing failures are DOM-less React component tests, unrelated).
- Built and installed the overlay on a Steam Deck / SteamOS device. Boot log confirms ordering:
  ```
  [overlay] seeded controller shortcuts from config { … }
  [overlay] input intercept ready — … 4 keyboard(s), 4 qam device(s)
  ```
  Seed runs before the input loop; the later `App.tsx` round-trip now writes back the correct value.

## Follow-up (not in this PR)

Optionally harden `App.tsx`'s startup sync to read the config file directly rather than the engine, closing the clobber path at the source as well. Not needed for correctness once the engine is seeded, so left out to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)