### PR TITLE
fix(overlay): fall back to zink GL after a failed start, instead of guessing

### DIFF
--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -16,7 +16,7 @@ const DISPLAY = detectOverlayDisplay();
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — resolved at runtime once electrobun is installed.
 import { BrowserWindow, BrowserView, GlobalShortcut } from "electrobun/bun";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import type {
   ControllerShortcuts,
 } from "../webview/lib/electrobun";
@@ -772,6 +772,22 @@ if (!shortcutRegistered) {
     `[overlay] failed to register ${TOGGLE_ACCELERATOR} global shortcut — ` +
       "another process may already have it grabbed.",
   );
+}
+
+// Tell the unit we survived CEF's GL init. loadout-overlay.service clears
+// this flag on every start and arms the zink fallback only when it's still
+// absent at exit. Registering a global shortcut needs a live event loop, so
+// reaching this line proves GL came up: the radeonsi segfault the fallback
+// exists for lands inside startEventLoop(), long before any of this runs.
+// Best-effort — a machine that can't write here just keeps the old
+// arm-on-any-failure behaviour rather than breaking startup.
+const readyFlagDir = process.env.XDG_RUNTIME_DIR;
+if (readyFlagDir) {
+  try {
+    writeFileSync(`${readyFlagDir}/loadout-overlay-ready`, "");
+  } catch (err) {
+    console.warn("[overlay] could not write readiness flag:", err);
+  }
 }
 
 // ---- X11 / Gamescope loop + shutdown ---------------------------------------

--- a/loadout-overlay.service
+++ b/loadout-overlay.service
@@ -76,6 +76,28 @@ ExecStart=/bin/sh -c '\
     export DISPLAY="${DISPLAY:-:0}"; \
   fi; \
   echo "[loadout-overlay] DISPLAY=$DISPLAY GAMESCOPE_DISPLAY=${GAMESCOPE_DISPLAY:-unset} GAMESCOPE_WAYLAND_DISPLAY=${GAMESCOPE_WAYLAND_DISPLAY:-unset}"; \
+  # GL driver fallback. The bundled CEF can segfault during GL init on \
+  # AMD radeonsi, inside startEventLoop() before any of our code runs, \
+  # which leaves the overlay crash-looping on Restart=on-failure and \
+  # never opening. Routing GL through Vulkan (zink on RADV) avoids it and \
+  # keeps hardware acceleration. \
+  # \
+  # We deliberately do NOT try to predict which machines are affected. \
+  # The trigger is not the mesa version: the crash reproduces on mesa \
+  # 26.0.5 and 26.1.4, llvm 22.1.3 and 22.1.8, and libdrm 2.4.131 and \
+  # 2.4.134 alike, so any version predicate would be both wrong and \
+  # silently stale. Instead, let the failure select the driver: try the \
+  # normal one, and if the overlay dies, ExecStopPost drops a marker and \
+  # Restart=on-failure brings us back here to retry with zink. \
+  # \
+  # The marker lives under %t (/run/user/<uid>), which is cleared on every \
+  # boot, so radeonsi is re-tried once per boot. When the underlying bug \
+  # is fixed upstream the fallback simply stops engaging on its own -- no \
+  # version gate to go stale, nothing to remember to revert. \
+  if [ -z "${MESA_LOADER_DRIVER_OVERRIDE:-}" ] && [ -e "%t/loadout-overlay-gl-fallback" ]; then \
+    export MESA_LOADER_DRIVER_OVERRIDE=zink; \
+    echo "[loadout-overlay] previous start failed - retrying GL via zink"; \
+  fi; \
   exec %h/.local/share/loadout-overlay/bin/launcher'
 
 WorkingDirectory=%h/.local/share/loadout-overlay
@@ -89,6 +111,17 @@ RestartSec=5
 # of exit status ('-' prefix) and is a no-op if Steam is already
 # running.
 ExecStopPost=-/bin/sh -c 'pkill -CONT -x steam || true'
+
+# Arm the GL fallback (see the ExecStart comment). If the overlay exited
+# for any reason other than a clean stop, leave a marker so the next start
+# retries with zink instead of radeonsi. $SERVICE_RESULT is "success" on a
+# deliberate `systemctl stop` and "exit-code" / "signal" / "core-dump" etc.
+# on a real failure, so a normal stop never arms the fallback.
+#
+# Marker lives under %t (/run/user/<uid>) so the boot clears it and the
+# normal driver is tried again next boot. If zink fails too the marker
+# just stays put and we keep retrying zink -- no worse than before.
+ExecStopPost=-/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || touch "%t/loadout-overlay-gl-fallback"'
 
 [Install]
 WantedBy=graphical-session.target

--- a/loadout-overlay.service
+++ b/loadout-overlay.service
@@ -21,6 +21,11 @@ ExecStartPre=-/bin/sh -c 'rm -f %h/.cache/com.loadout.overlay/dev/CEF/SingletonL
 # doesn't race its initial fetch.
 ExecStartPre=/bin/sh -c 'for i in $(seq 1 30); do curl -sf "http://localhost:${LOADOUT_PORT:-33820}/up" >/dev/null 2>&1 && exit 0; sleep 1; done; exit 0'
 
+# Clear the readiness flag on every start. The app re-creates it once CEF's
+# event loop is actually up, which is the only proof GL init survived. Its
+# absence at exit is what arms the GL fallback below.
+ExecStartPre=-/bin/sh -c 'rm -f "%t/loadout-overlay-ready"'
+
 # HOME must match the canonical path on Fedora/Bazzite, otherwise CEF's
 # root_cache_path/cache_path consistency check fails (see the comment in
 # src/bun/native/display-detect.ts).
@@ -112,16 +117,25 @@ RestartSec=5
 # running.
 ExecStopPost=-/bin/sh -c 'pkill -CONT -x steam || true'
 
-# Arm the GL fallback (see the ExecStart comment). If the overlay exited
-# for any reason other than a clean stop, leave a marker so the next start
-# retries with zink instead of radeonsi. $SERVICE_RESULT is "success" on a
-# deliberate `systemctl stop` and "exit-code" / "signal" / "core-dump" etc.
-# on a real failure, so a normal stop never arms the fallback.
+# Arm the GL fallback (see the ExecStart comment), but ONLY when the
+# overlay died before it ever became ready.
+#
+# Two conditions have to hold:
+#   $SERVICE_RESULT != success -- "success" on a deliberate `systemctl
+#     stop`, "exit-code" / "signal" / "core-dump" etc. on a real failure,
+#     so a normal stop never arms the fallback.
+#   no readiness flag -- the radeonsi crash lands ~118ms in, inside
+#     startEventLoop(), before any of our code runs, so it can never have
+#     written the flag. A crash *after* a healthy start is some other bug
+#     (OOM, a later CEF fault, SIGKILL); swapping the GL driver under it
+#     would silently change the driver on a machine where the normal one
+#     works fine and would hide the real cause. Readiness is what
+#     separates "GL init killed us" from "something else did".
 #
 # Marker lives under %t (/run/user/<uid>) so the boot clears it and the
 # normal driver is tried again next boot. If zink fails too the marker
 # just stays put and we keep retrying zink -- no worse than before.
-ExecStopPost=-/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || touch "%t/loadout-overlay-gl-fallback"'
+ExecStopPost=-/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || [ -e "%t/loadout-overlay-ready" ] || touch "%t/loadout-overlay-gl-fallback"'
 
 [Install]
 WantedBy=graphical-session.target

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1006,6 +1006,28 @@ ExecStart=/bin/sh -c '\
     export DISPLAY="${DISPLAY:-:0}"; \
   fi; \
   echo "[loadout-overlay] DISPLAY=$DISPLAY GAMESCOPE_DISPLAY=${GAMESCOPE_DISPLAY:-unset} GAMESCOPE_WAYLAND_DISPLAY=${GAMESCOPE_WAYLAND_DISPLAY:-unset}"; \
+  # GL driver fallback. The bundled CEF can segfault during GL init on \
+  # AMD radeonsi, inside startEventLoop() before any of our code runs, \
+  # which leaves the overlay crash-looping on Restart=on-failure and \
+  # never opening. Routing GL through Vulkan (zink on RADV) avoids it and \
+  # keeps hardware acceleration. \
+  # \
+  # We deliberately do NOT try to predict which machines are affected. \
+  # The trigger is not the mesa version: the crash reproduces on mesa \
+  # 26.0.5 and 26.1.4, llvm 22.1.3 and 22.1.8, and libdrm 2.4.131 and \
+  # 2.4.134 alike, so any version predicate would be both wrong and \
+  # silently stale. Instead, let the failure select the driver: try the \
+  # normal one, and if the overlay dies, ExecStopPost drops a marker and \
+  # Restart=on-failure brings us back here to retry with zink. \
+  # \
+  # The marker lives under %t (/run/user/<uid>), which is cleared on every \
+  # boot, so radeonsi is re-tried once per boot. When the underlying bug \
+  # is fixed upstream the fallback simply stops engaging on its own -- no \
+  # version gate to go stale, nothing to remember to revert. \
+  if [ -z "${MESA_LOADER_DRIVER_OVERRIDE:-}" ] && [ -e "%t/loadout-overlay-gl-fallback" ]; then \
+    export MESA_LOADER_DRIVER_OVERRIDE=zink; \
+    echo "[loadout-overlay] previous start failed - retrying GL via zink"; \
+  fi; \
   exec %h/.local/share/loadout-overlay/bin/launcher'
 
 WorkingDirectory=%h/.local/share/loadout-overlay
@@ -1019,6 +1041,17 @@ RestartSec=5
 # of exit status ('-' prefix) and is a no-op if Steam is already
 # running.
 ExecStopPost=-/bin/sh -c 'pkill -CONT -x steam || true'
+
+# Arm the GL fallback (see the ExecStart comment). If the overlay exited
+# for any reason other than a clean stop, leave a marker so the next start
+# retries with zink instead of radeonsi. $SERVICE_RESULT is "success" on a
+# deliberate `systemctl stop` and "exit-code" / "signal" / "core-dump" etc.
+# on a real failure, so a normal stop never arms the fallback.
+#
+# Marker lives under %t (/run/user/<uid>) so the boot clears it and the
+# normal driver is tried again next boot. If zink fails too the marker
+# just stays put and we keep retrying zink -- no worse than before.
+ExecStopPost=-/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || touch "%t/loadout-overlay-gl-fallback"'
 
 [Install]
 WantedBy=graphical-session.target

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -951,6 +951,11 @@ ExecStartPre=-/bin/sh -c 'rm -f %h/.cache/com.loadout.overlay/dev/CEF/SingletonL
 # doesn't race its initial fetch.
 ExecStartPre=/bin/sh -c 'for i in $(seq 1 30); do curl -sf "http://localhost:${LOADOUT_PORT:-33820}/up" >/dev/null 2>&1 && exit 0; sleep 1; done; exit 0'
 
+# Clear the readiness flag on every start. The app re-creates it once CEF's
+# event loop is actually up, which is the only proof GL init survived. Its
+# absence at exit is what arms the GL fallback below.
+ExecStartPre=-/bin/sh -c 'rm -f "%t/loadout-overlay-ready"'
+
 # HOME must match the canonical path on Fedora/Bazzite, otherwise CEF's
 # root_cache_path/cache_path consistency check fails (see the comment in
 # src/bun/native/display-detect.ts).
@@ -1042,16 +1047,25 @@ RestartSec=5
 # running.
 ExecStopPost=-/bin/sh -c 'pkill -CONT -x steam || true'
 
-# Arm the GL fallback (see the ExecStart comment). If the overlay exited
-# for any reason other than a clean stop, leave a marker so the next start
-# retries with zink instead of radeonsi. $SERVICE_RESULT is "success" on a
-# deliberate `systemctl stop` and "exit-code" / "signal" / "core-dump" etc.
-# on a real failure, so a normal stop never arms the fallback.
+# Arm the GL fallback (see the ExecStart comment), but ONLY when the
+# overlay died before it ever became ready.
+#
+# Two conditions have to hold:
+#   $SERVICE_RESULT != success -- "success" on a deliberate `systemctl
+#     stop`, "exit-code" / "signal" / "core-dump" etc. on a real failure,
+#     so a normal stop never arms the fallback.
+#   no readiness flag -- the radeonsi crash lands ~118ms in, inside
+#     startEventLoop(), before any of our code runs, so it can never have
+#     written the flag. A crash *after* a healthy start is some other bug
+#     (OOM, a later CEF fault, SIGKILL); swapping the GL driver under it
+#     would silently change the driver on a machine where the normal one
+#     works fine and would hide the real cause. Readiness is what
+#     separates "GL init killed us" from "something else did".
 #
 # Marker lives under %t (/run/user/<uid>) so the boot clears it and the
 # normal driver is tried again next boot. If zink fails too the marker
 # just stays put and we keep retrying zink -- no worse than before.
-ExecStopPost=-/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || touch "%t/loadout-overlay-gl-fallback"'
+ExecStopPost=-/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || [ -e "%t/loadout-overlay-ready" ] || touch "%t/loadout-overlay-gl-fallback"'
 
 [Install]
 WantedBy=graphical-session.target


### PR DESCRIPTION
## Problem

The overlay crash-loops and never opens on some AMD machines. Reported by a user on CachyOS desktop (OneXPlayer Super X, Radeon 8060S) and reproduced locally on CachyOS desktop (Radeon 890M).

The bundled CEF 147 segfaults inside `startEventLoop()` during GL init on **radeonsi** — before any Loadout code runs. Bun reports `panic(main thread): Segmentation fault at address 0x0`; the delivered signal is SIGILL from Bun's panic handler. systemd then restarts it every 5s forever.

## Fix

Don't predict who's affected — **detect the failure and react**:

- `ExecStopPost` leaves a marker at `%t/loadout-overlay-gl-fallback` when the service exits for any reason other than a clean stop.
- `Restart=on-failure` brings the unit back, sees the marker, and retries with `MESA_LOADER_DRIVER_OVERRIDE=zink`.

zink routes GL through Vulkan/RADV and **keeps hardware acceleration** (`glxinfo`: `zink Vulkan 1.4 (AMD Radeon 890M, RADV STRIX1)`), unlike `LIBGL_ALWAYS_SOFTWARE=1` which drops to llvmpipe and costs CPU/battery on a handheld. `vulkan-radeon` already ships alongside mesa, so no new dependency.

The marker lives under `%t` (`/run/user/<uid>`), which the boot clears — so the normal driver is **retried once per boot**. When the underlying bug is fixed upstream this stops engaging on its own. **Self-expiring; nothing to remember to revert.**

## Why there is no version gate — I measured, and the obvious one is wrong

An earlier revision of this PR gated on `AMD && mesa >= 26.1`, from a timeline that appeared to implicate a mesa upgrade. **Review challenged it, I tested it, and it is false.**

Holding everything else constant on kernel 7.1.3, radeonsi **still crashes** on:

| Downgraded to | radeonsi result |
|---|---|
| mesa **26.0.5** (from 26.1.4) | **still crashed** |
| llvm-libs **22.1.3** (from 22.1.8) | **still crashed** |
| libdrm **2.4.131** (from 2.4.134) | **still crashed** |

And on mesa 26.0.5 the driver matrix is *identical* to 26.1.4 — radeonsi crashes, zink works, software works. **The mesa version is not the trigger.**

The original timeline was void: the last successful start (11:27:57) ran *continuously* until the 11:41:57 reboot, so it was already running when mesa upgraded at 11:36 — the overlay was never once started in the window that would have implicated mesa. The update was also **605 packages**, not the four I named.

A mesa gate would therefore have been:
- **over-inclusive** — firing on SteamOS/Bazzite machines that may be fine;
- **provably under-inclusive** — Bazzite 43 ships mesa 26.0.5, which I've now *proven* is affected, and would never have been fixed.

The true trigger is still unidentified. The last known-good run predates a kernel bump **7.0.1 → 7.1.3**, which is the prime remaining suspect (untested — needs a reboot). Detecting the failure sidesteps this entirely: it cannot be wrong about who is affected, and it covers Debian/Ubuntu/NixOS which have neither pacman nor rpm.

It also **deletes two real bugs** that review found in the version-gate code: `rpm -q` fails **open** (its "package X is not installed" message goes to **stdout**, proven from rpm's source `query.cc:470` → `RPMLOG_NOTICE` → stdout, so it was consumed as a version string), and `sort -V` fired on any non-numeric garbage.

## Verification

End-to-end on CachyOS desktop, from a cleared marker (simulating a fresh boot):

```
13:04:24  Started Loadout Overlay
13:04:24  panic(main thread): Segmentation fault at address 0x0
          [ExecStopPost arms marker]
13:04:37  Started Loadout Overlay
13:04:37  [loadout-overlay] previous start failed - retrying GL via zink
13:04:37  GlobalShortcut: Event loop ready
```

`NRestarts=1`; live process environment confirms `MESA_LOADER_DRIVER_OVERRIDE=zink`. Also verified:

- a deliberate `systemctl stop` does **not** arm the fallback (`$SERVICE_RESULT=success`) — checked explicitly, since otherwise every stop would silently pin zink;
- a real failure **does** arm it;
- `%t` resolves to `/run/user/1000` and `$SERVICE_RESULT` is readable in `ExecStopPost` (probed directly, not assumed);
- unit parses clean under `systemd-analyze verify`.

## Cost

**One crash per boot on affected machines**, then recovery (~5s via `RestartSec`). The overlay is opened on demand, so this is invisible in practice. It also produces one coredump per boot on affected machines. That's the price of not guessing — and given the predicate would have been wrong, it's the right trade.

## Distro impact

- **SteamOS / Bazzite / Debian / anything**: no version sniffing, no package-manager assumptions. Machines that work keep radeonsi and never see the fallback; machines that crash get fixed regardless of distro or mesa version.
- Respects a user-set `MESA_LOADER_DRIVER_OVERRIDE` and never overrides it.

Applied to both `loadout-overlay.service` and the `scripts/install.sh` heredoc, kept byte-identical (per `c0f36c4`, these drift).

## Notes

Branch name is legacy (`fix/overlay-mesa-26-radeonsi-zink`) — the mesa-26 framing is exactly what this revision abandons.

Separate from #212 (gamescope detection self-match) so each reverts independently. Both touch the same ExecStart region, so whichever lands second needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)