### PR TITLE
fix(tdp-control): persist user-set TDP across shutdown (#204)

### DIFF
--- a/plugins/tdp-control/backend.test.ts
+++ b/plugins/tdp-control/backend.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { EmitPayload } from "@loadout/types";
 import TdpControlBackend from "./backend";
+import { readSavedTdp } from "./lib/saved-tdp";
 
 /**
  * TdpControlBackend tests.
@@ -268,6 +272,77 @@ describe("TdpControlBackend", () => {
       expect(info.maxWatts).toBe(55); // effective (on battery)
       expect(info.pluggedMaxWatts).toBe(80);
       expect(info.batteryMaxWatts).toBe(55);
+    });
+  });
+
+  // ── manual TDP persistence ────────────────────────────────────────
+  //
+  // The user's chosen TDP must survive a shutdown: setTdp() persists it to
+  // the plugin config file, and automatic applies (per-game/AC/resume, which
+  // route through the private applyTdp()) must NOT overwrite it.
+
+  describe("manual TDP persistence", () => {
+    let dir: string;
+    let prevXdg: string | undefined;
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), "tdp-persist-test-"));
+      prevXdg = process.env.XDG_CONFIG_HOME;
+      process.env.XDG_CONFIG_HOME = dir;
+    });
+
+    afterEach(() => {
+      if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = prevXdg;
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    function configure() {
+      const b = backend as unknown as {
+        method: string;
+        minWatts: number;
+        maxWatts: number;
+        batteryMaxWatts: number;
+        acPowerOnline: boolean | null;
+        setTdpViaRyzenadj: (w: number) => Promise<void>;
+        applyTdp: (w: number) => Promise<{ success: boolean }>;
+      };
+      b.method = "ryzenadj";
+      b.minWatts = 5;
+      b.maxWatts = 80;
+      b.batteryMaxWatts = 55;
+      b.acPowerOnline = true;
+      b.setTdpViaRyzenadj = async () => {}; // stub the SMU write
+      return b;
+    }
+
+    it("setTdp persists the user's chosen value", async () => {
+      configure();
+      const result = await backend.setTdp(28);
+      expect(result.success).toBe(true);
+      expect(await readSavedTdp("tdp-control")).toBe(28);
+    });
+
+    it("applyProfile persists the preset value", async () => {
+      const b = configure();
+      // Seed a known preset so applyProfile has something to apply.
+      (b as unknown as { profiles: Record<string, number> }).profiles = {
+        Silent: 10,
+        Balanced: 18,
+        Performance: 40,
+      };
+      const result = await backend.applyProfile("Balanced");
+      expect(result.success).toBe(true);
+      expect(await readSavedTdp("tdp-control")).toBe(18);
+    });
+
+    it("automatic applyTdp does NOT overwrite the saved value", async () => {
+      const b = configure();
+      await backend.setTdp(28);
+      expect(await readSavedTdp("tdp-control")).toBe(28);
+      // Simulate an automatic re-apply (per-game profile / AC / resume).
+      await b.applyTdp(12);
+      expect(await readSavedTdp("tdp-control")).toBe(28);
     });
   });
 

--- a/plugins/tdp-control/backend.test.ts
+++ b/plugins/tdp-control/backend.test.ts
@@ -344,6 +344,44 @@ describe("TdpControlBackend", () => {
       await b.applyTdp(12);
       expect(await readSavedTdp("tdp-control")).toBe(28);
     });
+
+    it("setTdp does NOT overwrite the saved value while a per-game profile governs TDP", async () => {
+      const b = configure();
+      // Establish the manual "no game" value (no engine → nothing governs).
+      await backend.setTdp(35);
+      expect(await readSavedTdp("tdp-control")).toBe(35);
+
+      // Now a per-game profile is actively governing TDP: the frontend routes
+      // the slider to setGameProfile, and the parallel setTdp must NOT clobber
+      // the manual no-game value with the in-game watts.
+      (b as unknown as { profileEngine: unknown }).profileEngine = {
+        getCurrentState: () => ({
+          activeProfile: null,
+          currentTdp: 35,
+          isGameRunning: true,
+          perGameEnabled: true,
+        }),
+      };
+      const result = await backend.setTdp(20);
+      expect(result.success).toBe(true); // still applied to hardware
+      expect(await readSavedTdp("tdp-control")).toBe(35); // saved value intact
+    });
+
+    it("setTdp DOES persist when a game runs but per-game is disabled", async () => {
+      const b = configure();
+      // Per-game off → setTdp is the only TDP control, so it must persist even
+      // if a game happens to be tracked as running.
+      (b as unknown as { profileEngine: unknown }).profileEngine = {
+        getCurrentState: () => ({
+          activeProfile: null,
+          currentTdp: 15,
+          isGameRunning: true,
+          perGameEnabled: false,
+        }),
+      };
+      await backend.setTdp(22);
+      expect(await readSavedTdp("tdp-control")).toBe(22);
+    });
   });
 
   // ── getProfiles ───────────────────────────────────────────────────

--- a/plugins/tdp-control/backend.ts
+++ b/plugins/tdp-control/backend.ts
@@ -412,6 +412,10 @@ export default class TdpControlBackend implements PluginBackend {
           },
         });
       },
+      // The user's saved manual TDP is the authoritative "no game" value —
+      // the engine applies it on game exit / for games without a profile,
+      // ahead of its own stored default.
+      getNoGameTdp: () => this.savedTdp,
     });
     await this.profileEngine.loadProfiles();
     console.log("[tdp-control] Per-game TDP profile engine initialized");
@@ -422,19 +426,26 @@ export default class TdpControlBackend implements PluginBackend {
     //     when we can't read the hardware directly (existing behavior).
     //   - Otherwise → restore the user's persisted manual TDP, if any.
     if (this.method !== "none") {
-      if (this.profileEngine.getPerGameEnabled()) {
-        if (this.tdpReadSource === "estimated") {
-          const defaultTdp = this.profileEngine.getDefaultTdp();
-          console.log(
-            `[tdp-control] Applying default TDP ${defaultTdp}W (source was estimated, per-game enabled)`,
-          );
-          await this.applyTdp(defaultTdp);
-        }
-      } else if (this.savedTdp !== null) {
+      // No game is running at startup, so the value to restore is the user's
+      // "no game" TDP. The saved manual TDP (set from the slider / home
+      // widget) is authoritative — it applies whether or not per-game
+      // profiles are enabled. A per-game profile still takes over later, when
+      // its game actually launches. The engine's stored default TDP is only a
+      // fallback for users who never set a manual value.
+      if (this.savedTdp !== null) {
         console.log(
           `[tdp-control] Restoring saved manual TDP ${this.savedTdp}W`,
         );
         await this.applyTdp(this.savedTdp);
+      } else if (
+        this.profileEngine.getPerGameEnabled() &&
+        this.tdpReadSource === "estimated"
+      ) {
+        const defaultTdp = this.profileEngine.getDefaultTdp();
+        console.log(
+          `[tdp-control] Applying default TDP ${defaultTdp}W (source was estimated, per-game enabled, no saved manual TDP)`,
+        );
+        await this.applyTdp(defaultTdp);
       }
     }
 

--- a/plugins/tdp-control/backend.ts
+++ b/plugins/tdp-control/backend.ts
@@ -529,10 +529,20 @@ export default class TdpControlBackend implements PluginBackend {
     watts: number,
   ): Promise<{ success: boolean; error?: string }> {
     const result = await this.applyTdp(watts);
-    // Persist the user's choice so it survives a shutdown. Only this RPC path
-    // (the slider + power presets via applyProfile) persists; automatic
-    // applies go straight to applyTdp() and leave the saved value untouched.
-    if (result.success && this.desiredTdp !== null) {
+    // Persist the user's choice as the manual "no game" TDP so it survives a
+    // shutdown. Only this RPC path (the slider + power presets via
+    // applyProfile) persists; automatic applies go straight to applyTdp() and
+    // leave the saved value untouched.
+    //
+    // BUT don't overwrite it while a per-game profile is actively governing
+    // TDP (per-game enabled + a game running): in that state the slider is
+    // tuning THAT game's profile (the frontend routes it to setGameProfile),
+    // so persisting here would let an in-game tweak silently redefine the
+    // menu/default TDP that gets restored on game exit and reboot.
+    const state = this.profileEngine?.getCurrentState();
+    const gameGoverning =
+      (state?.perGameEnabled ?? false) && (state?.isGameRunning ?? false);
+    if (result.success && this.desiredTdp !== null && !gameGoverning) {
       this.savedTdp = this.desiredTdp;
       try {
         await writeSavedTdp("tdp-control", this.desiredTdp);

--- a/plugins/tdp-control/backend.ts
+++ b/plugins/tdp-control/backend.ts
@@ -22,6 +22,7 @@ import {
   validateCustomDevice,
   type CustomDevice,
 } from "./lib/custom-device";
+import { readSavedTdp, writeSavedTdp } from "./lib/saved-tdp";
 
 // ---------------------------------------------------------------------------
 // Constants: sysfs paths
@@ -286,6 +287,14 @@ export default class TdpControlBackend implements PluginBackend {
    * battery, spring back up on AC) without ever mutating saved profiles.
    */
   private desiredTdp: number | null = null;
+  /**
+   * The last user-requested wattage persisted to disk, loaded on startup.
+   * Restored to hardware in onLoad() so the user's TDP choice survives a
+   * shutdown (hardware limits reset to firmware defaults on reboot). Only
+   * user-initiated setTdp()/applyProfile() calls update this — automatic
+   * applies (per-game profiles, AC transitions, resume) do not.
+   */
+  private savedTdp: number | null = null;
   private tdpReadSource: TdpReadSource = "estimated";
   private activeProfile: string | null = null;
   private trackedTdp: number | null = null;
@@ -344,6 +353,9 @@ export default class TdpControlBackend implements PluginBackend {
     // takes precedence over DMI auto-detection.
     this.customDevice = await readCustomDevice("tdp-control");
 
+    // Load the user's persisted manual TDP (restored to hardware below).
+    this.savedTdp = await readSavedTdp("tdp-control");
+
     // Apply device-specific ranges (custom device wins when present)
     this.applyDeviceDefaults();
 
@@ -386,7 +398,9 @@ export default class TdpControlBackend implements PluginBackend {
     this.profileEngine = createTdpProfileEngine({
       pluginId: "tdp-control",
       onApplyTdp: async (watts: number) => {
-        await this.setTdp(watts);
+        // Per-game applies are automatic — don't clobber the user's saved
+        // manual TDP with a game's profile value.
+        await this.applyTdp(watts);
       },
       onProfileChanged: (profile: TdpProfile | null, gameName: string) => {
         this.emit?.({
@@ -402,19 +416,26 @@ export default class TdpControlBackend implements PluginBackend {
     await this.profileEngine.loadProfiles();
     console.log("[tdp-control] Per-game TDP profile engine initialized");
 
-    // Apply the profile engine's default TDP on startup when we can't
-    // directly read the hardware (estimated/fallback) AND per-game
-    // profiles is enabled. Otherwise leave the user's manual TDP alone.
-    if (
-      this.tdpReadSource === "estimated" &&
-      this.method !== "none" &&
-      this.profileEngine.getPerGameEnabled()
-    ) {
-      const defaultTdp = this.profileEngine.getDefaultTdp();
-      console.log(
-        `[tdp-control] Applying default TDP ${defaultTdp}W (source was estimated, per-game enabled)`,
-      );
-      await this.setTdp(defaultTdp);
+    // Restore TDP on startup. Hardware limits reset to firmware defaults on
+    // reboot, so re-apply what the user left. Precedence:
+    //   - Per-game profiles enabled → the engine owns TDP; apply its default
+    //     when we can't read the hardware directly (existing behavior).
+    //   - Otherwise → restore the user's persisted manual TDP, if any.
+    if (this.method !== "none") {
+      if (this.profileEngine.getPerGameEnabled()) {
+        if (this.tdpReadSource === "estimated") {
+          const defaultTdp = this.profileEngine.getDefaultTdp();
+          console.log(
+            `[tdp-control] Applying default TDP ${defaultTdp}W (source was estimated, per-game enabled)`,
+          );
+          await this.applyTdp(defaultTdp);
+        }
+      } else if (this.savedTdp !== null) {
+        console.log(
+          `[tdp-control] Restoring saved manual TDP ${this.savedTdp}W`,
+        );
+        await this.applyTdp(this.savedTdp);
+      }
     }
 
     console.log(
@@ -494,6 +515,32 @@ export default class TdpControlBackend implements PluginBackend {
   // -----------------------------------------------------------------------
 
   async setTdp(
+    watts: number,
+  ): Promise<{ success: boolean; error?: string }> {
+    const result = await this.applyTdp(watts);
+    // Persist the user's choice so it survives a shutdown. Only this RPC path
+    // (the slider + power presets via applyProfile) persists; automatic
+    // applies go straight to applyTdp() and leave the saved value untouched.
+    if (result.success && this.desiredTdp !== null) {
+      this.savedTdp = this.desiredTdp;
+      try {
+        await writeSavedTdp("tdp-control", this.desiredTdp);
+      } catch (e) {
+        // Persistence is best-effort — a failed disk write must not fail the
+        // TDP apply the user just requested (it's already on hardware).
+        console.error(`[tdp-control] Failed to persist TDP: ${e}`);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Apply a TDP to hardware WITHOUT persisting it as the user's saved value.
+   * This is the shared implementation behind the setTdp RPC and every
+   * automatic re-apply (per-game profiles, AC transitions, resume, device
+   * changes). The public setTdp() wraps this and persists on success.
+   */
+  private async applyTdp(
     watts: number,
   ): Promise<{ success: boolean; error?: string }> {
     watts = Math.round(watts);
@@ -678,10 +725,11 @@ export default class TdpControlBackend implements PluginBackend {
       },
     });
     // Re-apply the standing intent through the new clamp so a value now out of
-    // range is corrected on hardware (setTdp emits its own tdpChanged).
+    // range is corrected on hardware (applyTdp emits its own tdpChanged). This
+    // is an automatic re-clamp, not a fresh user choice, so it doesn't persist.
     const intent = this.desiredTdp ?? this.currentTdp;
     if (intent !== null && this.method !== "none") {
-      await this.setTdp(intent);
+      await this.applyTdp(intent);
     }
   }
 
@@ -1114,7 +1162,7 @@ export default class TdpControlBackend implements PluginBackend {
 
       // Re-apply current TDP profile
       if (this.trackedTdp !== null) {
-        await this.setTdp(this.trackedTdp);
+        await this.applyTdp(this.trackedTdp);
         console.log(`[tdp-control] Resume: re-applied TDP ${this.trackedTdp}W`);
       }
       return { success: true };
@@ -1717,7 +1765,7 @@ export default class TdpControlBackend implements PluginBackend {
             // its own tdpChanged with the applied value.
             const intent = this.desiredTdp ?? this.currentTdp;
             if (intent !== null && this.method !== "none") {
-              await this.setTdp(intent);
+              await this.applyTdp(intent);
             }
             this.emit?.({
               event: "acPowerChanged",

--- a/plugins/tdp-control/lib/saved-tdp.test.ts
+++ b/plugins/tdp-control/lib/saved-tdp.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readSavedTdp, writeSavedTdp } from "./saved-tdp";
+import { readPluginStorage, writePluginStorage } from "@loadout/plugin-storage";
+
+const PLUGIN_ID = "tdp-control-test";
+
+describe("saved-tdp persistence", () => {
+  let dir: string;
+  let prevXdg: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "saved-tdp-test-"));
+    prevXdg = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = dir;
+  });
+
+  afterEach(() => {
+    if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prevXdg;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("read returns null when nothing is stored", async () => {
+    expect(await readSavedTdp(PLUGIN_ID)).toBeNull();
+  });
+
+  test("write then read round-trips the value", async () => {
+    await writeSavedTdp(PLUGIN_ID, 22);
+    expect(await readSavedTdp(PLUGIN_ID)).toBe(22);
+  });
+
+  test("write rounds fractional watts", async () => {
+    await writeSavedTdp(PLUGIN_ID, 17.6);
+    expect(await readSavedTdp(PLUGIN_ID)).toBe(18);
+  });
+
+  test("write preserves co-tenant keys in the same file", async () => {
+    await writePluginStorage(PLUGIN_ID, { defaultTdp: 15, profiles: [] });
+    await writeSavedTdp(PLUGIN_ID, 30);
+    const raw = await readPluginStorage<Record<string, unknown>>(PLUGIN_ID);
+    expect(raw.defaultTdp).toBe(15);
+    expect(raw.manualTdp).toBe(30);
+  });
+
+  test("read treats a non-number as nothing stored", async () => {
+    await writePluginStorage(PLUGIN_ID, { manualTdp: "twenty" });
+    expect(await readSavedTdp(PLUGIN_ID)).toBeNull();
+  });
+
+  test("read rejects out-of-range values", async () => {
+    await writePluginStorage(PLUGIN_ID, { manualTdp: 0 });
+    expect(await readSavedTdp(PLUGIN_ID)).toBeNull();
+    await writePluginStorage(PLUGIN_ID, { manualTdp: 9999 });
+    expect(await readSavedTdp(PLUGIN_ID)).toBeNull();
+  });
+});

--- a/plugins/tdp-control/lib/saved-tdp.ts
+++ b/plugins/tdp-control/lib/saved-tdp.ts
@@ -1,0 +1,55 @@
+/**
+ * Persistence for the user's manually-set TDP.
+ *
+ * The TDP the user picks (slider or power preset) is applied to hardware but,
+ * on AMD/Intel/WMI handhelds, the hardware limit resets to a firmware default
+ * on every reboot. Without persistence the user's choice is lost across a
+ * shutdown. We store the last user-requested wattage so `onLoad` can re-apply
+ * it, restoring the device to how the user left it.
+ *
+ * Persistence: the single `manualTdp` key inside the plugin's shared storage
+ * file (`~/.config/loadout/plugins/tdp-control.json`), written via
+ * `mutatePluginStorage` so it round-trips alongside the per-game profile
+ * engine's keys and the custom-device override in the same file.
+ */
+
+import { readPluginStorage, mutatePluginStorage } from "@loadout/plugin-storage";
+
+/** Top-level key under which the user's manual TDP is persisted. */
+const STORAGE_KEY = "manualTdp";
+
+/** Absolute watt bounds a stored value must fall within (sanity guard). */
+const MIN_WATTS = 1;
+const MAX_WATTS = 200;
+
+/**
+ * Load the stored manual TDP, or `null` when none is saved (or the stored
+ * value is missing/corrupt/out of range — treated as "nothing to restore").
+ */
+export async function readSavedTdp(pluginId: string): Promise<number | null> {
+  const stored = await readPluginStorage<Record<string, unknown>>(pluginId);
+  const raw = stored[STORAGE_KEY];
+  if (
+    typeof raw !== "number" ||
+    !Number.isFinite(raw) ||
+    raw < MIN_WATTS ||
+    raw > MAX_WATTS
+  ) {
+    return null;
+  }
+  return Math.round(raw);
+}
+
+/**
+ * Persist the user's manual TDP. Merges into the plugin's shared file so the
+ * per-game profile engine's keys and the custom-device override are preserved.
+ */
+export async function writeSavedTdp(
+  pluginId: string,
+  watts: number,
+): Promise<void> {
+  await mutatePluginStorage<Record<string, unknown>>(pluginId, (existing) => ({
+    ...existing,
+    [STORAGE_KEY]: Math.round(watts),
+  }));
+}

--- a/plugins/tdp-control/lib/tdp-profiles.test.ts
+++ b/plugins/tdp-control/lib/tdp-profiles.test.ts
@@ -50,6 +50,18 @@ function createEngine() {
   });
 }
 
+// Engine wired with the backend's `getNoGameTdp` injection — mirrors
+// production, where the user's persisted manual TDP is the authoritative
+// "no game" value (ahead of the engine's stored `defaultTdp`).
+function createEngineWithNoGameTdp(getNoGameTdp: () => number | null) {
+  return createTdpProfileEngine({
+    configPath,
+    onApplyTdp,
+    onProfileChanged,
+    getNoGameTdp,
+  });
+}
+
 async function writeConfig(store: Partial<TdpProfileStore> & {
   defaultTdp: number;
   profiles: Array<TdpProfile>;
@@ -342,6 +354,117 @@ describe("TDP Profile Engine", () => {
       expect(state.isGameRunning).toBe(false);
       expect(state.currentTdp).toBe(15);
       expect(state.activeProfile).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getNoGameTdp — the manual "no game" TDP takes precedence over defaultTdp
+  // -------------------------------------------------------------------------
+
+  describe("getNoGameTdp (manual no-game TDP)", () => {
+    test("handleGameExit restores the manual TDP, not defaultTdp", async () => {
+      await writeConfig({
+        defaultTdp: 12,
+        profiles: [{ appId: 730, gameName: "CS2", tdpWatts: 25 }],
+      });
+      // User's persisted manual TDP is 35W; engine default is 12W.
+      const engine = createEngineWithNoGameTdp(() => 35);
+      await engine.loadProfiles();
+
+      await engine.handleGameLaunch(730, "CS2"); // 25W (profile)
+      appliedTdpValues = [];
+
+      await engine.handleGameExit(730);
+
+      expect(appliedTdpValues).toEqual([35]); // manual, not the 12W default
+    });
+
+    test("falls back to defaultTdp when getNoGameTdp returns null", async () => {
+      await writeConfig({
+        defaultTdp: 12,
+        profiles: [{ appId: 730, gameName: "CS2", tdpWatts: 25 }],
+      });
+      const engine = createEngineWithNoGameTdp(() => null);
+      await engine.loadProfiles();
+
+      await engine.handleGameLaunch(730, "CS2");
+      appliedTdpValues = [];
+
+      await engine.handleGameExit(730);
+
+      expect(appliedTdpValues).toEqual([12]);
+    });
+
+    test("falls back to defaultTdp when the callback is not provided", async () => {
+      await writeConfig({
+        defaultTdp: 12,
+        profiles: [{ appId: 730, gameName: "CS2", tdpWatts: 25 }],
+      });
+      const engine = createEngine(); // no getNoGameTdp injection
+      await engine.loadProfiles();
+
+      await engine.handleGameLaunch(730, "CS2");
+      appliedTdpValues = [];
+
+      await engine.handleGameExit(730);
+
+      expect(appliedTdpValues).toEqual([12]);
+    });
+
+    test("launching a game WITHOUT a profile applies the manual TDP", async () => {
+      await writeConfig({ defaultTdp: 12, profiles: [] });
+      const engine = createEngineWithNoGameTdp(() => 35);
+      await engine.loadProfiles();
+
+      await engine.handleGameLaunch(999, "Unprofiled Game");
+
+      expect(appliedTdpValues).toEqual([35]);
+    });
+
+    test("a recognized per-game profile still wins over the manual TDP", async () => {
+      await writeConfig({
+        defaultTdp: 12,
+        profiles: [{ appId: 730, gameName: "CS2", tdpWatts: 25 }],
+      });
+      const engine = createEngineWithNoGameTdp(() => 35);
+      await engine.loadProfiles();
+
+      await engine.handleGameLaunch(730, "CS2");
+
+      expect(appliedTdpValues).toEqual([25]); // profile precedence intact
+    });
+
+    test("removing the running game's profile falls back to the manual TDP", async () => {
+      await writeConfig({
+        defaultTdp: 12,
+        profiles: [{ appId: 730, gameName: "CS2", tdpWatts: 25 }],
+      });
+      const engine = createEngineWithNoGameTdp(() => 35);
+      await engine.loadProfiles();
+
+      await engine.handleGameLaunch(730, "CS2"); // 25W
+      appliedTdpValues = [];
+
+      await engine.removeProfile(730);
+
+      expect(appliedTdpValues).toEqual([35]); // manual, consistent with exit
+    });
+
+    test("enabling per-game while an unprofiled game runs applies the manual TDP", async () => {
+      await writeConfig({
+        defaultTdp: 12,
+        profiles: [],
+        perGameEnabled: false,
+      });
+      const engine = createEngineWithNoGameTdp(() => 35);
+      await engine.loadProfiles();
+
+      await engine.handleGameLaunch(999, "Unprofiled Game"); // no apply (off)
+      appliedTdpValues = [];
+
+      await engine.setPerGameEnabled(true);
+
+      expect(appliedTdpValues).toEqual([35]);
     });
   });
 

--- a/plugins/tdp-control/lib/tdp-profiles.ts
+++ b/plugins/tdp-control/lib/tdp-profiles.ts
@@ -343,8 +343,11 @@ export function createTdpProfileEngine(options: TdpProfileEngineOptions) {
     if (isGameRunning && activeAppId === appId) {
       activeProfile = null;
       if (store.perGameEnabled) {
-        currentTdp = store.defaultTdp;
-        await commitTdp(store.defaultTdp);
+        // The running game no longer has a profile → same "no profile in
+        // effect" state as a game exit, so fall back to the manual no-game
+        // TDP (matches handleGameExit), not the raw engine default.
+        currentTdp = noGameTdp();
+        await commitTdp(currentTdp);
       }
       onProfileChanged(null, "");
     }

--- a/plugins/tdp-control/lib/tdp-profiles.ts
+++ b/plugins/tdp-control/lib/tdp-profiles.ts
@@ -43,6 +43,14 @@ export interface TdpProfileEngineOptions {
   onApplyTdp: (watts: number) => Promise<void>;
   /** Notify the UI that the active profile changed. */
   onProfileChanged: (profile: TdpProfile | null, gameName: string) => void;
+  /**
+   * The user's manual "no game" TDP (persisted by the backend). When it
+   * returns a value that value is the fallback applied on game exit and for
+   * games without a saved profile, taking precedence over the engine's
+   * stored `defaultTdp`. Returns null when the user has no saved manual TDP,
+   * in which case `defaultTdp` is used.
+   */
+  getNoGameTdp?: () => number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -105,7 +113,16 @@ function normalizeStore(parsed: unknown): TdpProfileStore | null {
 // ---------------------------------------------------------------------------
 
 export function createTdpProfileEngine(options: TdpProfileEngineOptions) {
-  const { pluginId, configPath, onApplyTdp, onProfileChanged } = options;
+  const { pluginId, configPath, onApplyTdp, onProfileChanged, getNoGameTdp } =
+    options;
+
+  // The TDP to apply when no per-game profile is in effect — i.e. a game
+  // exited, or a game without a saved profile launched. The user's manual
+  // TDP (set from the slider / home widget) is authoritative; the engine's
+  // stored default is only a fallback for users who never set one.
+  function noGameTdp(): number {
+    return getNoGameTdp?.() ?? store.defaultTdp;
+  }
   if ((!pluginId && !configPath) || (pluginId && configPath)) {
     throw new Error(
       "createTdpProfileEngine: exactly one of `pluginId` or `configPath` must be provided",
@@ -264,8 +281,9 @@ export function createTdpProfileEngine(options: TdpProfileEngineOptions) {
       await commitTdp(profile.tdpWatts);
       onProfileChanged(profile, gameName);
     } else {
-      currentTdp = store.defaultTdp;
-      await commitTdp(store.defaultTdp);
+      const watts = noGameTdp();
+      currentTdp = watts;
+      await commitTdp(watts);
       onProfileChanged(null, gameName);
     }
   }
@@ -281,8 +299,8 @@ export function createTdpProfileEngine(options: TdpProfileEngineOptions) {
       return;
     }
 
-    currentTdp = store.defaultTdp;
-    await commitTdp(store.defaultTdp);
+    currentTdp = noGameTdp();
+    await commitTdp(currentTdp);
     onProfileChanged(null, "");
   }
 
@@ -378,7 +396,7 @@ export function createTdpProfileEngine(options: TdpProfileEngineOptions) {
     if (enabled && isGameRunning && activeAppId != null) {
       const profile = store.profiles.find((p) => p.appId === activeAppId);
       activeProfile = profile ?? null;
-      currentTdp = profile?.tdpWatts ?? store.defaultTdp;
+      currentTdp = profile?.tdpWatts ?? noGameTdp();
       await commitTdp(currentTdp);
       onProfileChanged(profile ?? null, profile?.gameName ?? "");
     }


### PR DESCRIPTION
## Problem

The manually-set TDP lived only in memory, so the user's choice was lost on
every reboot — hardware power limits reset to firmware defaults on shutdown.

## Fix

Persist the last user-requested wattage to the plugin config file
(`~/.config/loadout/plugins/tdp-control.json`, `manualTdp` key) and re-apply it
on startup. Only user-initiated `setTdp()` / `applyProfile()` calls persist —
automatic applies (per-game profiles, AC transitions, resume, device changes)
route through a private `applyTdp()` and leave the saved value untouched.

## The "no game" TDP model

The saved manual TDP is the **authoritative "no game running" value**, and is
restored regardless of whether per-game profiles are enabled. Precedence:

- **A recognized per-game profile's game launches** → that profile's TDP wins.
- **No game running** (boot, game exit, or a game without a profile) → the
  saved manual TDP is applied.
- The engine's stored `defaultTdp` remains only as a fallback for users who
  never set a manual value.

Implemented via a `getNoGameTdp` callback injected into the profile engine, so
`handleGameExit`, the no-profile branch of `handleGameLaunch`, `removeProfile`,
and the per-game toggle-on path all resolve the same no-game value.

> Note: this supersedes the earlier "manual restore only runs when per-game is
> off" behavior — with per-game **on**, boot previously fell back to the engine
> `defaultTdp` and silently dropped the user's manual value (e.g. set 35W, got
> 12W after reboot).

## Guard against in-game drift

`setTdp()` does **not** overwrite the saved no-game value while a per-game
profile is actively governing TDP (per-game enabled + a game running). In that
state the slider tunes the running game's profile (the frontend routes it to
`setGameProfile`), so persisting there would let an in-game tweak silently
redefine the value restored on game exit / reboot.

## Tests

Added regression coverage for the `getNoGameTdp` paths (exit, no-profile launch,
profile precedence, `removeProfile`, toggle-on, null/omitted-callback fallback)
and the `setTdp` in-game persistence guard. 90/90 tdp-control tests pass;
typecheck clean.

## Verification

Built and installed on hardware (OneXPlayer APEX / Ryzen AI MAX+ 395). Service
logs confirm `Restoring saved manual TDP …W` on startup where it previously
applied the 12W per-game default.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XNKJxF3QuZjhsjn5CqKyJM