### PR TITLE
feat(recomp): nine new catalog titles + auto-extract game data from disc images and XBLA packages

### DIFF
--- a/plugins/recomp/README.md
+++ b/plugins/recomp/README.md
@@ -4,6 +4,23 @@
 
 Browse, install, and launch community recompilations and native ports of classic games — you supply your own game files and it handles the rest, turning supported retro titles into properly native Linux builds.
 
+## Game data & catalog policy
+
+RecompHub ships **no copyrighted game data** and downloads none. Every
+catalog entry links to a community recompilation/decompilation project;
+the plugin fetches only that project's own release binary from its
+GitHub releases. All game data (ROMs, disc images, XBLA packages) is
+supplied by the user from their own legally owned copy, via the ROM
+picker — nothing is bundled, downloaded, or auto-discovered from the
+network. The disc-image / XBLA extractors (`lib/rom-source.ts`) are
+plain unencrypted-filesystem readers: no keys, no decryption, no DRM
+circumvention.
+
+A catalog entry is a link to an upstream project, not a host for it. If
+an upstream project receives a DMCA takedown or is pulled, remove its
+entry from `games.json` promptly — the catalog's standing tracks the
+health of the projects it points at.
+
 ## Screenshots
 
 ### Overview

--- a/plugins/recomp/backend.ts
+++ b/plugins/recomp/backend.ts
@@ -34,6 +34,8 @@ import { applyArtwork, getCatalogArtUrl, getDetailHeroUrl } from "./lib/artwork"
 import { getEffectivePlatformValue } from "./lib/platform";
 import { pickRomFile } from "./lib/file-picker";
 import { suggestRomsForTitle, type RomSuggestion } from "./lib/rom-suggest";
+import { resolveWithinDir } from "./lib/path-confine";
+import { existsSync } from "node:fs";
 
 /**
  * Fallback ROM extensions used by `suggestRomFiles` when a catalog
@@ -743,6 +745,31 @@ export default class RecompBackend implements PluginBackend {
 
     const installed = this.state.games[id];
     if (!installed) throw new Error(`Game '${id}' is not installed`);
+
+    // Launch guard for structured-dump games: without its anchor file
+    // the engine exits instantly with a cryptic "game_data_root does
+    // not exist" log line the user never sees (today's field report:
+    // "castlevania crashes on launch"). Refuse with an actionable
+    // message instead — reinstalling with the dump repopulates it.
+    const romInfo = entry.romInfo;
+    if (
+      romInfo?.anchorFile &&
+      romInfo.sourceFormat &&
+      romInfo.sourceFormat !== "raw"
+    ) {
+      const anchor = resolveWithinDir(
+        installed.installDir,
+        `${romInfo.extractTo ?? "assets"}/${romInfo.anchorFile}`,
+        "romInfo anchor",
+      );
+      if (!existsSync(anchor)) {
+        throw new Error(
+          `${entry.name} is missing its game data (${romInfo.extractTo ?? "assets"}/` +
+            `${romInfo.anchorFile}). Reinstall the game and provide your ` +
+            `game dump when prompted.`,
+        );
+      }
+    }
 
     await launchGame(entry, installed);
   }

--- a/plugins/recomp/games.json
+++ b/plugins/recomp/games.json
@@ -1542,42 +1542,6 @@
       "steamGridDbId": 5256824
     },
     {
-      "id": "shortline",
-      "name": "ShortLine",
-      "project": "The reversed source code for ShortLine v1.1 game",
-      "platform": "unknown",
-      "repo": "konovalov-aleks/reSL",
-      "description": "Reverse-engineered recreation of the 1993 Russian railway game ShortLine. Fully self-contained.",
-      "installType": "prebuilt",
-      "releaseAssets": {
-        "windows": "resl-*-windows.zip",
-        "linux": null
-      },
-      "launchCommand": {
-        "windows": "{installDir}/resl.exe",
-        "linux": null
-      },
-      "tags": [
-        "coroutine",
-        "coroutines",
-        "cpp",
-        "decompilation",
-        "dos",
-        "emscripten",
-        "game",
-        "game-2d",
-        "ghidra",
-        "old-game",
-        "reimplementation",
-        "reverse-engineering",
-        "reversed",
-        "webassembly"
-      ],
-      "website": "https://konovalov-aleks.github.io/shortline-railroads.html",
-      "latestVersion": "release-1.1.2",
-      "steamGridDbId": 5310062
-    },
-    {
       "id": "samurai-vs-zombies",
       "name": "Samurai Vs Zombies",
       "project": "Decompilation of Samurai Vs Zombies by Glu",

--- a/plugins/recomp/games.json
+++ b/plugins/recomp/games.json
@@ -8414,7 +8414,7 @@
       "installType": "rom_extract",
       "requiresRom": true,
       "romInfo": {
-        "description": "Provide your legally dumped Castlevania: SotN XBLA package (the LIVE/STFS content file, title ID 58410847), or a zip/7z/rar containing it. XBLA content files have no file extension — if the picker can't see yours, type the path manually.",
+        "description": "Provide your legally dumped Castlevania: SotN XBLA package (the LIVE/STFS content file, found on your own console under Content/0000000000000000/58410847/000D0000/), or a zip/7z/rar containing it. XBLA content files have no file extension — if the picker can't see yours, type the path manually.",
         "validChecksums": [],
         "extractionCommand": "",
         "extensions": ["zip", "7z", "rar", "bin"],

--- a/plugins/recomp/games.json
+++ b/plugins/recomp/games.json
@@ -824,28 +824,6 @@
       "status": "in_progress"
     },
     {
-      "id": "space-cadet-pinball",
-      "name": "Space Cadet Pinball",
-      "project": "SpaceCadetPinball",
-      "platform": "ps1",
-      "repo": "k4zmu2a/SpaceCadetPinball",
-      "description": "Decompilation of 3D Pinball: Space Cadet from Windows XP. Standalone, no data files needed.",
-      "installType": "prebuilt",
-      "releaseAssets": {
-        "windows": "SpaceCadetPinballx64Win.zip"
-      },
-      "launchCommand": {
-        "windows": "{installDir}/SpaceCadetPinball.exe"
-      },
-      "tags": [
-        "pinball",
-        "windows",
-        "classic"
-      ],
-      "latestVersion": "Release_2.1.0",
-      "steamGridDbId": 17822
-    },
-    {
       "id": "redriver2",
       "name": "Driver 2",
       "project": "REDRIVER2",
@@ -2621,21 +2599,6 @@
       "steamGridDbId": 5265246
     },
     {
-      "id": "doom-64",
-      "name": "Doom 64",
-      "project": "Doom 64 Reverse Engineering By [GEC]",
-      "platform": "n64",
-      "repo": "Erick194/DOOM64-RE",
-      "description": "Doom 64 Reverse Engineering By [GEC]",
-      "installType": "prebuilt",
-      "releaseAssets": {},
-      "launchCommand": {},
-      "status": "in_progress",
-      "tags": [],
-      "website": null,
-      "steamGridDbId": 25626
-    },
-    {
       "id": "battle-city",
       "name": "Battle City",
       "project": "Source code of some NES games",
@@ -2951,21 +2914,6 @@
       "tags": [],
       "website": "https://bfbbdecomp.github.io/bfbb/",
       "steamGridDbId": 38661
-    },
-    {
-      "id": "doom-psx",
-      "name": "Doom PSX",
-      "project": "Psx Doom Reverse Engineering By [GEC]",
-      "platform": "ps1",
-      "repo": "Erick194/PSXDOOM-RE",
-      "description": "Psx Doom Reverse Engineering By [GEC]",
-      "installType": "prebuilt",
-      "releaseAssets": {},
-      "launchCommand": {},
-      "status": "in_progress",
-      "tags": [],
-      "website": null,
-      "steamGridDbId": 5461568
     },
     {
       "id": "resident-evil-code-veronica-x",
@@ -8565,32 +8513,6 @@
       "website": "https://github.com/999sian/tmc",
       "latestVersion": "v0.8.3",
       "steamGridDbId": 34539
-    },
-    {
-      "id": "psydoom",
-      "name": "Doom (PSX)",
-      "project": "PsyDoom",
-      "platform": "ps1",
-      "repo": "BodbDearg/PsyDoom",
-      "description": "Native PC port of PlayStation Doom and Final Doom built on the PSXDOOM-RE decompilation. Vulkan renderer with high-resolution and widescreen support, uncapped framerate and quality-of-life options. Requires a disc image (.cue) of PSX Doom or Final Doom - the built-in launcher lets you point at it on first run.",
-      "installType": "prebuilt",
-      "releaseAssets": {
-        "windows": "PsyDoom_*_Windows_x86_64.zip",
-        "linux": "PsyDoom_*_Linux_x86_64.AppImage"
-      },
-      "launchCommand": {
-        "windows": "{installDir}/PsyDoom.exe",
-        "linux": "{installDir}/PsyDoom.AppImage"
-      },
-      "tags": [
-        "doom",
-        "ps1",
-        "fps",
-        "3d"
-      ],
-      "website": "https://github.com/BodbDearg/PsyDoom",
-      "latestVersion": "1.1.1",
-      "steamGridDbId": 2460
     },
     {
       "id": "ssb64-battleship",

--- a/plugins/recomp/games.json
+++ b/plugins/recomp/games.json
@@ -8498,8 +8498,19 @@
       "project": "NocturneRecomp",
       "platform": "xbox360",
       "repo": "birabittoh/NocturneRecomp",
-      "description": "Native PC port of the Xbox 360 (XBLA) version of Castlevania: Symphony of the Night via ReXGlue static recompilation. Ships no game data: place your legally dumped XBLA package (the LIVE/STFS file) into game/ inside the install folder and run the bundled extraction script - or manage assets, mods and updates with the optional Goopie launcher.",
-      "installType": "prebuilt",
+      "description": "Native PC port of the Xbox 360 (XBLA) version of Castlevania: Symphony of the Night via ReXGlue static recompilation. Ships no game data: provide your legally dumped XBLA package (the LIVE/STFS content file, or an archive containing it) and the installer unpacks it into assets/ automatically.",
+      "installType": "rom_extract",
+      "requiresRom": true,
+      "romInfo": {
+        "description": "Provide your legally dumped Castlevania: SotN XBLA package (the LIVE/STFS content file, title ID 58410847), or a zip/7z/rar containing it. XBLA content files have no file extension — if the picker can't see yours, type the path manually.",
+        "validChecksums": [],
+        "extractionCommand": "",
+        "extensions": ["zip", "7z", "rar", "bin"],
+        "sourceFormat": "stfs",
+        "extractTo": "assets",
+        "anchorFile": "default.xex",
+        "anchorChecksums": ["88055ecfb131042522a28c9211b760f4d3ec4547"]
+      },
       "releaseAssets": {
         "windows": "nocturnerecomp-v*-windows-x64.zip",
         "linux": "nocturnerecomp-v*-linux-x64.tar.gz"
@@ -8663,8 +8674,19 @@
       "project": "TiP-Recomp",
       "platform": "xbox360",
       "repo": "SolarCookies/TiP-Recomp",
-      "description": "Native PC port of the Xbox 360 version of Viva Pinata: Trouble in Paradise via ReXGlue static recompilation, with mod support. Ships no game data: extract your legally owned World-region ISO into the install folder - the optional Goopie launcher automates this via Select Iso. Windows build, launched via Proton.",
-      "installType": "prebuilt",
+      "description": "Native PC port of the Xbox 360 version of Viva Pinata: Trouble in Paradise via ReXGlue static recompilation, with mod support. Ships no game data: provide a disc image ripped from your legally owned Xbox 360 copy (or an archive containing one) and the installer unpacks it into assets/ automatically. Windows build, launched via Proton.",
+      "installType": "rom_extract",
+      "requiresRom": true,
+      "romInfo": {
+        "description": "Provide a disc image (.iso) ripped from your legally owned Viva Pinata: Trouble in Paradise Xbox 360 disc, or a zip/7z/rar containing one. Upstream recommends a World-region disc.",
+        "validChecksums": [],
+        "extractionCommand": "",
+        "extensions": ["iso", "zip", "7z", "rar"],
+        "sourceFormat": "xgd-iso",
+        "extractTo": "assets",
+        "anchorFile": "default.xex",
+        "anchorChecksums": ["c5970941fcb201dda99de0d35b623827241d6b8b"]
+      },
       "releaseAssets": {
         "windows": "retip_*-windows-x64-*.zip"
       },
@@ -8687,8 +8709,19 @@
       "project": "SVR07 Recomp",
       "platform": "xbox360",
       "repo": "HollywoodAkeem/SVR07-Recomp",
-      "description": "Native PC port of the Xbox 360 version of WWE SmackDown vs. Raw 2007 via ReXGlue static recompilation. Ships no game data: rip your legally owned retail Xbox 360 copy and extract its files into assets/ next to the executable. Windows build, launched via Proton.",
-      "installType": "prebuilt",
+      "description": "Native PC port of the Xbox 360 version of WWE SmackDown vs. Raw 2007 via ReXGlue static recompilation. Ships no game data: provide a disc image ripped from your legally owned retail Xbox 360 copy (or an archive containing one) and the installer unpacks it into assets/ automatically. Windows build, launched via Proton.",
+      "installType": "rom_extract",
+      "requiresRom": true,
+      "romInfo": {
+        "description": "Provide a disc image (.iso) ripped from your legally owned WWE SmackDown vs. Raw 2007 Xbox 360 disc, or a zip/7z/rar containing one. USA/Canada discs are recommended by upstream; other regions are untested.",
+        "validChecksums": [],
+        "extractionCommand": "",
+        "extensions": ["iso", "zip", "7z", "rar"],
+        "sourceFormat": "xgd-iso",
+        "extractTo": "assets",
+        "anchorFile": "default.xex",
+        "anchorChecksums": ["5745805d807f672c7b1cb89767d7c884ecf76f53"]
+      },
       "releaseAssets": {
         "windows": "svr07.zip"
       },

--- a/plugins/recomp/games.json
+++ b/plugins/recomp/games.json
@@ -8465,6 +8465,245 @@
         "pc"
       ],
       "website": "https://www.timesplittersrewind.com/"
+    },
+    {
+      "id": "harvest-moon-64-recomp",
+      "name": "Harvest Moon 64",
+      "project": "Harvest Moon 64: Recompiled",
+      "platform": "n64",
+      "repo": "HarvestMoon64Recomp/HarvestMoon64Recomp",
+      "description": "Native PC port of Harvest Moon 64 via static recompilation (N64Recomp + RT64 renderer). Widescreen, high framerate and Thunderstore mod support. On first launch, provide your own North American (US) ROM in the main menu - assets load straight from it, no extraction step. Requires Vulkan 1.2.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "HarvestMoon64Recompiled-*-Windows.zip",
+        "linux": "HarvestMoon64Recompiled-*-Linux-X64.zip"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/HarvestMoon64Recompiled.exe",
+        "linux": "{installDir}/HarvestMoon64Recompiled"
+      },
+      "tags": [
+        "harvest-moon",
+        "n64",
+        "farming-sim",
+        "3d"
+      ],
+      "website": "https://github.com/HarvestMoon64Recomp/HarvestMoon64Recomp",
+      "latestVersion": "v1.2.1",
+      "steamGridDbId": 35297
+    },
+    {
+      "id": "sotn-xbla-recomp",
+      "name": "Castlevania: Symphony of the Night",
+      "project": "NocturneRecomp",
+      "platform": "xbox360",
+      "repo": "birabittoh/NocturneRecomp",
+      "description": "Native PC port of the Xbox 360 (XBLA) version of Castlevania: Symphony of the Night via ReXGlue static recompilation. Ships no game data: place your legally dumped XBLA package (the LIVE/STFS file) into game/ inside the install folder and run the bundled extraction script - or manage assets, mods and updates with the optional Goopie launcher.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "nocturnerecomp-v*-windows-x64.zip",
+        "linux": "nocturnerecomp-v*-linux-x64.tar.gz"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/nocturnerecomp.exe",
+        "linux": "{installDir}/nocturnerecomp"
+      },
+      "tags": [
+        "castlevania",
+        "xbox360",
+        "metroidvania",
+        "2d"
+      ],
+      "website": "https://github.com/birabittoh/NocturneRecomp",
+      "latestVersion": "v1.3.2",
+      "steamGridDbId": 37654
+    },
+    {
+      "id": "minish-cap-picori",
+      "name": "The Legend of Zelda: The Minish Cap",
+      "project": "Project Picori",
+      "platform": "gba",
+      "repo": "999sian/tmc",
+      "description": "Native PC port of The Minish Cap built on the zeldaret decompilation. SDL3 with widescreen support and native gamepad input. Provide your own GBA ROM during install - it is placed next to the binary as baserom.gba and the game reads assets from it directly.",
+      "installType": "rom_extract",
+      "releaseAssets": {
+        "windows": "tmc-multi-windows-x86_64-v*.tar.gz",
+        "linux": "tmc-multi-linux-x86_64-v*.tar.gz"
+      },
+      "romInfo": {
+        "description": "Provide your legally owned The Legend of Zelda: The Minish Cap GBA ROM, USA region (SHA-1 b4bd50e4131b027c334547b4524e2dbbd4227130). EU and JP dumps are supported by the port under different filenames, but this install uses the US filename.",
+        "validChecksums": [
+          "b4bd50e4131b027c334547b4524e2dbbd4227130"
+        ],
+        "extractionCommand": "",
+        "extensions": [
+          "gba"
+        ],
+        "placeRomAs": "baserom.gba"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/tmc_pc.exe",
+        "linux": "{installDir}/tmc_pc"
+      },
+      "tags": [
+        "zelda",
+        "gba",
+        "action-adventure",
+        "2d"
+      ],
+      "website": "https://github.com/999sian/tmc",
+      "latestVersion": "v0.8.3",
+      "steamGridDbId": 34539
+    },
+    {
+      "id": "psydoom",
+      "name": "Doom (PSX)",
+      "project": "PsyDoom",
+      "platform": "ps1",
+      "repo": "BodbDearg/PsyDoom",
+      "description": "Native PC port of PlayStation Doom and Final Doom built on the PSXDOOM-RE decompilation. Vulkan renderer with high-resolution and widescreen support, uncapped framerate and quality-of-life options. Requires a disc image (.cue) of PSX Doom or Final Doom - the built-in launcher lets you point at it on first run.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "PsyDoom_*_Windows_x86_64.zip",
+        "linux": "PsyDoom_*_Linux_x86_64.AppImage"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/PsyDoom.exe",
+        "linux": "{installDir}/PsyDoom.AppImage"
+      },
+      "tags": [
+        "doom",
+        "ps1",
+        "fps",
+        "3d"
+      ],
+      "website": "https://github.com/BodbDearg/PsyDoom",
+      "latestVersion": "1.1.1",
+      "steamGridDbId": 2460
+    },
+    {
+      "id": "ssb64-battleship",
+      "name": "Super Smash Bros.",
+      "project": "BattleShip",
+      "platform": "n64",
+      "repo": "JRickey/BattleShip",
+      "description": "Native PC port of Super Smash Bros. (N64) built on the ssb-decomp-re decompilation via libultraship. A first-run wizard extracts assets from your legally owned NTSC-U 1.0 ROM (SHA-1 e2929e10fccc0aa84e5776227e798abc07cedabf). This entry installs the US build; a separate JP build exists upstream.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "BattleShip-windows.zip",
+        "linux": "BattleShip-x86_64.AppImage"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/BattleShip.exe",
+        "linux": "{installDir}/BattleShip.AppImage"
+      },
+      "tags": [
+        "smash-bros",
+        "n64",
+        "fighting",
+        "3d"
+      ],
+      "website": "https://github.com/JRickey/BattleShip",
+      "latestVersion": "v1.5.1",
+      "steamGridDbId": 33624
+    },
+    {
+      "id": "aitd-rehaunted",
+      "name": "Alone in the Dark",
+      "project": "Alone in the Dark: ReHaunted",
+      "platform": "pc",
+      "repo": "spacefarergames/AloneInTheDarkReHaunted",
+      "description": "Modernized GPL engine for the original Alone in the Dark (1992) with HD backgrounds, upscaled masks and controller support. Ships no game data: copy the original .PAK/.ITD data files from your Steam or GOG install of the game into the install folder, then launch.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "AITD_REHAUNTED_*_Win64.zip",
+        "linux": "AITD_REHAUNTED_*_Linux.tar.gz"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/Tatou.exe",
+        "linux": "{installDir}/launch_tatou.sh"
+      },
+      "tags": [
+        "alone-in-the-dark",
+        "pc",
+        "survival-horror",
+        "3d"
+      ],
+      "website": "https://github.com/spacefarergames/AloneInTheDarkReHaunted",
+      "latestVersion": "2.2.0.2704",
+      "steamGridDbId": 3276
+    },
+    {
+      "id": "downpour-recomp",
+      "name": "Silent Hill: Downpour",
+      "project": "DownpourRecomp",
+      "platform": "xbox360",
+      "repo": "LittleBitUA/DownpourRecomp",
+      "description": "Native PC port of the Xbox 360 version of Silent Hill: Downpour via ReXGlue static recompilation, with unlocked 60 FPS. Ships no game data: copy your dumped Xbox 360 copy (default.xex plus the game data folders) into assets/ inside the install folder; the launcher opens a wizard to stage Title Update 1 (default.xexp) on first run. Windows build, launched via Proton.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "DownpourRecomp-v*.zip"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/PlayDownpour.exe"
+      },
+      "tags": [
+        "silent-hill",
+        "xbox360",
+        "survival-horror",
+        "3d"
+      ],
+      "website": "https://github.com/LittleBitUA/DownpourRecomp",
+      "latestVersion": "v1.1.6",
+      "steamGridDbId": 34912
+    },
+    {
+      "id": "viva-pinata-tip-recomp",
+      "name": "Viva Pinata: Trouble in Paradise",
+      "project": "TiP-Recomp",
+      "platform": "xbox360",
+      "repo": "SolarCookies/TiP-Recomp",
+      "description": "Native PC port of the Xbox 360 version of Viva Pinata: Trouble in Paradise via ReXGlue static recompilation, with mod support. Ships no game data: extract your legally owned World-region ISO into the install folder - the optional Goopie launcher automates this via Select Iso. Windows build, launched via Proton.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "retip_*-windows-x64-*.zip"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/retip.exe"
+      },
+      "tags": [
+        "viva-pinata",
+        "xbox360",
+        "simulation",
+        "3d"
+      ],
+      "website": "https://github.com/SolarCookies/TiP-Recomp",
+      "latestVersion": "1.11.2",
+      "steamGridDbId": 5262214
+    },
+    {
+      "id": "svr07-recomp",
+      "name": "WWE SmackDown vs. Raw 2007",
+      "project": "SVR07 Recomp",
+      "platform": "xbox360",
+      "repo": "HollywoodAkeem/SVR07-Recomp",
+      "description": "Native PC port of the Xbox 360 version of WWE SmackDown vs. Raw 2007 via ReXGlue static recompilation. Ships no game data: rip your legally owned retail Xbox 360 copy and extract its files into assets/ next to the executable. Windows build, launched via Proton.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "svr07.zip"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/svr07.exe"
+      },
+      "tags": [
+        "wwe",
+        "xbox360",
+        "wrestling",
+        "3d"
+      ],
+      "website": "https://github.com/HollywoodAkeem/SVR07-Recomp",
+      "latestVersion": "v1.0",
+      "steamGridDbId": 5264777
     }
   ]
 }

--- a/plugins/recomp/lib/pipeline.ts
+++ b/plugins/recomp/lib/pipeline.ts
@@ -20,6 +20,7 @@ import { updateInstalledGame, removeInstalledGame } from "./state";
 import { addToSteam, removeFromSteam } from "./steam-shortcut";
 import { applyArtwork } from "./artwork";
 import { extractArchive } from "./pipeline-archive";
+import { stageRomSource } from "./rom-source";
 import { downloadFile, githubToken, githubFetch } from "./github";
 import { runSetupScript } from "./installer-host";
 import { chownInstallDirToUser } from "./fs-owner";
@@ -605,6 +606,36 @@ export async function installGame(
 
     // Post-extract commands for ROM-based install types
     if (entry.installType === "rom_extract" || entry.installType === "toolchain" || entry.installType === "custom") {
+      // Structured dumps (Xbox 360 disc images / XBLA packages) get
+      // unpacked into the engine's data dir. Runs INSTEAD of the
+      // placeRomAs / extractionCommand paths below — a sourceFormat
+      // entry declares neither. The scratch dir lives under
+      // tmpGameDir, so the finally-block teardown reclaims the
+      // unwrapped archive bytes even on failure.
+      const sourceFormat = entry.romInfo?.sourceFormat;
+      if (romPath && entry.romInfo && sourceFormat && sourceFormat !== "raw") {
+        const { files, warnings } = await stageRomSource({
+          romInfo: entry.romInfo,
+          romPath,
+          stageDir: partialDir,
+          scratchDir: tmpGameDir,
+          onProgress: (message, percent) =>
+            onEvent({
+              type: "progress", gameId, stage: "extraction",
+              ...(percent != null ? { percent } : {}), message,
+            }),
+        });
+        onEvent({
+          type: "progress", gameId, stage: "extraction",
+          percent: 100, message: `Game data ready (${files} files)`,
+        });
+        for (const warning of warnings) {
+          onEvent({
+            type: "progress", gameId, stage: "extraction",
+            percent: 100, message: `Warning: ${warning}`,
+          });
+        }
+      }
       // `placeRomAs` is the simple case — engine ingests the ROM
       // on first launch from a known filename next to the binary
       // (Ship of Harkinian, 2 Ship 2 Harkinian, etc). Prefer over

--- a/plugins/recomp/lib/pipeline.ts
+++ b/plugins/recomp/lib/pipeline.ts
@@ -371,6 +371,20 @@ export async function installGame(
     return state;
   }
 
+  // A saved/reused romPath (update, or an install retry off
+  // `state.romPaths`) may point at a dump the user has since moved or
+  // deleted. Catch it here — before downloading the release — so the
+  // user gets an actionable "re-pick your dump" prompt instead of a raw
+  // ENOENT surfaced from deep inside the staging step after a multi-GB
+  // download completes.
+  if (requiresRom(entry) && romPath && !existsSync(romPath)) {
+    const description =
+      `Your saved game file for ${entry.name} (${romPath}) no longer exists — ` +
+      `pick it again.`;
+    onEvent({ type: "rom_required", gameId, message: description });
+    return state;
+  }
+
   const installDir = join(state.installPath || gamesDir(), gameId);
   const partialDir = `${installDir}.partial`;
   const tmpGameDir = join(tempDir(), gameId);

--- a/plugins/recomp/lib/rom-source.test.ts
+++ b/plugins/recomp/lib/rom-source.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  sniffRomSourceKind,
+  extractXgdIso,
+  extractStfs,
+  locateDumpFile,
+  stageRomSource,
+} from "./rom-source";
+
+let sandbox: string;
+
+beforeAll(async () => {
+  sandbox = await mkdtemp(join(tmpdir(), "recomp-rom-source-spec-"));
+});
+
+afterAll(async () => {
+  await rm(sandbox, { recursive: true, force: true });
+});
+
+// ── Synthetic image builders ─────────────────────────────────────────
+
+const SECTOR = 2048;
+
+/** One GDF directory entry: u16 left, u16 right, u32 startSector,
+ *  u32 size, u8 attrs, u8 nameLen, name — offsets in 4-byte units. */
+function gdfEntry(opts: {
+  left: number;
+  right: number;
+  startSector: number;
+  size: number;
+  attrs: number;
+  name: string;
+}): Buffer {
+  const name = Buffer.from(opts.name, "latin1");
+  const buf = Buffer.alloc(14 + name.length);
+  buf.writeUInt16LE(opts.left, 0);
+  buf.writeUInt16LE(opts.right, 2);
+  buf.writeUInt32LE(opts.startSector, 4);
+  buf.writeUInt32LE(opts.size, 8);
+  buf[12] = opts.attrs;
+  buf[13] = name.length;
+  name.copy(buf, 14);
+  return buf;
+}
+
+/**
+ * Minimal XGD image, game-partition base 0:
+ *
+ *   /DATA/inner.bin  ("abc")
+ *   /b.txt           ("hello")
+ *
+ * Root table (sector 33): entry "b.txt" at offset 0 with its left
+ * child "DATA" at byte 32 (= offset unit 8). DATA's table lives at
+ * sector 34; file payloads at sectors 40 and 41.
+ */
+function buildXgdImage(opts?: { evilName?: string }): Buffer {
+  // Padded past locateDumpFile's 1 MiB size floor so the synthetic
+  // image is treated like a real dump; the tail is unreferenced.
+  const img = Buffer.alloc(Math.max(42 * SECTOR, 1024 * 1024 + SECTOR));
+  // Volume descriptor at sector 32
+  Buffer.from("MICROSOFT*XBOX*MEDIA", "ascii").copy(img, 32 * SECTOR);
+  img.writeUInt32LE(33, 32 * SECTOR + 20); // root dir sector
+  img.writeUInt32LE(SECTOR, 32 * SECTOR + 24); // root dir size
+
+  // Root directory table
+  const rootBase = 33 * SECTOR;
+  img.fill(0xff, rootBase, rootBase + SECTOR);
+  gdfEntry({
+    left: 8, right: 0, startSector: 40, size: 5, attrs: 0,
+    name: opts?.evilName ?? "b.txt",
+  }).copy(img, rootBase);
+  gdfEntry({
+    left: 0, right: 0, startSector: 34, size: SECTOR, attrs: 0x10,
+    name: "DATA",
+  }).copy(img, rootBase + 32);
+
+  // DATA directory table
+  const dataBase = 34 * SECTOR;
+  img.fill(0xff, dataBase, dataBase + SECTOR);
+  gdfEntry({
+    left: 0, right: 0, startSector: 41, size: 3, attrs: 0,
+    name: "inner.bin",
+  }).copy(img, dataBase);
+
+  Buffer.from("hello").copy(img, 40 * SECTOR);
+  Buffer.from("abc").copy(img, 41 * SECTOR);
+  return img;
+}
+
+/** One STFS file-table entry (0x40 bytes). */
+function stfsEntry(opts: {
+  name: string;
+  dir?: boolean;
+  blocks?: number;
+  startBlock?: number;
+  parent: number;
+  size?: number;
+}): Buffer {
+  const buf = Buffer.alloc(0x40);
+  const name = Buffer.from(opts.name, "latin1");
+  name.copy(buf, 0);
+  buf[0x28] = (opts.dir ? 0x80 : 0) | name.length;
+  const blocks = opts.blocks ?? 0;
+  buf[0x29] = blocks & 0xff;
+  buf[0x2a] = (blocks >> 8) & 0xff;
+  buf[0x2b] = (blocks >> 16) & 0xff;
+  const start = opts.startBlock ?? 0;
+  buf[0x2f] = start & 0xff;
+  buf[0x30] = (start >> 8) & 0xff;
+  buf[0x31] = (start >> 16) & 0xff;
+  buf.writeUInt16BE(opts.parent, 0x32);
+  buf.writeUInt32BE(opts.size ?? 0, 0x34);
+  return buf;
+}
+
+/**
+ * Minimal LIVE package:
+ *
+ *   /sub/a.bin      ("abc")
+ *   /default.xex    ("hello")
+ *
+ * File table at 0xC000 (logical block 0). Payload blocks: logical 1
+ * (physical 0x0D → offset 0xD000) and logical 2 (0xE000). Single-block
+ * files never consult the hash chain.
+ */
+function buildStfsPackage(opts?: { evilName?: string }): Buffer {
+  // Padded past locateDumpFile's 1 MiB size floor (see buildXgdImage).
+  const img = Buffer.alloc(Math.max(0x10000, 1024 * 1024 + 0x1000));
+  Buffer.from("LIVE", "ascii").copy(img, 0);
+  const table = 0xc000;
+  stfsEntry({ name: "sub", dir: true, parent: 0xffff }).copy(img, table);
+  stfsEntry({
+    name: opts?.evilName ?? "default.xex",
+    blocks: 1, startBlock: 1, parent: 0xffff, size: 5,
+  }).copy(img, table + 0x40);
+  stfsEntry({
+    name: "a.bin", blocks: 1, startBlock: 2, parent: 0, size: 3,
+  }).copy(img, table + 0x80);
+  Buffer.from("hello").copy(img, 0xd000);
+  Buffer.from("abc").copy(img, 0xe000);
+  return img;
+}
+
+// ── sniffRomSourceKind ───────────────────────────────────────────────
+
+describe("sniffRomSourceKind", () => {
+  it("detects zip / 7z / rar / gzip as archive", async () => {
+    const cases: [string, Buffer][] = [
+      ["a.zip", Buffer.from("PK\x03\x04rest")],
+      ["a.7z", Buffer.from([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0, 0])],
+      ["a.rar", Buffer.from("Rar!\x1a\x07\x00")],
+      ["a.tgz", Buffer.from([0x1f, 0x8b, 8, 0, 0, 0, 0, 0])],
+    ];
+    for (const [name, bytes] of cases) {
+      const p = join(sandbox, `sniff-${name}`);
+      await writeFile(p, bytes);
+      expect(await sniffRomSourceKind(p)).toBe("archive");
+    }
+  });
+
+  it("detects STFS package magics", async () => {
+    for (const magic of ["LIVE", "PIRS", "CON "]) {
+      const p = join(sandbox, `sniff-stfs-${magic.trim()}`);
+      await writeFile(p, Buffer.from(`${magic}rest-of-header`));
+      expect(await sniffRomSourceKind(p)).toBe("stfs");
+    }
+  });
+
+  it("detects an XGD image by its volume descriptor", async () => {
+    const p = join(sandbox, "sniff-xgd.iso");
+    await writeFile(p, buildXgdImage());
+    expect(await sniffRomSourceKind(p)).toBe("xgd-iso");
+  });
+
+  it("returns unknown for a plain file", async () => {
+    const p = join(sandbox, "sniff-unknown.bin");
+    await writeFile(p, Buffer.from("just some bytes, nothing special"));
+    expect(await sniffRomSourceKind(p)).toBe("unknown");
+  });
+});
+
+// ── extractXgdIso ────────────────────────────────────────────────────
+
+describe("extractXgdIso", () => {
+  it("extracts the directory tree with contents intact", async () => {
+    const iso = join(sandbox, "mini.iso");
+    await writeFile(iso, buildXgdImage());
+    const dest = join(sandbox, "xgd-out");
+
+    const result = await extractXgdIso(iso, dest);
+
+    expect(result.files).toBe(2);
+    expect(await readFile(join(dest, "b.txt"), "utf-8")).toBe("hello");
+    expect(await readFile(join(dest, "DATA/inner.bin"), "utf-8")).toBe("abc");
+  });
+
+  it("reports progress with real totals", async () => {
+    const iso = join(sandbox, "mini2.iso");
+    await writeFile(iso, buildXgdImage());
+    const seen: number[] = [];
+    await extractXgdIso(iso, join(sandbox, "xgd-out2"), (p) => {
+      seen.push(p.filesTotal);
+      expect(p.bytesTotal).toBe(8);
+    });
+    expect(seen).toEqual([2, 2]);
+  });
+
+  it("rejects an image whose entry name escapes the dest dir", async () => {
+    const iso = join(sandbox, "evil.iso");
+    await writeFile(iso, buildXgdImage({ evilName: "../evil.txt" }));
+    const dest = join(sandbox, "xgd-evil-out");
+    await expect(extractXgdIso(iso, dest)).rejects.toThrow(
+      /escapes the install directory/,
+    );
+    expect(existsSync(join(sandbox, "evil.txt"))).toBe(false);
+  });
+
+  it("rejects a non-XGD file", async () => {
+    const p = join(sandbox, "not-an-iso.iso");
+    await writeFile(p, Buffer.alloc(1024 * 1024));
+    await expect(extractXgdIso(p, join(sandbox, "nope"))).rejects.toThrow(
+      /no XDVDFS volume descriptor/,
+    );
+  });
+});
+
+// ── extractStfs ──────────────────────────────────────────────────────
+
+describe("extractStfs", () => {
+  it("extracts files with parent-chain paths intact", async () => {
+    const pkg = join(sandbox, "mini.stfs");
+    await writeFile(pkg, buildStfsPackage());
+    const dest = join(sandbox, "stfs-out");
+
+    const result = await extractStfs(pkg, dest);
+
+    expect(result.files).toBe(2);
+    expect(await readFile(join(dest, "default.xex"), "utf-8")).toBe("hello");
+    expect(await readFile(join(dest, "sub/a.bin"), "utf-8")).toBe("abc");
+  });
+
+  it("rejects a package whose entry name escapes the dest dir", async () => {
+    const pkg = join(sandbox, "evil.stfs");
+    await writeFile(pkg, buildStfsPackage({ evilName: "../evil.xex" }));
+    await expect(
+      extractStfs(pkg, join(sandbox, "stfs-evil-out")),
+    ).rejects.toThrow(/escapes the install directory/);
+  });
+
+  it("rejects a non-STFS file", async () => {
+    const p = join(sandbox, "not-stfs.bin");
+    await writeFile(p, Buffer.from("NOPE-not-a-package"));
+    await expect(extractStfs(p, join(sandbox, "nope2"))).rejects.toThrow(
+      /not an Xbox 360 STFS package/,
+    );
+  });
+});
+
+// ── locateDumpFile ───────────────────────────────────────────────────
+
+describe("locateDumpFile", () => {
+  it("finds a dump nested in subdirectories, ignoring small files", async () => {
+    const dir = join(sandbox, "locate");
+    await mkdir(join(dir, "nested/deeper"), { recursive: true });
+    await writeFile(join(dir, "readme.txt"), "not a dump");
+    // Small file with the right magic — must be skipped by the size floor.
+    await writeFile(join(dir, "tiny.iso"), Buffer.from("LIVE"));
+    await writeFile(join(dir, "nested/deeper/game.iso"), buildXgdImage());
+
+    expect(await locateDumpFile(dir, "xgd-iso")).toBe(
+      join(dir, "nested/deeper/game.iso"),
+    );
+    expect(await locateDumpFile(dir, "stfs")).toBeNull();
+  });
+
+  it("prefers the largest candidate when several match", async () => {
+    const dir = join(sandbox, "locate-multi");
+    await mkdir(dir, { recursive: true });
+    const small = buildXgdImage();
+    const big = Buffer.concat([buildXgdImage(), Buffer.alloc(SECTOR)]);
+    await writeFile(join(dir, "a.iso"), small);
+    await writeFile(join(dir, "b.iso"), big);
+    expect(await locateDumpFile(dir, "xgd-iso")).toBe(join(dir, "b.iso"));
+  });
+});
+
+// ── stageRomSource ───────────────────────────────────────────────────
+
+// sha1("hello") — the payload of the synthetic images' anchor files.
+const HELLO_SHA1 = "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d";
+
+describe("stageRomSource", () => {
+  const baseRomInfo = {
+    description: "test",
+    validChecksums: [],
+    extractionCommand: "",
+  };
+
+  it("stages a bare XGD iso into extractTo and validates the anchor", async () => {
+    const iso = join(sandbox, "stage.iso");
+    await writeFile(iso, buildXgdImage());
+    const stageDir = join(sandbox, "stage-install");
+    await mkdir(stageDir, { recursive: true });
+
+    const messages: string[] = [];
+    const { files, warnings } = await stageRomSource({
+      romInfo: {
+        ...baseRomInfo,
+        sourceFormat: "xgd-iso",
+        extractTo: "assets",
+        anchorFile: "b.txt",
+        anchorChecksums: [HELLO_SHA1],
+      },
+      romPath: iso,
+      stageDir,
+      scratchDir: join(sandbox, "stage-scratch"),
+      onProgress: (m) => messages.push(m),
+    });
+
+    expect(files).toBe(2);
+    expect(warnings).toEqual([]);
+    expect(
+      await readFile(join(stageDir, "assets/b.txt"), "utf-8"),
+    ).toBe("hello");
+    expect(messages.length).toBeGreaterThan(0);
+  });
+
+  it("stages a zip-wrapped dump by locating it inside the archive", async () => {
+    // Build a real zip via the system tools the extractor itself uses.
+    const payloadDir = join(sandbox, "zip-payload");
+    await mkdir(payloadDir, { recursive: true });
+    await writeFile(join(payloadDir, "game.stfs"), buildStfsPackage());
+    const zipPath = join(sandbox, "wrapped.zip");
+    const proc = Bun.spawn(["zip", "-j", zipPath, join(payloadDir, "game.stfs")], {
+      stdout: "ignore", stderr: "ignore",
+    });
+    if ((await proc.exited) !== 0) {
+      // No `zip` binary on this host — the unwrap path is covered by
+      // pipeline-archive tests; skip the integration variant.
+      return;
+    }
+
+    const stageDir = join(sandbox, "stage-zip-install");
+    await mkdir(stageDir, { recursive: true });
+    const { files, warnings } = await stageRomSource({
+      romInfo: {
+        ...baseRomInfo,
+        sourceFormat: "stfs",
+        anchorFile: "default.xex",
+        anchorChecksums: [HELLO_SHA1],
+      },
+      romPath: zipPath,
+      stageDir,
+      scratchDir: join(sandbox, "stage-zip-scratch"),
+      onProgress: () => {},
+    });
+
+    expect(files).toBe(2);
+    expect(warnings).toEqual([]);
+    // extractTo defaults to "assets"
+    expect(
+      await readFile(join(stageDir, "assets/default.xex"), "utf-8"),
+    ).toBe("hello");
+  });
+
+  it("warns (but succeeds) on an anchor checksum mismatch", async () => {
+    const iso = join(sandbox, "stage-warn.iso");
+    await writeFile(iso, buildXgdImage());
+    const stageDir = join(sandbox, "stage-warn-install");
+    await mkdir(stageDir, { recursive: true });
+
+    const { warnings } = await stageRomSource({
+      romInfo: {
+        ...baseRomInfo,
+        sourceFormat: "xgd-iso",
+        anchorFile: "b.txt",
+        anchorChecksums: ["0000000000000000000000000000000000000000"],
+      },
+      romPath: iso,
+      stageDir,
+      scratchDir: join(sandbox, "stage-warn-scratch"),
+      onProgress: () => {},
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/doesn't match a known-good dump/);
+  });
+
+  it("fails when the anchor file is missing from the dump", async () => {
+    const iso = join(sandbox, "stage-noanchor.iso");
+    await writeFile(iso, buildXgdImage());
+    const stageDir = join(sandbox, "stage-noanchor-install");
+    await mkdir(stageDir, { recursive: true });
+
+    await expect(
+      stageRomSource({
+        romInfo: {
+          ...baseRomInfo,
+          sourceFormat: "xgd-iso",
+          anchorFile: "default.xex",
+        },
+        romPath: iso,
+        stageDir,
+        scratchDir: join(sandbox, "stage-noanchor-scratch"),
+        onProgress: () => {},
+      }),
+    ).rejects.toThrow(/default\.xex is missing/);
+  });
+
+  it("fails clearly when handed the wrong kind of file", async () => {
+    const p = join(sandbox, "stage-wrong.bin");
+    await writeFile(p, Buffer.from("some random file"));
+    await expect(
+      stageRomSource({
+        romInfo: { ...baseRomInfo, sourceFormat: "xgd-iso" },
+        romPath: p,
+        stageDir: join(sandbox, "stage-wrong-install"),
+        scratchDir: join(sandbox, "stage-wrong-scratch"),
+        onProgress: () => {},
+      }),
+    ).rejects.toThrow(/not a supported dump/);
+  });
+
+  it("confines a hostile extractTo to the stage dir", async () => {
+    const iso = join(sandbox, "stage-evil-to.iso");
+    await writeFile(iso, buildXgdImage());
+    await expect(
+      stageRomSource({
+        romInfo: {
+          ...baseRomInfo,
+          sourceFormat: "xgd-iso",
+          extractTo: "../../outside",
+        },
+        romPath: iso,
+        stageDir: join(sandbox, "stage-evil-install"),
+        scratchDir: join(sandbox, "stage-evil-scratch"),
+        onProgress: () => {},
+      }),
+    ).rejects.toThrow(/escapes the install directory/);
+  });
+});

--- a/plugins/recomp/lib/rom-source.test.ts
+++ b/plugins/recomp/lib/rom-source.test.ts
@@ -126,11 +126,15 @@ function stfsEntry(opts: {
  * File table at 0xC000 (logical block 0). Payload blocks: logical 1
  * (physical 0x0D → offset 0xD000) and logical 2 (0xE000). Single-block
  * files never consult the hash chain.
+ *
+ * Sets the header-size field at 0x340 to 0xAD0E (matching a real LIVE
+ * package) so `stfsTableSizeShift` derives shift 0.
  */
-function buildStfsPackage(opts?: { evilName?: string }): Buffer {
+function buildStfsPackage(opts?: { evilName?: string; headerSize?: number }): Buffer {
   // Padded past locateDumpFile's 1 MiB size floor (see buildXgdImage).
   const img = Buffer.alloc(Math.max(0x10000, 1024 * 1024 + 0x1000));
   Buffer.from("LIVE", "ascii").copy(img, 0);
+  img.writeUInt32BE(opts?.headerSize ?? 0xad0e, 0x340); // ⇒ table_size_shift 0
   const table = 0xc000;
   stfsEntry({ name: "sub", dir: true, parent: 0xffff }).copy(img, table);
   stfsEntry({
@@ -331,6 +335,12 @@ describe("stageRomSource", () => {
 
   it("stages a zip-wrapped dump by locating it inside the archive", async () => {
     // Build a real zip via the system tools the extractor itself uses.
+    // Bun.spawn THROWS synchronously when the executable is missing, so
+    // a bare try/exit-code guard would error rather than skip on a host
+    // without `zip`; gate on Bun.which so the skip is explicit and a
+    // non-zero exit for any OTHER reason fails loudly instead of passing
+    // vacuously.
+    if (!Bun.which("zip")) return;
     const payloadDir = join(sandbox, "zip-payload");
     await mkdir(payloadDir, { recursive: true });
     await writeFile(join(payloadDir, "game.stfs"), buildStfsPackage());
@@ -338,11 +348,7 @@ describe("stageRomSource", () => {
     const proc = Bun.spawn(["zip", "-j", zipPath, join(payloadDir, "game.stfs")], {
       stdout: "ignore", stderr: "ignore",
     });
-    if ((await proc.exited) !== 0) {
-      // No `zip` binary on this host — the unwrap path is covered by
-      // pipeline-archive tests; skip the integration variant.
-      return;
-    }
+    expect(await proc.exited).toBe(0);
 
     const stageDir = join(sandbox, "stage-zip-install");
     await mkdir(stageDir, { recursive: true });
@@ -441,5 +447,186 @@ describe("stageRomSource", () => {
         onProgress: () => {},
       }),
     ).rejects.toThrow(/escapes the install directory/);
+  });
+});
+
+// ── Regression: the format-parser hardening (review findings) ────────
+
+describe("GDF walk hardening", () => {
+  // Full mini-image whose root table's second entry ("bbb") has a left
+  // pointer of 0x01FF — low byte 0xFF. The OLD `data[pos] === 0xff`
+  // padding check read that low byte and silently dropped "bbb" and its
+  // subtree (finding C1). Build it directly so the regression is exact.
+  function imageWith0xFFLeftByte(): Buffer {
+    const img = Buffer.alloc(1024 * 1024 + SECTOR);
+    Buffer.from("MICROSOFT*XBOX*MEDIA", "ascii").copy(img, 32 * SECTOR);
+    img.writeUInt32LE(33, 32 * SECTOR + 20);
+    img.writeUInt32LE(SECTOR, 32 * SECTOR + 24);
+    const rootBase = 33 * SECTOR;
+    img.fill(0xff, rootBase, rootBase + SECTOR);
+    // offset 0: "aaa", left → dword offset 8 (byte 32, "bbb"), no right.
+    gdfEntry({ left: 8, right: 0xffff, startSector: 40, size: 5, attrs: 0, name: "aaa" })
+      .copy(img, rootBase);
+    // byte 32: "bbb", left = 0x01FF (low byte 0xFF) → dword offset 511
+    // (byte 2044), past the table end → skipped. The old code instead
+    // read that 0xFF low byte and dropped "bbb" itself.
+    gdfEntry({ left: 0x01ff, right: 0xffff, startSector: 41, size: 3, attrs: 0, name: "bbb" })
+      .copy(img, rootBase + 32);
+    Buffer.from("hello").copy(img, 40 * SECTOR);
+    Buffer.from("abc").copy(img, 41 * SECTOR);
+    return img;
+  }
+
+  it("does NOT drop an entry whose left-pointer low byte is 0xFF (C1)", async () => {
+    const iso = join(sandbox, "gdf-0xff.iso");
+    await writeFile(iso, imageWith0xFFLeftByte());
+    const dest = join(sandbox, "gdf-0xff-out");
+    const r = await extractXgdIso(iso, dest);
+    expect(r.files).toBe(2);
+    expect(await readFile(join(dest, "aaa"), "utf-8")).toBe("hello");
+    expect(await readFile(join(dest, "bbb"), "utf-8")).toBe("abc"); // was dropped
+  });
+
+  it("terminates on a directory-tree cycle instead of blowing the stack (S1)", async () => {
+    // Root entry whose left points back at itself (offset 0) — a naive
+    // recursive walk would loop forever; the visited-set must stop it.
+    const img = Buffer.alloc(1024 * 1024 + SECTOR);
+    Buffer.from("MICROSOFT*XBOX*MEDIA", "ascii").copy(img, 32 * SECTOR);
+    img.writeUInt32LE(33, 32 * SECTOR + 20);
+    img.writeUInt32LE(SECTOR, 32 * SECTOR + 24);
+    const rootBase = 33 * SECTOR;
+    img.fill(0xff, rootBase, rootBase + SECTOR);
+    // "self" points left → dword offset 8 (byte 32), which points left
+    // back to offset 0 → cycle.
+    gdfEntry({ left: 8, right: 0xffff, startSector: 40, size: 5, attrs: 0, name: "self" })
+      .copy(img, rootBase);
+    gdfEntry({ left: 0, right: 0xffff, startSector: 40, size: 5, attrs: 0, name: "back" })
+      .copy(img, rootBase + 32);
+    Buffer.from("hello").copy(img, 40 * SECTOR);
+    const iso = join(sandbox, "gdf-cycle.iso");
+    await writeFile(iso, img);
+    // Must return promptly with both distinct entries, not hang/overflow.
+    const r = await extractXgdIso(iso, join(sandbox, "gdf-cycle-out"));
+    expect(r.files).toBe(2);
+  });
+
+  it("reads an entry that lives beyond the first sector of a 2-sector table", async () => {
+    const img = Buffer.alloc(1024 * 1024 + 3 * SECTOR);
+    Buffer.from("MICROSOFT*XBOX*MEDIA", "ascii").copy(img, 32 * SECTOR);
+    img.writeUInt32LE(33, 32 * SECTOR + 20);
+    img.writeUInt32LE(2 * SECTOR, 32 * SECTOR + 24); // 2-sector root table
+    const rootBase = 33 * SECTOR;
+    img.fill(0xff, rootBase, rootBase + 2 * SECTOR);
+    // root "first" with left → dword offset 512 (byte 2048 = sector 2).
+    gdfEntry({ left: 512, right: 0xffff, startSector: 40, size: 5, attrs: 0, name: "first" })
+      .copy(img, rootBase);
+    gdfEntry({ left: 0xffff, right: 0xffff, startSector: 41, size: 3, attrs: 0, name: "second" })
+      .copy(img, rootBase + 2048);
+    Buffer.from("hello").copy(img, 40 * SECTOR);
+    Buffer.from("abc").copy(img, 41 * SECTOR);
+    const iso = join(sandbox, "gdf-2sector.iso");
+    await writeFile(iso, img);
+    const dest = join(sandbox, "gdf-2sector-out");
+    const r = await extractXgdIso(iso, dest);
+    expect(r.files).toBe(2);
+    expect(await readFile(join(dest, "second"), "utf-8")).toBe("abc");
+  });
+});
+
+describe("STFS multi-block + hardening", () => {
+  const HELLO2 = "hello".repeat(1000); // 5000 bytes = 2 blocks
+
+  /** LIVE package with one 2-block file whose block chain steps through
+   *  the group-0 hash table (exercises stfsNextBlock / hash math that no
+   *  single-block fixture reached — finding C9). File logical blocks 1→2;
+   *  the next-block pointer for logical 1 lives at hash offset 0xB018+0x15. */
+  function buildMultiBlockStfs(): Buffer {
+    const img = Buffer.alloc(0x11000);
+    Buffer.from("LIVE", "ascii").copy(img, 0);
+    img.writeUInt32BE(0xad0e, 0x340); // shift 0
+    const table = 0xc000;
+    stfsEntry({
+      name: "big.bin", blocks: 2, startBlock: 1, parent: 0xffff, size: HELLO2.length,
+    }).copy(img, table);
+    // Group-0 hash entry for logical block 1: next block = 2 (u24 BE @ +0x15).
+    const hashEntry1 = 0x0b * 0x1000 + 1 * 0x18;
+    img.writeUIntBE(2, hashEntry1 + 0x15, 3);
+    // Payload: logical 1 → physical 0x0D (0xD000), logical 2 → 0x0E (0xE000).
+    Buffer.from(HELLO2.slice(0, 0x1000)).copy(img, 0xd000);
+    Buffer.from(HELLO2.slice(0x1000)).copy(img, 0xe000);
+    return img;
+  }
+
+  it("extracts a multi-block file by following the hash-table chain", async () => {
+    const pkg = join(sandbox, "stfs-multiblock.stfs");
+    await writeFile(pkg, buildMultiBlockStfs());
+    const dest = join(sandbox, "stfs-multiblock-out");
+    const r = await extractStfs(pkg, dest);
+    expect(r.files).toBe(1);
+    expect(await readFile(join(dest, "big.bin"), "utf-8")).toBe(HELLO2);
+  });
+
+  it("rejects a resigned (shift-1) package instead of extracting corrupt data (C2)", async () => {
+    // headerSize 0x9000 ⇒ ((0x9000+0xFFF)&0xF000)>>12 = 0x9 ≠ 0xB ⇒ shift 1.
+    const pkg = join(sandbox, "stfs-con.stfs");
+    await writeFile(pkg, buildStfsPackage({ headerSize: 0x9000 }));
+    await expect(extractStfs(pkg, join(sandbox, "stfs-con-out"))).rejects.toThrow(
+      /resigned\/read-write STFS package/,
+    );
+  });
+
+  it("throws on a cyclic block chain rather than amplifying writes (S3)", async () => {
+    // A 2-block file whose logical block 1 chains back to itself, with a
+    // size that would otherwise drive many iterations.
+    const img = Buffer.alloc(0x11000);
+    Buffer.from("LIVE", "ascii").copy(img, 0);
+    img.writeUInt32BE(0xad0e, 0x340);
+    stfsEntry({
+      name: "loop.bin", blocks: 5, startBlock: 1, parent: 0xffff, size: 5 * 0x1000,
+    }).copy(img, 0xc000);
+    img.writeUIntBE(1, 0x0b * 0x1000 + 1 * 0x18 + 0x15, 3); // logical 1 → 1 (self)
+    Buffer.alloc(0x1000, 0x41).copy(img, 0xd000);
+    const pkg = join(sandbox, "stfs-cycle.stfs");
+    await writeFile(pkg, img);
+    await expect(extractStfs(pkg, join(sandbox, "stfs-cycle-out"))).rejects.toThrow(
+      /[Cc]yclic block chain/,
+    );
+  });
+});
+
+describe("archive dispatch by magic (C5)", () => {
+  it("unwraps a magic-detected archive whose name lacks an extension", async () => {
+    if (!Bun.which("zip")) return;
+    // A real zip wrapping an STFS package, but named with no recognized
+    // archive extension — sniffs as archive, must still extract.
+    const payloadDir = join(sandbox, "noext-payload");
+    await mkdir(payloadDir, { recursive: true });
+    await writeFile(join(payloadDir, "content"), buildStfsPackage());
+    const zipReal = join(sandbox, "mkzip.zip");
+    expect(
+      await Bun.spawn(["zip", "-j", zipReal, join(payloadDir, "content")], {
+        stdout: "ignore", stderr: "ignore",
+      }).exited,
+    ).toBe(0);
+    // Rename to an extensionless path — the SOTN "type the path manually"
+    // case: the extractor dispatches by extension, so without the
+    // magic-derived symlink this would be "unsupported format".
+    const noExt = join(sandbox, "downloaded_file");
+    await writeFile(noExt, await readFile(zipReal));
+
+    const stageDir = join(sandbox, "noext-install");
+    await mkdir(stageDir, { recursive: true });
+    const { files } = await stageRomSource({
+      romInfo: {
+        description: "t", validChecksums: [], extractionCommand: "",
+        sourceFormat: "stfs", anchorFile: "default.xex",
+      },
+      romPath: noExt,
+      stageDir,
+      scratchDir: join(sandbox, "noext-scratch"),
+      onProgress: () => {},
+    });
+    expect(files).toBe(2);
+    expect(existsSync(join(stageDir, "assets/default.xex"))).toBe(true);
   });
 });

--- a/plugins/recomp/lib/rom-source.ts
+++ b/plugins/recomp/lib/rom-source.ts
@@ -1,0 +1,605 @@
+/**
+ * Game-data staging for recomps whose "ROM" is a disc image or
+ * container package rather than a single flat file.
+ *
+ * The ReXGlue family of Xbox 360 recomps (NocturneRecomp / SVR07 /
+ * TiP-Recomp) ships no game data: the engine reads its files from
+ * `--game_data_root` (default `assets/` next to the binary) and exits
+ * with "game_data_root does not exist" when the folder is missing.
+ * Users hold their dump as a 7z/zip/rar wrapping either a raw XGD
+ * disc ISO (retail titles) or an STFS/LIVE package (XBLA titles).
+ *
+ * This module turns the user-picked file into a populated data dir:
+ *
+ *   picked file ── sniff ──▶ archive? ─ unwrap ─▶ locate dump by magic
+ *                     │                                  │
+ *                     └── already a dump ────────────────┤
+ *                                                        ▼
+ *                              format extractor (XGD / STFS) ─▶ extractTo/
+ *                                                        │
+ *                                        anchor-file validation
+ *
+ * Everything is magic-byte driven — filenames are hints at best (XBLA
+ * content files have no extension at all), so nothing here trusts them.
+ *
+ * Legal boundary (deliberate): this only ever restructures a dump the
+ * user already owns, locally. Both XGD and STFS are plain unencrypted
+ * filesystems — no keys, no DRM circumvention, no downloads.
+ */
+import { open, mkdir, readdir, stat } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import { join, basename } from "node:path";
+import { resolveWithinDir } from "./path-confine";
+import { extractArchive } from "./pipeline-archive";
+import type { RomInfo } from "./types";
+
+// ── Format detection ─────────────────────────────────────────────────
+
+export type RomSourceKind =
+  | "archive"   // zip / 7z / rar / tar(.gz) — unwrap first
+  | "xgd-iso"   // Xbox / Xbox 360 disc image (XDVDFS a.k.a. GDF)
+  | "stfs"      // Xbox 360 STFS package (LIVE / PIRS / CON)
+  | "unknown";
+
+const SECTOR = 2048;
+const XGD_MAGIC = Buffer.from("MICROSOFT*XBOX*MEDIA", "ascii");
+/** Game-partition base offsets to probe: a game-partition-only rip,
+ *  XGD3, XGD2, XGD1 — in that order. The volume descriptor lives at
+ *  sector 32 of the partition. */
+const XGD_BASES = [0x0, 0x2080000, 0xfd90000, 0x18300000] as const;
+
+async function readAt(
+  fh: FileHandle,
+  position: number,
+  length: number,
+): Promise<Buffer> {
+  const buf = Buffer.alloc(length);
+  const { bytesRead } = await fh.read(buf, 0, length, position);
+  return bytesRead === length ? buf : buf.subarray(0, bytesRead);
+}
+
+/** Find the XGD game-partition base offset, or null if `fh` isn't an
+ *  Xbox disc image. */
+async function findXgdBase(fh: FileHandle): Promise<number | null> {
+  for (const base of XGD_BASES) {
+    const magic = await readAt(fh, base + 32 * SECTOR, XGD_MAGIC.length);
+    if (magic.equals(XGD_MAGIC)) return base;
+  }
+  return null;
+}
+
+/**
+ * Classify a file by magic bytes. `archive` covers every wrapper
+ * format `extractArchive` can unpack; the two dump formats are the
+ * ones `stageRomSource` knows how to restructure.
+ */
+export async function sniffRomSourceKind(path: string): Promise<RomSourceKind> {
+  const fh = await open(path, "r");
+  try {
+    const head = await readAt(fh, 0, 8);
+    if (head.length >= 4) {
+      const ascii4 = head.subarray(0, 4).toString("latin1");
+      // zip (incl. empty/spanned variants) — "PK" + 03/05/07
+      if (ascii4.startsWith("PK")) return "archive";
+      if (head.subarray(0, 6).equals(Buffer.from([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]))) {
+        return "archive"; // 7z
+      }
+      if (ascii4 === "Rar!") return "archive";
+      if (head[0] === 0x1f && head[1] === 0x8b) return "archive"; // gzip
+      if (ascii4 === "LIVE" || ascii4 === "PIRS" || ascii4 === "CON ") {
+        return "stfs";
+      }
+    }
+    if ((await findXgdBase(fh)) != null) return "xgd-iso";
+    // Plain tar has its magic at offset 257 ("ustar").
+    const tarMagic = await readAt(fh, 257, 5);
+    if (tarMagic.toString("latin1") === "ustar") return "archive";
+    return "unknown";
+  } finally {
+    await fh.close();
+  }
+}
+
+// ── XGD / XDVDFS (GDF) extraction ────────────────────────────────────
+
+interface GdfEntry {
+  name: string;
+  attrs: number;
+  startSector: number;
+  size: number;
+}
+
+const GDF_ATTR_DIR = 0x10;
+/** Padding / no-child sentinels in the directory entry tree. */
+const GDF_NO_CHILD = new Set([0, 0xffff]);
+
+/**
+ * In-order walk of one directory table's entry tree. Entries are
+ * `u16 left, u16 right, u32 startSector, u32 size, u8 attrs,
+ * u8 nameLen, name` with left/right in 4-byte units from the table
+ * start. `atRoot` unrolls the offset-0 root entry, since offset 0
+ * doubles as the "no child" sentinel everywhere else.
+ */
+function walkGdfTable(
+  data: Buffer,
+  offset: number,
+  entries: GdfEntry[],
+  atRoot = false,
+  depth = 0,
+): void {
+  if (depth > 64) throw new Error("XGD directory tree too deep (corrupt image?)");
+  if (!atRoot && GDF_NO_CHILD.has(offset)) return;
+  const pos = offset * 4;
+  if (pos + 14 > data.length || data[pos] === 0xff) return;
+  const left = data.readUInt16LE(pos);
+  const right = data.readUInt16LE(pos + 2);
+  const startSector = data.readUInt32LE(pos + 4);
+  const size = data.readUInt32LE(pos + 8);
+  const attrs = data[pos + 12]!;
+  const nameLen = data[pos + 13]!;
+  const name = data
+    .subarray(pos + 14, pos + 14 + nameLen)
+    .toString("latin1");
+  walkGdfTable(data, left, entries, false, depth + 1);
+  if (name.length > 0) entries.push({ name, attrs, startSector, size });
+  walkGdfTable(data, right, entries, false, depth + 1);
+}
+
+async function readGdfDirTable(
+  fh: FileHandle,
+  base: number,
+  sector: number,
+  size: number,
+): Promise<GdfEntry[]> {
+  if (size === 0 || size > 64 * 1024 * 1024) return [];
+  const data = await readAt(fh, base + sector * SECTOR, size);
+  const entries: GdfEntry[] = [];
+  walkGdfTable(data, 0, entries, true);
+  return entries;
+}
+
+export interface ExtractProgress {
+  /** Files written so far / total (listing pass runs first). */
+  filesDone: number;
+  filesTotal: number;
+  bytesDone: number;
+  bytesTotal: number;
+  currentFile: string;
+}
+
+interface GdfFileRef {
+  /** Path relative to the image root, "/"-joined. */
+  relPath: string;
+  startSector: number;
+  size: number;
+}
+
+/** Recursively list every file in the image (cheap — directory tables
+ *  only). Separated from extraction so progress can show real totals. */
+async function listGdfFiles(
+  fh: FileHandle,
+  base: number,
+  sector: number,
+  size: number,
+  prefix: string,
+  out: GdfFileRef[],
+  depth = 0,
+): Promise<void> {
+  if (depth > 32) throw new Error("XGD directory nesting too deep (corrupt image?)");
+  const entries = await readGdfDirTable(fh, base, sector, size);
+  for (const e of entries) {
+    const rel = prefix === "" ? e.name : `${prefix}/${e.name}`;
+    if (e.attrs & GDF_ATTR_DIR) {
+      await listGdfFiles(fh, base, e.startSector, e.size, rel, out, depth + 1);
+    } else {
+      out.push({ relPath: rel, startSector: e.startSector, size: e.size });
+    }
+  }
+}
+
+const COPY_CHUNK = 4 * 1024 * 1024;
+
+async function copyOut(
+  fh: FileHandle,
+  position: number,
+  size: number,
+  destPath: string,
+): Promise<void> {
+  const out = await open(destPath, "w");
+  try {
+    let remaining = size;
+    let pos = position;
+    const buf = Buffer.alloc(Math.min(COPY_CHUNK, Math.max(size, 1)));
+    while (remaining > 0) {
+      const want = Math.min(buf.length, remaining);
+      const { bytesRead } = await fh.read(buf, 0, want, pos);
+      if (bytesRead <= 0) {
+        throw new Error(`Truncated image while reading ${basename(destPath)}`);
+      }
+      await out.write(buf, 0, bytesRead);
+      remaining -= bytesRead;
+      pos += bytesRead;
+    }
+  } finally {
+    await out.close();
+  }
+}
+
+/**
+ * Extract every file of an XGD disc image's game partition into
+ * `destDir`, preserving the directory tree. Each destination path is
+ * confined to `destDir` — entry names come from the image and are not
+ * trusted.
+ */
+export async function extractXgdIso(
+  isoPath: string,
+  destDir: string,
+  onProgress?: (p: ExtractProgress) => void,
+): Promise<{ files: number; bytes: number }> {
+  const fh = await open(isoPath, "r");
+  try {
+    const base = await findXgdBase(fh);
+    if (base == null) {
+      throw new Error(
+        `${basename(isoPath)} has no XDVDFS volume descriptor — not an Xbox disc image.`,
+      );
+    }
+    const desc = await readAt(fh, base + 32 * SECTOR + XGD_MAGIC.length, 8);
+    const rootSector = desc.readUInt32LE(0);
+    const rootSize = desc.readUInt32LE(4);
+
+    const files: GdfFileRef[] = [];
+    await listGdfFiles(fh, base, rootSector, rootSize, "", files);
+    if (files.length === 0) {
+      throw new Error(`${basename(isoPath)}: image contains no files.`);
+    }
+    const bytesTotal = files.reduce((acc, f) => acc + f.size, 0);
+
+    await mkdir(destDir, { recursive: true });
+    let filesDone = 0;
+    let bytesDone = 0;
+    for (const f of files) {
+      const dest = resolveWithinDir(destDir, f.relPath, "XGD image entry");
+      await mkdir(join(dest, ".."), { recursive: true });
+      await copyOut(fh, base + f.startSector * SECTOR, f.size, dest);
+      filesDone += 1;
+      bytesDone += f.size;
+      onProgress?.({
+        filesDone, filesTotal: files.length,
+        bytesDone, bytesTotal, currentFile: f.relPath,
+      });
+    }
+    return { files: filesDone, bytes: bytesDone };
+  } finally {
+    await fh.close();
+  }
+}
+
+// ── STFS (LIVE / PIRS / CON) extraction ──────────────────────────────
+//
+// Narrow-but-sufficient reader for the fixed STFS layout XBLA releases
+// use (single file table at 0xC000, 0x1000-byte blocks, one hash table
+// per 0xAA-block group). Mirrors the extraction script NocturneRecomp
+// bundles, which this replaces so the root backend never has to spawn
+// an interpreter from inside a downloaded release.
+
+const STFS_BLOCK = 0x1000;
+const STFS_FILE_TABLE_OFFSET = 0xc000;
+const STFS_ENTRY_SIZE = 0x40;
+const STFS_ROOT_PARENT = 0xffff;
+const STFS_END_OF_CHAIN = 0xffffff;
+const STFS_ATTR_DIR = 0x80;
+
+interface StfsEntry {
+  index: number;
+  name: string;
+  flags: number;
+  blocks: number;
+  startBlock: number;
+  parent: number;
+  size: number;
+}
+
+function stfsPhysicalBlock(logicalBlock: number): number {
+  const group = Math.floor(logicalBlock / 0xaa);
+  const level1Groups = Math.floor(group / 0xaa);
+  const level1Overhead = level1Groups > 0 ? level1Groups + 1 : 0;
+  return (
+    logicalBlock + 0x0c + group + (group > 0 ? 1 : 0) + level1Overhead
+  );
+}
+
+function stfsHashEntryOffset(logicalBlock: number): number {
+  const group = Math.floor(logicalBlock / 0xaa);
+  const index = logicalBlock % 0xaa;
+  const level1Groups = Math.floor(group / 0xaa);
+  const level1Overhead = level1Groups > 0 ? level1Groups + 1 : 0;
+  const tableBlock =
+    0x0b + group * 0xab + (group > 0 ? 1 : 0) + level1Overhead;
+  return tableBlock * STFS_BLOCK + index * 0x18;
+}
+
+async function stfsNextBlock(
+  fh: FileHandle,
+  logicalBlock: number,
+): Promise<number> {
+  const raw = await readAt(fh, stfsHashEntryOffset(logicalBlock) + 0x15, 3);
+  if (raw.length < 3) throw new Error("Truncated STFS package (hash table)");
+  return (raw[0]! << 16) | (raw[1]! << 8) | raw[2]!;
+}
+
+async function stfsParseEntries(fh: FileHandle): Promise<StfsEntry[]> {
+  const entries: StfsEntry[] = [];
+  let offset = STFS_FILE_TABLE_OFFSET;
+  for (let index = 0; ; index++, offset += STFS_ENTRY_SIZE) {
+    const raw = await readAt(fh, offset, STFS_ENTRY_SIZE);
+    if (raw.length !== STFS_ENTRY_SIZE || raw.every((b) => b === 0)) break;
+    const nameFlags = raw[0x28]!;
+    const nameLen = nameFlags & 0x3f;
+    if (nameLen === 0) break;
+    entries.push({
+      index,
+      name: raw.subarray(0, nameLen).toString("latin1"),
+      flags: nameFlags,
+      blocks: raw[0x29]! | (raw[0x2a]! << 8) | (raw[0x2b]! << 16),
+      startBlock: raw[0x2f]! | (raw[0x30]! << 8) | (raw[0x31]! << 16),
+      parent: raw.readUInt16BE(0x32),
+      size: raw.readUInt32BE(0x34),
+    });
+  }
+  return entries;
+}
+
+/** Rebuild an entry's path from its parent chain ("/"-joined, root-relative). */
+function stfsEntryPath(entry: StfsEntry, entries: StfsEntry[]): string {
+  const parts = [entry.name];
+  const seen = new Set([entry.index]);
+  let parent = entry.parent;
+  while (parent !== STFS_ROOT_PARENT) {
+    const p = entries[parent];
+    if (!p || seen.has(parent)) {
+      throw new Error(`Invalid STFS parent chain for ${entry.name}`);
+    }
+    parts.push(p.name);
+    seen.add(parent);
+    parent = p.parent;
+  }
+  return parts.reverse().join("/");
+}
+
+/**
+ * Extract every file of an STFS package into `destDir`. Destination
+ * paths are confined to `destDir` — entry names are untrusted.
+ */
+export async function extractStfs(
+  pkgPath: string,
+  destDir: string,
+  onProgress?: (p: ExtractProgress) => void,
+): Promise<{ files: number; bytes: number }> {
+  const fh = await open(pkgPath, "r");
+  try {
+    const magic = (await readAt(fh, 0, 4)).toString("latin1");
+    if (magic !== "LIVE" && magic !== "PIRS" && magic !== "CON ") {
+      throw new Error(
+        `${basename(pkgPath)} is not an Xbox 360 STFS package (LIVE/PIRS/CON).`,
+      );
+    }
+    const entries = await stfsParseEntries(fh);
+    const files = entries.filter((e) => (e.flags & STFS_ATTR_DIR) === 0);
+    if (files.length === 0) {
+      throw new Error(`${basename(pkgPath)}: package contains no files.`);
+    }
+    const bytesTotal = files.reduce((acc, f) => acc + f.size, 0);
+
+    await mkdir(destDir, { recursive: true });
+    let filesDone = 0;
+    let bytesDone = 0;
+    for (const entry of files) {
+      const relPath = stfsEntryPath(entry, entries);
+      const dest = resolveWithinDir(destDir, relPath, "STFS package entry");
+      await mkdir(join(dest, ".."), { recursive: true });
+
+      const out = await open(dest, "w");
+      try {
+        let remaining = entry.size;
+        let logicalBlock = entry.startBlock;
+        const blocksToCopy = Math.max(
+          entry.blocks,
+          Math.ceil(entry.size / STFS_BLOCK),
+        );
+        for (let i = 0; i < blocksToCopy && remaining > 0; i++) {
+          if (logicalBlock === STFS_END_OF_CHAIN) {
+            throw new Error(
+              `Unexpected end of block chain extracting ${entry.name}`,
+            );
+          }
+          const chunk = await readAt(
+            fh,
+            stfsPhysicalBlock(logicalBlock) * STFS_BLOCK,
+            Math.min(STFS_BLOCK, remaining),
+          );
+          if (chunk.length === 0) {
+            throw new Error(`Unexpected EOF extracting ${entry.name}`);
+          }
+          await out.write(chunk);
+          remaining -= chunk.length;
+          if (i + 1 < blocksToCopy) {
+            logicalBlock = await stfsNextBlock(fh, logicalBlock);
+          }
+        }
+      } finally {
+        await out.close();
+      }
+      filesDone += 1;
+      bytesDone += entry.size;
+      onProgress?.({
+        filesDone, filesTotal: files.length,
+        bytesDone, bytesTotal, currentFile: relPath,
+      });
+    }
+    return { files: filesDone, bytes: bytesDone };
+  } finally {
+    await fh.close();
+  }
+}
+
+// ── Locate the dump inside an unwrapped archive ──────────────────────
+
+/**
+ * Walk `dir` looking for files matching `format` by magic. Multiple
+ * candidates resolve to the largest (a real dump always dwarfs any
+ * readme/artwork siblings). Returns null when nothing matches.
+ */
+export async function locateDumpFile(
+  dir: string,
+  format: "xgd-iso" | "stfs",
+): Promise<string | null> {
+  const candidates: { path: string; size: number }[] = [];
+  const visit = async (d: string, depth: number): Promise<void> => {
+    if (depth > 6) return;
+    let entries;
+    try {
+      entries = await readdir(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const full = join(d, e.name);
+      if (e.isDirectory()) {
+        await visit(full, depth + 1);
+      } else if (e.isFile()) {
+        // Every plausible dump is at least 1 MiB; skip the tiny stuff
+        // before paying for a magic sniff.
+        const info = await stat(full);
+        if (info.size < 1024 * 1024) continue;
+        if ((await sniffRomSourceKind(full)) === format) {
+          candidates.push({ path: full, size: info.size });
+        }
+      }
+    }
+  };
+  await visit(dir, 0);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => b.size - a.size);
+  return candidates[0]!.path;
+}
+
+// ── Anchor validation ────────────────────────────────────────────────
+
+async function sha1File(path: string): Promise<string> {
+  const hasher = new Bun.CryptoHasher("sha1");
+  const stream = Bun.file(path).stream();
+  for await (const chunk of stream) hasher.update(chunk);
+  return hasher.digest("hex").toLowerCase();
+}
+
+// ── Orchestrator ─────────────────────────────────────────────────────
+
+export interface StageRomSourceOptions {
+  romInfo: RomInfo;
+  /** The user-picked file (archive or bare dump). */
+  romPath: string;
+  /** The staged install dir (`${installDir}.partial` during install). */
+  stageDir: string;
+  /** Scratch dir for the archive unwrap; caller owns cleanup (the
+   *  install pipeline's tmpGameDir teardown covers it). */
+  scratchDir: string;
+  onProgress: (message: string, percent?: number) => void;
+}
+
+/**
+ * Populate `stageDir/{extractTo}` from the user's dump, per the
+ * catalog's `romInfo.sourceFormat`. Returns the list of non-fatal
+ * warnings (anchor-checksum mismatch etc.) for the caller to surface.
+ *
+ * Throws on: unrecognizable input, an archive with no dump inside,
+ * a dump missing the declared `anchorFile`.
+ */
+export async function stageRomSource(
+  opts: StageRomSourceOptions,
+): Promise<{ files: number; warnings: string[] }> {
+  const { romInfo, romPath, stageDir, scratchDir, onProgress } = opts;
+  const format = romInfo.sourceFormat;
+  if (format !== "xgd-iso" && format !== "stfs") {
+    throw new Error(`stageRomSource called for sourceFormat=${format}`);
+  }
+
+  // 1. What did the user actually hand us?
+  let dumpPath = romPath;
+  const kind = await sniffRomSourceKind(romPath);
+  if (kind === "archive") {
+    onProgress(`Unpacking ${basename(romPath)}…`);
+    const unwrapDir = join(scratchDir, "rom-source");
+    await mkdir(unwrapDir, { recursive: true });
+    await extractArchive(romPath, unwrapDir);
+    const located = await locateDumpFile(unwrapDir, format);
+    if (!located) {
+      throw new Error(
+        `${basename(romPath)} does not contain a ${format === "stfs" ? "Xbox 360 XBLA package" : "Xbox disc image"}. ` +
+          `Check that you picked the right archive.`,
+      );
+    }
+    dumpPath = located;
+  } else if (kind !== format) {
+    throw new Error(
+      `${basename(romPath)} is not a supported dump for this game ` +
+        `(expected ${format === "stfs" ? "an XBLA STFS package" : "an Xbox disc image"} or an archive containing one).`,
+    );
+  }
+
+  // 2. Extract into the (confined) data dir.
+  const destDir = resolveWithinDir(
+    stageDir,
+    romInfo.extractTo ?? "assets",
+    "romInfo.extractTo",
+  );
+  const report = (p: ExtractProgress) => {
+    const pct = p.bytesTotal > 0 ? (p.bytesDone / p.bytesTotal) * 100 : 0;
+    onProgress(
+      `Extracting game data ${p.filesDone}/${p.filesTotal} files…`,
+      pct,
+    );
+  };
+  const result =
+    format === "xgd-iso"
+      ? await extractXgdIso(dumpPath, destDir, report)
+      : await extractStfs(dumpPath, destDir, report);
+
+  // 3. Anchor validation: presence is fatal (the port cannot boot
+  //    without it), checksum mismatch is a warning (other-region dumps
+  //    frequently work; upstream docs mostly say "untested", not "no").
+  const warnings: string[] = [];
+  if (romInfo.anchorFile) {
+    const anchorPath = resolveWithinDir(
+      destDir,
+      romInfo.anchorFile,
+      "romInfo.anchorFile",
+    );
+    let anchorOk = false;
+    try {
+      anchorOk = (await stat(anchorPath)).isFile();
+    } catch {
+      anchorOk = false;
+    }
+    if (!anchorOk) {
+      throw new Error(
+        `The dump extracted, but ${romInfo.anchorFile} is missing — this doesn't look ` +
+          `like the right game. Nothing was installed from it.`,
+      );
+    }
+    const expected = (romInfo.anchorChecksums ?? []).map((c) =>
+      c.trim().toLowerCase(),
+    );
+    if (expected.length > 0) {
+      const got = await sha1File(anchorPath);
+      if (!expected.includes(got)) {
+        warnings.push(
+          `${romInfo.anchorFile} doesn't match a known-good dump (sha1 ${got}). ` +
+            `Probably a different region/revision — the game may still work.`,
+        );
+      }
+    }
+  }
+
+  return { files: result.files, warnings };
+}

--- a/plugins/recomp/lib/rom-source.ts
+++ b/plugins/recomp/lib/rom-source.ts
@@ -26,9 +26,9 @@
  * user already owns, locally. Both XGD and STFS are plain unencrypted
  * filesystems — no keys, no DRM circumvention, no downloads.
  */
-import { open, mkdir, readdir, stat } from "node:fs/promises";
+import { open, mkdir, readdir, stat, rm, symlink } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
-import { join, basename } from "node:path";
+import { join, basename, resolve } from "node:path";
 import { resolveWithinDir } from "./path-confine";
 import { extractArchive } from "./pipeline-archive";
 import type { RomInfo } from "./types";
@@ -79,8 +79,18 @@ export async function sniffRomSourceKind(path: string): Promise<RomSourceKind> {
     const head = await readAt(fh, 0, 8);
     if (head.length >= 4) {
       const ascii4 = head.subarray(0, 4).toString("latin1");
-      // zip (incl. empty/spanned variants) — "PK" + 03/05/07
-      if (ascii4.startsWith("PK")) return "archive";
+      // zip: "PK" followed by a real record signature — \x03\x04 (local
+      // file), \x05\x06 (empty archive end-of-central-dir), or \x07\x08
+      // (spanned). Checking the third/fourth bytes avoids misrouting an
+      // arbitrary file that merely starts with the letters "PK".
+      if (
+        head[0] === 0x50 && head[1] === 0x4b &&
+        ((head[2] === 0x03 && head[3] === 0x04) ||
+          (head[2] === 0x05 && head[3] === 0x06) ||
+          (head[2] === 0x07 && head[3] === 0x08))
+      ) {
+        return "archive";
+      }
       if (head.subarray(0, 6).equals(Buffer.from([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]))) {
         return "archive"; // 7z
       }
@@ -100,6 +110,63 @@ export async function sniffRomSourceKind(path: string): Promise<RomSourceKind> {
   }
 }
 
+/** Archive extensions `extractArchive` (lib/pipeline-archive.ts)
+ *  dispatches on. Kept in sync with that module. */
+const EXTRACTABLE_EXTENSIONS = [
+  ".zip", ".tar.gz", ".tgz", ".tar", ".rar", ".7z", ".appimage",
+] as const;
+
+/** Map a file's magic bytes to the archive extension `extractArchive`
+ *  needs, or null if it isn't an archive we can unpack. */
+async function archiveExtensionByMagic(path: string): Promise<string | null> {
+  const fh = await open(path, "r");
+  try {
+    const head = await readAt(fh, 0, 8);
+    if (head.length >= 4) {
+      if (head[0] === 0x50 && head[1] === 0x4b) return ".zip";
+      if (head.subarray(0, 6).equals(Buffer.from([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]))) {
+        return ".7z";
+      }
+      if (head.subarray(0, 4).toString("latin1") === "Rar!") return ".rar";
+      if (head[0] === 0x1f && head[1] === 0x8b) return ".tar.gz";
+    }
+    const tarMagic = await readAt(fh, 257, 5);
+    if (tarMagic.toString("latin1") === "ustar") return ".tar";
+    return null;
+  } finally {
+    await fh.close();
+  }
+}
+
+/**
+ * Return a path `extractArchive` will accept for `archivePath`. If its
+ * real name already ends in an extractable extension, use it as-is;
+ * otherwise create a symlink named `<scratch>/rom-source-input<ext>`
+ * with a magic-derived extension so the extension-dispatching extractor
+ * picks the right unpacker. Symlink (not copy) keeps this O(1) for a
+ * multi-GB archive.
+ */
+async function archivePathForExtraction(
+  archivePath: string,
+  scratchDir: string,
+): Promise<string> {
+  const lower = basename(archivePath).toLowerCase();
+  if (EXTRACTABLE_EXTENSIONS.some((ext) => lower.endsWith(ext))) {
+    return archivePath;
+  }
+  const ext = await archiveExtensionByMagic(archivePath);
+  if (!ext) return archivePath; // let extractArchive throw its own error
+  await mkdir(scratchDir, { recursive: true });
+  const linkPath = join(scratchDir, `rom-source-input${ext}`);
+  try {
+    await rm(linkPath, { force: true });
+    await symlink(resolve(archivePath), linkPath);
+    return linkPath;
+  } catch {
+    return archivePath; // symlink unsupported → fall back to real path
+  }
+}
+
 // ── XGD / XDVDFS (GDF) extraction ────────────────────────────────────
 
 interface GdfEntry {
@@ -110,39 +177,68 @@ interface GdfEntry {
 }
 
 const GDF_ATTR_DIR = 0x10;
-/** Padding / no-child sentinels in the directory entry tree. */
+/** No-child sentinels for a subtree pointer: 0xFFFF is the XDVDFS
+ *  sentinel; 0 doubles as "none" everywhere except the table root
+ *  (which lives at offset 0). */
 const GDF_NO_CHILD = new Set([0, 0xffff]);
+/** Hard ceiling on entries in a single directory table. Real tables
+ *  hold at most a few thousand; this only bounds a crafted table. */
+const GDF_MAX_ENTRIES_PER_TABLE = 1 << 20;
 
 /**
- * In-order walk of one directory table's entry tree. Entries are
- * `u16 left, u16 right, u32 startSector, u32 size, u8 attrs,
- * u8 nameLen, name` with left/right in 4-byte units from the table
- * start. `atRoot` unrolls the offset-0 root entry, since offset 0
- * doubles as the "no child" sentinel everywhere else.
+ * Collect one directory table's entries by walking its binary tree.
+ * Entries are `u16 left, u16 right, u32 startSector, u32 size,
+ * u8 attrs, u8 nameLen, name`, with left/right in 4-byte units from
+ * the table start.
+ *
+ * Iterative with an explicit stack + a visited-offset set: a crafted
+ * table can point two parents at the same child (a DAG) or form a
+ * cycle, which a naive recursive walk would follow into 2^depth calls
+ * — a synchronous CPU/heap bomb in the root backend. Visiting each
+ * offset once makes the walk O(table size) and also lets a legitimate
+ * but deeply-unbalanced tree extract without a depth-limit false
+ * positive.
+ *
+ * Padding detection: the walk only ever LANDS on a real entry, because
+ * every child pointer is filtered through `GDF_NO_CHILD` before being
+ * pushed — so a pointer never targets the 0xFF fill between/after
+ * entries. The one exception is the root of an empty directory, whose
+ * whole slot is 0xFF fill (nameLen 0xFF, size 0xFFFFFFFF); that is
+ * skipped explicitly. (The previous `data[pos] === 0xff` check was
+ * wrong: `data[pos]` is the low byte of the entry's own `left`
+ * pointer, so any real entry whose left child sat at an offset ending
+ * in 0xFF — e.g. 0x02FF — was silently dropped along with both its
+ * subtrees.)
  */
-function walkGdfTable(
-  data: Buffer,
-  offset: number,
-  entries: GdfEntry[],
-  atRoot = false,
-  depth = 0,
-): void {
-  if (depth > 64) throw new Error("XGD directory tree too deep (corrupt image?)");
-  if (!atRoot && GDF_NO_CHILD.has(offset)) return;
-  const pos = offset * 4;
-  if (pos + 14 > data.length || data[pos] === 0xff) return;
-  const left = data.readUInt16LE(pos);
-  const right = data.readUInt16LE(pos + 2);
-  const startSector = data.readUInt32LE(pos + 4);
-  const size = data.readUInt32LE(pos + 8);
-  const attrs = data[pos + 12]!;
-  const nameLen = data[pos + 13]!;
-  const name = data
-    .subarray(pos + 14, pos + 14 + nameLen)
-    .toString("latin1");
-  walkGdfTable(data, left, entries, false, depth + 1);
-  if (name.length > 0) entries.push({ name, attrs, startSector, size });
-  walkGdfTable(data, right, entries, false, depth + 1);
+function walkGdfTable(data: Buffer, entries: GdfEntry[]): void {
+  const visited = new Set<number>();
+  const stack: number[] = [0]; // root entry sits at table offset 0
+  while (stack.length > 0) {
+    const offset = stack.pop()!;
+    if (visited.has(offset)) continue;
+    visited.add(offset);
+    if (visited.size > GDF_MAX_ENTRIES_PER_TABLE) {
+      throw new Error("XGD directory table has too many entries (corrupt image?)");
+    }
+    const pos = offset * 4;
+    if (pos + 14 > data.length) continue;
+    const left = data.readUInt16LE(pos);
+    const right = data.readUInt16LE(pos + 2);
+    const startSector = data.readUInt32LE(pos + 4);
+    const size = data.readUInt32LE(pos + 8);
+    const attrs = data[pos + 12]!;
+    const nameLen = data[pos + 13]!;
+    // 0xFF fill (empty-table root, or a malformed slot the walk should
+    // never reach): a padding slot has nameLen 0xFF and size 0xFFFFFFFF.
+    // A zero-length name is never a valid entry either.
+    const isPadding = nameLen === 0 || (nameLen === 0xff && size === 0xffffffff);
+    if (!isPadding) {
+      const name = data.subarray(pos + 14, pos + 14 + nameLen).toString("latin1");
+      if (name.length > 0) entries.push({ name, attrs, startSector, size });
+    }
+    if (!GDF_NO_CHILD.has(left)) stack.push(left);
+    if (!GDF_NO_CHILD.has(right)) stack.push(right);
+  }
 }
 
 async function readGdfDirTable(
@@ -154,8 +250,33 @@ async function readGdfDirTable(
   if (size === 0 || size > 64 * 1024 * 1024) return [];
   const data = await readAt(fh, base + sector * SECTOR, size);
   const entries: GdfEntry[] = [];
-  walkGdfTable(data, 0, entries, true);
+  walkGdfTable(data, entries);
   return entries;
+}
+
+/**
+ * Global budget threaded through a whole disc/package extraction to
+ * bound total work regardless of how a crafted image inflates it
+ * (directory cycles, thousands of entries pointing at the same extent).
+ * Ceilings are far above any real dump: an XGD3 dual-layer disc is
+ * ~7.9 GB / a few thousand files.
+ */
+interface ExtractBudget {
+  files: number;
+  bytes: number;
+}
+const MAX_TOTAL_FILES = 200_000;
+const MAX_TOTAL_BYTES = 24 * 1024 * 1024 * 1024; // 24 GiB
+
+function chargeFile(budget: ExtractBudget, size: number, label: string): void {
+  budget.files += 1;
+  budget.bytes += size;
+  if (budget.files > MAX_TOTAL_FILES) {
+    throw new Error(`${label}: image declares too many files (corrupt or hostile?).`);
+  }
+  if (budget.bytes > MAX_TOTAL_BYTES) {
+    throw new Error(`${label}: image declares more data than any real disc (corrupt or hostile?).`);
+  }
 }
 
 export interface ExtractProgress {
@@ -175,7 +296,14 @@ interface GdfFileRef {
 }
 
 /** Recursively list every file in the image (cheap — directory tables
- *  only). Separated from extraction so progress can show real totals. */
+ *  only). Separated from extraction so progress can show real totals.
+ *
+ *  `visitedDirs` (keyed by directory start sector) breaks cycles a
+ *  crafted image can form between directory tables — without it, a
+ *  dir whose entry points back at an ancestor sector recurses until
+ *  the depth cap, re-reading tables the whole way. `budget` bounds the
+ *  total file count so a table of thousands of entries all pointing at
+ *  the same subdirectory can't inflate `out` without limit. */
 async function listGdfFiles(
   fh: FileHandle,
   base: number,
@@ -183,15 +311,20 @@ async function listGdfFiles(
   size: number,
   prefix: string,
   out: GdfFileRef[],
+  budget: ExtractBudget,
+  visitedDirs: Set<number>,
   depth = 0,
 ): Promise<void> {
-  if (depth > 32) throw new Error("XGD directory nesting too deep (corrupt image?)");
+  if (depth > 64) throw new Error("XGD directory nesting too deep (corrupt image?)");
+  if (visitedDirs.has(sector)) return; // cycle between directory tables
+  visitedDirs.add(sector);
   const entries = await readGdfDirTable(fh, base, sector, size);
   for (const e of entries) {
     const rel = prefix === "" ? e.name : `${prefix}/${e.name}`;
     if (e.attrs & GDF_ATTR_DIR) {
-      await listGdfFiles(fh, base, e.startSector, e.size, rel, out, depth + 1);
+      await listGdfFiles(fh, base, e.startSector, e.size, rel, out, budget, visitedDirs, depth + 1);
     } else {
+      chargeFile(budget, e.size, "XGD image");
       out.push({ relPath: rel, startSector: e.startSector, size: e.size });
     }
   }
@@ -249,7 +382,10 @@ export async function extractXgdIso(
     const rootSize = desc.readUInt32LE(4);
 
     const files: GdfFileRef[] = [];
-    await listGdfFiles(fh, base, rootSector, rootSize, "", files);
+    await listGdfFiles(
+      fh, base, rootSector, rootSize, "", files,
+      { files: 0, bytes: 0 }, new Set<number>(),
+    );
     if (files.length === 0) {
       throw new Error(`${basename(isoPath)}: image contains no files.`);
     }
@@ -300,6 +436,27 @@ interface StfsEntry {
   size: number;
 }
 
+/**
+ * STFS packages come in two hash-table layouts: "read-only" (one hash
+ * block per 0xAA-block group — `table_size_shift = 0`) and
+ * "read-write"/resigned (doubled hash blocks — shift 1). Marketplace
+ * XBLA content (what these catalog entries target) is LIVE-signed and
+ * always shift 0; the block-mapping math below is derived and verified
+ * for shift 0 only. We read the header-size field and, rather than
+ * silently mis-map a shift-1 package into corrupt output (the previous
+ * behavior — the only symptom was a *non-fatal* checksum warning),
+ * reject it with an actionable message. `extractStfs` calls this and
+ * throws on a non-zero shift.
+ *
+ * Formula matches py360 / Velocity: `((headerSize + 0xFFF) & 0xF000)
+ * >> 12 == 0xB` ⇒ shift 0, else shift 1. (Verified: SOTN's real LIVE
+ * package has headerSize 0xAD0E ⇒ 0xB ⇒ shift 0.)
+ */
+async function stfsTableSizeShift(fh: FileHandle): Promise<number> {
+  const headerSize = (await readAt(fh, 0x340, 4)).readUInt32BE(0);
+  return ((headerSize + 0xfff) & 0xf000) >> 12 === 0xb ? 0 : 1;
+}
+
 function stfsPhysicalBlock(logicalBlock: number): number {
   const group = Math.floor(logicalBlock / 0xaa);
   const level1Groups = Math.floor(group / 0xaa);
@@ -328,14 +485,32 @@ async function stfsNextBlock(
   return (raw[0]! << 16) | (raw[1]! << 8) | raw[2]!;
 }
 
-async function stfsParseEntries(fh: FileHandle): Promise<StfsEntry[]> {
+/** File-table length in entries, from the STFS volume descriptor's
+ *  block count (u16 LE at 0x37C). Bounds the linear scan below so a
+ *  table that exactly fills its block(s) — no zero terminator — can't
+ *  run on into the following data block and parse content as entries.
+ *  Falls back to a generous cap if the field is missing/absurd. */
+async function stfsFileTableEntryCap(fh: FileHandle): Promise<number> {
+  const blockCount = (await readAt(fh, 0x37c, 2)).readUInt16LE(0);
+  const entriesPerBlock = STFS_BLOCK / STFS_ENTRY_SIZE; // 64
+  const cap = blockCount * entriesPerBlock;
+  return cap > 0 && cap <= 1_000_000 ? cap : 1_000_000;
+}
+
+async function stfsParseEntries(
+  fh: FileHandle,
+  maxEntries: number,
+): Promise<StfsEntry[]> {
   const entries: StfsEntry[] = [];
   let offset = STFS_FILE_TABLE_OFFSET;
-  for (let index = 0; ; index++, offset += STFS_ENTRY_SIZE) {
+  for (let index = 0; index < maxEntries; index++, offset += STFS_ENTRY_SIZE) {
     const raw = await readAt(fh, offset, STFS_ENTRY_SIZE);
     if (raw.length !== STFS_ENTRY_SIZE || raw.every((b) => b === 0)) break;
     const nameFlags = raw[0x28]!;
-    const nameLen = nameFlags & 0x3f;
+    // Name length is the low 6 bits (max 63), but the name field is
+    // only 0x28 (40) bytes — clamp so a corrupt length can't read the
+    // blocks/startBlock fields into the filename.
+    const nameLen = Math.min(nameFlags & 0x3f, 0x28);
     if (nameLen === 0) break;
     entries.push({
       index,
@@ -384,7 +559,18 @@ export async function extractStfs(
         `${basename(pkgPath)} is not an Xbox 360 STFS package (LIVE/PIRS/CON).`,
       );
     }
-    const entries = await stfsParseEntries(fh);
+    // Only the shift-0 (read-only, LIVE-signed marketplace) layout is
+    // supported; a resigned/read-write package has doubled hash tables
+    // that this mapping would mis-read into corrupt output. Reject it
+    // loudly rather than ship garbage assets.
+    const shift = await stfsTableSizeShift(fh);
+    if (shift !== 0) {
+      throw new Error(
+        `${basename(pkgPath)} is a resigned/read-write STFS package (doubled hash tables), ` +
+          `which isn't supported. Provide the original LIVE-signed XBLA content file.`,
+      );
+    }
+    const entries = await stfsParseEntries(fh, await stfsFileTableEntryCap(fh));
     const files = entries.filter((e) => (e.flags & STFS_ATTR_DIR) === 0);
     if (files.length === 0) {
       throw new Error(`${basename(pkgPath)}: package contains no files.`);
@@ -392,9 +578,11 @@ export async function extractStfs(
     const bytesTotal = files.reduce((acc, f) => acc + f.size, 0);
 
     await mkdir(destDir, { recursive: true });
+    const budget: ExtractBudget = { files: 0, bytes: 0 };
     let filesDone = 0;
     let bytesDone = 0;
     for (const entry of files) {
+      chargeFile(budget, entry.size, "STFS package");
       const relPath = stfsEntryPath(entry, entries);
       const dest = resolveWithinDir(destDir, relPath, "STFS package entry");
       await mkdir(join(dest, ".."), { recursive: true });
@@ -407,19 +595,33 @@ export async function extractStfs(
           entry.blocks,
           Math.ceil(entry.size / STFS_BLOCK),
         );
+        // Track visited blocks: a crafted block chain can form a cycle
+        // (A→B→A) that never reaches END_OF_CHAIN, which — combined with
+        // a large declared size — would otherwise re-read two blocks for
+        // millions of iterations, amplifying a tiny package into a
+        // disk-filling write.
+        const visitedBlocks = new Set<number>();
         for (let i = 0; i < blocksToCopy && remaining > 0; i++) {
           if (logicalBlock === STFS_END_OF_CHAIN) {
             throw new Error(
               `Unexpected end of block chain extracting ${entry.name}`,
             );
           }
+          if (visitedBlocks.has(logicalBlock)) {
+            throw new Error(`Cyclic block chain extracting ${entry.name} (corrupt package?)`);
+          }
+          visitedBlocks.add(logicalBlock);
+          const want = Math.min(STFS_BLOCK, remaining);
           const chunk = await readAt(
             fh,
             stfsPhysicalBlock(logicalBlock) * STFS_BLOCK,
-            Math.min(STFS_BLOCK, remaining),
+            want,
           );
-          if (chunk.length === 0) {
-            throw new Error(`Unexpected EOF extracting ${entry.name}`);
+          // A short (but non-empty) read means the package is truncated
+          // mid-block: writing it and advancing the chain would splice
+          // wrong bytes into the file. Fail instead.
+          if (chunk.length < want) {
+            throw new Error(`Truncated STFS package extracting ${entry.name}`);
           }
           await out.write(chunk);
           remaining -= chunk.length;
@@ -531,7 +733,14 @@ export async function stageRomSource(
     onProgress(`Unpacking ${basename(romPath)}…`);
     const unwrapDir = join(scratchDir, "rom-source");
     await mkdir(unwrapDir, { recursive: true });
-    await extractArchive(romPath, unwrapDir);
+    // `extractArchive` dispatches by file EXTENSION, but we detected the
+    // archive by MAGIC — so a correctly-identified archive with a wrong
+    // or absent extension (the SOTN entry warns users their file may be
+    // extensionless) would be rejected as "unsupported format". Present
+    // it to the extractor under a magic-derived extension via a symlink
+    // (no multi-GB copy) when the real name wouldn't dispatch.
+    const archiveInput = await archivePathForExtraction(romPath, scratchDir);
+    await extractArchive(archiveInput, unwrapDir);
     const located = await locateDumpFile(unwrapDir, format);
     if (!located) {
       throw new Error(

--- a/plugins/recomp/lib/types.ts
+++ b/plugins/recomp/lib/types.ts
@@ -61,6 +61,40 @@ export interface RomInfo {
    *  no CLI extraction mode despite `extractionCommand` historically
    *  trying to invoke a `--generate-otr` flag that doesn't exist. */
   placeRomAs?: string;
+  /**
+   * How the user's dump is structured, when it isn't a single flat
+   * ROM file. Drives `lib/rom-source.ts`'s staging step:
+   *
+   *   - `"raw"` (or absent): existing behavior — the picked file IS
+   *     the ROM; `placeRomAs` / `extractionCommand` handle it.
+   *   - `"xgd-iso"`: an Xbox / Xbox 360 disc image. The GDF
+   *     filesystem is unpacked into `extractTo`.
+   *   - `"stfs"`: an Xbox 360 STFS (LIVE/PIRS/CON) package — XBLA
+   *     titles. Unpacked into `extractTo`.
+   *
+   * For the non-raw formats the picked file may also be a zip/7z/rar
+   * wrapping the dump — the staging step unwraps it and locates the
+   * dump by magic bytes, so `extensions` should include the archive
+   * extensions users actually have.
+   */
+  sourceFormat?: "raw" | "xgd-iso" | "stfs";
+  /** Directory (relative to the install dir) that receives the
+   *  unpacked dump for non-raw `sourceFormat`s. Defaults to
+   *  `"assets"` — the ReXGlue family's `--game_data_root` default. */
+  extractTo?: string;
+  /**
+   * File (relative to `extractTo`) whose presence proves the dump was
+   * the right game — `default.xex` for Xbox 360 titles. Missing ⇒ the
+   * install fails with a clear message instead of shipping a data dir
+   * the engine can't boot. Also the launch-time guard's probe target:
+   * the backend refuses to launch when it's absent (the engine would
+   * just exit with a cryptic "game_data_root does not exist").
+   */
+  anchorFile?: string;
+  /** Known-good SHA-1s of `anchorFile`. Mismatch is a WARNING, not an
+   *  error — other-region dumps frequently work and upstreams mostly
+   *  document them as "untested" rather than broken. */
+  anchorChecksums?: string[];
 }
 
 export interface ToolchainInfo {


### PR DESCRIPTION
## What

Combined PR (folds in #220):

1. **Catalog: nine fully-released recomp/port titles** (`da5bd87`, previously #220) — including the Xbox 360 ReXGlue family this PR's feature exists for.
2. **Auto-extraction of game data** (`a15b7ab`): the new ReXGlue titles (Castlevania SotN XBLA, WWE SmackDown vs. Raw 2007, Viva Piñata TiP) ship no game data — installed via the plugin they "crash on launch" because `assets/` is empty and the engine exits with a log line the user never sees. The ROM picker now accepts the user's dump (bare `.iso`, raw XBLA content file, or a zip/7z/rar wrapping either) and the installer unpacks it into `assets/` automatically.

## How

- **`lib/rom-source.ts`** (new):
  - magic-byte sniffing — filenames are never trusted (XBLA content files have no extension at all)
  - pure-TS **XDVDFS/GDF extractor** for Xbox disc images, probing all four partition bases (XGD1/2/3 + game-partition-only rips)
  - pure-TS **STFS reader** (LIVE/PIRS/CON) — replaces spawning the extraction script NocturneRecomp bundles, so the root backend never execs anything from a downloaded release
  - archive unwrap (reuses `extractArchive` + its traversal pre-flight) and dump location by magic, largest candidate wins
  - anchor validation: missing `default.xex` ⇒ fatal with a clear message; SHA-1 mismatch ⇒ warning only (other-region dumps frequently work)
- **`romInfo`** gains `sourceFormat` / `extractTo` / `anchorFile` / `anchorChecksums`; all destinations confined via `resolveWithinDir` (entry names inside images are untrusted input)
- **Launch guard**: `launchGame` refuses with an actionable message when the anchor file is missing, instead of the engine's silent instant exit
- **Catalog**: the three titles switch `prebuilt` → `rom_extract` with anchor SHA-1s recorded from verified working installs

Deliberately *not* included: no downloads of game data, no keys, no DRM circumvention — both formats are plain unencrypted filesystems and the only input is the user's own dump via the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EW4g8X7to5NGXqCvhTiVH