### PR TITLE
feat(tdp-control): target-FPS auto-TDP per game

### DIFF
--- a/plugins/tdp-control/app.tsx
+++ b/plugins/tdp-control/app.tsx
@@ -76,7 +76,49 @@ interface SavedGameProfile {
   appId: number;
   gameName: string;
   tdpWatts: number;
+  mode?: "fixed" | "targetFps";
+  targetFps?: number;
+  minWatts?: number;
+  maxWatts?: number;
 }
+
+/** Live snapshot of the closed-loop FPS controller (getControllerState). */
+interface ControllerState {
+  running: boolean;
+  appId: number | null;
+  currentFps: number | null;
+  targetFps: number | null;
+  currentWatts: number | null;
+  minWatts: number | null;
+  maxWatts: number | null;
+  settled: boolean;
+  reason: string;
+  mangoHudActive: boolean;
+}
+
+interface MangoHudStatus {
+  installed: boolean;
+  configured: boolean;
+  logging: boolean;
+}
+
+const TARGET_FPS_MIN = 30;
+const TARGET_FPS_MAX = 120;
+const TARGET_FPS_STEP = 5;
+const DEFAULT_TARGET_FPS = 60;
+
+/** Human labels for controller reasons (badge text). */
+const CONTROLLER_REASON_LABELS: Record<string, string> = {
+  "warming-up": "Starting…",
+  settling: "Adjusting…",
+  holding: "Holding",
+  climbing: "Adding power",
+  reducing: "Saving power",
+  floor: "At min watts",
+  unreachable: "Target unreachable",
+  stopped: "Stopped",
+  "no-fps-source": "No FPS source",
+};
 
 function TdpControl() {
   const { call, useEvent } = useBackend("tdp-control");
@@ -88,6 +130,8 @@ function TdpControl() {
   const [applying, setApplying] = useState(false);
   const [perGameEnabled, setPerGameEnabled] = useState<boolean>(false);
   const [gameProfiles, setGameProfiles] = useState<SavedGameProfile[]>([]);
+  const [controller, setController] = useState<ControllerState | null>(null);
+  const [mangoHud, setMangoHud] = useState<MangoHudStatus | null>(null);
   // Landing (TDP controls) vs the settings sub-view (custom-device form),
   // reached via the header gear — mirrors the convention other plugins use.
   const [view, setView] = useState<"main" | "settings">("main");
@@ -213,6 +257,72 @@ function TdpControl() {
     },
   });
 
+  // Live FPS controller telemetry (target-FPS mode).
+  useEvent({
+    event: "fpsUpdate",
+    handler: (data) => {
+      const d = data as {
+        appId: number;
+        fps: number | null;
+        targetFps: number | null;
+        watts: number;
+        settled: boolean;
+        reason: string;
+      };
+      setController((prev) => ({
+        running: true,
+        appId: d.appId,
+        currentFps: d.fps,
+        targetFps: d.targetFps,
+        currentWatts: d.watts,
+        minWatts: prev?.minWatts ?? null,
+        maxWatts: prev?.maxWatts ?? null,
+        settled: d.settled,
+        reason: d.reason,
+        mangoHudActive: d.fps !== null || (prev?.mangoHudActive ?? false),
+      }));
+    },
+  });
+
+  useEvent({
+    event: "controllerStateChanged",
+    handler: (data) => {
+      const d = data as { running: boolean; appId: number; reason: string };
+      // Re-sync the authoritative snapshot; running=false clears the readout.
+      call("getControllerState")
+        .then((s) => setController(s as ControllerState))
+        .catch(() => {});
+      if (!d.running) {
+        setController((prev) =>
+          prev ? { ...prev, running: false, reason: d.reason } : prev,
+        );
+      }
+    },
+  });
+
+  // Refresh MangoHud + controller status when the active game changes.
+  const currentAppId = currentGame?.appId ?? null;
+  useEffect(() => {
+    let alive = true;
+    if (currentAppId == null) {
+      setMangoHud(null);
+      return;
+    }
+    Promise.all([
+      call("getMangoHudStatus", currentAppId),
+      call("getControllerState"),
+    ])
+      .then(([mh, ctrl]) => {
+        if (!alive) return;
+        setMangoHud(mh as MangoHudStatus);
+        setController(ctrl as ControllerState);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [call, currentAppId]);
+
   const handleSetTdp = useCallback(
     async (watts: number) => {
       setApplying(true);
@@ -289,6 +399,88 @@ function TdpControl() {
       }
     },
     [call],
+  );
+
+  // Switch the running game between fixed-TDP and target-FPS mode.
+  const handleSetMode = useCallback(
+    async (mode: "fixed" | "targetFps") => {
+      if (!currentGame) return;
+      setError(null);
+      try {
+        if (mode === "targetFps") {
+          const existing = gameProfiles.find(
+            (p) => p.appId === currentGame.appId,
+          );
+          const target = existing?.targetFps ?? DEFAULT_TARGET_FPS;
+          // Enabling target mode needs a live FPS source — turn MangoHud on.
+          if (!mangoHud?.configured) {
+            await call("enableMangoHudForGame", currentGame.appId).catch(
+              () => {},
+            );
+            await call("getMangoHudStatus", currentGame.appId)
+              .then((s) => setMangoHud(s as MangoHudStatus))
+              .catch(() => {});
+          }
+          await call(
+            "setGameTargetFps",
+            currentGame.appId,
+            currentGame.gameName,
+            target,
+          );
+        } else {
+          await call("clearGameTargetFps", currentGame.appId);
+        }
+        const profiles = (await call("getGameProfiles").catch(
+          () => [],
+        )) as SavedGameProfile[];
+        setGameProfiles(profiles);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to switch mode");
+      }
+    },
+    [call, currentGame, gameProfiles, mangoHud],
+  );
+
+  const handleSetTargetFps = useCallback(
+    async (fps: number) => {
+      if (!currentGame) return;
+      // Optimistic local update so the stepper feels responsive.
+      setGameProfiles((prev) =>
+        prev.map((p) =>
+          p.appId === currentGame.appId ? { ...p, targetFps: fps } : p,
+        ),
+      );
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+      debounceTimer.current = setTimeout(() => {
+        call(
+          "setGameTargetFps",
+          currentGame.appId,
+          currentGame.gameName,
+          fps,
+        ).catch(() => {});
+      }, 400);
+    },
+    [call, currentGame],
+  );
+
+  const handleToggleMangoHud = useCallback(
+    async (next: boolean) => {
+      if (!currentGame) return;
+      try {
+        await call(
+          next ? "enableMangoHudForGame" : "disableMangoHudForGame",
+          currentGame.appId,
+        );
+        const s = (await call(
+          "getMangoHudStatus",
+          currentGame.appId,
+        )) as MangoHudStatus;
+        setMangoHud(s);
+      } catch {
+        /* best-effort */
+      }
+    },
+    [call, currentGame],
   );
 
   const handleApplyProfile = useCallback(
@@ -525,6 +717,134 @@ function TdpControl() {
                 moving the slider while a game is running saves that game's profile.
               </div>
 
+              {/* AUTO-FPS — per-game Fixed TDP vs Target FPS, shown for the
+                  running game. In Target mode the controller adjusts wattage to
+                  hold the chosen frame rate (MangoHud supplies live FPS). */}
+              {perGameEnabled && currentGame && (
+                <div style={{ marginTop: 10 }}>
+                  {(() => {
+                    const profile = gameProfiles.find(
+                      (p) => p.appId === currentGame.appId,
+                    );
+                    const isTarget = profile?.mode === "targetFps";
+                    const targetFps = profile?.targetFps ?? DEFAULT_TARGET_FPS;
+                    const live =
+                      controller &&
+                      controller.appId === currentGame.appId &&
+                      controller.running
+                        ? controller
+                        : null;
+                    return (
+                      <>
+                        <div
+                          className="segmented w-full"
+                          style={{ marginBottom: 8 }}
+                        >
+                          <SegmentedItem
+                            active={!isTarget}
+                            onSelect={() => handleSetMode("fixed")}
+                            disabled={applying}
+                            style={{ flex: 1 }}
+                          >
+                            <span className="text-[13px] font-semibold">
+                              Fixed TDP
+                            </span>
+                          </SegmentedItem>
+                          <SegmentedItem
+                            active={isTarget}
+                            onSelect={() => handleSetMode("targetFps")}
+                            disabled={applying}
+                            style={{ flex: 1 }}
+                          >
+                            <span className="text-[13px] font-semibold">
+                              Target FPS
+                            </span>
+                          </SegmentedItem>
+                        </div>
+
+                        {isTarget && (
+                          <div>
+                            <div className="flex items-center justify-between mb-2">
+                              <div className="flex items-baseline gap-1.5">
+                                <span
+                                  className="metric-value mono"
+                                  style={{ fontSize: 30 }}
+                                >
+                                  {live?.currentFps != null
+                                    ? Math.round(live.currentFps)
+                                    : "--"}
+                                </span>
+                                <span className="metric-unit">
+                                  / {targetFps} fps
+                                </span>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                {live?.currentWatts != null && (
+                                  <span className="chip mono">
+                                    {live.currentWatts}W
+                                  </span>
+                                )}
+                                <span
+                                  className={`chip ${live?.settled ? "chip-accent" : ""}`}
+                                >
+                                  {CONTROLLER_REASON_LABELS[
+                                    live?.reason ?? "warming-up"
+                                  ] ?? "…"}
+                                </span>
+                              </div>
+                            </div>
+
+                            <Slider
+                              value={targetFps}
+                              onChange={handleSetTargetFps}
+                              min={TARGET_FPS_MIN}
+                              max={TARGET_FPS_MAX}
+                              step={TARGET_FPS_STEP}
+                              disabled={applying}
+                            />
+                            <div className="flex justify-between mono text-[11px] text-base-content/50 mt-1.5">
+                              <span>{TARGET_FPS_MIN}</span>
+                              <span>{targetFps} fps target</span>
+                              <span>{TARGET_FPS_MAX}</span>
+                            </div>
+
+                            <div
+                              className="flex items-center justify-between"
+                              style={{ marginTop: 10 }}
+                            >
+                              <div className="flex flex-col pr-3">
+                                <span className="text-[12px] font-semibold">
+                                  MangoHud logging
+                                </span>
+                                <span
+                                  className="subsection-desc"
+                                  style={{ marginTop: 0 }}
+                                >
+                                  {mangoHud?.installed === false
+                                    ? "MangoHud not installed — install it to enable auto-FPS."
+                                    : mangoHud?.logging
+                                      ? "Logging FPS for this game."
+                                      : mangoHud?.configured
+                                        ? "Enabled — launch the game to start logging."
+                                        : "Required as the live FPS source."}
+                                </span>
+                              </div>
+                              <Toggle
+                                checked={Boolean(mangoHud?.configured)}
+                                onChange={handleToggleMangoHud}
+                                disabled={
+                                  applying || mangoHud?.installed === false
+                                }
+                              />
+                            </div>
+                          </div>
+                        )}
+                      </>
+                    );
+                  })()}
+                </div>
+              )}
+
               {perGameEnabled && gameProfiles.length > 0 && (
                 <div style={{ marginTop: 8 }}>
                   <div className="subsection-desc" style={{ marginBottom: 4 }}>
@@ -570,7 +890,11 @@ function TdpControl() {
                               size="xs"
                               className="font-semibold"
                             >
-                              <span className="mono">{p.tdpWatts}W</span>
+                              <span className="mono">
+                                {p.mode === "targetFps" && p.targetFps
+                                  ? `${p.targetFps} FPS`
+                                  : `${p.tdpWatts}W`}
+                              </span>
                             </Badge>
                           }
                           action={

--- a/plugins/tdp-control/backend.ts
+++ b/plugins/tdp-control/backend.ts
@@ -1,5 +1,5 @@
-import type { PluginBackend, EmitPayload } from "@loadout/types";
-import { readdir } from "node:fs/promises";
+import type { PluginBackend, EmitPayload, CallPlugin } from "@loadout/types";
+import { readdir, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { runFull, commandExists } from "@loadout/exec";
@@ -9,6 +9,17 @@ import {
   type TdpProfile,
   type TdpProfileEngineState,
 } from "./lib/tdp-profiles";
+import {
+  createFpsController,
+  type FpsController,
+  type ControllerReason,
+} from "./lib/fps-controller";
+import { createFpsReader, type FpsReader } from "./lib/fps-reader";
+import {
+  mangoHudLogDir,
+  mangoHudTokens,
+  MANGOHUD_TOKEN_KEYS,
+} from "./lib/mangohud";
 import {
   matchDevice,
   matchProfileName,
@@ -338,6 +349,28 @@ export default class TdpControlBackend implements PluginBackend {
   // Per-game TDP profile engine
   private profileEngine?: TdpProfileEngine;
 
+  // Cross-plugin call handle injected by the loader (used to drive the
+  // launch-options plugin for MangoHud enablement). Undefined in unit tests.
+  callPlugin?: CallPlugin;
+
+  // -----------------------------------------------------------------------
+  // Target-FPS closed-loop controller state
+  // -----------------------------------------------------------------------
+  private controllerInterval?: Timer;
+  private fpsController?: FpsController;
+  private fpsReader?: FpsReader;
+  private controllerAppId: number | null = null;
+  private controllerProfile?: TdpProfile;
+  private controllerLastFps: number | null = null;
+  private controllerReason: ControllerReason = "warming-up";
+  private controllerSettled = false;
+  private controllerHadSample = false;
+  private controllerStartedAt = 0;
+  /** How often the controller re-measures FPS and nudges TDP. */
+  private static readonly CONTROLLER_TICK_MS = 2000;
+  /** If no FPS sample arrives within this window of starting, give up. */
+  private static readonly CONTROLLER_GRACE_MS = 8000;
+
   // -----------------------------------------------------------------------
   // Lifecycle
   // -----------------------------------------------------------------------
@@ -457,6 +490,7 @@ export default class TdpControlBackend implements PluginBackend {
 
   async onUnload(): Promise<void> {
     if (this.pollInterval) clearInterval(this.pollInterval);
+    this._stopController(false);
     console.log("[tdp-control] Unloaded");
   }
 
@@ -529,6 +563,11 @@ export default class TdpControlBackend implements PluginBackend {
   async setTdp(
     watts: number,
   ): Promise<{ success: boolean; error?: string }> {
+    // A manual TDP change is an explicit "take control back" — pause any
+    // running FPS controller so the loop doesn't immediately fight the slider.
+    if (this.controllerInterval != null) {
+      this._stopController(true);
+    }
     const result = await this.applyTdp(watts);
     // Persist the user's choice as the manual "no game" TDP so it survives a
     // shutdown. Only this RPC path (the slider + power presets via
@@ -847,6 +886,9 @@ export default class TdpControlBackend implements PluginBackend {
     }
     try {
       await this.profileEngine.setPerGameEnabled(enabled);
+      // Toggling per-game off must stop a running controller; toggling on while
+      // a target-mode game is already running should start it.
+      await this._syncControllerForActiveGame();
       this.emit?.({
         event: "perGameEnabledChanged",
         data: {
@@ -876,6 +918,8 @@ export default class TdpControlBackend implements PluginBackend {
     }
     try {
       await this.profileEngine.handleGameLaunch(appId, gameName);
+      // Start/stop the FPS controller depending on the launched game's mode.
+      await this._syncControllerForActiveGame();
       console.log(
         `[tdp-control] Game launched: appId=${appId}, name=${gameName}`,
       );
@@ -900,12 +944,389 @@ export default class TdpControlBackend implements PluginBackend {
     }
     try {
       await this.profileEngine.handleGameExit(appId);
+      // No game running ⇒ this stops the controller (and reverts to no-game TDP
+      // via the engine's exit handling).
+      await this._syncControllerForActiveGame();
       console.log(`[tdp-control] Game exited: appId=${appId}`);
       return { success: true };
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       return { success: false, error: msg };
     }
+  }
+
+  // -----------------------------------------------------------------------
+  // RPC: Target-FPS control (closed-loop TDP)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Put a game into target-FPS mode: the controller adjusts wattage to hold
+   * `targetFps`. Optional min/max watts bound the loop (default to the device
+   * range). If this game is currently running, the controller starts now.
+   */
+  async setGameTargetFps(
+    appId: number,
+    gameName: string,
+    targetFps: number,
+    minWatts?: number,
+    maxWatts?: number,
+  ): Promise<{ success: boolean; error?: string }> {
+    if (!this.profileEngine) {
+      return { success: false, error: "Profile engine not initialized" };
+    }
+    try {
+      await this.profileEngine.setTargetFpsProfile(appId, gameName, targetFps, {
+        minWatts,
+        maxWatts,
+        seedWatts: this.trackedTdp ?? this.currentTdp ?? undefined,
+      });
+      await this._syncControllerForActiveGame();
+      return { success: true };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { success: false, error: msg };
+    }
+  }
+
+  /**
+   * Revert a game from target-FPS mode back to a fixed-wattage profile (kept
+   * at the controller's last-good seed wattage). Stops the controller if this
+   * game is the one being governed.
+   */
+  async clearGameTargetFps(
+    appId: number,
+  ): Promise<{ success: boolean; error?: string }> {
+    if (!this.profileEngine) {
+      return { success: false, error: "Profile engine not initialized" };
+    }
+    try {
+      const profile = this.profileEngine.getProfile(appId);
+      if (profile && profile.mode === "targetFps") {
+        // Persist as a plain fixed profile at the seed watts.
+        await this.profileEngine.setProfile(
+          appId,
+          profile.gameName,
+          profile.tdpWatts,
+        );
+      }
+      await this._syncControllerForActiveGame();
+      return { success: true };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { success: false, error: msg };
+    }
+  }
+
+  /** Snapshot of the closed-loop controller for the UI. */
+  async getControllerState(): Promise<{
+    running: boolean;
+    appId: number | null;
+    currentFps: number | null;
+    targetFps: number | null;
+    currentWatts: number | null;
+    minWatts: number | null;
+    maxWatts: number | null;
+    settled: boolean;
+    reason: ControllerReason;
+    mangoHudActive: boolean;
+  }> {
+    const profile = this.controllerProfile;
+    const bounds = profile ? this._controllerBounds(profile) : null;
+    return {
+      running: this.controllerInterval != null,
+      appId: this.controllerAppId,
+      currentFps: this.controllerLastFps,
+      targetFps: profile?.targetFps ?? null,
+      currentWatts: this.trackedTdp ?? this.currentTdp,
+      minWatts: bounds?.effMin ?? null,
+      maxWatts: bounds?.effMax ?? null,
+      settled: this.controllerSettled,
+      reason: this.controllerReason,
+      mangoHudActive: this.controllerHadSample,
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // RPC: MangoHud enablement (FPS source for the controller)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Enable per-game MangoHud logging by injecting the MangoHud launch-option
+   * tokens (via the launch-options plugin) and creating the log directory.
+   * The controller tails that log for live FPS.
+   */
+  async enableMangoHudForGame(
+    appId: number,
+  ): Promise<{ success: boolean; error?: string; installed?: boolean }> {
+    if (!this.callPlugin) {
+      return {
+        success: false,
+        error: "launch-options plugin unavailable (no loader)",
+      };
+    }
+    try {
+      // MangoHud requires output_folder to exist to log into it.
+      await mkdir(mangoHudLogDir(appId), { recursive: true }).catch(() => {});
+      for (const { token, key } of mangoHudTokens(appId)) {
+        await this.callPlugin(
+          "launch-options",
+          "appendLaunchToken",
+          String(appId),
+          token,
+          { key, position: "before" },
+        );
+      }
+      const installed = await commandExists("mangohud");
+      console.log(`[tdp-control] MangoHud enabled for appId=${appId}`);
+      return { success: true, installed };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { success: false, error: msg };
+    }
+  }
+
+  /** Remove the injected MangoHud launch-option tokens for a game. */
+  async disableMangoHudForGame(
+    appId: number,
+  ): Promise<{ success: boolean; error?: string }> {
+    if (!this.callPlugin) {
+      return {
+        success: false,
+        error: "launch-options plugin unavailable (no loader)",
+      };
+    }
+    try {
+      for (const key of MANGOHUD_TOKEN_KEYS) {
+        await this.callPlugin(
+          "launch-options",
+          "removeLaunchToken",
+          String(appId),
+          key,
+        );
+      }
+      console.log(`[tdp-control] MangoHud disabled for appId=${appId}`);
+      return { success: true };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { success: false, error: msg };
+    }
+  }
+
+  /**
+   * Report whether MangoHud is set up and actually producing logs for a game.
+   *   - installed: `mangohud` is on PATH.
+   *   - configured: the MangoHud launch token is present.
+   *   - logging: a fresh log with a readable FPS value exists right now.
+   */
+  async getMangoHudStatus(appId: number): Promise<{
+    installed: boolean;
+    configured: boolean;
+    logging: boolean;
+  }> {
+    const installed = await commandExists("mangohud");
+    let configured = false;
+    if (this.callPlugin) {
+      try {
+        configured = Boolean(
+          await this.callPlugin(
+            "launch-options",
+            "hasLaunchToken",
+            String(appId),
+            "MANGOHUD_CONFIG",
+          ),
+        );
+      } catch {
+        configured = false;
+      }
+    }
+    let logging = false;
+    try {
+      const reader = createFpsReader({ outputFolder: mangoHudLogDir(appId) });
+      logging = (await reader.readSmoothedFps()) !== null;
+    } catch {
+      logging = false;
+    }
+    return { installed, configured, logging };
+  }
+
+  // -----------------------------------------------------------------------
+  // Target-FPS controller internals (underscore-prefixed ⇒ not RPC-exposed)
+  // -----------------------------------------------------------------------
+
+  /** Effective watt bounds for a target-mode profile, power-state clamped. */
+  private _controllerBounds(profile: TdpProfile): {
+    effMin: number;
+    effMax: number;
+  } {
+    const effMin = Math.max(profile.minWatts ?? this.minWatts, this.minWatts);
+    const effMax = Math.min(
+      profile.maxWatts ?? this.maxWatts,
+      this.effectiveMaxWatts(),
+    );
+    return { effMin, effMax: Math.max(effMin, effMax) };
+  }
+
+  private _configureController(profile: TdpProfile): void {
+    if (!this.fpsController) return;
+    const { effMin, effMax } = this._controllerBounds(profile);
+    this.fpsController.configure({
+      targetFps: profile.targetFps ?? 60,
+      minWatts: effMin,
+      maxWatts: effMax,
+    });
+  }
+
+  /**
+   * Decide whether the FPS controller should be running for the currently
+   * active game, and (re)start or stop it accordingly. Idempotent — safe to
+   * call from game launch/exit, the per-game toggle, and target-profile edits.
+   */
+  private async _syncControllerForActiveGame(): Promise<void> {
+    const engine = this.profileEngine;
+    if (!engine) return;
+    const state = engine.getCurrentState();
+    const appId = engine.getActiveAppId();
+    const profile = appId != null ? engine.getProfile(appId) : undefined;
+    const shouldRun =
+      state.perGameEnabled &&
+      state.isGameRunning &&
+      this.method !== "none" &&
+      appId != null &&
+      profile?.mode === "targetFps" &&
+      typeof profile.targetFps === "number";
+
+    if (shouldRun) {
+      if (this.controllerAppId !== appId) {
+        await this._startController(appId, profile!);
+      } else {
+        // Same game, updated bounds/target — reconfigure in place.
+        this.controllerProfile = profile;
+        this._configureController(profile!);
+      }
+    } else {
+      this._stopController(true);
+    }
+  }
+
+  private async _startController(
+    appId: number,
+    profile: TdpProfile,
+  ): Promise<void> {
+    this._stopController(false); // clear any prior run silently
+    this.controllerAppId = appId;
+    this.controllerProfile = profile;
+    this.fpsController = createFpsController();
+    this._configureController(profile);
+    this.fpsReader = createFpsReader({ outputFolder: mangoHudLogDir(appId) });
+    this.controllerHadSample = false;
+    this.controllerStartedAt = Date.now();
+    this.controllerLastFps = null;
+    this.controllerReason = "warming-up";
+    this.controllerSettled = false;
+
+    // Seed hardware once at a sensible starting point (the profile's last-good
+    // wattage, clamped into the effective band), then let the loop take over.
+    const { effMin, effMax } = this._controllerBounds(profile);
+    const seed = Math.max(effMin, Math.min(effMax, profile.tdpWatts));
+    await this.profileEngine?.applyManagedTdp(seed);
+
+    this.controllerInterval = setInterval(() => {
+      this._controllerTick().catch((e) => {
+        console.error(`[tdp-control] controller tick failed: ${e}`);
+      });
+    }, TdpControlBackend.CONTROLLER_TICK_MS);
+
+    this.emit?.({
+      event: "controllerStateChanged",
+      data: { running: true, appId, reason: "warming-up" },
+    });
+    console.log(
+      `[tdp-control] FPS controller started for appId=${appId} (target ${profile.targetFps}fps, ${effMin}-${effMax}W)`,
+    );
+  }
+
+  private _stopController(emitEvent: boolean): void {
+    const wasRunning = this.controllerInterval != null;
+    const appId = this.controllerAppId;
+    if (this.controllerInterval) {
+      clearInterval(this.controllerInterval);
+      this.controllerInterval = undefined;
+    }
+    this.fpsReader?.reset();
+    this.fpsController?.reset();
+    this.fpsReader = undefined;
+    this.fpsController = undefined;
+    this.controllerAppId = null;
+    this.controllerProfile = undefined;
+    this.controllerLastFps = null;
+    this.controllerReason = "warming-up";
+    this.controllerSettled = false;
+    this.controllerHadSample = false;
+
+    if (emitEvent && wasRunning && appId != null) {
+      this.emit?.({
+        event: "controllerStateChanged",
+        data: { running: false, appId, reason: "stopped" },
+      });
+    }
+  }
+
+  private async _controllerTick(): Promise<void> {
+    const engine = this.profileEngine;
+    const controller = this.fpsController;
+    const reader = this.fpsReader;
+    const profile = this.controllerProfile;
+    if (!engine || !controller || !reader || !profile || this.controllerAppId == null) {
+      return;
+    }
+
+    // Refresh bounds each tick so AC transitions (which lower effectiveMaxWatts)
+    // are respected immediately.
+    this._configureController(profile);
+
+    const fps = await reader.readSmoothedFps();
+    if (fps !== null) this.controllerHadSample = true;
+
+    // Grace period: if MangoHud never produced a log, stop and tell the UI.
+    if (
+      fps === null &&
+      !this.controllerHadSample &&
+      Date.now() - this.controllerStartedAt >
+        TdpControlBackend.CONTROLLER_GRACE_MS
+    ) {
+      const appId = this.controllerAppId;
+      this._stopController(false);
+      this.emit?.({
+        event: "controllerStateChanged",
+        data: { running: false, appId, reason: "no-fps-source" },
+      });
+      console.warn(
+        `[tdp-control] No FPS source for appId=${appId}; controller stopped`,
+      );
+      return;
+    }
+
+    const currentWatts = this.trackedTdp ?? this.currentTdp ?? profile.tdpWatts;
+    const decision = controller.update(fps, currentWatts);
+    this.controllerLastFps = fps;
+    this.controllerReason = decision.reason;
+    this.controllerSettled = decision.settled;
+
+    if (decision.changed) {
+      await engine.applyManagedTdp(decision.targetWatts);
+    }
+
+    this.emit?.({
+      event: "fpsUpdate",
+      data: {
+        appId: this.controllerAppId,
+        fps,
+        targetFps: profile.targetFps ?? null,
+        watts: decision.targetWatts,
+        settled: decision.settled,
+        reason: decision.reason,
+      },
+    });
   }
 
   // -----------------------------------------------------------------------

--- a/plugins/tdp-control/lib/fps-controller.test.ts
+++ b/plugins/tdp-control/lib/fps-controller.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect } from "bun:test";
+import { createFpsController } from "./fps-controller";
+
+function make(targetFps = 60, minWatts = 5, maxWatts = 30) {
+  const c = createFpsController();
+  c.configure({ targetFps, minWatts, maxWatts });
+  return c;
+}
+
+describe("FPS controller", () => {
+  test("returns warming-up and no change while FPS is null", () => {
+    const c = make();
+    const d = c.update(null, 15);
+    expect(d.reason).toBe("warming-up");
+    expect(d.changed).toBe(false);
+    expect(d.targetWatts).toBe(15);
+  });
+
+  test("below target adds a bounded amount of power", () => {
+    const c = make(60, 5, 30);
+    const d = c.update(45, 15); // 15 fps short
+    expect(d.reason).toBe("climbing");
+    expect(d.changed).toBe(true);
+    // ceil(15 * 0.2) = 3, capped at upStepMax 3
+    expect(d.targetWatts).toBe(18);
+  });
+
+  test("up-step is clamped to the max step size", () => {
+    const c = make(120, 5, 30);
+    const d = c.update(30, 15); // 90 fps short -> huge error
+    expect(d.targetWatts).toBe(18); // still only +3
+  });
+
+  test("within the deadband it settles and holds", () => {
+    const c = make(60, 5, 30);
+    const d = c.update(61, 20); // 1 over, inside deadbandAbove
+    expect(d.reason).toBe("holding");
+    expect(d.settled).toBe(true);
+    expect(d.changed).toBe(false);
+    expect(d.targetWatts).toBe(20);
+  });
+
+  test("a change is followed by a one-tick settle skip", () => {
+    const c = make(60, 5, 30);
+    const first = c.update(45, 15);
+    expect(first.changed).toBe(true);
+    const skipped = c.update(80, first.targetWatts); // would normally reduce
+    expect(skipped.reason).toBe("settling");
+    expect(skipped.changed).toBe(false);
+    expect(skipped.targetWatts).toBe(first.targetWatts);
+  });
+
+  test("reduces only after sustained over-target ticks (hysteresis)", () => {
+    const c = make(60, 5, 30);
+    // First over-target tick: hold, don't reduce yet.
+    const t1 = c.update(80, 20);
+    expect(t1.reason).toBe("holding");
+    expect(t1.changed).toBe(false);
+    // Second consecutive over-target tick: now reduce.
+    const t2 = c.update(80, 20);
+    expect(t2.reason).toBe("reducing");
+    expect(t2.changed).toBe(true);
+    expect(t2.targetWatts).toBeLessThan(20);
+  });
+
+  test("clamps at the max watt bound and reports unreachable when stuck", () => {
+    const c = make(60, 5, 20);
+    let watts = 20; // already at ceiling
+    let sawUnreachable = false;
+    for (let i = 0; i < 8; i++) {
+      const d = c.update(45, watts); // always short
+      watts = d.targetWatts;
+      expect(watts).toBeLessThanOrEqual(20);
+      if (d.reason === "unreachable") sawUnreachable = true;
+    }
+    expect(watts).toBe(20);
+    expect(sawUnreachable).toBe(true);
+  });
+
+  test("clamps at the min watt bound and reports floor", () => {
+    const c = make(60, 5, 30);
+    // Drive it well over target repeatedly; it should walk down to the floor.
+    let watts = 8;
+    let sawFloor = false;
+    for (let i = 0; i < 20; i++) {
+      const d = c.update(140, watts);
+      watts = d.targetWatts;
+      expect(watts).toBeGreaterThanOrEqual(5);
+      if (d.reason === "floor") sawFloor = true;
+    }
+    expect(watts).toBe(5);
+    expect(sawFloor).toBe(true);
+  });
+
+  test("alternating high/low readings do not oscillate the watts", () => {
+    const c = make(60, 5, 30);
+    let watts = 15;
+    const history: number[] = [watts];
+    const samples = [45, 80, 45, 80, 45, 80, 45, 80];
+    for (const fps of samples) {
+      const d = c.update(fps, watts);
+      watts = d.targetWatts;
+      history.push(watts);
+    }
+    // Because every change is followed by a settle-skip, the tick that sees a
+    // high reading right after an up-step is ignored — so watts never steps
+    // down in response to the alternation. The series is monotonic non-decreasing.
+    for (let i = 1; i < history.length; i++) {
+      expect(history[i]).toBeGreaterThanOrEqual(history[i - 1]);
+    }
+  });
+
+  test("converges on a synthetic monotone watts→fps curve", () => {
+    const c = make(60, 5, 40);
+    // Simple linear model: fps = watts * 3 (so 20W ⇒ 60fps is the solution).
+    let watts = 8;
+    let settledWatts = -1;
+    for (let i = 0; i < 60; i++) {
+      const fps = watts * 3;
+      const d = c.update(fps, watts);
+      watts = d.targetWatts;
+      if (d.settled && d.reason === "holding") {
+        settledWatts = watts;
+        break;
+      }
+    }
+    expect(settledWatts).toBeGreaterThan(0);
+    // Solution is 20W; allow a small band for the deadband/step granularity.
+    expect(settledWatts).toBeGreaterThanOrEqual(18);
+    expect(settledWatts).toBeLessThanOrEqual(23);
+  });
+
+  test("reset clears streak state", () => {
+    const c = make(60, 5, 30);
+    c.update(80, 20); // aboveStreak = 1
+    c.reset();
+    // After reset the first over-target tick should hold again, not reduce.
+    const d = c.update(80, 20);
+    expect(d.reason).toBe("holding");
+    expect(d.changed).toBe(false);
+  });
+});

--- a/plugins/tdp-control/lib/fps-controller.ts
+++ b/plugins/tdp-control/lib/fps-controller.ts
@@ -1,0 +1,221 @@
+/**
+ * Pure closed-loop controller that nudges TDP (watts) to hold a target FPS.
+ *
+ * No I/O, no timers, no clock — every input arrives via `configure()` /
+ * `update()` and every decision is returned. This keeps the control math
+ * fully deterministic and unit-testable; the backend owns the interval, the
+ * FPS reader, and the (serialized) hardware write.
+ *
+ * Design notes
+ * ------------
+ * The watts→fps transfer function is unknown, nonlinear, and game-specific,
+ * so we deliberately avoid a tuned PID. Instead: a bounded proportional step
+ * with an **asymmetric deadband** (wider on the reduce side, so we bias toward
+ * holding frames and only give power back when there's clear, sustained
+ * headroom), plus a one-tick **settle skip** after every change (so we never
+ * react to an FPS sample measured *before* the last watt change took effect),
+ * plus **direction hysteresis** on the reduce side (requires the over-target
+ * condition to persist before stepping down). Together these stop the loop
+ * from oscillating on noisy frame rates.
+ */
+
+export type ControllerReason =
+  | "warming-up" // no FPS sample yet
+  | "settling" // just changed watts, skipping a tick to let it take effect
+  | "holding" // within the deadband — target met
+  | "climbing" // below target, adding power
+  | "reducing" // above target with headroom, giving power back
+  | "floor" // above target but already at the minimum watt bound
+  | "unreachable"; // below target but pinned at the maximum watt bound
+
+export interface ControllerConfig {
+  targetFps: number;
+  /** Lower watt bound the loop may not go below. */
+  minWatts: number;
+  /** Upper watt bound the loop may not exceed (already power-state clamped). */
+  maxWatts: number;
+}
+
+export interface ControllerTuning {
+  /** Below-target FPS slack (fps) before we add power. */
+  deadbandBelowFps: number;
+  /** Above-target FPS slack (fps) before we consider reducing power. */
+  deadbandAboveFps: number;
+  /** Proportional gain on the up (add power) side. */
+  upGain: number;
+  /** Proportional gain on the down (reduce power) side. */
+  downGain: number;
+  /** Bounds on a single up-step, in watts. */
+  upStepMin: number;
+  upStepMax: number;
+  /** Bounds on a single down-step, in watts. */
+  downStepMin: number;
+  downStepMax: number;
+  /** Consecutive over-target ticks required before stepping down. */
+  aboveStreakNeeded: number;
+  /** Consecutive at-ceiling-but-below-target ticks before reporting unreachable. */
+  saturationTicks: number;
+}
+
+export interface ControllerDecision {
+  /** The watts the backend should apply this tick. */
+  targetWatts: number;
+  /** True when targetWatts differs from the currentWatts we were given. */
+  changed: boolean;
+  /** True when the loop believes it has reached a stable resting point. */
+  settled: boolean;
+  reason: ControllerReason;
+}
+
+/**
+ * Default tuning. Deadbands are also scaled by the target at configure()
+ * time (a 3%/7% band), whichever is larger — so 30fps and 120fps targets
+ * both get a sensible slack.
+ */
+export const DEFAULT_TUNING: ControllerTuning = {
+  deadbandBelowFps: 2,
+  deadbandAboveFps: 4,
+  upGain: 0.2,
+  downGain: 0.1,
+  upStepMin: 1,
+  upStepMax: 3,
+  downStepMin: 1,
+  downStepMax: 2,
+  aboveStreakNeeded: 2,
+  saturationTicks: 3,
+};
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+export function createFpsController(tuning: Partial<ControllerTuning> = {}) {
+  const cfg: ControllerTuning = { ...DEFAULT_TUNING, ...tuning };
+
+  let targetFps = 60;
+  let minWatts = 5;
+  let maxWatts = 35;
+  let deadbandBelow = cfg.deadbandBelowFps;
+  let deadbandAbove = cfg.deadbandAboveFps;
+
+  // Mutable per-run state.
+  let aboveStreak = 0;
+  let settleSkip = 0;
+  let saturationStreak = 0;
+
+  function reset(): void {
+    aboveStreak = 0;
+    settleSkip = 0;
+    saturationStreak = 0;
+  }
+
+  function configure(config: ControllerConfig): void {
+    targetFps = config.targetFps;
+    // Keep min <= max even if callers pass a collapsed/inverted band.
+    minWatts = Math.min(config.minWatts, config.maxWatts);
+    maxWatts = Math.max(config.minWatts, config.maxWatts);
+    // Scale the deadband with the target, but never below the floor slack.
+    deadbandBelow = Math.max(cfg.deadbandBelowFps, Math.round(targetFps * 0.03));
+    deadbandAbove = Math.max(cfg.deadbandAboveFps, Math.round(targetFps * 0.07));
+  }
+
+  /**
+   * Advance the loop one tick.
+   *
+   * @param currentFps  Smoothed FPS, or null when no sample is available yet.
+   * @param currentWatts  The watts currently applied (post-clamp).
+   */
+  function update(
+    currentFps: number | null,
+    currentWatts: number,
+  ): ControllerDecision {
+    const hold = (
+      reason: ControllerReason,
+      settled: boolean,
+    ): ControllerDecision => ({
+      targetWatts: currentWatts,
+      changed: false,
+      settled,
+      reason,
+    });
+
+    // No data yet — do nothing, don't advance streaks.
+    if (currentFps === null || !Number.isFinite(currentFps)) {
+      return hold("warming-up", false);
+    }
+
+    // One-tick cooldown after any change so we measure the *new* watts, not
+    // the frame rate produced by the previous setting.
+    if (settleSkip > 0) {
+      settleSkip -= 1;
+      return hold("settling", false);
+    }
+
+    const err = targetFps - currentFps; // >0 ⇒ below target ⇒ want more power
+
+    // --- Below target: add power (respond promptly, no streak gate) ---------
+    if (err > deadbandBelow) {
+      aboveStreak = 0;
+      if (currentWatts >= maxWatts) {
+        // Pinned at the ceiling and still short — GPU/thermal bound.
+        saturationStreak += 1;
+        return hold(
+          saturationStreak >= cfg.saturationTicks ? "unreachable" : "climbing",
+          saturationStreak >= cfg.saturationTicks,
+        );
+      }
+      saturationStreak = 0;
+      const step = clamp(
+        Math.ceil(err * cfg.upGain),
+        cfg.upStepMin,
+        cfg.upStepMax,
+      );
+      const next = Math.min(maxWatts, currentWatts + step);
+      const changed = next !== currentWatts;
+      if (changed) settleSkip = 1;
+      return {
+        targetWatts: next,
+        changed,
+        settled: false,
+        reason: "climbing",
+      };
+    }
+
+    // --- Above target: reduce power, but only after sustained headroom ------
+    if (err < -deadbandAbove) {
+      saturationStreak = 0;
+      aboveStreak += 1;
+      if (aboveStreak < cfg.aboveStreakNeeded) {
+        // Not yet convinced the headroom is real — hold and watch.
+        return hold("holding", false);
+      }
+      if (currentWatts <= minWatts) {
+        return hold("floor", true);
+      }
+      const overBy = -err;
+      const step = clamp(
+        Math.ceil(overBy * cfg.downGain),
+        cfg.downStepMin,
+        cfg.downStepMax,
+      );
+      const next = Math.max(minWatts, currentWatts - step);
+      const changed = next !== currentWatts;
+      if (changed) settleSkip = 1;
+      return {
+        targetWatts: next,
+        changed,
+        settled: false,
+        reason: "reducing",
+      };
+    }
+
+    // --- Within the deadband: target met, rest here -------------------------
+    aboveStreak = 0;
+    saturationStreak = 0;
+    return hold("holding", true);
+  }
+
+  return { configure, update, reset };
+}
+
+export type FpsController = ReturnType<typeof createFpsController>;

--- a/plugins/tdp-control/lib/fps-reader.test.ts
+++ b/plugins/tdp-control/lib/fps-reader.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  appendFileSync,
+  utimesSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createFpsReader } from "./fps-reader";
+
+let dir: string;
+let clock: number;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "fps-reader-test-"));
+  clock = 1_000_000;
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const now = () => clock;
+
+// MangoHud-style log: hardware preamble, then a data header including `fps`,
+// then data rows.
+function logHeader(): string {
+  return [
+    "os,cpu,gpu,ram,kernel,driver",
+    "Arch Linux,AMD Ryzen Z1,AMD 780M,16GB,6.9,mesa",
+    "fps,frametime,cpu_load,gpu_load,cpu_temp,gpu_temp,elapsed",
+  ].join("\n");
+}
+
+function rows(...fps: number[]): string {
+  return fps.map((f) => `${f},16.6,40,90,60,70,1000`).join("\n");
+}
+
+/** Write a file and force its mtime to the current test clock. */
+function writeLog(name: string, content: string) {
+  const path = join(dir, name);
+  writeFileSync(path, content);
+  const secs = clock / 1000;
+  utimesSync(path, secs, secs);
+  return path;
+}
+
+describe("FPS reader", () => {
+  test("returns null when the folder does not exist", async () => {
+    const r = createFpsReader({ outputFolder: join(dir, "nope"), now });
+    expect(await r.readSmoothedFps()).toBeNull();
+  });
+
+  test("returns null when there are no CSV files", async () => {
+    writeFileSync(join(dir, "notes.txt"), "hello");
+    const r = createFpsReader({ outputFolder: dir, now });
+    expect(await r.readSmoothedFps()).toBeNull();
+  });
+
+  test("averages the fps column, tolerating extra columns", async () => {
+    writeLog("session.csv", logHeader() + "\n" + rows(58, 60, 62) + "\n");
+    const r = createFpsReader({ outputFolder: dir, now });
+    expect(await r.readSmoothedFps()).toBeCloseTo(60, 5);
+  });
+
+  test("reads only appended rows across calls (incremental offset)", async () => {
+    const path = writeLog("session.csv", logHeader() + "\n" + rows(50) + "\n");
+    const r = createFpsReader({ outputFolder: dir, now });
+    expect(await r.readSmoothedFps()).toBeCloseTo(50, 5);
+
+    appendFileSync(path, rows(70) + "\n");
+    utimesSync(path, clock / 1000, clock / 1000);
+    // Average of 50 and 70 = 60 (both within the sample window).
+    expect(await r.readSmoothedFps()).toBeCloseTo(60, 5);
+  });
+
+  test("honours the sample window", async () => {
+    writeLog("session.csv", logHeader() + "\n" + rows(10, 10, 10, 100) + "\n");
+    const r = createFpsReader({ outputFolder: dir, now, sampleWindow: 1 });
+    // Only the last sample is kept.
+    expect(await r.readSmoothedFps()).toBeCloseTo(100, 5);
+  });
+
+  test("returns null when the newest log is stale", async () => {
+    writeLog("session.csv", logHeader() + "\n" + rows(60) + "\n");
+    const r = createFpsReader({ outputFolder: dir, now, staleMs: 5000 });
+    clock += 10_000; // advance well past staleMs; file mtime stays old
+    expect(await r.readSmoothedFps()).toBeNull();
+  });
+
+  test("picks the newest file and resets on rotation", async () => {
+    writeLog("old.csv", logHeader() + "\n" + rows(30) + "\n");
+    const r = createFpsReader({ outputFolder: dir, now });
+    expect(await r.readSmoothedFps()).toBeCloseTo(30, 5);
+
+    // A newer session file appears.
+    clock += 1000;
+    writeLog("new.csv", logHeader() + "\n" + rows(90) + "\n");
+    // Should switch to the new file and only reflect its samples.
+    expect(await r.readSmoothedFps()).toBeCloseTo(90, 5);
+  });
+
+  test("buffers a partial trailing line until it completes", async () => {
+    const path = writeLog(
+      "session.csv",
+      logHeader() + "\n" + "58,16.6,40,90,60,70,1000\n" + "62,16.6,40,90", // no newline: partial
+    );
+    const r = createFpsReader({ outputFolder: dir, now });
+    // Only the first complete row is counted so far.
+    expect(await r.readSmoothedFps()).toBeCloseTo(58, 5);
+
+    // Complete the partial row and add another.
+    appendFileSync(path, ",60,70,1000\n" + rows(60) + "\n");
+    utimesSync(path, clock / 1000, clock / 1000);
+    // Now 58, 62, 60 -> average 60.
+    expect(await r.readSmoothedFps()).toBeCloseTo(60, 5);
+  });
+
+  test("reset drops state", async () => {
+    writeLog("session.csv", logHeader() + "\n" + rows(60) + "\n");
+    const r = createFpsReader({ outputFolder: dir, now });
+    await r.readSmoothedFps();
+    r.reset();
+    // After reset it re-reads the file from scratch and still returns a value.
+    expect(await r.readSmoothedFps()).toBeCloseTo(60, 5);
+  });
+});

--- a/plugins/tdp-control/lib/fps-reader.ts
+++ b/plugins/tdp-control/lib/fps-reader.ts
@@ -1,0 +1,157 @@
+/**
+ * Reads a game's live FPS by tailing the CSV that MangoHud writes when
+ * logging is enabled (see lib/mangohud.ts for how logging is turned on).
+ *
+ * MangoHud writes one timestamped CSV per session into the configured
+ * `output_folder`. The file begins with a hardware/preamble section, then a
+ * header row whose columns include `fps`, then one data row per `log_interval`.
+ * We locate the newest CSV (the active session), tail only the bytes appended
+ * since the last read, and return a rolling average of the recent `fps` column.
+ *
+ * Notes that match the rest of the plugin:
+ *   - No `Bun.file(...).exists()` gate before reading (see readFileText in
+ *     backend.ts): a genuinely missing file just throws and is caught.
+ *   - Reads are incremental (byte offset) so a multi-minute log isn't
+ *     re-parsed every tick.
+ */
+
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+export interface FpsReaderOptions {
+  /** Directory MangoHud logs into for this game (MangoHud `output_folder`). */
+  outputFolder: string;
+  /** How many recent samples to average. Default 15 (~3s at 200ms interval). */
+  sampleWindow?: number;
+  /** A log whose newest file is older than this (ms) is treated as dead. */
+  staleMs?: number;
+  /** Injectable clock for tests. Defaults to Date.now. */
+  now?: () => number;
+}
+
+export function createFpsReader(options: FpsReaderOptions) {
+  const { outputFolder } = options;
+  const sampleWindow = options.sampleWindow ?? 15;
+  const staleMs = options.staleMs ?? 5000;
+  const now = options.now ?? (() => Date.now());
+
+  let currentFile: string | null = null;
+  let byteOffset = 0;
+  let fpsColIndex = -1;
+  let partialLine = "";
+  let samples: number[] = [];
+
+  function reset(): void {
+    currentFile = null;
+    byteOffset = 0;
+    fpsColIndex = -1;
+    partialLine = "";
+    samples = [];
+  }
+
+  function switchFile(path: string): void {
+    currentFile = path;
+    byteOffset = 0;
+    fpsColIndex = -1;
+    partialLine = "";
+    samples = [];
+  }
+
+  /** Find the newest *.csv in the output folder, or null if none/unreadable. */
+  function newestCsv(): { path: string; mtimeMs: number } | null {
+    let entries: string[];
+    try {
+      entries = readdirSync(outputFolder);
+    } catch {
+      // Folder doesn't exist yet — MangoHud hasn't created it.
+      return null;
+    }
+    let best: { path: string; mtimeMs: number } | null = null;
+    for (const name of entries) {
+      if (!name.toLowerCase().endsWith(".csv")) continue;
+      const path = join(outputFolder, name);
+      try {
+        const st = statSync(path);
+        if (!st.isFile()) continue;
+        if (best === null || st.mtimeMs > best.mtimeMs) {
+          best = { path, mtimeMs: st.mtimeMs };
+        }
+      } catch {
+        // Race with rotation/removal — skip.
+      }
+    }
+    return best;
+  }
+
+  function processChunk(chunk: string): void {
+    const text = partialLine + chunk;
+    const lines = text.split("\n");
+    // If the chunk didn't end on a newline, the last element is incomplete.
+    partialLine = text.endsWith("\n") ? "" : (lines.pop() ?? "");
+
+    for (const raw of lines) {
+      const line = raw.trim();
+      if (!line) continue;
+      const fields = line.split(",");
+
+      if (fpsColIndex === -1) {
+        // Still looking for the data header row (columns include "fps").
+        const idx = fields.findIndex((f) => f.trim().toLowerCase() === "fps");
+        if (idx !== -1) fpsColIndex = idx;
+        continue; // header or preamble line — never a data sample
+      }
+
+      const val = parseFloat(fields[fpsColIndex] ?? "");
+      if (Number.isFinite(val) && val > 0) samples.push(val);
+    }
+
+    if (samples.length > sampleWindow) {
+      samples = samples.slice(samples.length - sampleWindow);
+    }
+  }
+
+  /**
+   * Read any newly-appended rows and return the smoothed current FPS, or null
+   * when there's no fresh data (no log yet, stale session, or still warming up).
+   */
+  async function readSmoothedFps(): Promise<number | null> {
+    const newest = newestCsv();
+    if (newest === null) return null;
+
+    // A log that stopped growing means the game exited or logging stopped.
+    if (now() - newest.mtimeMs > staleMs) return null;
+
+    if (newest.path !== currentFile) switchFile(newest.path);
+
+    try {
+      const file = Bun.file(currentFile!);
+      const size = file.size;
+      // File was truncated or replaced under the same name — restart from top.
+      if (size < byteOffset) {
+        byteOffset = 0;
+        fpsColIndex = -1;
+        partialLine = "";
+      }
+      if (size > byteOffset) {
+        const chunk = await file.slice(byteOffset, size).text();
+        byteOffset = size;
+        processChunk(chunk);
+      }
+    } catch {
+      // Missing/unreadable file: fall through to whatever we have buffered.
+      return samples.length ? mean(samples) : null;
+    }
+
+    return samples.length ? mean(samples) : null;
+  }
+
+  return { readSmoothedFps, reset };
+}
+
+function mean(xs: number[]): number {
+  let sum = 0;
+  for (const x of xs) sum += x;
+  return sum / xs.length;
+}
+
+export type FpsReader = ReturnType<typeof createFpsReader>;

--- a/plugins/tdp-control/lib/mangohud.test.ts
+++ b/plugins/tdp-control/lib/mangohud.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "bun:test";
+import { appendLaunchToken, removeLaunchToken } from "@loadout/vdf";
+import {
+  mangoHudLogDir,
+  buildMangoHudConfig,
+  mangoHudTokens,
+  MANGOHUD_TOKEN_KEYS,
+} from "./mangohud";
+
+describe("MangoHud helpers", () => {
+  test("log dir is per-app under loadout/mangohud-logs", () => {
+    const dir = mangoHudLogDir(1091500);
+    expect(dir.endsWith("loadout/mangohud-logs/1091500")).toBe(true);
+  });
+
+  test("config enables continuous per-app logging", () => {
+    const cfg = buildMangoHudConfig("/tmp/logs", 200);
+    expect(cfg).toContain("output_folder=/tmp/logs");
+    expect(cfg).toContain("autostart_log=1");
+    expect(cfg).toContain("log_interval=200");
+    expect(cfg).toContain("no_display=1");
+    // No spaces — must stay a single launch-options token.
+    expect(cfg.includes(" ")).toBe(false);
+  });
+
+  test("emits three keyed tokens", () => {
+    const tokens = mangoHudTokens(42);
+    expect(tokens.map((t) => t.key)).toEqual(MANGOHUD_TOKEN_KEYS);
+    expect(tokens[0].token.startsWith("MANGOHUD_CONFIG=")).toBe(true);
+    expect(tokens[1].token).toBe("MANGOHUD=1");
+    expect(tokens[2].token).toBe("mangohud");
+  });
+
+  test("round-trips cleanly through append/remove (no orphans)", () => {
+    const tokens = mangoHudTokens(42);
+    // Apply all three, preserving an existing user token.
+    let opts = "PROTON_LOG=1 %command%";
+    for (const { token, key } of tokens) {
+      opts = appendLaunchToken(opts, token, { key, position: "before" });
+    }
+    expect(opts).toContain("mangohud");
+    expect(opts).toContain("MANGOHUD=1");
+    expect(opts).toContain("MANGOHUD_CONFIG=");
+    // mangohud wrapper sits immediately before %command%.
+    expect(opts.trim().endsWith("mangohud %command%")).toBe(true);
+
+    // Idempotent re-apply is a no-op.
+    let again = opts;
+    for (const { token, key } of tokens) {
+      again = appendLaunchToken(again, token, { key, position: "before" });
+    }
+    expect(again).toBe(opts);
+
+    // Remove all three — user's token survives, nothing orphaned.
+    for (const key of MANGOHUD_TOKEN_KEYS) {
+      opts = removeLaunchToken(opts, key);
+    }
+    expect(opts).toBe("PROTON_LOG=1 %command%");
+    expect(opts).not.toContain("mangohud");
+    expect(opts).not.toContain("MANGOHUD");
+  });
+});

--- a/plugins/tdp-control/lib/mangohud.ts
+++ b/plugins/tdp-control/lib/mangohud.ts
@@ -1,0 +1,86 @@
+/**
+ * Helpers for driving MangoHud as the FPS source for the target-FPS TDP loop.
+ *
+ * MangoHud is enabled per game by injecting three launch-option tokens into
+ * the game's Steam launch options (via the launch-options plugin's
+ * `appendLaunchToken` RPC, which builds on `@loadout/vdf`):
+ *
+ *   MANGOHUD_CONFIG=output_folder=<dir>,autostart_log=1,log_interval=200,no_display=1
+ *   MANGOHUD=1
+ *   mangohud
+ *
+ * We inject them as three *separate* single tokens rather than one space-joined
+ * blob so each is individually idempotent AND individually removable by key —
+ * `removeLaunchToken` only strips the first token matching a key, so a joined
+ * blob would leave orphans behind on disable.
+ *
+ *   - `MANGOHUD_CONFIG` (env) configures per-app continuous logging without
+ *     touching the user's global ~/.config/MangoHud/MangoHud.conf.
+ *   - `MANGOHUD=1` (env) auto-loads the Vulkan layer.
+ *   - `mangohud` (wrapper word) covers OpenGL titles.
+ *   - `no_display=1` logs without drawing the overlay.
+ *
+ * Steam launches MangoHud (not this backend), so no `permissions.commands`
+ * grant is needed for `mangohud`.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Default MangoHud log interval (ms). Faster than the controller tick. */
+export const DEFAULT_LOG_INTERVAL_MS = 200;
+
+export interface MangoHudToken {
+  /** The launch-options token string to inject. */
+  token: string;
+  /** Idempotency / removal key for appendLaunchToken / removeLaunchToken. */
+  key: string;
+}
+
+/** XDG data home, honouring $XDG_DATA_HOME. */
+function dataHome(): string {
+  return process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+}
+
+/**
+ * Per-app folder MangoHud logs into. Kept per-appId so the FPS reader can find
+ * the right session log unambiguously.
+ */
+export function mangoHudLogDir(appId: number | string): string {
+  return join(dataHome(), "loadout", "mangohud-logs", String(appId));
+}
+
+/** The MANGOHUD_CONFIG value string enabling continuous per-app logging. */
+export function buildMangoHudConfig(
+  logDir: string,
+  logIntervalMs: number = DEFAULT_LOG_INTERVAL_MS,
+): string {
+  return [
+    `output_folder=${logDir}`,
+    "autostart_log=1",
+    `log_interval=${logIntervalMs}`,
+    "no_display=1",
+  ].join(",");
+}
+
+/** The idempotency keys for all injected MangoHud tokens (for removal). */
+export const MANGOHUD_TOKEN_KEYS = ["MANGOHUD_CONFIG", "MANGOHUD", "mangohud"];
+
+/**
+ * The three tokens to inject for a game, in the order they should be appended
+ * (env assignments first, wrapper word last — each inserted before %command%).
+ */
+export function mangoHudTokens(
+  appId: number | string,
+  logIntervalMs: number = DEFAULT_LOG_INTERVAL_MS,
+): MangoHudToken[] {
+  const logDir = mangoHudLogDir(appId);
+  return [
+    {
+      token: `MANGOHUD_CONFIG=${buildMangoHudConfig(logDir, logIntervalMs)}`,
+      key: "MANGOHUD_CONFIG",
+    },
+    { token: "MANGOHUD=1", key: "MANGOHUD" },
+    { token: "mangohud", key: "mangohud" },
+  ];
+}

--- a/plugins/tdp-control/lib/tdp-profiles.test.ts
+++ b/plugins/tdp-control/lib/tdp-profiles.test.ts
@@ -804,6 +804,147 @@ describe("TDP Profile Engine", () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Target-FPS mode (closed-loop controller profiles)
+  // -------------------------------------------------------------------------
+
+  describe("target-FPS profiles", () => {
+    test("setTargetFpsProfile persists mode/targetFps/bounds without applying TDP", async () => {
+      const engine = createEngine();
+      await engine.loadProfiles();
+      await engine.setPerGameEnabled(true);
+      appliedTdpValues = [];
+
+      await engine.setTargetFpsProfile(730, "CS2", 60, {
+        minWatts: 8,
+        maxWatts: 25,
+      });
+
+      // No fixed wattage is committed — the controller owns hardware.
+      expect(appliedTdpValues).toEqual([]);
+      const p = engine.getProfile(730);
+      expect(p?.mode).toBe("targetFps");
+      expect(p?.targetFps).toBe(60);
+      expect(p?.minWatts).toBe(8);
+      expect(p?.maxWatts).toBe(25);
+      // Seed defaults to the midpoint of the bounds when nothing else is known.
+      expect(p?.tdpWatts).toBe(Math.round((8 + 25) / 2));
+    });
+
+    test("setTargetFpsProfile clamps target and swaps inverted bounds", async () => {
+      const engine = createEngine();
+      await engine.loadProfiles();
+
+      await engine.setTargetFpsProfile(1, "Game", 9999, {
+        minWatts: 30,
+        maxWatts: 6,
+      });
+      const p = engine.getProfile(1);
+      expect(p?.targetFps).toBe(240); // clamped to MAX_TARGET_FPS
+      expect(p?.minWatts).toBe(6);
+      expect(p?.maxWatts).toBe(30);
+    });
+
+    test("launching a target-mode game does not commit a fixed hold", async () => {
+      await writeConfig({
+        defaultTdp: 15,
+        profiles: [
+          {
+            appId: 730,
+            gameName: "CS2",
+            tdpWatts: 18,
+            mode: "targetFps",
+            targetFps: 90,
+          },
+        ],
+        perGameEnabled: true,
+      });
+      const engine = createEngine();
+      await engine.loadProfiles();
+
+      await engine.handleGameLaunch(730, "CS2");
+
+      // Controller governs — no automatic fixed apply from the engine.
+      expect(appliedTdpValues).toEqual([]);
+      const state = engine.getCurrentState();
+      expect(state.activeProfile?.mode).toBe("targetFps");
+      expect(state.activeProfile?.targetFps).toBe(90);
+    });
+
+    test("applyManagedTdp routes through the serialized/debounced queue", async () => {
+      const engine = createEngine();
+      await engine.loadProfiles();
+
+      // A rapid burst collapses to a single hardware write of the latest value.
+      const p1 = engine.applyManagedTdp(10);
+      const p2 = engine.applyManagedTdp(20);
+      const p3 = engine.applyManagedTdp(30);
+      await Promise.all([p1, p2, p3]);
+
+      expect(appliedTdpValues).toEqual([30]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // v1 -> v2 migration
+  // -------------------------------------------------------------------------
+
+  describe("store migration", () => {
+    test("legacy v1 profiles load as fixed; a target profile keeps its fields", async () => {
+      await Bun.write(
+        configPath,
+        JSON.stringify({
+          version: 1,
+          defaultTdp: 15,
+          perGameEnabled: true,
+          profiles: [
+            { appId: 730, gameName: "CS2", tdpWatts: 25 }, // legacy fixed
+            {
+              appId: 570,
+              gameName: "Dota",
+              tdpWatts: 12,
+              mode: "targetFps",
+              targetFps: 60,
+              minWatts: 5,
+              maxWatts: 20,
+            },
+          ],
+        }),
+      );
+      const engine = createEngine();
+      await engine.loadProfiles();
+
+      const fixed = engine.getProfile(730);
+      expect(fixed).toEqual({ appId: 730, gameName: "CS2", tdpWatts: 25 });
+      expect(fixed?.mode).toBeUndefined();
+
+      const target = engine.getProfile(570);
+      expect(target?.mode).toBe("targetFps");
+      expect(target?.targetFps).toBe(60);
+
+      // Saving rewrites the store at the current schema version.
+      await engine.saveProfiles();
+      expect((await readConfig()).version).toBe(2);
+    });
+
+    test("a target profile with no numeric targetFps coerces to fixed", async () => {
+      await Bun.write(
+        configPath,
+        JSON.stringify({
+          version: 2,
+          defaultTdp: 15,
+          perGameEnabled: true,
+          profiles: [{ appId: 1, gameName: "Bad", tdpWatts: 10, mode: "targetFps" }],
+        }),
+      );
+      const engine = createEngine();
+      await engine.loadProfiles();
+      const p = engine.getProfile(1);
+      expect(p?.mode).toBeUndefined();
+      expect(p).toEqual({ appId: 1, gameName: "Bad", tdpWatts: 10 });
+    });
+  });
+
   describe("getProfile / getAllProfiles", () => {
     test("getProfile returns undefined for non-existent appId", async () => {
       const engine = createEngine();

--- a/plugins/tdp-control/lib/tdp-profiles.ts
+++ b/plugins/tdp-control/lib/tdp-profiles.ts
@@ -5,15 +5,30 @@ import { readPluginStorage, mutatePluginStorage } from "@loadout/plugin-storage"
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * How a per-game profile drives TDP:
+ *   - "fixed": apply a constant wattage (the original behavior).
+ *   - "targetFps": let the closed-loop FPS controller adjust wattage to hold
+ *     `targetFps`. `tdpWatts` becomes the controller's seed / last-good value.
+ * Undefined ⇒ "fixed" (back-compat with v1 stores).
+ */
+export type TdpProfileMode = "fixed" | "targetFps";
+
 export interface TdpProfile {
   appId: number;
   gameName: string;
-  tdpWatts: number; // 3-80
+  tdpWatts: number; // 3-80; in target mode this is the controller seed
+  mode?: TdpProfileMode;
+  /** Required when mode === "targetFps". */
+  targetFps?: number;
+  /** Optional controller lower/upper watt bounds; default to the device range. */
+  minWatts?: number;
+  maxWatts?: number;
 }
 
 export interface TdpProfileStore {
   /** Schema version. Bumped when the shape changes. */
-  version: 1;
+  version: 1 | 2;
   /** TDP applied when no game is running, or when a game has no profile. */
   defaultTdp: number;
   /** Per-game saved TDP. */
@@ -61,6 +76,14 @@ const MIN_TDP_WATTS = 3;
 const MAX_TDP_WATTS = 80;
 const DEFAULT_TDP_WATTS = 15;
 
+export const MIN_TARGET_FPS = 20;
+export const MAX_TARGET_FPS = 240;
+export const DEFAULT_TARGET_FPS = 60;
+
+// Current on-disk schema version. v2 adds the optional target-FPS fields to
+// each profile; all additive/optional, so a v1 store loads unchanged.
+const STORE_VERSION = 2;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -69,9 +92,13 @@ function clampTdp(watts: number): number {
   return Math.max(MIN_TDP_WATTS, Math.min(MAX_TDP_WATTS, Math.round(watts)));
 }
 
+function clampTargetFps(fps: number): number {
+  return Math.max(MIN_TARGET_FPS, Math.min(MAX_TARGET_FPS, Math.round(fps)));
+}
+
 function createDefaultStore(): TdpProfileStore {
   return {
-    version: 1,
+    version: STORE_VERSION,
     defaultTdp: DEFAULT_TDP_WATTS,
     profiles: [],
     perGameEnabled: false,
@@ -95,13 +122,40 @@ function normalizeStore(parsed: unknown): TdpProfileStore | null {
         typeof (p as TdpProfile).gameName === "string" &&
         typeof (p as TdpProfile).tdpWatts === "number",
     )
-    .map((p) => ({
-      appId: p.appId,
-      gameName: p.gameName,
-      tdpWatts: clampTdp(p.tdpWatts),
-    }));
+    .map((p) => {
+      // Every legacy (v1) profile normalizes to a plain fixed profile, so the
+      // v1→v2 migration is a no-op in shape and old data loads unchanged.
+      const base: TdpProfile = {
+        appId: p.appId,
+        gameName: p.gameName,
+        tdpWatts: clampTdp(p.tdpWatts),
+      };
+      // Target-FPS mode is only honored when it's the exact literal AND a
+      // sane numeric target is present; anything else coerces back to fixed.
+      const isTarget =
+        p.mode === "targetFps" &&
+        typeof p.targetFps === "number" &&
+        Number.isFinite(p.targetFps);
+      if (!isTarget) return base;
+
+      const out: TdpProfile = {
+        ...base,
+        mode: "targetFps",
+        targetFps: clampTargetFps(p.targetFps as number),
+      };
+      if (typeof p.minWatts === "number") out.minWatts = clampTdp(p.minWatts);
+      if (typeof p.maxWatts === "number") out.maxWatts = clampTdp(p.maxWatts);
+      if (
+        out.minWatts !== undefined &&
+        out.maxWatts !== undefined &&
+        out.minWatts > out.maxWatts
+      ) {
+        [out.minWatts, out.maxWatts] = [out.maxWatts, out.minWatts];
+      }
+      return out;
+    });
   return {
-    version: 1,
+    version: STORE_VERSION,
     defaultTdp: clampTdp(obj.defaultTdp),
     profiles,
     perGameEnabled: typeof obj.perGameEnabled === "boolean" ? obj.perGameEnabled : false,
@@ -278,8 +332,15 @@ export function createTdpProfileEngine(options: TdpProfileEngineOptions) {
 
     if (profile) {
       currentTdp = profile.tdpWatts;
-      await commitTdp(profile.tdpWatts);
-      onProfileChanged(profile, gameName);
+      if (profile.mode === "targetFps") {
+        // The FPS controller governs wattage for this game — do NOT commit a
+        // fixed hold here (that would fight the loop). The backend seeds the
+        // starting wattage once and drives the controller from there.
+        onProfileChanged(profile, gameName);
+      } else {
+        await commitTdp(profile.tdpWatts);
+        onProfileChanged(profile, gameName);
+      }
     } else {
       const watts = noGameTdp();
       currentTdp = watts;
@@ -332,6 +393,61 @@ export function createTdpProfileEngine(options: TdpProfileEngineOptions) {
         currentTdp = clamped;
         await commitTdp(clamped);
       }
+      onProfileChanged(activeProfile, gameName);
+    }
+  }
+
+  /**
+   * Create or update a per-game profile in **target-FPS** mode. The profile's
+   * `tdpWatts` becomes the controller seed (existing value, explicit seed, or
+   * the midpoint of the bounds). Unlike setProfile this never commits a fixed
+   * wattage — the backend's FPS controller owns hardware for target-mode games.
+   */
+  async function setTargetFpsProfile(
+    appId: number,
+    gameName: string,
+    targetFps: number,
+    opts?: { minWatts?: number; maxWatts?: number; seedWatts?: number },
+  ): Promise<void> {
+    const clampedTarget = clampTargetFps(targetFps);
+    const existing = store.profiles.find((p) => p.appId === appId);
+
+    let minWatts = opts?.minWatts !== undefined ? clampTdp(opts.minWatts) : existing?.minWatts;
+    let maxWatts = opts?.maxWatts !== undefined ? clampTdp(opts.maxWatts) : existing?.maxWatts;
+    if (minWatts !== undefined && maxWatts !== undefined && minWatts > maxWatts) {
+      [minWatts, maxWatts] = [maxWatts, minWatts];
+    }
+
+    const midpoint =
+      minWatts !== undefined && maxWatts !== undefined
+        ? Math.round((minWatts + maxWatts) / 2)
+        : undefined;
+    const seed = clampTdp(
+      existing?.tdpWatts ?? opts?.seedWatts ?? midpoint ?? DEFAULT_TDP_WATTS,
+    );
+
+    const next: TdpProfile = {
+      appId,
+      gameName,
+      tdpWatts: seed,
+      mode: "targetFps",
+      targetFps: clampedTarget,
+    };
+    if (minWatts !== undefined) next.minWatts = minWatts;
+    if (maxWatts !== undefined) next.maxWatts = maxWatts;
+
+    if (existing) {
+      const idx = store.profiles.indexOf(existing);
+      store.profiles[idx] = next;
+    } else {
+      store.profiles.push(next);
+    }
+    await saveProfiles();
+
+    // Reflect it if this game is running. Never commit a fixed wattage — the
+    // backend (re)starts the controller in response to onProfileChanged.
+    if (isGameRunning && activeAppId === appId) {
+      activeProfile = { ...next };
       onProfileChanged(activeProfile, gameName);
     }
   }
@@ -422,12 +538,25 @@ export function createTdpProfileEngine(options: TdpProfileEngineOptions) {
     return activeAppId;
   }
 
+  /**
+   * Apply a wattage through the same 250ms-debounced, strictly-serialized
+   * commit queue the engine uses internally. The FPS controller writes ONLY
+   * through this, so controller writes, game-launch applies, and slider writes
+   * can never issue concurrent SMU-mailbox writes (the documented APU-hang
+   * hazard — see commitTdp above).
+   */
+  function applyManagedTdp(watts: number): Promise<void> {
+    return commitTdp(watts);
+  }
+
   return {
     loadProfiles,
     saveProfiles,
     handleGameLaunch,
     handleGameExit,
     setProfile,
+    setTargetFpsProfile,
+    applyManagedTdp,
     removeProfile,
     getProfile,
     getAllProfiles,


### PR DESCRIPTION
Add a per-game "Target FPS" mode to the TDP plugin. When enabled for a
game, a closed-loop controller nudges wattage up/down to hold the chosen
frame rate, using MangoHud as the live FPS source. Games can still use a
fixed wattage (existing behaviour); each game picks its own mode.

- lib/fps-controller.ts: pure control math — proportional step with an
  asymmetric deadband, one-tick settle skip, reduce-side hysteresis, and
  saturation/floor detection. No I/O or timers, fully unit-tested.
- lib/fps-reader.ts: tails the newest MangoHud CSV, incremental byte-offset
  reads, header-driven fps column, rolling average, stale/rotation handling
  (follows the no-.exists() pseudo-file read rule).
- lib/mangohud.ts: per-app log dir + the three keyed launch-option tokens
  (MANGOHUD_CONFIG / MANGOHUD=1 / mangohud) injected and removed
  individually so nothing is orphaned on disable.
- lib/tdp-profiles.ts: additive mode/targetFps/min/maxWatts fields, v1->v2
  store migration, setTargetFpsProfile, and applyManagedTdp so controller
  writes share the existing 250ms debounced/serialised commit queue (the
  documented SMU-mailbox / APU-hang mitigation).
- backend.ts: 2s controller loop, AC-aware watt bounds, start/stop wired to
  game launch/exit + the per-game toggle, FPS-source grace period, and RPCs
  (setGameTargetFps / clearGameTargetFps / getControllerState /
  enable|disable|getMangoHudStatus). A manual setTdp pauses the controller.
- app.tsx: per-game Fixed | Target FPS selector, target stepper, live
  fps/watts/status readout, MangoHud toggle, and target-mode grid badges.

Note: SteamOS's native handheld TDP is a manual slider + framerate *cap*;
it has no closed-loop "raise power to hit a target" mode, so this is
additive. The controller deliberately doesn't fight the manual slider.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UCN3xL3tW5vRECAR8qTnrY