### PR TITLE
fix(battery): detect charge limit on write-only ECs (APEX oxpec)

### DIFF
--- a/plugins/battery-tracker/backend.test.ts
+++ b/plugins/battery-tracker/backend.test.ts
@@ -530,6 +530,93 @@ describe("BatteryTrackerBackend", () => {
       expect(info.chargeLimitPercent).toBeNull();
     });
 
+    // Regression: the OneXPlayer APEX (oxpec) exposes
+    // charge_control_end_threshold as write-only — the file exists and accepts
+    // writes, but read() returns EINVAL. Detecting support via a successful
+    // read hid the charge-limit UI on that device while bypass stayed visible.
+    // Support must be recognised from PRESENCE, not readability.
+    it("detects charge-limit support when the attr exists but read() returns EINVAL", async () => {
+      // Battery files resolve as normal, but the threshold read is rejected
+      // with EINVAL (present-but-write-only) rather than ENOENT (absent).
+      const map = makeSysfsMap(base, {
+        type: "Battery",
+        capacity: "62",
+        status: "Full",
+      });
+      const limitPath = `${base}/charge_control_end_threshold`;
+      (fsPromises.readFile as ReturnType<typeof spyOn>).mockImplementation(
+        (path: unknown): Promise<string> => {
+          const p = path as string;
+          if (p === limitPath) {
+            return Promise.reject(Object.assign(new Error("EINVAL"), { code: "EINVAL" }));
+          }
+          if (map.has(p)) return Promise.resolve(map.get(p)!);
+          return Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+        },
+      );
+      readdirSpy.mockImplementation(() => Promise.resolve(["BATT"] as unknown as string[]));
+
+      await backend.onLoad();
+
+      const info = await backend.getChargeControl();
+      expect(info.supportsChargeLimit).toBe(true);
+      // Read fails, no persisted value yet → reported as unknown (null), but
+      // the control is advertised as supported so the UI renders.
+      expect(info.chargeLimitPercent).toBeNull();
+    });
+
+    // Companion to the above: on a write-only EC the current threshold can't be
+    // read back, so getChargeControl falls back to the persisted intent — the
+    // slider must show the applied limit, not snap back to "unlimited".
+    it("reports the persisted limit when the attr is write-only (read → EINVAL)", async () => {
+      const map = makeSysfsMap(base, {
+        type: "Battery",
+        capacity: "62",
+        status: "Full",
+      });
+      const limitPath = `${base}/charge_control_end_threshold`;
+      (fsPromises.readFile as ReturnType<typeof spyOn>).mockImplementation(
+        (path: unknown): Promise<string> => {
+          const p = path as string;
+          if (p === limitPath) {
+            return Promise.reject(Object.assign(new Error("EINVAL"), { code: "EINVAL" }));
+          }
+          if (map.has(p)) return Promise.resolve(map.get(p)!);
+          return Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+        },
+      );
+      readdirSpy.mockImplementation(() => Promise.resolve(["BATT"] as unknown as string[]));
+
+      // The storage fallback reads the persisted file via async readFile —
+      // delegate non-sysfs paths to the real fs so plugin-storage round-trips.
+      (fsPromises.readFile as ReturnType<typeof spyOn>).mockImplementation(
+        (path: unknown): Promise<string> => {
+          const p = path as string;
+          if (p === limitPath) {
+            return Promise.reject(Object.assign(new Error("EINVAL"), { code: "EINVAL" }));
+          }
+          if (p.startsWith("/sys/")) {
+            if (map.has(p)) return Promise.resolve(map.get(p)!);
+            return Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+          }
+          try {
+            return Promise.resolve(readFileSync(p, "utf8"));
+          } catch (e) {
+            return Promise.reject(e);
+          }
+        },
+      );
+
+      await backend.onLoad();
+      // Apply a limit (write succeeds); it persists to plugin storage.
+      const set = await backend.setChargeLimit(80);
+      expect(set.success).toBe(true);
+
+      const info = await backend.getChargeControl();
+      expect(info.supportsChargeLimit).toBe(true);
+      expect(info.chargeLimitPercent).toBe(80);
+    });
+
     it("accepts legacy charge_type bypass on OneXPlayer hardware only", async () => {
       setupBattery(
         { charge_type: "Standard" },

--- a/plugins/battery-tracker/backend.test.ts
+++ b/plugins/battery-tracker/backend.test.ts
@@ -530,32 +530,43 @@ describe("BatteryTrackerBackend", () => {
       expect(info.chargeLimitPercent).toBeNull();
     });
 
+    /**
+     * Mock a BATT whose charge_control_end_threshold READ is rejected with
+     * `code` (the file is present, but the driver refuses reads — e.g. the
+     * APEX's oxpec returns EINVAL). Battery files resolve normally; other
+     * sysfs paths are ENOENT; non-sysfs paths (plugin storage) delegate to the
+     * real fs so persistence round-trips through the temp XDG_CONFIG_HOME dir.
+     */
+    function mockThresholdReadError(code: string) {
+      const map = makeSysfsMap(base, { type: "Battery", capacity: "62", status: "Full" });
+      const limitPath = `${base}/charge_control_end_threshold`;
+      (fsPromises.readFile as ReturnType<typeof spyOn>).mockImplementation(
+        (path: unknown): Promise<string> => {
+          const p = path as string;
+          if (p === limitPath) {
+            return Promise.reject(Object.assign(new Error(code), { code }));
+          }
+          if (p.startsWith("/sys/")) {
+            if (map.has(p)) return Promise.resolve(map.get(p)!);
+            return Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+          }
+          try {
+            return Promise.resolve(readFileSync(p, "utf8"));
+          } catch (e) {
+            return Promise.reject(e);
+          }
+        },
+      );
+      readdirSpy.mockImplementation(() => Promise.resolve(["BATT"] as unknown as string[]));
+    }
+
     // Regression: the OneXPlayer APEX (oxpec) exposes
     // charge_control_end_threshold as write-only — the file exists and accepts
     // writes, but read() returns EINVAL. Detecting support via a successful
     // read hid the charge-limit UI on that device while bypass stayed visible.
     // Support must be recognised from PRESENCE, not readability.
     it("detects charge-limit support when the attr exists but read() returns EINVAL", async () => {
-      // Battery files resolve as normal, but the threshold read is rejected
-      // with EINVAL (present-but-write-only) rather than ENOENT (absent).
-      const map = makeSysfsMap(base, {
-        type: "Battery",
-        capacity: "62",
-        status: "Full",
-      });
-      const limitPath = `${base}/charge_control_end_threshold`;
-      (fsPromises.readFile as ReturnType<typeof spyOn>).mockImplementation(
-        (path: unknown): Promise<string> => {
-          const p = path as string;
-          if (p === limitPath) {
-            return Promise.reject(Object.assign(new Error("EINVAL"), { code: "EINVAL" }));
-          }
-          if (map.has(p)) return Promise.resolve(map.get(p)!);
-          return Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
-        },
-      );
-      readdirSpy.mockImplementation(() => Promise.resolve(["BATT"] as unknown as string[]));
-
+      mockThresholdReadError("EINVAL");
       await backend.onLoad();
 
       const info = await backend.getChargeControl();
@@ -569,44 +580,7 @@ describe("BatteryTrackerBackend", () => {
     // read back, so getChargeControl falls back to the persisted intent — the
     // slider must show the applied limit, not snap back to "unlimited".
     it("reports the persisted limit when the attr is write-only (read → EINVAL)", async () => {
-      const map = makeSysfsMap(base, {
-        type: "Battery",
-        capacity: "62",
-        status: "Full",
-      });
-      const limitPath = `${base}/charge_control_end_threshold`;
-      (fsPromises.readFile as ReturnType<typeof spyOn>).mockImplementation(
-        (path: unknown): Promise<string> => {
-          const p = path as string;
-          if (p === limitPath) {
-            return Promise.reject(Object.assign(new Error("EINVAL"), { code: "EINVAL" }));
-          }
-          if (map.has(p)) return Promise.resolve(map.get(p)!);
-          return Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
-        },
-      );
-      readdirSpy.mockImplementation(() => Promise.resolve(["BATT"] as unknown as string[]));
-
-      // The storage fallback reads the persisted file via async readFile —
-      // delegate non-sysfs paths to the real fs so plugin-storage round-trips.
-      (fsPromises.readFile as ReturnType<typeof spyOn>).mockImplementation(
-        (path: unknown): Promise<string> => {
-          const p = path as string;
-          if (p === limitPath) {
-            return Promise.reject(Object.assign(new Error("EINVAL"), { code: "EINVAL" }));
-          }
-          if (p.startsWith("/sys/")) {
-            if (map.has(p)) return Promise.resolve(map.get(p)!);
-            return Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
-          }
-          try {
-            return Promise.resolve(readFileSync(p, "utf8"));
-          } catch (e) {
-            return Promise.reject(e);
-          }
-        },
-      );
-
+      mockThresholdReadError("EINVAL");
       await backend.onLoad();
       // Apply a limit (write succeeds); it persists to plugin storage.
       const set = await backend.setChargeLimit(80);
@@ -615,6 +589,21 @@ describe("BatteryTrackerBackend", () => {
       const info = await backend.getChargeControl();
       expect(info.supportsChargeLimit).toBe(true);
       expect(info.chargeLimitPercent).toBe(80);
+    });
+
+    // Lock the ENOENT/ENODEV allowlist: a present-but-unreadable node (EACCES
+    // here) is supported, but ENODEV (parent device gone) is genuinely absent.
+    it("treats EACCES on the threshold as present but ENODEV as absent", async () => {
+      mockThresholdReadError("EACCES");
+      await backend.onLoad();
+      expect((await backend.getChargeControl()).supportsChargeLimit).toBe(true);
+
+      // Fresh backend for the ENODEV case (detection runs once in onLoad).
+      backend = new BatteryTrackerBackend();
+      backend.emit = () => {};
+      mockThresholdReadError("ENODEV");
+      await backend.onLoad();
+      expect((await backend.getChargeControl()).supportsChargeLimit).toBe(false);
     });
 
     it("accepts legacy charge_type bypass on OneXPlayer hardware only", async () => {

--- a/plugins/battery-tracker/backend.ts
+++ b/plugins/battery-tracker/backend.ts
@@ -257,7 +257,7 @@ export default class BatteryTrackerBackend implements PluginBackend {
     if (!base) return;
 
     const limitPath = `${base}/charge_control_end_threshold`;
-    if (await this._sysfsReadable(limitPath)) {
+    if (await this._sysfsPresent(limitPath)) {
       this.chargeLimitPath = limitPath;
     }
 
@@ -341,6 +341,29 @@ export default class BatteryTrackerBackend implements PluginBackend {
   }
 
   /**
+   * Whether a sysfs attribute is PRESENT, even if reading its value fails.
+   *
+   * Some EC drivers expose `charge_control_end_threshold` as effectively
+   * write-only: the file exists and accepts writes, but read() returns EINVAL.
+   * Verified on the OneXPlayer APEX (oxpec) — `cat` yields "Invalid argument"
+   * while writes take effect. Probing support with a successful read
+   * (_sysfsReadable) therefore HIDES a control that actually works, which is
+   * why the charge-limit UI vanished on that device while bypass (a readable
+   * `charge_behaviour` attr) stayed. A genuinely-absent attribute fails with
+   * ENOENT/ENODEV; any other error (EINVAL, EIO, EACCES) means the node is
+   * there but the driver refused the read — so treat those as present.
+   */
+  private async _sysfsPresent(path: string): Promise<boolean> {
+    try {
+      await readFile(path, "utf8");
+      return true;
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException | null)?.code;
+      return code !== "ENOENT" && code !== "ENODEV";
+    }
+  }
+
+  /**
    * Write a sysfs node. The backend runs as root (system service), so a
    * direct write succeeds; `tee` is a fallback for the rare node that
    * rejects a plain write() but accepts a fresh open via tee.
@@ -363,7 +386,18 @@ export default class BatteryTrackerBackend implements PluginBackend {
     let chargeLimitPercent: number | null = null;
     if (this.chargeLimitPath) {
       const raw = await this._readSysfs(this.chargeLimitPath).catch(() => null);
-      chargeLimitPercent = thresholdToLimitPercent(raw === null ? null : parseSysfsInt(raw));
+      if (raw !== null) {
+        chargeLimitPercent = thresholdToLimitPercent(parseSysfsInt(raw));
+      } else {
+        // Write-only EC (e.g. APEX oxpec: read → EINVAL). Fall back to the
+        // persisted intent so the slider shows the limit the user applied
+        // instead of snapping back to "unlimited" on every refresh.
+        const stored = await readPluginStorage<ChargeControlStorage>(PLUGIN_ID);
+        chargeLimitPercent =
+          typeof stored.chargeLimitPercent === "number"
+            ? thresholdToLimitPercent(stored.chargeLimitPercent)
+            : null;
+      }
     }
 
     let bypassMode: BypassMode = "disabled";


### PR DESCRIPTION
## Problem

On the OneXPlayer APEX the **charge-limit** control disappeared from the Battery plugin, while **bypass charging** stayed visible. The UI is capability-driven (unsupported controls are hidden), so the backend was reporting charge-limit as unsupported.

## Root cause

The APEX's `oxpec` driver exposes `charge_control_end_threshold` as effectively **write-only**: the sysfs attribute exists and accepts writes, but `read()` returns `EINVAL`. Confirmed on-device:

```
$ cat /sys/class/power_supply/BATT/charge_control_end_threshold
cat: ...: Invalid argument
```

`_detectChargeControl` probed support with `_sysfsReadable` (a successful `readFile`), so the failed read looked like "unsupported" → the control was hidden. Bypass uses `charge_behaviour`, which reads fine, so it stayed.

## Fix

- **Detect by presence, not readability.** New `_sysfsPresent()` treats any read error other than `ENOENT`/`ENODEV` (i.e. `EINVAL` — node present but read refused) as supported. `_detectChargeControl` uses it for the charge-limit attribute.
- **Persisted fallback in `getChargeControl()`.** When the threshold read fails, fall back to the persisted `chargeLimitPercent` so the slider shows the applied limit instead of snapping to "unlimited" on write-only ECs.

## Testing

- New tests: detection when the attr exists but `read()` returns `EINVAL`; and the persisted read-back fallback.
- `bun test plugins/battery-tracker/backend.test.ts` — 35/35 pass.
- Device verification (charge-limit UI reappears + limit applies) pending backend redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DQjRxnovMbC2Knu14XSCt