### PR TITLE
fix(overlay): ignore phantom wake events during startup grace window

### DIFF
--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -163,10 +163,14 @@ const webviewEverAlive: { current: boolean } = { current: false };
 // toggleOverlay.
 const intercept: { current: InputInterceptHandle | null } = { current: null };
 // Monotonic baseline for the startup phantom-wake guard (see onWake /
-// isStartupWakePhantom). Captured at module load — a hair before the input
-// paths open their evdev nodes below — so the grace window covers the boot
-// race where InputPlumber emits a spurious F16 before the session is up.
-const inputStartedAt = performance.now();
+// isStartupWakePhantom). Seeded at module load so the guard is armed even for
+// a wake that somehow arrives before the interceptors finish starting, then
+// RE-ANCHORED to the moment the evdev nodes actually open (the evdev
+// `onReady` below). The phantom F16 is observed ~1s after the nodes open, and
+// the async startup before that (persisted-config read + IP DBus discovery)
+// is variable — anchoring to node-open gives a deterministic 5s window that
+// matches the observed failure timing rather than eating into it.
+const inputStartedAt = { current: performance.now() };
 // InputPlumber intercept-mode path — runs alongside the evdev interceptor on
 // IP-managed handhelds (deck-uhid target, no grabbable evdev). On grab it sets
 // InterceptMode=2 so Steam BPM is starved and nav arrives over D-Bus; on hosts
@@ -571,7 +575,7 @@ function onWake(event: WakeEvent): void {
   // boot; acting on it opens the overlay invisibly and diverts the pad away
   // from Steam (Steam looks dead until InputPlumber is restarted). See
   // isStartupWakePhantom. Only opens are suppressed — a close always works.
-  const elapsed = performance.now() - inputStartedAt;
+  const elapsed = performance.now() - inputStartedAt.current;
   if (isStartupWakePhantom({ elapsedSinceStartMs: elapsed, isOpen: state.isOpen })) {
     trace(
       `[overlay] ignoring wake=${event} within startup grace (${Math.round(elapsed)}ms) — likely boot phantom`,
@@ -688,10 +692,16 @@ void (async () => {
         // main content area with its own rAF + momentum loop.
         sendToWebview("overlay-scroll", { axis, value });
       },
-      onReady: (c) =>
+      onReady: (c) => {
+        // Re-anchor the phantom-wake grace window to the moment the evdev
+        // nodes are open (see inputStartedAt). onReady fires synchronously
+        // after the devices are opened and before the read loop polls, so no
+        // wake can be observed before this reset.
+        inputStartedAt.current = performance.now();
         console.log(
           `[overlay] input intercept ready — ${c.controllers} controller(s), ${c.keyboards} keyboard(s), ${c.qam} qam device(s) (readVirtualPadsForNav=${readVirtualPadsForNav})`,
-        ),
+        );
+      },
     });
     intercept.current = handle;
   } catch (err) {

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -51,7 +51,7 @@ import {
 
 import { trace } from "./native/trace";
 import { createOverlayState } from "./lib/overlay-state";
-import { routeWake } from "./lib/wake-routing";
+import { routeWake, isStartupWakePhantom } from "./lib/wake-routing";
 import { loadPersistedShortcuts } from "./lib/persisted-shortcuts";
 
 // ---- State ------------------------------------------------------------------
@@ -162,6 +162,11 @@ const webviewEverAlive: { current: boolean } = { current: false };
 // and to the close-path `intercept.current?.release()` inside
 // toggleOverlay.
 const intercept: { current: InputInterceptHandle | null } = { current: null };
+// Monotonic baseline for the startup phantom-wake guard (see onWake /
+// isStartupWakePhantom). Captured at module load — a hair before the input
+// paths open their evdev nodes below — so the grace window covers the boot
+// race where InputPlumber emits a spurious F16 before the session is up.
+const inputStartedAt = performance.now();
 // InputPlumber intercept-mode path — runs alongside the evdev interceptor on
 // IP-managed handhelds (deck-uhid target, no grabbable evdev). On grab it sets
 // InterceptMode=2 so Steam BPM is starved and nav arrives over D-Bus; on hosts
@@ -560,6 +565,19 @@ function toggleOverlay(source: string) {
 // these were a hardcoded subset that ignored the config — Guide+X
 // did nothing despite defaulting to ToggleOverlay).
 function onWake(event: WakeEvent): void {
+  // Drop boot-time phantom wakes that would open the overlay before the
+  // graphical session is ready. On IP-managed handhelds the InputPlumber
+  // virtual keyboard sometimes emits a spurious F16 (→ QamToggle) ~1s into
+  // boot; acting on it opens the overlay invisibly and diverts the pad away
+  // from Steam (Steam looks dead until InputPlumber is restarted). See
+  // isStartupWakePhantom. Only opens are suppressed — a close always works.
+  const elapsed = performance.now() - inputStartedAt;
+  if (isStartupWakePhantom({ elapsedSinceStartMs: elapsed, isOpen: state.isOpen })) {
+    trace(
+      `[overlay] ignoring wake=${event} within startup grace (${Math.round(elapsed)}ms) — likely boot phantom`,
+    );
+    return;
+  }
   // The branch-table for "which wake event does what given the current
   // shortcut config" is pure — extracted into lib/wake-routing.ts so
   // the table is unit-tested without booting the full main process.

--- a/apps/loadout-overlay/src/bun/lib/wake-routing.test.ts
+++ b/apps/loadout-overlay/src/bun/lib/wake-routing.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "bun:test";
-import { routeWake } from "./wake-routing";
+import {
+  routeWake,
+  isStartupWakePhantom,
+  STARTUP_WAKE_GRACE_MS,
+} from "./wake-routing";
 import type { ControllerShortcuts } from "../../webview/lib/electrobun";
 
 // These specs cover audit finding B-006 — the onWake() branch table in
@@ -230,6 +234,70 @@ describe("routeWake — issue #141 action types (OpenSettings / OpenHome / Toggl
       kind: "ignore",
       reason: "reserved",
     });
+  });
+});
+
+// Regression: on IP-managed handhelds a spurious F16 (→ QamToggle) fires
+// ~1s into boot, before the session is up. Acting on it opened the overlay
+// invisibly and diverted the pad from Steam ("Steam looks dead to the
+// controller until InputPlumber is restarted"). Confirmed in loadout-overlay
+// journal 2026-07-24: `wake=QamToggle` → `QamToggle → SHOW` one second after
+// the interceptors started.
+describe("isStartupWakePhantom — boot-time phantom guard", () => {
+  it("suppresses an OPEN wake within the grace window", () => {
+    // The exact boot case: overlay closed, ~1s elapsed.
+    expect(
+      isStartupWakePhantom({ elapsedSinceStartMs: 1000, isOpen: false }),
+    ).toBe(true);
+  });
+
+  it("suppresses a would-be open right at t=0", () => {
+    expect(
+      isStartupWakePhantom({ elapsedSinceStartMs: 0, isOpen: false }),
+    ).toBe(true);
+  });
+
+  it("does NOT suppress once the grace window has elapsed", () => {
+    expect(
+      isStartupWakePhantom({
+        elapsedSinceStartMs: STARTUP_WAKE_GRACE_MS,
+        isOpen: false,
+      }),
+    ).toBe(false);
+    expect(
+      isStartupWakePhantom({
+        elapsedSinceStartMs: STARTUP_WAKE_GRACE_MS + 1,
+        isOpen: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("NEVER suppresses a close — an open overlay must always be escapable", () => {
+    // Even at t=0 with the overlay open, the wake (a close) goes through, so
+    // a user can never be trapped in the overlay by the guard.
+    expect(
+      isStartupWakePhantom({ elapsedSinceStartMs: 0, isOpen: true }),
+    ).toBe(false);
+    expect(
+      isStartupWakePhantom({ elapsedSinceStartMs: 1000, isOpen: true }),
+    ).toBe(false);
+  });
+
+  it("respects a caller-supplied graceMs override", () => {
+    expect(
+      isStartupWakePhantom({
+        elapsedSinceStartMs: 500,
+        isOpen: false,
+        graceMs: 100,
+      }),
+    ).toBe(false);
+    expect(
+      isStartupWakePhantom({
+        elapsedSinceStartMs: 50,
+        isOpen: false,
+        graceMs: 100,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/loadout-overlay/src/bun/lib/wake-routing.ts
+++ b/apps/loadout-overlay/src/bun/lib/wake-routing.ts
@@ -73,6 +73,40 @@ function shortcutForEvent(
 }
 
 /**
+ * Grace window (ms) after the input interceptors start during which a wake
+ * event that would OPEN the overlay is dropped as a likely boot phantom.
+ * See {@link isStartupWakePhantom}.
+ */
+export const STARTUP_WAKE_GRACE_MS = 5000;
+
+/**
+ * True when a wake event should be ignored as a likely boot-time phantom.
+ *
+ * On IP-managed handhelds (OXP APEX etc.) the InputPlumber virtual keyboard
+ * sometimes emits a spurious F16 — routed here as `QamToggle` — about a second
+ * after the overlay opens its evdev nodes at boot, before gamescope / Steam are
+ * even up (the toggle logs `desktop mode (no gamescope)` on a device that IS in
+ * gaming mode). Acting on it opens the overlay invisibly: the open path grabs
+ * the pad and sets InterceptMode=GamepadOnly, diverting controller input to our
+ * DBus nav — so Steam looks dead to the controller while the hidden overlay
+ * eats the input. The user's workaround is to restart InputPlumber, which
+ * resets InterceptMode. Observed live in loadout-overlay logs (2026-07-24).
+ *
+ * We only suppress *opens* (`isOpen === false`): a close must never be blocked,
+ * so the user can always escape, and once the grace elapses everything behaves
+ * normally. At boot the session isn't ready to show the overlay anyway, so
+ * dropping a genuine early press costs nothing — pressing again works.
+ */
+export function isStartupWakePhantom(opts: {
+  elapsedSinceStartMs: number;
+  isOpen: boolean;
+  graceMs?: number;
+}): boolean {
+  const grace = opts.graceMs ?? STARTUP_WAKE_GRACE_MS;
+  return !opts.isOpen && opts.elapsedSinceStartMs < grace;
+}
+
+/**
  * Decide what side-effect (if any) a wake event should produce.
  * Pure — same inputs produce the same outputs, no state mutation. The
  * caller is responsible for actually running the side-effect.


### PR DESCRIPTION
## Problem

On boot, pressing the controller sometimes drives the **not-visible** overlay while Steam appears dead to the controller. Restarting InputPlumber clears it.

## Root cause (confirmed from on-device logs)

On IP-managed handhelds (OXP APEX) the InputPlumber virtual keyboard emits a **spurious `F16` → `QamToggle`** about a second into boot — *before* gamescope/Steam are up. Acting on it silently runs the overlay's **open** path, which grabs the pad and sets `InterceptMode=GamepadOnly`, diverting controller input to the overlay's DBus nav. Net effect: Steam is starved of input (looks dead) while a not-really-visible overlay consumes it. Restarting InputPlumber resets `InterceptMode` → symptom clears.

Reproduced in `journalctl --user -u loadout-overlay.service` (2026-07-24, 15:32:36), ~1s after the interceptors started:

```
[input-intercept] wake=QamToggle from 'InputPlumber Keyboard' (/dev/input/event26)
[toggle] desktop mode (no gamescope) — skipping Steam freeze
[ip-intercept] intercept ON — InterceptMode=GamepadOnly(3) on 1 device(s)
[toggle] QamToggle → SHOW
```

Note `desktop mode (no gamescope)` on a device that IS in gaming mode — the session simply hadn't come up yet, which is the tell that this fired too early.

## Fix

A startup phantom-wake guard at `onWake` — the single chokepoint shared by both the evdev and IP wake paths. `isStartupWakePhantom()` drops any wake that would **open** the overlay for `STARTUP_WAKE_GRACE_MS` (5s) after module load.

Key safety property: **only opens are suppressed** (`isOpen === false`). A *close* is never blocked, so the user can never be trapped in the overlay by the guard, and after the grace window everything behaves normally. At boot the session isn't ready to show the overlay anyway, so dropping a genuine early press costs nothing — pressing again works.

The decision logic is extracted as a pure, unit-tested helper in `wake-routing.ts`.

## Testing

- New specs in `wake-routing.test.ts` cover the boot case, the grace boundary, the graceMs override, and the **close-always-allowed** invariant.
- `bun test src/bun/` — 266/266 pass.
- Built the dev overlay bundle, verified `isStartupWakePhantom` is present in the compiled `Resources/app/bun/index.js`, installed it, and confirmed a clean startup with no phantom open. On-device restart verification by the maintainer is in progress (the phantom is intermittent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DQjRxnovMbC2Knu14XSCt