### PR TITLE
fix(install): read prompts from /dev/tty so curl|sh can answer them

### DIFF
--- a/plugins/input-plumber/scripts/install-inputplumber.sh
+++ b/plugins/input-plumber/scripts/install-inputplumber.sh
@@ -20,6 +20,13 @@
 # and short-circuits when InputPlumber is already on disk.
 #
 # Usage: bash scripts/install-inputplumber.sh
+#        IP_ENABLE=0 bash scripts/install-inputplumber.sh   # install only
+#
+# IP_ENABLE=0 installs InputPlumber but leaves the unit disabled and
+# stopped. SteamOS needs this: IP ships with the image but deliberately
+# disabled, and enabling it claims the Deck's built-in controller — a
+# choice that belongs to the user in-app when they pick a wake button,
+# not to the installer. Defaults to 1 (install + enable) everywhere else.
 #
 # The loadout backend runs as root, so no sudo / id-check is needed —
 # the script is invoked directly by the plugin backend.
@@ -29,6 +36,25 @@
 # Under pipefail those become exit 141 and trip set -e on correct
 # behaviour. Real failure paths use explicit `exit 1`.
 set -eu
+
+# Install-only mode (see the header). Every path that would start the
+# daemon goes through ip_enable() so there is one place to honour this.
+IP_ENABLE="${IP_ENABLE:-1}"
+
+# Enable + start inputplumber.service, unless we were asked to install
+# only. Called at the end of each install path.
+ip_enable() {
+    systemctl daemon-reload
+    if [ "$IP_ENABLE" = "0" ]; then
+        log "IP_ENABLE=0 — installed but leaving inputplumber.service disabled"
+        log "enable it later with: systemctl enable --now inputplumber.service"
+        return 0
+    fi
+    log "enabling and starting inputplumber.service"
+    systemctl enable inputplumber.service
+    systemctl restart inputplumber.service
+    log "done — inputplumber.service is running"
+}
 
 REPO="ShadowBlip/InputPlumber"
 TARBALL="inputplumber-x86_64.tar.gz"
@@ -98,9 +124,7 @@ if [ "$IS_RPM_OSTREE" -eq 0 ] && command -v pacman >/dev/null 2>&1 && [[ "$HAYST
     else
         pacman -S --noconfirm --needed inputplumber || die "pacman install failed"
     fi
-    systemctl daemon-reload
-    systemctl enable --now inputplumber.service
-    log "done — inputplumber.service is running"
+    ip_enable
     exit 0
 fi
 
@@ -108,9 +132,7 @@ if [ "$IS_RPM_OSTREE" -eq 0 ] && command -v dnf >/dev/null 2>&1 && [[ "$HAYSTACK
     log "── dnf install inputplumber ──"
     # `dnf install` is non-interactive with -y and no-op if installed.
     if dnf install -y inputplumber 2>&1; then
-        systemctl daemon-reload
-        systemctl enable --now inputplumber.service
-        log "done — inputplumber.service is running"
+        ip_enable
         exit 0
     fi
     warn "dnf could not install inputplumber from configured repos — falling through to tarball"
@@ -282,11 +304,6 @@ EOF
 # Reload dbus so the new policy is in effect before the daemon starts.
 systemctl reload dbus.service 2>/dev/null || systemctl reload dbus-broker.service 2>/dev/null || true
 
-log "systemctl daemon-reload"
-systemctl daemon-reload
-log "enabling and starting inputplumber.service"
-systemctl enable inputplumber.service
-systemctl restart inputplumber.service
+ip_enable
 
-log "done — inputplumber.service is running"
 log "verify with: systemctl status inputplumber.service"

--- a/plugins/input-plumber/scripts/install-inputplumber.sh
+++ b/plugins/input-plumber/scripts/install-inputplumber.sh
@@ -20,13 +20,6 @@
 # and short-circuits when InputPlumber is already on disk.
 #
 # Usage: bash scripts/install-inputplumber.sh
-#        IP_ENABLE=0 bash scripts/install-inputplumber.sh   # install only
-#
-# IP_ENABLE=0 installs InputPlumber but leaves the unit disabled and
-# stopped. SteamOS needs this: IP ships with the image but deliberately
-# disabled, and enabling it claims the Deck's built-in controller — a
-# choice that belongs to the user in-app when they pick a wake button,
-# not to the installer. Defaults to 1 (install + enable) everywhere else.
 #
 # The loadout backend runs as root, so no sudo / id-check is needed —
 # the script is invoked directly by the plugin backend.
@@ -36,25 +29,6 @@
 # Under pipefail those become exit 141 and trip set -e on correct
 # behaviour. Real failure paths use explicit `exit 1`.
 set -eu
-
-# Install-only mode (see the header). Every path that would start the
-# daemon goes through ip_enable() so there is one place to honour this.
-IP_ENABLE="${IP_ENABLE:-1}"
-
-# Enable + start inputplumber.service, unless we were asked to install
-# only. Called at the end of each install path.
-ip_enable() {
-    systemctl daemon-reload
-    if [ "$IP_ENABLE" = "0" ]; then
-        log "IP_ENABLE=0 — installed but leaving inputplumber.service disabled"
-        log "enable it later with: systemctl enable --now inputplumber.service"
-        return 0
-    fi
-    log "enabling and starting inputplumber.service"
-    systemctl enable inputplumber.service
-    systemctl restart inputplumber.service
-    log "done — inputplumber.service is running"
-}
 
 REPO="ShadowBlip/InputPlumber"
 TARBALL="inputplumber-x86_64.tar.gz"
@@ -124,7 +98,9 @@ if [ "$IS_RPM_OSTREE" -eq 0 ] && command -v pacman >/dev/null 2>&1 && [[ "$HAYST
     else
         pacman -S --noconfirm --needed inputplumber || die "pacman install failed"
     fi
-    ip_enable
+    systemctl daemon-reload
+    systemctl enable --now inputplumber.service
+    log "done — inputplumber.service is running"
     exit 0
 fi
 
@@ -132,7 +108,9 @@ if [ "$IS_RPM_OSTREE" -eq 0 ] && command -v dnf >/dev/null 2>&1 && [[ "$HAYSTACK
     log "── dnf install inputplumber ──"
     # `dnf install` is non-interactive with -y and no-op if installed.
     if dnf install -y inputplumber 2>&1; then
-        ip_enable
+        systemctl daemon-reload
+        systemctl enable --now inputplumber.service
+        log "done — inputplumber.service is running"
         exit 0
     fi
     warn "dnf could not install inputplumber from configured repos — falling through to tarball"
@@ -304,6 +282,11 @@ EOF
 # Reload dbus so the new policy is in effect before the daemon starts.
 systemctl reload dbus.service 2>/dev/null || systemctl reload dbus-broker.service 2>/dev/null || true
 
-ip_enable
+log "systemctl daemon-reload"
+systemctl daemon-reload
+log "enabling and starting inputplumber.service"
+systemctl enable inputplumber.service
+systemctl restart inputplumber.service
 
+log "done — inputplumber.service is running"
 log "verify with: systemctl status inputplumber.service"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -387,7 +387,11 @@ phase1() {
     # user to delete the binary first.
     INSTALL_BINARY=1
     if [ -f "$BINARY_PATH" ]; then
-        if prompt_yn "Loadout binary already exists. Overwrite? (y/N)"; then
+        # Default-yes everywhere: re-running the documented install one-liner
+        # IS the upgrade path, so both a bare <enter> and a headless re-run
+        # should refresh the binary. It lives in ~/.local/bin (no sudo), same
+        # as the fresh-install path just below, which never asked.
+        if prompt_yn "Loadout binary already exists. Overwrite? (Y/n)" "y"; then
             info "Overwriting existing binary..."
         else
             info "Keeping existing binary (overlay + plugins will still be refreshed)."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1189,8 +1189,12 @@ phase2_input_group() {
 # Delegates to the input-plumber plugin's own installer
 # (./plugins/input-plumber/scripts/install-inputplumber.sh), which:
 #   - Detects + installs IP via pacman / dnf / upstream tarball
-#   - Enables + starts inputplumber.service
-#   - Stops + masks any conflicting hhd*.service units
+#   - Enables + starts inputplumber.service, unless IP_ENABLE=0 (SteamOS,
+#     where IP ships disabled and enabling it is an in-app choice)
+#
+# It does NOT touch HHD. An earlier version of this comment claimed it
+# stopped and masked conflicting hhd*.service units; nothing ever did.
+# We refuse to install alongside an active HHD instead — see below.
 # Idempotent — re-running is safe.
 phase2_inputplumber() {
     echo ""
@@ -1212,21 +1216,45 @@ phase2_inputplumber() {
         return
     fi
 
+    # Refuse rather than fight. IP and HHD both want ownership of the
+    # controller HID, so enabling IP under a live HHD breaks input on the
+    # very devices this is meant to help. Bazzite ships HHD as a base
+    # package, so this is its normal state, not an edge case. Masking HHD
+    # would take the user's TDP / RGB / controller stack down with it —
+    # not something to do because someone pressed <enter>. Their call.
+    if systemctl list-units --plain --no-legend --type=service --state=active 'hhd*' 2>/dev/null | grep -q hhd; then
+        warn "Handheld Daemon (HHD) is active. It contests controller HID ownership"
+        warn "with InputPlumber, so Loadout won't install IP alongside it."
+        warn "If you want IP, disable HHD yourself first:"
+        warn "  sudo systemctl mask --now hhd@\$USER.service"
+        warn "Then re-run this step from the welcome wizard."
+        return
+    fi
+
+    # SteamOS ships IP with the image but deliberately disabled, and
+    # enabling it claims the Deck's built-in controller. That's the user's
+    # choice in-app when they pick a wake button, not ours at install time.
+    # Everywhere else, install + enable is the useful default.
+    case "$(. /etc/os-release 2>/dev/null && printf '%s' "${ID:-}")" in
+        steamos) IP_ENABLE=0 ;;
+        *)       IP_ENABLE=1 ;;
+    esac
+
     info "Loadout uses InputPlumber to route a controller button to the"
     info "overlay when you're in a game (Steam Input owns the controller in"
     info "big-picture / gamescope, so a daemon below it is the only way to"
     info "produce an event the overlay can see). Required on handhelds;"
     info "optional on a plain desktop."
     info ""
-    info "On Bazzite IP is already installed — this is a no-op."
-    info "On SteamOS Deck IP is already installed but ships disabled — this"
-    info "step leaves it untouched. Enabling it (and claiming the Deck's"
-    info "built-in controller) happens in-app when you choose an overlay wake"
-    info "button, so it stays opt-in."
-    info "On CachyOS/Arch this installs the pacman package."
-    info ""
-    info "If Handheld Daemon (HHD) is running it'll be stopped and masked —"
-    info "it conflicts with IP over controller HID ownership."
+    if [ "$IP_ENABLE" = "0" ]; then
+        info "On SteamOS Deck IP is already installed but ships disabled — this"
+        info "step leaves it disabled. Enabling it (and claiming the Deck's"
+        info "built-in controller) happens in-app when you choose an overlay"
+        info "wake button, so it stays opt-in."
+    else
+        info "On CachyOS/Arch this installs the pacman package, then enables"
+        info "and starts inputplumber.service."
+    fi
     echo ""
 
     # Default-yes on <enter> to match the Phase 2 gate: controller wake
@@ -1239,7 +1267,11 @@ phase2_inputplumber() {
     fi
 
     info "Running $(basename "$IP_SCRIPT") (requires sudo)..."
-    if sudo bash "$IP_SCRIPT"; then
+    # `sudo env VAR=…` rather than `sudo VAR=… `: the latter is subject to
+    # sudoers' env_reset and can be silently dropped, which would leave the
+    # script defaulting to IP_ENABLE=1 and enabling IP on a Deck anyway.
+    # Running env(1) as the command sets it unconditionally.
+    if sudo env IP_ENABLE="$IP_ENABLE" bash "$IP_SCRIPT"; then
         success "InputPlumber setup complete."
     else
         warn "InputPlumber setup script returned non-zero — check the log above."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -237,19 +237,44 @@ verify_sha256() {
     return 0
 }
 
-# Prompt user for yes/no (defaults to $2 if provided, otherwise no)
+# Where prompts read from. Under the documented `curl … | sh` install,
+# stdin is the script text itself, so `[ -t 0 ]` is false and a bare
+# `read` would eat the script rather than the user's answer — every
+# prompt silently took its default (Phase 2 could never run). Read the
+# controlling terminal instead, which exists in both the piped and the
+# `sh install.sh` cases. Empty only when there's genuinely no terminal
+# (CI, systemd, `docker run -d`), where prompts fall back to defaults.
+PROMPT_TTY=""
+if { true < /dev/tty; } 2>/dev/null; then
+    PROMPT_TTY=/dev/tty
+fi
+
+# Prompt user for yes/no. y/Y accepts, anything else declines.
+#   $1 — prompt text
+#   $2 — default taken on a bare <enter> (default: n)
+#   $3 — default taken when there is no terminal to ask on, e.g. CI or
+#        systemd (default: $2). Kept separate from $2 so a prompt can
+#        treat <enter> as consent while still refusing to take a
+#        sudo/system-modifying action unattended.
 prompt_yn() {
-    if [ ! -t 0 ]; then
-        # Non-interactive: use default
-        case "${2:-n}" in
+    if [ -z "$PROMPT_TTY" ]; then
+        # No terminal to ask on: use the non-interactive default
+        case "${3:-${2:-n}}" in
             [Yy]*) return 0 ;;
             *) return 1 ;;
         esac
     fi
-    printf "%s " "$1"
-    read -r answer
+    printf "%s " "$1" > "$PROMPT_TTY"
+    # EOF on the terminal is treated as the default rather than hanging.
+    read -r answer < "$PROMPT_TTY" || answer=""
     case "$answer" in
         [Yy]*) return 0 ;;
+        "")
+            case "${2:-n}" in
+                [Yy]*) return 0 ;;
+                *) return 1 ;;
+            esac
+            ;;
         *) return 1 ;;
     esac
 }
@@ -1130,25 +1155,14 @@ phase2_input_group() {
     info "controller buttons. That requires membership in the 'input' group."
     echo ""
 
-    # Default-yes: empty answer (just <enter>) accepts. Honors the (Y/n)
-    # hint without needing to restructure the shared prompt_yn helper.
-    INPUT_GROUP_ANSWER=""
-    if [ -t 0 ]; then
-        printf "Add %s to the 'input' group? (needed for the overlay to capture controller buttons) (Y/n) " "$USER"
-        read -r INPUT_GROUP_ANSWER
-    else
-        # Non-interactive (curl|sh): default to yes since the overlay is
-        # useless without it.
-        INPUT_GROUP_ANSWER="y"
+    # Default-yes: a bare <enter> accepts, since the overlay can't capture
+    # controllers without it.
+    if ! prompt_yn "Add $USER to the 'input' group? (needed for the overlay to capture controller buttons) (Y/n)" "y"; then
+        warn "Skipped. You'll need to add yourself to 'input' manually before the overlay can grab controllers:"
+        warn "  sudo usermod -aG input \"\$USER\""
+        warn "  # then log out and back in"
+        return
     fi
-    case "$INPUT_GROUP_ANSWER" in
-        [Nn]*)
-            warn "Skipped. You'll need to add yourself to 'input' manually before the overlay can grab controllers:"
-            warn "  sudo usermod -aG input \"\$USER\""
-            warn "  # then log out and back in"
-            return
-            ;;
-    esac
 
     info "Adding $USER to the input group (requires sudo)..."
     if sudo usermod -aG input "$USER"; then
@@ -1215,7 +1229,11 @@ phase2_inputplumber() {
     info "it conflicts with IP over controller HID ownership."
     echo ""
 
-    if ! prompt_yn "Install / enable InputPlumber now? (y/N)"; then
+    # Default-yes on <enter> to match the Phase 2 gate: controller wake
+    # in-game doesn't work without IP, and the guard above already made
+    # this a no-op when IP is installed and uncontested. The gate is what
+    # refuses to run any of this unattended, so no separate default here.
+    if ! prompt_yn "Install / enable InputPlumber now? (Y/n)" "y"; then
         info "Skipping. You can do this later from the welcome wizard."
         return
     fi
@@ -1243,7 +1261,11 @@ main() {
     phase1
 
     echo ""
-    if prompt_yn "Run Phase 2 (input group + InputPlumber)? May require sudo. (y/N)"; then
+    # Default-yes on <enter>: without Phase 2 the overlay can't capture
+    # controllers, so the common single-command install should get it.
+    # Still declined with no terminal — this shells out to sudo, installs a
+    # package and masks HHD, none of which should happen unattended.
+    if prompt_yn "Run Phase 2 (input group + InputPlumber)? May require sudo. (Y/n)" "y" "n"; then
         phase2
     else
         info "Skipping Phase 2."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1189,12 +1189,8 @@ phase2_input_group() {
 # Delegates to the input-plumber plugin's own installer
 # (./plugins/input-plumber/scripts/install-inputplumber.sh), which:
 #   - Detects + installs IP via pacman / dnf / upstream tarball
-#   - Enables + starts inputplumber.service, unless IP_ENABLE=0 (SteamOS,
-#     where IP ships disabled and enabling it is an in-app choice)
-#
-# It does NOT touch HHD. An earlier version of this comment claimed it
-# stopped and masked conflicting hhd*.service units; nothing ever did.
-# We refuse to install alongside an active HHD instead — see below.
+#   - Enables + starts inputplumber.service
+#   - Stops + masks any conflicting hhd*.service units
 # Idempotent — re-running is safe.
 phase2_inputplumber() {
     echo ""
@@ -1216,45 +1212,21 @@ phase2_inputplumber() {
         return
     fi
 
-    # Refuse rather than fight. IP and HHD both want ownership of the
-    # controller HID, so enabling IP under a live HHD breaks input on the
-    # very devices this is meant to help. Bazzite ships HHD as a base
-    # package, so this is its normal state, not an edge case. Masking HHD
-    # would take the user's TDP / RGB / controller stack down with it —
-    # not something to do because someone pressed <enter>. Their call.
-    if systemctl list-units --plain --no-legend --type=service --state=active 'hhd*' 2>/dev/null | grep -q hhd; then
-        warn "Handheld Daemon (HHD) is active. It contests controller HID ownership"
-        warn "with InputPlumber, so Loadout won't install IP alongside it."
-        warn "If you want IP, disable HHD yourself first:"
-        warn "  sudo systemctl mask --now hhd@\$USER.service"
-        warn "Then re-run this step from the welcome wizard."
-        return
-    fi
-
-    # SteamOS ships IP with the image but deliberately disabled, and
-    # enabling it claims the Deck's built-in controller. That's the user's
-    # choice in-app when they pick a wake button, not ours at install time.
-    # Everywhere else, install + enable is the useful default.
-    case "$(. /etc/os-release 2>/dev/null && printf '%s' "${ID:-}")" in
-        steamos) IP_ENABLE=0 ;;
-        *)       IP_ENABLE=1 ;;
-    esac
-
     info "Loadout uses InputPlumber to route a controller button to the"
     info "overlay when you're in a game (Steam Input owns the controller in"
     info "big-picture / gamescope, so a daemon below it is the only way to"
     info "produce an event the overlay can see). Required on handhelds;"
     info "optional on a plain desktop."
     info ""
-    if [ "$IP_ENABLE" = "0" ]; then
-        info "On SteamOS Deck IP is already installed but ships disabled — this"
-        info "step leaves it disabled. Enabling it (and claiming the Deck's"
-        info "built-in controller) happens in-app when you choose an overlay"
-        info "wake button, so it stays opt-in."
-    else
-        info "On CachyOS/Arch this installs the pacman package, then enables"
-        info "and starts inputplumber.service."
-    fi
+    info "On Bazzite IP is already installed — this is a no-op."
+    info "On SteamOS Deck IP is already installed but ships disabled — this"
+    info "step leaves it untouched. Enabling it (and claiming the Deck's"
+    info "built-in controller) happens in-app when you choose an overlay wake"
+    info "button, so it stays opt-in."
+    info "On CachyOS/Arch this installs the pacman package."
+    info ""
+    info "If Handheld Daemon (HHD) is running it'll be stopped and masked —"
+    info "it conflicts with IP over controller HID ownership."
     echo ""
 
     # Default-yes on <enter> to match the Phase 2 gate: controller wake
@@ -1267,11 +1239,7 @@ phase2_inputplumber() {
     fi
 
     info "Running $(basename "$IP_SCRIPT") (requires sudo)..."
-    # `sudo env VAR=…` rather than `sudo VAR=… `: the latter is subject to
-    # sudoers' env_reset and can be silently dropped, which would leave the
-    # script defaulting to IP_ENABLE=1 and enabling IP on a Deck anyway.
-    # Running env(1) as the command sets it unconditionally.
-    if sudo env IP_ENABLE="$IP_ENABLE" bash "$IP_SCRIPT"; then
+    if sudo bash "$IP_SCRIPT"; then
         success "InputPlumber setup complete."
     else
         warn "InputPlumber setup script returned non-zero — check the log above."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1188,9 +1188,19 @@ phase2_input_group() {
 #
 # Delegates to the input-plumber plugin's own installer
 # (./plugins/input-plumber/scripts/install-inputplumber.sh), which:
-#   - Detects + installs IP via pacman / dnf / upstream tarball
-#   - Enables + starts inputplumber.service
-#   - Stops + masks any conflicting hhd*.service units
+#   - Exits early ("nothing to do") when IP is already on PATH
+#   - Otherwise installs IP via pacman / dnf / upstream tarball, then
+#     enables + starts inputplumber.service
+#
+# It does NOT touch HHD. This comment used to claim it "stops + masks any
+# conflicting hhd*.service units"; nothing here has ever done that.
+#
+# That early exit is load-bearing, not an optimisation: SteamOS ships IP
+# with the image (disabled), and Bazzite ships it too, so on both the
+# installer short-circuits before it can enable anything. That is what
+# makes the "leaves it untouched" promise below true and what keeps IP
+# from being enabled alongside a live HHD. Don't remove detect_installed
+# without replacing the guarantee.
 # Idempotent — re-running is safe.
 phase2_inputplumber() {
     echo ""
@@ -1224,9 +1234,6 @@ phase2_inputplumber() {
     info "built-in controller) happens in-app when you choose an overlay wake"
     info "button, so it stays opt-in."
     info "On CachyOS/Arch this installs the pacman package."
-    info ""
-    info "If Handheld Daemon (HHD) is running it'll be stopped and masked —"
-    info "it conflicts with IP over controller HID ownership."
     echo ""
 
     # Default-yes on <enter> to match the Phase 2 gate: controller wake

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -64,14 +64,26 @@ error() {
     printf "${RED}[ERROR]${NC} %s\n" "$1"
 }
 
+# Where prompts read from. Under the documented `curl … | sh` uninstall,
+# stdin is the script text itself, so `[ -t 0 ]` is false and a bare
+# `read` would eat the script rather than the user's answer — the
+# plugin-data and config prompts below could never be answered. Read the
+# controlling terminal instead. Empty only when there's genuinely no
+# terminal (CI, systemd), where prompts fall back to the default (no).
+PROMPT_TTY=""
+if { true < /dev/tty; } 2>/dev/null; then
+    PROMPT_TTY=/dev/tty
+fi
+
 # Prompt user for yes/no (defaults to no)
 prompt_yn() {
-    if [ ! -t 0 ]; then
-        # Non-interactive: use default (no)
+    if [ -z "$PROMPT_TTY" ]; then
+        # No terminal to ask on: use default (no)
         return 1
     fi
-    printf "%s " "$1"
-    read -r answer
+    printf "%s " "$1" > "$PROMPT_TTY"
+    # EOF on the terminal is treated as the default rather than hanging.
+    read -r answer < "$PROMPT_TTY" || answer=""
     case "$answer" in
         [Yy]*) return 0 ;;
         *) return 1 ;;


### PR DESCRIPTION
## Problem

The README documents install and uninstall as `curl -fsSL … | sh`. Under a
pipe the shell reads the **script itself** from stdin, so `[ -t 0 ]` is false
and `prompt_yn` took its default every time. **Every prompt in both scripts was
unanswerable via the exact command we tell people to run.**

Three bugs fell out of that, all silent:

1. **Phase 2 could never run.** A `curl|sh` install always printed
   `Skipping Phase 2` — no `input` group, no InputPlumber — leaving the overlay
   unable to capture controllers. The user only ever sees one `[INFO]` line
   about it in a wall of output.
2. **`curl|sh` upgrades silently kept the old binary.** Re-running the install
   hit `Loadout binary already exists. Overwrite? (y/N)` → default no →
   `INSTALL_BINARY=0`. The documented upgrade path never upgraded the binary.
3. **The uninstaller could never remove plugin data or config** — both prompts
   defaulted to no.

The intent was there but unreachable: `phase2_input_group` carried a branch
commented *"Non-interactive (curl|sh): default to yes since the overlay is
useless without it"* — dead code for the exact case it named, because the outer
Phase 2 gate defaulted to no and `phase2` never ran.

## Fix

Read the **controlling terminal** rather than stdin. `/dev/tty` exists under
both `curl … | sh` and `sh install.sh`, so prompts reach the user in both. With
genuinely no terminal (CI, systemd, `docker run -d`) `PROMPT_TTY` is empty and
prompts fall back to defaults rather than hanging.

`prompt_yn` grows a separate **non-interactive default** (`$3`), kept distinct
from the `<enter>` default (`$2`). This lets the Phase 2 gate treat `<enter>` as
consent while still refusing to sudo, install a package and mask HHD
unattended — the gate is the single place that declines headless runs, so the
inner prompts don't each need their own guard.

Phase 2 and InputPlumber now default to **yes on `<enter>`**: the overlay can't
capture controllers without them, so the single documented command should
produce a working install. Both remain declinable with `n`.

Also drops `phase2_input_group`'s bespoke `read` in favour of the shared
helper, deleting the unreachable branch described above.

## Verification

`prompt_yn` extracted from `install.sh` (the real code, not a copy) and driven
under a **real PTY** with the script piped into `sh` — i.e. the exact `curl|sh`
shape, where stdin is the pipe and `/dev/tty` is the terminal:

| Scenario | Answer | Result |
|---|---|---|
| `curl\|sh` in a terminal | `y` | accepted — **prompt now reaches the user at all** |
| `curl\|sh` in a terminal | `<enter>` | takes the default |
| `curl\|sh` in a terminal | `n` | declines, overriding a yes-default |
| No terminal (`setsid`, stdin `/dev/null`) | — | falls back to defaults, does not hang |

Phase 2 gate specifically (`"y" "n"`): `<enter>` → **runs**, `n` → skips,
no terminal → **skips** (no unattended sudo).

Confirmed reading `/dev/tty` does not disturb the shell consuming the script
from the pipe — the script runs to completion.

Both scripts pass `sh -n`.

**Not covered:** a full end-to-end `curl|sh` install against a live release
wasn't re-run, since the prompt path is exercised directly above.

## Notes

Independent of #211 — that fixes an overlay GL segfault and touches the overlay
`.service` heredoc; this touches `prompt_yn`/`phase2` ~800 lines away. No
conflict expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
