### PR TITLE
fix(input-plumber): log + retry the boot-time wake-button reload

### DIFF
--- a/plugins/input-plumber/backend.ts
+++ b/plugins/input-plumber/backend.ts
@@ -90,16 +90,36 @@ export default class InputPlumberBackend implements PluginBackend {
     // `/up` before the overlay user-service starts, and `reloadPersistedProfile`
     // waits internally for IP, so the keyboard exists before the overlay
     // enumerates devices. Non-blocking so a slow/absent IP can't stall onLoad.
-    void wake
-      .reloadPersistedProfile()
-      .then((r) => {
-        if (!r.ok && r.error) this.log?.warn(`wake reload: ${r.error}`);
-      })
-      .catch((e) =>
-        this.log?.warn(
-          `wake reload threw: ${e instanceof Error ? e.message : String(e)}`,
-        ),
-      );
+    //
+    // Retry the reload a few times: on a cold boot IP can be *up* (so the
+    // internal waitForIp passes) but the composite device not yet enumerated,
+    // which returns "Bound device not connected" and would otherwise drop the
+    // binding for the whole session — the wake button silently reverts to its
+    // OS default until the user re-binds. Mirrors restartInputPlumber()'s
+    // retry. reloadPersistedProfile() returns ok immediately when nothing is
+    // bound, so this is a no-op on setups without a wake button.
+    void (async () => {
+      let last = { ok: true } as Awaited<
+        ReturnType<typeof wake.reloadPersistedProfile>
+      >;
+      for (let attempt = 0; attempt < 5; attempt++) {
+        last = await wake.reloadPersistedProfile();
+        if (last.ok) break;
+        this.log?.info(
+          `wake reload: attempt ${attempt + 1} not ready (${last.error ?? "unknown"}); retrying`,
+        );
+        await new Promise((r) => setTimeout(r, 2000));
+      }
+      if (!last.ok && last.error) this.log?.warn(`wake reload: ${last.error}`);
+      else
+        this.log?.info(
+          "wake reload: completed (see [input-plumber] logs for detail)",
+        );
+    })().catch((e) =>
+      this.log?.warn(
+        `wake reload threw: ${e instanceof Error ? e.message : String(e)}`,
+      ),
+    );
     this.log?.info("Plugin loaded");
   }
 

--- a/plugins/input-plumber/backend.ts
+++ b/plugins/input-plumber/backend.ts
@@ -98,28 +98,25 @@ export default class InputPlumberBackend implements PluginBackend {
     // OS default until the user re-binds. Mirrors restartInputPlumber()'s
     // retry. reloadPersistedProfile() returns ok immediately when nothing is
     // bound, so this is a no-op on setups without a wake button.
-    void (async () => {
-      let last = { ok: true } as Awaited<
-        ReturnType<typeof wake.reloadPersistedProfile>
-      >;
-      for (let attempt = 0; attempt < 5; attempt++) {
-        last = await wake.reloadPersistedProfile();
-        if (last.ok) break;
-        this.log?.info(
-          `wake reload: attempt ${attempt + 1} not ready (${last.error ?? "unknown"}); retrying`,
-        );
-        await new Promise((r) => setTimeout(r, 2000));
-      }
-      if (!last.ok && last.error) this.log?.warn(`wake reload: ${last.error}`);
-      else
-        this.log?.info(
-          "wake reload: completed (see [input-plumber] logs for detail)",
-        );
-    })().catch((e) =>
-      this.log?.warn(
-        `wake reload threw: ${e instanceof Error ? e.message : String(e)}`,
-      ),
-    );
+    void wake
+      .reloadPersistedProfileWithRetry({
+        onRetry: (attempt, error) =>
+          this.log?.info(
+            `wake reload: attempt ${attempt} not ready (${error}); retrying`,
+          ),
+      })
+      .then((last) => {
+        if (!last.ok && last.error) this.log?.warn(`wake reload: ${last.error}`);
+        else
+          this.log?.info(
+            "wake reload: completed (see [input-plumber] logs for detail)",
+          );
+      })
+      .catch((e) =>
+        this.log?.warn(
+          `wake reload threw: ${e instanceof Error ? e.message : String(e)}`,
+        ),
+      );
     this.log?.info("Plugin loaded");
   }
 

--- a/plugins/input-plumber/lib/wake-trigger.test.ts
+++ b/plugins/input-plumber/lib/wake-trigger.test.ts
@@ -16,6 +16,7 @@ import {
   clearWakeButton,
   captureWakeButton,
   reloadPersistedProfile,
+  reloadPersistedProfileWithRetry,
   restartInputPlumber,
 } from "./wake-trigger";
 import { PROFILE_PATH } from "./profile";
@@ -382,5 +383,92 @@ describe("wake-trigger orchestration", () => {
     };
     expect(persisted.wake?.selectedRaw).toBeNull();
     expect(calls).toHaveLength(0);
+  });
+});
+
+// reloadPersistedProfileWithRetry drives the boot reload with retries. It
+// takes injectable `reload` + `wait` so we exercise the loop directly —
+// no DBus, no real 2s sleeps.
+describe("reloadPersistedProfileWithRetry", () => {
+  const noWait = async () => {};
+
+  it("calls reload once and returns when it succeeds first try", async () => {
+    let calls = 0;
+    const res = await reloadPersistedProfileWithRetry({
+      wait: noWait,
+      reload: async () => {
+        calls++;
+        return { ok: true };
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  it("does not wait when nothing is bound (immediate ok)", async () => {
+    let waitCount = 0;
+    const res = await reloadPersistedProfileWithRetry({
+      reload: async () => ({ ok: true }),
+      wait: async () => {
+        waitCount++;
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect(waitCount).toBe(0);
+  });
+
+  it("retries a transient failure, then succeeds", async () => {
+    let calls = 0;
+    const waits: number[] = [];
+    const retries: Array<{ attempt: number; error: string }> = [];
+    const res = await reloadPersistedProfileWithRetry({
+      delayMs: 2000,
+      wait: async (ms) => {
+        waits.push(ms);
+      },
+      onRetry: (attempt, error) => retries.push({ attempt, error }),
+      reload: async () => {
+        calls++;
+        return calls < 3
+          ? { ok: false, error: "Bound device not connected; wake button not reloaded." }
+          : { ok: true };
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect(calls).toBe(3); // failed twice, succeeded on the third
+    expect(waits).toEqual([2000, 2000]); // one wait after each failure
+    expect(retries.map((r) => r.attempt)).toEqual([1, 2]);
+  });
+
+  it("gives up after `attempts` and returns the last failure (no trailing wait)", async () => {
+    let calls = 0;
+    let waitCount = 0;
+    const res = await reloadPersistedProfileWithRetry({
+      attempts: 5,
+      wait: async () => {
+        waitCount++;
+      },
+      reload: async () => {
+        calls++;
+        return { ok: false, error: "still not ready" };
+      },
+    });
+    expect(res).toEqual({ ok: false, error: "still not ready" });
+    expect(calls).toBe(5); // exactly `attempts` tries
+    expect(waitCount).toBe(4); // no sleep after the final attempt
+  });
+
+  it("honors a custom attempts count", async () => {
+    let calls = 0;
+    const res = await reloadPersistedProfileWithRetry({
+      attempts: 2,
+      wait: noWait,
+      reload: async () => {
+        calls++;
+        return { ok: false, error: "nope" };
+      },
+    });
+    expect(res.ok).toBe(false);
+    expect(calls).toBe(2);
   });
 });

--- a/plugins/input-plumber/lib/wake-trigger.ts
+++ b/plugins/input-plumber/lib/wake-trigger.ts
@@ -563,6 +563,45 @@ export async function reloadPersistedProfile(): Promise<WakeOpResult> {
 const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 /**
+ * Boot reconciliation with retry. `reloadPersistedProfile()` can transiently
+ * fail on a cold boot when InputPlumber is up (so its internal `waitForIp`
+ * passes) but the composite device hasn't been enumerated yet — it returns
+ * "Bound device not connected", and a single-shot reload would drop the wake
+ * binding for the whole session (the button silently reverts to its OS
+ * default). Retrying a few times lets the pad finish enumerating.
+ *
+ * Cheap when nothing is bound: `reloadPersistedProfile()` returns `ok`
+ * immediately, so the loop breaks on the first attempt with no delay.
+ *
+ * `reload` and `wait` are injectable so the retry logic is unit-testable
+ * without real DBus or real multi-second sleeps.
+ */
+export async function reloadPersistedProfileWithRetry(
+  opts: {
+    attempts?: number;
+    delayMs?: number;
+    reload?: () => Promise<WakeOpResult>;
+    wait?: (ms: number) => Promise<void>;
+    onRetry?: (attempt: number, error: string) => void;
+  } = {},
+): Promise<WakeOpResult> {
+  const attempts = Math.max(1, opts.attempts ?? 5);
+  const delayMs = opts.delayMs ?? 2000;
+  const reload = opts.reload ?? reloadPersistedProfile;
+  const wait = opts.wait ?? delay;
+
+  let last: WakeOpResult = { ok: true };
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    last = await reload();
+    if (last.ok) break;
+    opts.onRetry?.(attempt + 1, last.error ?? "unknown");
+    // No sleep after the final attempt — nothing follows it.
+    if (attempt < attempts - 1) await wait(delayMs);
+  }
+  return last;
+}
+
+/**
  * User-triggered recovery: restart the InputPlumber daemon, then re-load the
  * wake profile onto the freshly-recreated composite device.
  *

--- a/plugins/input-plumber/lib/wake-trigger.ts
+++ b/plugins/input-plumber/lib/wake-trigger.ts
@@ -245,6 +245,9 @@ export async function setWakeButton(raw: string): Promise<WakeOpResult> {
   }
 
   await writeWake({ selectedRaw: raw, deviceName: device.name });
+  console.log(
+    `[input-plumber] wake bound + persisted (setWakeButton): raw="${raw}" device="${device.name}"`,
+  );
   return { ok: true };
 }
 
@@ -426,6 +429,9 @@ async function captureWakeButtonInner(timeoutMs: number): Promise<WakeCaptureRes
   }
 
   await writeWake({ selectedRaw: raw, deviceName: device.name });
+  console.log(
+    `[input-plumber] wake bound + persisted (capture): raw="${raw}" device="${device.name}"`,
+  );
   return {
     ok: true,
     capturedRaw: raw,
@@ -490,19 +496,49 @@ export async function clearWakeButton(): Promise<WakeOpResult> {
 export async function reloadPersistedProfile(): Promise<WakeOpResult> {
   if (await isSteamDeck()) return wakeDeck.reloadPersistedProfile();
   const wake = await readWake();
-  if (!wake?.selectedRaw) return { ok: true };
+  if (!wake?.selectedRaw) {
+    // Not an error, but log it: a lost/empty binding here is exactly how the
+    // wake button silently reverts to its OS default after a reboot.
+    console.log(
+      `[input-plumber] wake reload: no persisted binding (${JSON.stringify(wake ?? null)}) — nothing to restore`,
+    );
+    return { ok: true };
+  }
+  console.log(
+    `[input-plumber] wake reload: restoring binding raw="${wake.selectedRaw}" device="${wake.deviceName ?? "?"}"`,
+  );
 
   // The IP service may have just started; give it a window to come up
   // before we conclude it's broken. 15s covers cold boot on slower handhelds.
   if (!(await waitForIp(15_000))) {
+    console.warn(
+      "[input-plumber] wake reload: InputPlumber did not come up within 15s — wake button NOT restored",
+    );
     return { ok: false, error: "InputPlumber did not come up; wake button not reloaded." };
   }
 
   const composites = await listCompositeDevices();
+  console.log(
+    `[input-plumber] wake reload: IP up, ${composites.length} composite device(s): [${composites
+      .map((d) => d.name)
+      .join(", ")}]`,
+  );
   const device = pickDevice(composites, wake.selectedRaw, wake.deviceName);
   if (!device) {
+    console.warn(
+      `[input-plumber] wake reload: bound device not found (wanted name="${wake.deviceName ?? "?"}" / cap="${wake.selectedRaw}") — wake button NOT restored`,
+    );
     return { ok: false, error: "Bound device not connected; wake button not reloaded." };
   }
+  // A capability-string mismatch (e.g. after an InputPlumber update renamed
+  // the button) is a prime suspect for a reload that "succeeds" but doesn't
+  // actually map anything — surface whether the saved cap is still present.
+  const capPresent = device.capabilities.includes(wake.selectedRaw);
+  console.log(
+    `[input-plumber] wake reload: applying to device "${device.name}" (${device.path}); saved cap "${wake.selectedRaw}" ${
+      capPresent ? "present" : "NOT PRESENT in device capabilities"
+    }`,
+  );
 
   // Re-render from the live targets in case the device's emulation changed,
   // then load. (The file may already exist from a prior boot, but re-rendering
@@ -510,9 +546,18 @@ export async function reloadPersistedProfile(): Promise<WakeOpResult> {
   const targets = await getTargetKinds(device.path);
   await writeFileMkdir(PROFILE_PATH, renderProfile(parseCapability(wake.selectedRaw), targets));
   const loaded = await loadProfilePath(device.path, PROFILE_PATH);
-  return loaded.ok
-    ? { ok: true }
-    : { ok: false, error: `LoadProfilePath failed: exit ${loaded.code}` };
+  if (loaded.ok) {
+    console.log(
+      `[input-plumber] wake reload: LoadProfilePath OK — wake button "${wake.selectedRaw}" restored on "${device.name}"`,
+    );
+    return { ok: true };
+  }
+  console.warn(
+    `[input-plumber] wake reload: LoadProfilePath FAILED (exit ${loaded.code}${
+      loaded.stderr ? `: ${loaded.stderr.trim()}` : ""
+    })`,
+  );
+  return { ok: false, error: `LoadProfilePath failed: exit ${loaded.code}` };
 }
 
 const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));


### PR DESCRIPTION
## Problem

The overlay wake button — a physical button bound through InputPlumber (e.g. the handheld's **Keyboard button** → F16) — is re-applied on every boot by `reloadPersistedProfile()`. When that reload fails, the button silently reverts to its OS default (opening the on-screen keyboard), and there were almost **no diagnostics** to explain why:

- `reloadPersistedProfile()` had no internal logging.
- `onLoad` only logged on failure, and did a single attempt.

Two real failure modes hit this:
1. **Stale saved capability after an InputPlumber update** (observed: SteamOS 3.9 / build 20260630 bumped IP to 0.77.7). The old saved capability string no longer matched the device, so the reload restored nothing. Re-capturing the button fixes it — but that's invisible without logs.
2. **Cold-boot race**: IP is up (so the internal `waitForIp` passes) but the composite device isn't enumerated yet → `reloadPersistedProfile()` returns "Bound device not connected" and the binding is dropped for the whole session.

## Changes

- **Logging** in `reloadPersistedProfile()` (non-Deck path): binding read, IP-up + device list, whether the saved capability is still **present** in the device's capabilities (catches post-update renames), and the `LoadProfilePath` result. Also log when a binding is persisted at bind time.
- **Retry** in `onLoad`: reload is retried up to 5× (2s apart), mirroring the existing `restartInputPlumber()` retry, so the cold-boot enumeration race can't silently drop the binding. No-op when nothing is bound (early `ok` return).

## Diagnose

```
journalctl -u loadout.service -b --no-pager | grep "wake reload"
```

## Verification

Built and installed on a OneXPlayer APEX (non-Deck). A real cold reboot logs the full happy path and restores the binding:

```
wake reload: restoring binding raw="Gamepad:Button:Keyboard" device="ONEXPLAYER APEX"
wake reload: IP up, 1 composite device(s): [ONEXPLAYER APEX]
wake reload: applying to device "ONEXPLAYER APEX" … saved cap "Gamepad:Button:Keyboard" present
wake reload: LoadProfilePath OK — wake button "Gamepad:Button:Keyboard" restored
```

Typecheck clean; input-plumber lib tests pass (67). The `app.spec.tsx` render tests were already failing on `main` (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)