### PR TITLE
fix(tdp-control): read TDP back through the resolved ryzenadj path

### DIFF
--- a/plugins/tdp-control/backend.test.ts
+++ b/plugins/tdp-control/backend.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { EmitPayload } from "@loadout/types";
@@ -272,6 +272,47 @@ describe("TdpControlBackend", () => {
       expect(info.maxWatts).toBe(55); // effective (on battery)
       expect(info.pluggedMaxWatts).toBe(80);
       expect(info.batteryMaxWatts).toBe(55);
+    });
+  });
+
+  // ── TDP read-back via bundled ryzenadj ────────────────────────────
+  //
+  // readTdpViaRyzenadj() must exec the resolved ryzenadjPath (the bundled
+  // binary on stock SteamOS), not a bare "ryzenadj" that only works when a
+  // system install happens to be on $PATH. Regression: the read-back
+  // silently failed on every poll and the UI stayed on the "tracked" value.
+
+  describe("TDP read-back via ryzenadjPath", () => {
+    let dir: string;
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), "tdp-ryzenadj-read-"));
+    });
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("reads STAPM LIMIT through the resolved binary path", async () => {
+      const fake = join(dir, "ryzenadj");
+      await Bun.write(
+        fake,
+        '#!/bin/sh\necho "STAPM LIMIT : 25.000 | some other columns"\n',
+      );
+      chmodSync(fake, 0o755);
+
+      const b = backend as unknown as {
+        method: string;
+        ryzenadjCanRead: boolean;
+        ryzenadjPath: string;
+      };
+      b.method = "ryzenadj";
+      b.ryzenadjCanRead = true;
+      b.ryzenadjPath = fake;
+
+      const info = await backend.getTdpInfo();
+      expect(info.currentTdp).toBe(25);
+      expect(info.tdpReadSource).toBe("read");
     });
   });
 

--- a/plugins/tdp-control/backend.ts
+++ b/plugins/tdp-control/backend.ts
@@ -1642,7 +1642,7 @@ export default class TdpControlBackend implements PluginBackend {
   private async readTdpViaRyzenadj(): Promise<number | null> {
     try {
       const { exitCode, stdout } = await runCommand([
-        "ryzenadj",
+        this.ryzenadjPath || "ryzenadj",
         "--info",
       ]);
       if (exitCode !== 0) return null;


### PR DESCRIPTION
`readTdpViaRyzenadj()` exec'd a bare `ryzenadj` instead of `this.ryzenadjPath`, so on stock SteamOS (where only the bundled binary exists) every TDP read-back silently failed: `testRyzenadjRead()` uses the resolved path and reports read-capable, but the actual reads — the 5-second poll loop and `getTdpInfo()` — spawned a doomed bare `ryzenadj` and fell back to the "tracked" value. Net effect: the UI displays the configured limit as if it were a live reading, and every poll wastes a failing subprocess spawn.

One-line fix plus a regression test that drives `getTdpInfo()` through a fixture script standing in for the bundled binary (fails on the old code, deterministic regardless of whether a system ryzenadj is installed).

Note: on Strix Halo devices (APEX, GPD Win 5) ryzenadj can't read STAPM at all, so `ryzenadjCanRead` is false there and this path never runs — the fix matters for APUs that can read (Phoenix/Hawk Point etc.).

Heads-up: #216 touches the same file; whichever lands second is a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWbDpnQ7amkzT5AS2Dq633