### PR TITLE
fix(overlay): capture the controller on Steam Deck (hidraw nav + per-host input strategy)

### DIFF
--- a/apps/loadout-overlay/package.json
+++ b/apps/loadout-overlay/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@noriginmedia/norigin-spatial-navigation": "^3.0.0",
     "@loadout/deck-hid": "workspace:*",
+    "@loadout/devices": "workspace:*",
     "@loadout/exec": "workspace:*",
     "@loadout/plugin-storage": "workspace:*",
     "@loadout/types": "workspace:*",

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -55,6 +55,7 @@ import { routeWake, isStartupWakePhantom } from "./lib/wake-routing";
 import { loadPersistedShortcuts } from "./lib/persisted-shortcuts";
 import { decideInputStrategy } from "./lib/input-strategy";
 import { isSteamDeck } from "@loadout/devices";
+import { isBindableDeckButton } from "@loadout/deck-hid";
 
 // ---- State ------------------------------------------------------------------
 // PendingFlags + the flag-lifecycle helpers live in lib/overlay-state.ts so
@@ -879,8 +880,14 @@ async function readDeckWakeBinding(): Promise<string | null> {
   const raw = s.wake?.selectedRaw ?? null;
   // Raw is either a synthetic "deck:<Button>" string we wrote here, or an
   // InputPlumber capability string written on a non-Deck host. Only the
-  // deck:* form is meaningful for the watcher.
-  if (raw && raw.startsWith("deck:")) return raw.slice(5);
+  // deck:* form is meaningful for the watcher — and only bindable buttons:
+  // Steam/Qam are reserved system buttons (the picker no longer offers
+  // them, but a binding persisted before they were blocked must not arm
+  // the watcher either).
+  if (raw && raw.startsWith("deck:")) {
+    const name = raw.slice(5);
+    return isBindableDeckButton(name) ? name : null;
+  }
   return null;
 }
 

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -387,6 +387,17 @@ let deckNavActive = false;
 /** Controller id prefix for hidraw-injected nav events (see
  *  externalNavSources in input-intercept). */
 const DECK_NAV_SOURCE = "deck-hidraw";
+// Deck resume-burst mitigation state (see the close path in toggleOverlay):
+// whether THIS open actually SIGSTOPped Steam, and the deferred evdev
+// release that stays grabbed across SIGCONT + drain so the game can't see
+// Steam's replayed hidraw backlog.
+let steamFrozenThisOpen = false;
+let pendingReleaseTimer: ReturnType<typeof setTimeout> | null = null;
+/** How long after SIGCONT the evdev grabs are held so Steam's buffered
+ *  hidraw backlog (≤64 reports) drains into a grabbed virtual pad instead
+ *  of the game. Chosen > TOGGLE_DEBOUNCE_MS - 250 so a reopen can overlap
+ *  it — the open path cancels + flushes the deferred release. */
+const DECK_RESUME_DRAIN_MS = 500;
 
 // Startup safety net for the frozen-Steam risk: a previous overlay instance
 // that crashed or was SIGKILLed *while open* could have left Steam SIGSTOPped
@@ -458,11 +469,18 @@ function forceCloseOverlay(reason: string): void {
     clearTimeout(pendingResumeTimer.current);
     pendingResumeTimer.current = null;
   }
+  if (pendingReleaseTimer !== null) {
+    clearTimeout(pendingReleaseTimer);
+    pendingReleaseTimer = null;
+  }
   if (steamPid.current === null) steamPid.current = findSteamPid();
   if (steamPid.current !== null) resumeSteam(steamPid.current);
+  // Emergency path: release immediately (no resume-burst drain — a wedged
+  // renderer is worse than a replayed edge) and thaw.
   intercept.current?.release();
   ipIntercept.current?.release();
   deckHidraw.current?.setNavActive(false);
+  steamFrozenThisOpen = false;
   atoms.hide().catch((e) => console.warn("[freeze-watchdog] atoms.hide:", e));
   try {
     overlay.minimize();
@@ -508,7 +526,20 @@ function toggleOverlay(source: string) {
     stopFreezeWatchdog();
     overlay.minimize();
     atoms.hide().catch((e) => console.warn("[overlay] atoms.hide:", e));
-    intercept.current?.release();
+    // Deck strategy resume-burst mitigation: while Steam was SIGSTOPped its
+    // own hidraw fd kept buffering (the kernel ring keeps the FIRST ~64
+    // reports after the freeze — which contain the wake button's release
+    // edge and any early nav input — and drops the rest). On SIGCONT Steam
+    // drains that backlog and forwards it to the virtual pad; if our evdev
+    // grabs were already gone, the game would replay those stale edges on
+    // every overlay close. So on a frozen-Deck close the evdev release is
+    // DEFERRED until after SIGCONT + a drain window, keeping the virtual
+    // pad (and built-in nodes) grabbed while the burst flushes. Steam's own
+    // BPM reaction to the buffered wake release can't be blocked this way —
+    // paddle wake bindings (R4/L4/…) avoid it entirely since Steam ignores
+    // unmapped paddles. Non-Deck hosts keep the immediate release.
+    const deferRelease = deckNavActive && steamFrozenThisOpen;
+    if (!deferRelease) intercept.current?.release();
     ipIntercept.current?.release();
     // Stop decoding Deck hidraw nav. The wake-bit path stays live so the
     // wake button can re-open; the diff baseline resets on next open.
@@ -529,8 +560,19 @@ function toggleOverlay(source: string) {
       pendingResumeTimer.current = setTimeout(() => {
         pendingResumeTimer.current = null;
         resumeSteam(pid);
+        if (deferRelease) {
+          if (pendingReleaseTimer !== null) clearTimeout(pendingReleaseTimer);
+          pendingReleaseTimer = setTimeout(() => {
+            pendingReleaseTimer = null;
+            intercept.current?.release();
+          }, DECK_RESUME_DRAIN_MS);
+        }
       }, 250);
+    } else if (deferRelease) {
+      // No Steam pid found — nothing to drain; release now rather than never.
+      intercept.current?.release();
     }
+    steamFrozenThisOpen = false;
     state.isOpen = false;
     broadcastOverlayVisibility();
     trace(`[toggle] ${source} → MINIMIZE`);
@@ -544,11 +586,26 @@ function toggleOverlay(source: string) {
     // so freezing it just wedges Steam — the bug this gate fixes. The evdev
     // grab below still runs in both modes, so the controller overlay keeps
     // working on the desktop without touching Steam.
+    // A rapid close→open can land while the close path's deferred SIGCONT /
+    // deferred release timers are still pending. Cancel them (this open owns
+    // the freeze again), and if the evdev release was still deferred (grabs
+    // held from last session), flush it synchronously so grab() below runs
+    // a fresh generation with clean NavController/combo state.
+    if (pendingResumeTimer.current !== null) {
+      clearTimeout(pendingResumeTimer.current);
+      pendingResumeTimer.current = null;
+    }
+    if (pendingReleaseTimer !== null) {
+      clearTimeout(pendingReleaseTimer);
+      pendingReleaseTimer = null;
+      intercept.current?.release();
+    }
     if (suspendSteamEnabled && isGameModeActive()) {
       if (steamPid.current === null) steamPid.current = findSteamPid();
       if (steamPid.current !== null) {
         suspendSteam(steamPid.current);
         startFreezeWatchdog();
+        steamFrozenThisOpen = true;
       }
     } else if (suspendSteamEnabled) {
       trace("[toggle] desktop mode (no gamescope) — skipping Steam freeze");
@@ -707,6 +764,28 @@ void (async () => {
       // nav mode can't be active before the first grab() anyway.
       onNavEvents: (events) =>
         intercept.current?.injectNavEvents(DECK_NAV_SOURCE, events),
+      // Mid-session stream death (driver rebind, controller re-enumeration
+      // around suspend/resume): under the Deck strategy the watcher is the
+      // ONLY nav source AND the wake button, while the baked-in strategy
+      // would still freeze Steam + grab everything on the next open — the
+      // exact stranded-with-zero-nav state the startup gate exists to
+      // prevent. The strategy can't be re-derived live (intercept options
+      // are fixed at startInputIntercept), so exit and let systemd restart
+      // us: startup re-probes and picks the right strategy (watcher back →
+      // full Deck strategy; still dead → legacy fallback). The startup
+      // unconditional SIGCONT covers a death while frozen.
+      onDeath: () => {
+        console.error(
+          "[overlay] Deck hidraw watcher died mid-session — " +
+            (deckNavActive
+              ? "restarting overlay to re-derive the input strategy"
+              : "Deck wake button lost until next overlay restart"),
+        );
+        if (deckNavActive) {
+          if (state.isOpen) forceCloseOverlay("deck hidraw watcher died");
+          process.exit(1);
+        }
+      },
     });
     if (handle) {
       deckHidraw.current = handle;
@@ -722,7 +801,9 @@ void (async () => {
   const strategy = decideInputStrategy({
     isDeck,
     ipAvailable: !!ipHandle?.available,
-    deckHidrawOpened: deckHidraw.current !== null,
+    // isAlive guards the (tiny) window where the stream died between open
+    // and this decision — a dead watcher must not enable the freeze.
+    deckHidrawOpened: deckHidraw.current?.isAlive() ?? false,
     suspendEnv: SUSPEND_STEAM_ENV,
     deckCaptureEnv: DECK_CAPTURE_ENV,
   });

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -53,6 +53,8 @@ import { trace } from "./native/trace";
 import { createOverlayState } from "./lib/overlay-state";
 import { routeWake, isStartupWakePhantom } from "./lib/wake-routing";
 import { loadPersistedShortcuts } from "./lib/persisted-shortcuts";
+import { decideInputStrategy } from "./lib/input-strategy";
+import { isSteamDeck } from "@loadout/devices";
 
 // ---- State ------------------------------------------------------------------
 // PendingFlags + the flag-lifecycle helpers live in lib/overlay-state.ts so
@@ -353,22 +355,38 @@ function broadcastOverlayVisibility(): void {
 // the overlay: the Deck's built-in pad navigates via Steam Input's virtual pad
 // (read by CEF's Web Gamepad API), and a frozen Steam stops emitting on it.
 //
-// These two hosts need OPPOSITE behaviour, so the freeze is decided PER-HOST
-// (finalized after IP discovery below, since it keys off ipHandle.available):
+// These hosts need DIFFERENT behaviour, so the freeze is decided PER-HOST by
+// decideInputStrategy (lib/input-strategy.ts), finalized after IP + Deck-hidraw
+// discovery below. The rule: freeze wherever overlay nav does NOT depend on a
+// live Steam process —
 //   - External IP-managed pad (e.g. OXP APEX): nav arrives over IP's DBus
 //     stream, independent of Steam, so freezing Steam blocks its direct hidraw
 //     read (no double-capture) WITHOUT starving overlay nav → freeze ON.
-//   - Steam Deck alone (no IP composite): built-in nav reads Steam's virtual
-//     pad, which a frozen Steam stops emitting → freeze OFF.
+//   - Steam Deck with a working hidraw watcher: nav now arrives from OUR OWN
+//     hidraw read (deck-hidraw-watcher nav mode), also independent of Steam →
+//     freeze ON. This is what stops BPM / Steam-Input-fed games responding
+//     behind the overlay on the Deck — the historical "Deck must not freeze"
+//     rule only applied while the Deck's nav source was Steam's virtual pad.
+//   - Deck whose hidraw watcher failed (EACCES etc.): nav falls back to
+//     reading Steam's virtual pad, which a frozen Steam stops emitting →
+//     freeze OFF, exactly the legacy behavior.
 // #99 made freeze a single global opt-in to save the Deck, which regressed the
 // APEX (Steam captured the pad again behind the overlay). Coupling the decision
 // to host type fixes both. DECK_OVERLAY_SUSPEND_STEAM=1/0 force on/off and
-// override the auto policy.
+// override the auto policy; DECK_OVERLAY_DECK_CAPTURE=0 disables the whole
+// Deck strategy (nav + grabs + freeze) as a kill switch.
 const SUSPEND_STEAM_ENV = process.env.DECK_OVERLAY_SUSPEND_STEAM; // "1"=force on, "0"=force off, unset=auto
-// Provisional until finalized post-IP-discovery. A forced-on freeze applies
+const DECK_CAPTURE_ENV = process.env.DECK_OVERLAY_DECK_CAPTURE; // "0"=disable Deck strategy
+// Provisional until finalized post-discovery. A forced-on freeze applies
 // immediately; auto/off start false so an open during the brief discovery
 // window can't freeze the Deck.
 let suspendSteamEnabled = SUSPEND_STEAM_ENV === "1";
+// True once the Deck strategy is live: overlay nav comes from the hidraw
+// watcher while open (toggleOverlay flips its nav mode on show/hide).
+let deckNavActive = false;
+/** Controller id prefix for hidraw-injected nav events (see
+ *  externalNavSources in input-intercept). */
+const DECK_NAV_SOURCE = "deck-hidraw";
 
 // Startup safety net for the frozen-Steam risk: a previous overlay instance
 // that crashed or was SIGKILLed *while open* could have left Steam SIGSTOPped
@@ -444,6 +462,7 @@ function forceCloseOverlay(reason: string): void {
   if (steamPid.current !== null) resumeSteam(steamPid.current);
   intercept.current?.release();
   ipIntercept.current?.release();
+  deckHidraw.current?.setNavActive(false);
   atoms.hide().catch((e) => console.warn("[freeze-watchdog] atoms.hide:", e));
   try {
     overlay.minimize();
@@ -491,6 +510,9 @@ function toggleOverlay(source: string) {
     atoms.hide().catch((e) => console.warn("[overlay] atoms.hide:", e));
     intercept.current?.release();
     ipIntercept.current?.release();
+    // Stop decoding Deck hidraw nav. The wake-bit path stays live so the
+    // wake button can re-open; the diff baseline resets on next open.
+    deckHidraw.current?.setNavActive(false);
     // Always SIGCONT Steam on close, even when suspendSteamEnabled is
     // off. Users have reported Steam appearing frozen after the overlay
     // closes (menu visible but inputs ignored) — if anything left Steam
@@ -533,6 +555,10 @@ function toggleOverlay(source: string) {
     }
     intercept.current?.grab();
     ipIntercept.current?.grab();
+    // Deck strategy: overlay nav comes from the hidraw stream while open.
+    // AFTER intercept.grab() so the first injected events land on the new
+    // grab generation, not the previous one.
+    if (deckNavActive) deckHidraw.current?.setNavActive(true);
     overlay.show();
     atoms.show().catch((e) => console.warn("[overlay] atoms.show:", e));
     // Desktop mode has no gamescope to composite us above Big Picture, so
@@ -614,16 +640,17 @@ function onWake(event: WakeEvent): void {
   }
 }
 
-// Start the two input paths. ORDER MATTERS: the InputPlumber intercept-mode
-// path discovers IP composite devices first, then the evdev interceptor starts
-// with `readVirtualPadsForNav` set from whether any IP composites exist.
+// Start the input paths. ORDER MATTERS: the InputPlumber intercept-mode path
+// discovers IP composite devices first, then the Deck hidraw watcher starts,
+// and only then is the strategy decided (lib/input-strategy.ts) and the evdev
+// interceptor configured from it.
 //
-// Why: on the Steam Deck, when a game/app is running Steam Input exposes the
-// BUILT-IN controller only as the virtual Xbox 360 pad (28de:11ff). With no IP
-// composite to drive nav over DBus, that virtual pad is the Deck's sole nav
-// source, so the evdev path must READ it (not exclude/grab-only it). When an
-// external IP-managed pad IS present, IP's DBus stream drives nav and the
-// virtual pad is a mirror we only grab — so we DON'T read it (would double).
+// Why: nav sources differ per host. IP hosts get nav over IP's DBus stream
+// (virtual pads grab-only). A Deck with a working hidraw watcher gets nav from
+// OUR hidraw read (virtual pads + built-in nodes grab-only, Steam frozen while
+// open — see the freeze comment above). A Deck whose watcher failed falls back
+// to reading Steam's virtual X360 pad (28de:11ff) — the only evdev nav source
+// Steam Input leaves for the built-in controller, and only while a game runs.
 void (async () => {
   // Seed the wake-routing engine from the persisted config BEFORE either
   // intercept starts — no wake event can arrive until they do, so the ref
@@ -659,27 +686,63 @@ void (async () => {
     console.error("[overlay] ip intercept failed to start:", err);
   }
 
-  // No IP composites (Deck alone, or no external IP-managed pad) → the virtual
-  // pad is the Deck's built-in controls; read it for nav.
-  const readVirtualPadsForNav = !ipHandle?.available;
+  // Deck hidraw watcher — started BEFORE the strategy decision because the
+  // Deck strategy (hidraw nav + Steam freeze) is only safe when the watcher
+  // actually opened; a Deck where it failed (EACCES) must keep the legacy
+  // virtual-pad-nav behavior or the user is stranded with zero nav. On
+  // non-Deck hosts findDeckHidrawPath() returns null and this is a no-op.
+  let isDeck = false;
+  try {
+    isDeck = await isSteamDeck();
+  } catch (err) {
+    console.warn("[overlay] isSteamDeck probe failed:", err);
+  }
+  try {
+    const initialButton = await readDeckWakeBinding();
+    const handle = await startDeckHidrawWatcher({
+      onWake,
+      initialButton,
+      // Nav events flow into the evdev interceptor's NavController. The
+      // optional chain covers the watcher-before-intercept startup window;
+      // nav mode can't be active before the first grab() anyway.
+      onNavEvents: (events) =>
+        intercept.current?.injectNavEvents(DECK_NAV_SOURCE, events),
+    });
+    if (handle) {
+      deckHidraw.current = handle;
+      armDeckWakeBindingRefresh(handle);
+    }
+  } catch (err) {
+    console.error("[overlay] Deck hidraw watcher failed to start:", err);
+  }
 
-  // Finalize the Steam-freeze policy now that host type is known (see the
-  // SUSPEND_STEAM_ENV comment above). Auto = freeze iff an IP-managed external
-  // pad is present; that's the case (OXP APEX) where nav comes over IP's DBus
-  // stream and freezing Steam blocks its hidraw double-capture without starving
-  // overlay nav. On the Deck alone we must NOT freeze (it would kill the
-  // virtual-pad nav we just opted to read). env "1"/"0" override the auto rule.
-  if (SUSPEND_STEAM_ENV === "1") suspendSteamEnabled = true;
-  else if (SUSPEND_STEAM_ENV === "0") suspendSteamEnabled = false;
-  else suspendSteamEnabled = !!ipHandle?.available;
+  // Finalize the input strategy now that host type is known (see the
+  // SUSPEND_STEAM_ENV comment above and lib/input-strategy.ts for the row
+  // table). IP hosts keep their exact pre-Deck behavior.
+  const strategy = decideInputStrategy({
+    isDeck,
+    ipAvailable: !!ipHandle?.available,
+    deckHidrawOpened: deckHidraw.current !== null,
+    suspendEnv: SUSPEND_STEAM_ENV,
+    deckCaptureEnv: DECK_CAPTURE_ENV,
+  });
+  deckNavActive = strategy.deckNavActive;
+  suspendSteamEnabled = strategy.suspendSteamEnabled;
+  const readVirtualPadsForNav = strategy.readVirtualPadsForNav;
   console.log(
-    `[overlay] steam-freeze ${suspendSteamEnabled ? "ON" : "OFF"} ` +
-      `(env=${SUSPEND_STEAM_ENV ?? "auto"}, ipManaged=${!!ipHandle?.available})`,
+    `[overlay] input strategy: deckNav=${deckNavActive ? "ON" : "OFF"} ` +
+      `steam-freeze=${suspendSteamEnabled ? "ON" : "OFF"} ` +
+      `readVirtualPads=${readVirtualPadsForNav} ` +
+      `(isDeck=${isDeck}, ipManaged=${!!ipHandle?.available}, ` +
+      `hidraw=${deckHidraw.current !== null}, ` +
+      `env: suspend=${SUSPEND_STEAM_ENV ?? "auto"}, deckCapture=${DECK_CAPTURE_ENV ?? "auto"})`,
   );
 
   try {
     const handle = await startInputIntercept({
       readVirtualPadsForNav,
+      grabDeckBuiltinNodes: strategy.grabDeckBuiltinNodes,
+      externalNavSources: deckNavActive ? [DECK_NAV_SOURCE] : [],
       onWake,
       onAction: (action) => {
         // Bridge to the webview. onOverlayAction() in main.tsx turns these
@@ -709,12 +772,13 @@ void (async () => {
   }
 })();
 
-// Steam-Deck-native wake button: read /dev/hidrawN (the controller's
-// gamepad interface) in parallel with Steam Input. Open multiplexes
-// fine — the kernel hid-steam driver allows concurrent readers — and
-// the bound button fires onWake("QamToggle") just like F16 does over
-// evdev. On non-Deck hosts findDeckHidrawPath() returns null and this
-// is a no-op.
+// Steam-Deck-native wake button + nav source: read /dev/hidrawN (the
+// controller's gamepad interface) in parallel with Steam Input. Open
+// multiplexes fine — the kernel hid-steam driver allows concurrent
+// readers — and the bound button fires onWake("QamToggle") just like F16
+// does over evdev. Started from the startup IIFE above (the strategy
+// decision needs to know whether it opened); the binding-refresh plumbing
+// lives in armDeckWakeBindingRefresh below.
 const STORAGE_PATH = pluginStoragePath("input-plumber");
 const STORAGE_DIR = dirname(STORAGE_PATH);
 const STORAGE_FILENAME = basename(STORAGE_PATH);
@@ -739,62 +803,55 @@ async function readDeckWakeBinding(): Promise<string | null> {
   return null;
 }
 
-readDeckWakeBinding()
-  .then(async (initialButton) => {
-    const handle = await startDeckHidrawWatcher({
-      onWake,
-      initialButton,
-    });
-    if (!handle) return;
-    deckHidraw.current = handle;
-
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-    const refresh = async (): Promise<void> => {
-      try {
-        const next = await readDeckWakeBinding();
-        if (next !== handle.getBinding()) handle.setBinding(next);
-      } catch {
-        // Storage read failure is transient — try again next tick / event.
-      }
-    };
-    const scheduleRefresh = (): void => {
-      if (debounceTimer) return;
-      debounceTimer = setTimeout(() => {
-        debounceTimer = null;
-        void refresh();
-      }, DECK_WAKE_DEBOUNCE_MS);
-    };
-
-    // fs.watch on the parent dir (not the file itself — atomic rename
-    // invalidates a file-scoped watcher). Filter for any filename that
-    // matches our storage or its `<storage>.<uuid>.tmp` siblings.
+/** Wire live wake-binding updates into a started watcher: fs.watch on the
+ *  plugin-storage dir (debounced across atomic write-tmp+rename) plus a slow
+ *  heartbeat for inotify-silent filesystems. Extracted from the startup IIFE
+ *  so it stays a readable wire-up. */
+function armDeckWakeBindingRefresh(handle: DeckHidrawWatcherHandle): void {
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  const refresh = async (): Promise<void> => {
     try {
-      deckWakeStorageWatcher.current = fsWatch(
-        STORAGE_DIR,
-        (_event, filename) => {
-          if (!filename) return;
-          if (filename === STORAGE_FILENAME || filename.startsWith(STORAGE_FILENAME + ".")) {
-            scheduleRefresh();
-          }
-        },
-      );
-    } catch (err) {
-      // Storage dir might not exist on first boot if no plugin has written
-      // yet — heartbeat picks it up. Log so the journal records why fs.watch
-      // didn't arm.
-      console.warn(
-        `[overlay] Deck wake-binding fs.watch failed (${err instanceof Error ? err.message : String(err)}); falling back to heartbeat only.`,
-      );
+      const next = await readDeckWakeBinding();
+      if (next !== handle.getBinding()) handle.setBinding(next);
+    } catch {
+      // Storage read failure is transient — try again next tick / event.
     }
+  };
+  const scheduleRefresh = (): void => {
+    if (debounceTimer) return;
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      void refresh();
+    }, DECK_WAKE_DEBOUNCE_MS);
+  };
 
-    // Heartbeat: covers inotify-silent filesystems (NFS, some container
-    // overlays). 30s is long enough that the cost is negligible and short
-    // enough that a stuck watcher self-heals within the typical session.
-    deckWakeRefreshTimer.current = setInterval(refresh, DECK_WAKE_HEARTBEAT_MS);
-  })
-  .catch((err) => {
-    console.error("[overlay] Deck hidraw watcher failed to start:", err);
-  });
+  // fs.watch on the parent dir (not the file itself — atomic rename
+  // invalidates a file-scoped watcher). Filter for any filename that
+  // matches our storage or its `<storage>.<uuid>.tmp` siblings.
+  try {
+    deckWakeStorageWatcher.current = fsWatch(
+      STORAGE_DIR,
+      (_event, filename) => {
+        if (!filename) return;
+        if (filename === STORAGE_FILENAME || filename.startsWith(STORAGE_FILENAME + ".")) {
+          scheduleRefresh();
+        }
+      },
+    );
+  } catch (err) {
+    // Storage dir might not exist on first boot if no plugin has written
+    // yet — heartbeat picks it up. Log so the journal records why fs.watch
+    // didn't arm.
+    console.warn(
+      `[overlay] Deck wake-binding fs.watch failed (${err instanceof Error ? err.message : String(err)}); falling back to heartbeat only.`,
+    );
+  }
+
+  // Heartbeat: covers inotify-silent filesystems (NFS, some container
+  // overlays). 30s is long enough that the cost is negligible and short
+  // enough that a stuck watcher self-heals within the typical session.
+  deckWakeRefreshTimer.current = setInterval(refresh, DECK_WAKE_HEARTBEAT_MS);
+}
 
 // Backup shortcut for desktop dev — works whether or not evdev picks up
 // the QAM button correctly. Useful when we're investigating why F16

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -462,7 +462,14 @@ function startFreezeWatchdog(): void {
 // Emergency teardown when the watchdog fires: thaw Steam IMMEDIATELY, drop the
 // grabs/intercept, hide the window and mark closed. Mirrors the close path but
 // skips the debounce/deferred-resume so a wedged overlay self-heals.
-function forceCloseOverlay(reason: string): void {
+/** Returns once the gamescope atom writes have settled. Callers that are
+ *  about to kill the process MUST await this (see the onDeath handler):
+ *  atoms.hide() restores ROOT STEAM_TOUCH_CLICK_MODE and Steam's BPM
+ *  STEAM_OVERLAY / STEAM_INPUT_FOCUS, none of which die with our window.
+ *  Exiting before those writes land leaves gamescope routing touch at a
+ *  window that no longer exists — the same strand shutdown() in
+ *  lifecycle.ts already guards with an awaited, retried hide(). */
+function forceCloseOverlay(reason: string): Promise<void> {
   console.warn(`[freeze-watchdog] ${reason} — emergency close + thaw Steam`);
   trace(`[freeze-watchdog] ${reason} — emergency close`);
   stopFreezeWatchdog();
@@ -482,7 +489,9 @@ function forceCloseOverlay(reason: string): void {
   ipIntercept.current?.release();
   deckHidraw.current?.setNavActive(false);
   steamFrozenThisOpen = false;
-  atoms.hide().catch((e) => console.warn("[freeze-watchdog] atoms.hide:", e));
+  const hidden = atoms
+    .hide()
+    .catch((e) => console.warn("[freeze-watchdog] atoms.hide:", e));
   try {
     overlay.minimize();
   } catch (e) {
@@ -490,7 +499,13 @@ function forceCloseOverlay(reason: string): void {
   }
   state.isOpen = false;
   broadcastOverlayVisibility();
+  return hidden;
 }
+
+/** Cap on how long a process-killing path waits for forceCloseOverlay's atom
+ *  writes. Bounded because the writes shell out to xprop — if that wedges we
+ *  still have to exit, and systemd's ExecStopPost thaws Steam regardless. */
+const ATOM_CLEAR_TIMEOUT_MS = 1000;
 
 // Minimum gap between toggleOverlay() calls. On the OXP Apex, InputPlumber
 // emits F16 on several evdev nodes simultaneously when the user presses
@@ -599,14 +614,25 @@ function toggleOverlay(source: string) {
     if (pendingReleaseTimer !== null) {
       clearTimeout(pendingReleaseTimer);
       pendingReleaseTimer = null;
-      intercept.current?.release();
     }
+    // Release UNCONDITIONALLY, not just when a deferred release was pending.
+    // A reopen inside the close path's 250ms pre-SIGCONT window cancels the
+    // resume timer above while pendingReleaseTimer is still null (it's only
+    // armed inside the resume callback), so keying the flush off that handle
+    // would skip it — and doGrab() below would then early-return on
+    // `intercepting`, reusing the previous generation's NavController and
+    // combo state (stuck-held direction, or dead nav for the whole session).
+    // doRelease() no-ops when not intercepting, so this is free otherwise.
+    intercept.current?.release();
     if (suspendSteamEnabled && isGameModeActive()) {
       if (steamPid.current === null) steamPid.current = findSteamPid();
       if (steamPid.current !== null) {
-        suspendSteam(steamPid.current);
-        startFreezeWatchdog();
-        steamFrozenThisOpen = true;
+        // Track what ACTUALLY happened: steamPid is cached for the session, so
+        // after Steam restarts the SIGSTOP can fail with ESRCH/EPERM. Assuming
+        // success made every later close take the deferred-release path and
+        // hold the grabs ~750ms for a drain that never happens.
+        steamFrozenThisOpen = suspendSteam(steamPid.current);
+        if (steamFrozenThisOpen) startFreezeWatchdog();
       }
     } else if (suspendSteamEnabled) {
       trace("[toggle] desktop mode (no gamescope) — skipping Steam freeze");
@@ -783,8 +809,20 @@ void (async () => {
               : "Deck wake button lost until next overlay restart"),
         );
         if (deckNavActive) {
-          if (state.isOpen) forceCloseOverlay("deck hidraw watcher died");
-          process.exit(1);
+          // Steam's SIGCONT and the evdev release inside forceCloseOverlay are
+          // synchronous, so they're already done when it returns. The atom
+          // writes are NOT — they shell out to xprop — and exiting before they
+          // land strands ROOT STEAM_TOUCH_CLICK_MODE at TOUCH_MODE_OVERLAY,
+          // i.e. gamescope routing touch to a window that no longer exists.
+          // Deferring the exit costs nothing: nothing else can use this
+          // process, and the timeout bounds a wedged xprop.
+          const settled = state.isOpen
+            ? forceCloseOverlay("deck hidraw watcher died")
+            : Promise.resolve();
+          void Promise.race([
+            settled,
+            new Promise((r) => setTimeout(r, ATOM_CLEAR_TIMEOUT_MS)),
+          ]).then(() => process.exit(1));
         }
       },
     });

--- a/apps/loadout-overlay/src/bun/lib/input-strategy.test.ts
+++ b/apps/loadout-overlay/src/bun/lib/input-strategy.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "bun:test";
+import { decideInputStrategy } from "./input-strategy";
+
+const base = {
+  isDeck: false,
+  ipAvailable: false,
+  deckHidrawOpened: false,
+  suspendEnv: undefined,
+  deckCaptureEnv: undefined,
+};
+
+describe("decideInputStrategy", () => {
+  it("IP host (APEX): identical to pre-Deck behavior", () => {
+    expect(decideInputStrategy({ ...base, ipAvailable: true })).toEqual({
+      deckNavActive: false,
+      readVirtualPadsForNav: false,
+      grabDeckBuiltinNodes: false,
+      suspendSteamEnabled: true,
+    });
+  });
+
+  it("Deck with working hidraw watcher: full Deck strategy", () => {
+    expect(
+      decideInputStrategy({ ...base, isDeck: true, deckHidrawOpened: true }),
+    ).toEqual({
+      deckNavActive: true,
+      readVirtualPadsForNav: false,
+      grabDeckBuiltinNodes: true,
+      suspendSteamEnabled: true,
+    });
+  });
+
+  it("Deck with FAILED hidraw watcher: exact legacy fallback (no freeze, virtual-pad nav)", () => {
+    // Freezing Steam with no hidraw nav source would strand the user with
+    // zero nav — must fall back to today's behavior wholesale.
+    expect(
+      decideInputStrategy({ ...base, isDeck: true, deckHidrawOpened: false }),
+    ).toEqual({
+      deckNavActive: false,
+      readVirtualPadsForNav: true,
+      grabDeckBuiltinNodes: false,
+      suspendSteamEnabled: false,
+    });
+  });
+
+  it("DECK_OVERLAY_DECK_CAPTURE=0 kill switch restores legacy Deck behavior", () => {
+    expect(
+      decideInputStrategy({
+        ...base,
+        isDeck: true,
+        deckHidrawOpened: true,
+        deckCaptureEnv: "0",
+      }),
+    ).toEqual({
+      deckNavActive: false,
+      readVirtualPadsForNav: true,
+      grabDeckBuiltinNodes: false,
+      suspendSteamEnabled: false,
+    });
+  });
+
+  it("Deck WITH IP composites: IP wins, Deck strategy stays off", () => {
+    expect(
+      decideInputStrategy({
+        ...base,
+        isDeck: true,
+        ipAvailable: true,
+        deckHidrawOpened: true,
+      }),
+    ).toEqual({
+      deckNavActive: false,
+      readVirtualPadsForNav: false,
+      grabDeckBuiltinNodes: false,
+      suspendSteamEnabled: true,
+    });
+  });
+
+  it("non-Deck, non-IP host (Bazzite desktop): legacy evdev path", () => {
+    expect(decideInputStrategy({ ...base })).toEqual({
+      deckNavActive: false,
+      readVirtualPadsForNav: true,
+      grabDeckBuiltinNodes: false,
+      suspendSteamEnabled: false,
+    });
+  });
+
+  it("DECK_OVERLAY_SUSPEND_STEAM=1 forces the freeze on regardless of strategy", () => {
+    expect(decideInputStrategy({ ...base, suspendEnv: "1" }).suspendSteamEnabled).toBe(true);
+    expect(
+      decideInputStrategy({
+        ...base,
+        isDeck: true,
+        deckHidrawOpened: false,
+        suspendEnv: "1",
+      }).suspendSteamEnabled,
+    ).toBe(true);
+  });
+
+  it("DECK_OVERLAY_SUSPEND_STEAM=0 forces the freeze off but keeps deck nav", () => {
+    const s = decideInputStrategy({
+      ...base,
+      isDeck: true,
+      deckHidrawOpened: true,
+      suspendEnv: "0",
+    });
+    expect(s.suspendSteamEnabled).toBe(false);
+    expect(s.deckNavActive).toBe(true); // nav-without-freeze debug mode
+    expect(s.grabDeckBuiltinNodes).toBe(true);
+  });
+
+  it("hidraw watcher open on a NON-Deck host does not enable the Deck strategy", () => {
+    // findDeckHidrawPath is VID/PID-gated so this shouldn't happen, but the
+    // strategy must not rely on it.
+    expect(
+      decideInputStrategy({ ...base, deckHidrawOpened: true }).deckNavActive,
+    ).toBe(false);
+  });
+});

--- a/apps/loadout-overlay/src/bun/lib/input-strategy.ts
+++ b/apps/loadout-overlay/src/bun/lib/input-strategy.ts
@@ -1,0 +1,79 @@
+/**
+ * Input-strategy decision — pure, so every row of the host matrix is
+ * unit-testable (pattern: wake-routing.ts).
+ *
+ * Three host shapes exist:
+ *
+ *  1. IP-managed handheld (OXP APEX …): InputPlumber composites exist. Nav
+ *     arrives over IP's DBus stream, the Steam virtual pad is a grab-only
+ *     mirror, and Steam is frozen (SIGSTOP) while the overlay is open so its
+ *     direct hidraw reads can't drive BPM behind us. UNCHANGED by the Deck
+ *     work — this path is working in the field.
+ *
+ *  2. Steam Deck, no IP composites: Steam Input owns the built-in controller
+ *     via hidraw, which EVIOCGRAB can never intercept, and the virtual X360
+ *     pad only exists while a game runs — in BPM home there is NO evdev nav
+ *     source at all. The Deck strategy reads nav from our own hidraw stream
+ *     (deck-hidraw-watcher), makes every built-in evdev node grab-only, and
+ *     freezes Steam in game mode for capture. Freezing is only safe when the
+ *     hidraw watcher actually opened — a Deck where it failed (EACCES) must
+ *     keep today's behavior or the user is stranded with zero nav.
+ *
+ *  3. Everything else (Bazzite desktop, dev boxes): plain evdev grab+read,
+ *     virtual pads read for nav, no freeze.
+ *
+ * Kill switches:
+ *   DECK_OVERLAY_DECK_CAPTURE=0    — disable the Deck strategy entirely
+ *                                    (falls back to shape 3 behavior).
+ *   DECK_OVERLAY_SUSPEND_STEAM=1/0 — force the Steam freeze on/off
+ *                                    independent of strategy (pre-existing).
+ */
+
+export interface InputStrategyInputs {
+  /** DMI says this is a Steam Deck (Jupiter/Galileo/Valve). */
+  isDeck: boolean;
+  /** InputPlumber has ≥1 CompositeDevice (ipHandle.available). */
+  ipAvailable: boolean;
+  /** startDeckHidrawWatcher returned a live handle. */
+  deckHidrawOpened: boolean;
+  /** process.env.DECK_OVERLAY_SUSPEND_STEAM — "1" force on, "0" force off. */
+  suspendEnv: string | undefined;
+  /** process.env.DECK_OVERLAY_DECK_CAPTURE — "0" disables the Deck strategy. */
+  deckCaptureEnv: string | undefined;
+}
+
+export interface InputStrategy {
+  /** Drive overlay nav from the Deck hidraw stream while open. */
+  deckNavActive: boolean;
+  /** Read Steam virtual pads (28de:11ff) for nav vs grab-only. */
+  readVirtualPadsForNav: boolean;
+  /** EVIOCGRAB all Deck built-in evdev nodes while intercepting. */
+  grabDeckBuiltinNodes: boolean;
+  /** SIGSTOP Steam while the overlay is open (game mode only; the
+   *  toggleOverlay call site additionally gates on isGameModeActive()). */
+  suspendSteamEnabled: boolean;
+}
+
+export function decideInputStrategy(i: InputStrategyInputs): InputStrategy {
+  // IP composites present → IP owns nav + intercept, even on a Deck the
+  // user pointed IP at. The Deck strategy only covers the IP-less Deck.
+  const deckCaptureWanted =
+    i.deckCaptureEnv !== "0" && i.isDeck && !i.ipAvailable;
+  const deckNavActive = deckCaptureWanted && i.deckHidrawOpened;
+
+  const readVirtualPadsForNav = !i.ipAvailable && !deckNavActive;
+
+  // Auto: freeze wherever nav does NOT depend on a live Steam process —
+  // IP DBus nav, or our own hidraw nav. The evdev-virtual-pad fallback
+  // (readVirtualPadsForNav) needs Steam alive to emit, so no freeze there.
+  const suspendAuto = i.ipAvailable || deckNavActive;
+  const suspendSteamEnabled =
+    i.suspendEnv === "1" ? true : i.suspendEnv === "0" ? false : suspendAuto;
+
+  return {
+    deckNavActive,
+    readVirtualPadsForNav,
+    grabDeckBuiltinNodes: deckNavActive,
+    suspendSteamEnabled,
+  };
+}

--- a/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.test.ts
+++ b/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.test.ts
@@ -29,9 +29,14 @@ function stubOpenOk() {
 }
 
 /** Build a Deck input report (REPORT_LEN bytes) with optional byte overrides. */
+/** Realistic Deck state frame — header `01 00 09 40`. See makeReport in
+ *  packages/deck-hid/src/index.test.ts. */
 function frame(overrides: Record<number, number> = {}): Buffer {
   const b = Buffer.alloc(REPORT_LEN);
   b[0] = REPORT_ID_INPUT;
+  b[1] = 0x00;
+  b[2] = 0x09;
+  b[3] = 0x40;
   for (const [k, v] of Object.entries(overrides)) b[parseInt(k, 10)] = v;
   return b;
 }

--- a/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.test.ts
+++ b/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.test.ts
@@ -454,3 +454,171 @@ describe("navStateToInputEvents", () => {
     expect(navStateToInputEvents(neutral(), cur)).toEqual([]);
   });
 });
+
+describe("deck-hidraw-watcher stick dead-band", () => {
+  it("silences rest drift that straddles a quantization boundary", async () => {
+    const findSpy = spyOn(deckHid, "findDeckHidrawPath").mockResolvedValue(
+      "/dev/hidraw-fake",
+    );
+    const stream = fakeStream();
+    const openSpy = stubOpenOk();
+    const streamSpy = spyOn(fs, "createReadStream").mockReturnValue(
+      stream as unknown as ReturnType<typeof fs.createReadStream>,
+    );
+    const navBatches: InputEvent[][] = [];
+    const handle = await startDeckHidrawWatcher({
+      onWake: () => {},
+      initialButton: "Steam",
+      log: () => {},
+      onNavEvents: (events) => navBatches.push(events),
+    });
+    const t = {
+      handle: handle!,
+      stream,
+      navBatches,
+      restore: () => {
+        handle!.stop();
+        findSpy.mockRestore();
+        streamSpy.mockRestore();
+        openSpy.mockRestore();
+      },
+    };
+    t.handle.setNavActive(true);
+    t.stream.push(frame()); // baseline
+    // Alternate around a 1/128 boundary (raw 128 ≈ 0.0039, raw 384 ≈ 0.0117
+    // — both inside the 0.10 dead-band). Without the dead-band this would
+    // emit an axis RPC per report, forever.
+    for (let i = 0; i < 10; i++) {
+      const f = frame();
+      f.writeInt16LE(i % 2 === 0 ? 128 : 384, 52); // RightStickX
+      t.stream.push(f);
+    }
+    expect(t.navBatches).toHaveLength(0);
+    // Measured Jupiter rest drift (~0.04 ≈ raw 1300) also stays silent.
+    const drift = frame();
+    drift.writeInt16LE(1300, 48);
+    t.stream.push(drift);
+    expect(t.navBatches).toHaveLength(0);
+    // A deliberate tilt still gets through.
+    const tilt = frame();
+    tilt.writeInt16LE(16384, 52); // ~0.5
+    t.stream.push(tilt);
+    expect(t.navBatches).toHaveLength(1);
+    expect(t.navBatches[0]![0]).toEqual({
+      kind: "axis",
+      axis: "RightStickX",
+      value: expect.closeTo(0.5, 1),
+    });
+    t.restore();
+  });
+});
+
+describe("deck-hidraw-watcher death signal", () => {
+  it("fires onDeath on stream error (not on stop) and flips isAlive", async () => {
+    const findSpy = spyOn(deckHid, "findDeckHidrawPath").mockResolvedValue(
+      "/dev/hidraw-fake",
+    );
+    const stream = fakeStream();
+    const openSpy = stubOpenOk();
+    const streamSpy = spyOn(fs, "createReadStream").mockReturnValue(
+      stream as unknown as ReturnType<typeof fs.createReadStream>,
+    );
+    const onDeath = mock(() => {});
+    const handle = await startDeckHidrawWatcher({
+      onWake: () => {},
+      initialButton: "Steam",
+      log: () => {},
+      onDeath,
+    });
+    expect(handle!.isAlive()).toBe(true);
+    stream.emit("error", new Error("device unplugged"));
+    expect(onDeath).toHaveBeenCalledTimes(1);
+    expect(handle!.isAlive()).toBe(false);
+    // stop() after death is idempotent and does NOT re-fire onDeath.
+    handle!.stop();
+    expect(onDeath).toHaveBeenCalledTimes(1);
+    findSpy.mockRestore();
+    streamSpy.mockRestore();
+    openSpy.mockRestore();
+  });
+
+  it("does not fire onDeath on a deliberate stop()", async () => {
+    const findSpy = spyOn(deckHid, "findDeckHidrawPath").mockResolvedValue(
+      "/dev/hidraw-fake",
+    );
+    const stream = fakeStream();
+    const openSpy = stubOpenOk();
+    const streamSpy = spyOn(fs, "createReadStream").mockReturnValue(
+      stream as unknown as ReturnType<typeof fs.createReadStream>,
+    );
+    const onDeath = mock(() => {});
+    const handle = await startDeckHidrawWatcher({
+      onWake: () => {},
+      log: () => {},
+      onDeath,
+    });
+    handle!.stop();
+    expect(onDeath).toHaveBeenCalledTimes(0);
+    expect(handle!.isAlive()).toBe(false);
+    findSpy.mockRestore();
+    streamSpy.mockRestore();
+    openSpy.mockRestore();
+  });
+});
+
+describe("deck-hidraw-watcher wake-button-is-a-nav-button (production-shaped)", () => {
+  it("a closing wake press does not leak a nav edge; reopening re-latches", async () => {
+    // Wake bound to "A" — also a nav button. Production wiring: onWake runs
+    // toggleOverlay synchronously, which flips setNavActive. The closing
+    // press's wake fires BEFORE the same frame's nav decode (wake-bit chase
+    // runs first in onChunk), so by decode time navActive is false and no
+    // "A" edge may leak into a NavController that release() has just reset.
+    const findSpy = spyOn(deckHid, "findDeckHidrawPath").mockResolvedValue(
+      "/dev/hidraw-fake",
+    );
+    const stream = fakeStream();
+    const openSpy = stubOpenOk();
+    const streamSpy = spyOn(fs, "createReadStream").mockReturnValue(
+      stream as unknown as ReturnType<typeof fs.createReadStream>,
+    );
+    const navBatches: InputEvent[][] = [];
+    let isOpen = false;
+    let handleRef: Awaited<ReturnType<typeof startDeckHidrawWatcher>> = null;
+    const handle = await startDeckHidrawWatcher({
+      // Mirrors toggleOverlay: synchronous open/close flipping nav mode.
+      onWake: () => {
+        isOpen = !isOpen;
+        handleRef!.setNavActive(isOpen);
+      },
+      initialButton: "A",
+      log: () => {},
+      onNavEvents: (events) => navBatches.push(events),
+    });
+    handleRef = handle;
+
+    stream.push(frame()); // consume startup edge-suppress
+    // OPEN press: wake fires, nav mode activates mid-frame; the same frame
+    // becomes the silent baseline (A held) — no nav emission.
+    stream.push(frame({ 8: 0x80 }));
+    expect(isOpen).toBe(true);
+    expect(navBatches).toHaveLength(0);
+    // Release while open — the baseline held A releases; NavController-side
+    // this is a no-op (never counted as pressed), but the edge itself is
+    // fine to emit.
+    stream.push(frame());
+    expect(navBatches).toHaveLength(1);
+    expect(navBatches[0]).toEqual([
+      { kind: "button", button: "A", pressed: false },
+    ]);
+    // CLOSE press: wake fires first (overlay closes, nav deactivates), so
+    // the same frame's decode is skipped — NO nav press edge leaks.
+    stream.push(frame({ 8: 0x80 }));
+    expect(isOpen).toBe(false);
+    expect(navBatches).toHaveLength(1);
+
+    handle!.stop();
+    findSpy.mockRestore();
+    streamSpy.mockRestore();
+    openSpy.mockRestore();
+  });
+});

--- a/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.test.ts
+++ b/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.test.ts
@@ -11,11 +11,12 @@
 
 import { describe, it, expect, spyOn, mock } from "bun:test";
 import * as deckHid from "@loadout/deck-hid";
-import { REPORT_ID_INPUT, REPORT_LEN } from "@loadout/deck-hid";
+import { REPORT_ID_INPUT, REPORT_LEN, decodeNavState } from "@loadout/deck-hid";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import { EventEmitter } from "node:events";
-import { startDeckHidrawWatcher } from "./deck-hidraw-watcher";
+import { startDeckHidrawWatcher, navStateToInputEvents } from "./deck-hidraw-watcher";
+import type { InputEvent } from "./nav-controller";
 
 /** The watcher pre-flights with fs.promises.open before constructing a
  *  stream from the resulting fd — that's how it surfaces EACCES sync.
@@ -271,5 +272,185 @@ describe("deck-hidraw-watcher", () => {
     findSpy.mockRestore();
     streamSpy.mockRestore();
     openSpy.mockRestore();
+  });
+});
+
+describe("deck-hidraw-watcher nav mode", () => {
+  /** Boilerplate: stubbed Deck stream + started watcher with nav sink. */
+  async function startWithNav() {
+    const findSpy = spyOn(deckHid, "findDeckHidrawPath").mockResolvedValue(
+      "/dev/hidraw-fake",
+    );
+    const stream = fakeStream();
+    const openSpy = stubOpenOk();
+    const streamSpy = spyOn(fs, "createReadStream").mockReturnValue(
+      stream as unknown as ReturnType<typeof fs.createReadStream>,
+    );
+    const onWake = mock(() => {});
+    const navBatches: InputEvent[][] = [];
+    const handle = await startDeckHidrawWatcher({
+      onWake,
+      initialButton: "Steam",
+      log: () => {},
+      onNavEvents: (events) => navBatches.push(events),
+    });
+    const restore = () => {
+      handle!.stop();
+      findSpy.mockRestore();
+      streamSpy.mockRestore();
+      openSpy.mockRestore();
+    };
+    return { stream, onWake, navBatches, handle: handle!, restore };
+  }
+
+  it("emits nothing while nav mode is off", async () => {
+    const t = await startWithNav();
+    t.stream.push(frame());
+    t.stream.push(frame({ 8: 0x80 })); // A pressed
+    expect(t.navBatches).toHaveLength(0);
+    t.restore();
+  });
+
+  it("latches the first frame as a silent baseline, then emits edges", async () => {
+    const t = await startWithNav();
+    t.handle.setNavActive(true);
+    // First frame arrives with A ALREADY held (wake button was "A") —
+    // baseline latch, no emission.
+    t.stream.push(frame({ 8: 0x80 }));
+    expect(t.navBatches).toHaveLength(0);
+    // Release → one batch with the A release edge.
+    t.stream.push(frame());
+    expect(t.navBatches).toHaveLength(1);
+    expect(t.navBatches[0]).toEqual([
+      { kind: "button", button: "A", pressed: false },
+    ]);
+    // Fresh press → press edge.
+    t.stream.push(frame({ 8: 0x80 }));
+    expect(t.navBatches[1]).toEqual([
+      { kind: "button", button: "A", pressed: true },
+    ]);
+    t.restore();
+  });
+
+  it("maps the d-pad to Hat axes and sticks to quantized axis events", async () => {
+    const t = await startWithNav();
+    t.handle.setNavActive(true);
+    t.stream.push(frame()); // baseline
+    // dpadRight (byte 9 bit 1) + left stick pushed fully right.
+    const f = frame({ 9: 0x02 });
+    f.writeInt16LE(32767, 48);
+    t.stream.push(f);
+    expect(t.navBatches).toHaveLength(1);
+    expect(t.navBatches[0]).toContainEqual({ kind: "axis", axis: "HatX", value: 1 });
+    expect(t.navBatches[0]).toContainEqual({ kind: "axis", axis: "LeftStickX", value: 1 });
+    // Back to neutral → both return to 0.
+    t.stream.push(frame());
+    expect(t.navBatches[1]).toContainEqual({ kind: "axis", axis: "HatX", value: 0 });
+    expect(t.navBatches[1]).toContainEqual({ kind: "axis", axis: "LeftStickX", value: 0 });
+    t.restore();
+  });
+
+  it("suppresses sub-quantum stick jitter", async () => {
+    const t = await startWithNav();
+    t.handle.setNavActive(true);
+    t.stream.push(frame()); // baseline
+    const jitter = frame();
+    jitter.writeInt16LE(60, 48); // ~0.0018 — far below one 1/128 quantum
+    t.stream.push(jitter);
+    expect(t.navBatches).toHaveLength(0);
+    t.restore();
+  });
+
+  it("wake still fires while nav mode is active", async () => {
+    const t = await startWithNav();
+    t.handle.setNavActive(true);
+    t.stream.push(frame()); // baseline + consumes startup edge-suppress
+    t.stream.push(frame({ 9: 0x20 })); // Steam (bound wake button) pressed
+    expect(t.onWake).toHaveBeenCalledTimes(1);
+    // The same press also reached nav as a Mode edge (Steam → Mode).
+    expect(t.navBatches[0]).toContainEqual({
+      kind: "button",
+      button: "Mode",
+      pressed: true,
+    });
+    t.restore();
+  });
+
+  it("setNavActive(false) stops emission and re-arming re-latches the baseline", async () => {
+    const t = await startWithNav();
+    t.handle.setNavActive(true);
+    t.stream.push(frame()); // baseline
+    t.stream.push(frame({ 8: 0x80 }));
+    expect(t.navBatches).toHaveLength(1);
+
+    t.handle.setNavActive(false);
+    t.stream.push(frame()); // A released while closed — must not emit
+    expect(t.navBatches).toHaveLength(1);
+
+    t.handle.setNavActive(true);
+    // Re-open with B already held: silent baseline again.
+    t.stream.push(frame({ 8: 0x20 }));
+    expect(t.navBatches).toHaveLength(1);
+    t.stream.push(frame());
+    expect(t.navBatches[1]).toEqual([
+      { kind: "button", button: "B", pressed: false },
+    ]);
+    t.restore();
+  });
+
+  it("decodes nav from each report of a coalesced chunk", async () => {
+    const t = await startWithNav();
+    t.handle.setNavActive(true);
+    t.stream.push(frame()); // baseline
+    // One chunk holding press-then-release — two batches, in order.
+    t.stream.push(Buffer.concat([frame({ 8: 0x80 }), frame()]));
+    expect(t.navBatches).toHaveLength(2);
+    expect(t.navBatches[0]).toEqual([{ kind: "button", button: "A", pressed: true }]);
+    expect(t.navBatches[1]).toEqual([{ kind: "button", button: "A", pressed: false }]);
+    t.restore();
+  });
+
+  it("ignores non-input reports in nav mode too", async () => {
+    const t = await startWithNav();
+    t.handle.setNavActive(true);
+    t.stream.push(frame()); // baseline
+    const nonInput = frame({ 8: 0xff });
+    nonInput[0] = 0x09;
+    t.stream.push(nonInput);
+    expect(t.navBatches).toHaveLength(0);
+    t.restore();
+  });
+});
+
+describe("navStateToInputEvents", () => {
+  const neutral = (): NonNullable<ReturnType<typeof decodeNavState>> =>
+    decodeNavState(frame())!;
+
+  it("returns [] for a null prev (baseline latch)", () => {
+    expect(navStateToInputEvents(null, neutral())).toEqual([]);
+  });
+
+  it("maps every button edge to the evdev-path names", () => {
+    const cur = {
+      ...neutral(),
+      a: true, b: true, x: true, y: true,
+      l1: true, r1: true, view: true, steam: true,
+    };
+    const events = navStateToInputEvents(neutral(), cur);
+    for (const button of ["A", "B", "X", "Y", "LB", "RB", "Select", "Mode"] as const) {
+      expect(events).toContainEqual({ kind: "button", button, pressed: true });
+    }
+  });
+
+  it("resolves opposing d-pad bits with positive direction winning", () => {
+    // Physically near-impossible, but the mapping must stay deterministic.
+    const cur = { ...neutral(), dpadLeft: true, dpadRight: true };
+    const events = navStateToInputEvents(neutral(), cur);
+    expect(events).toContainEqual({ kind: "axis", axis: "HatX", value: 1 });
+  });
+
+  it("does not emit for qam/menu (wake-path and unmapped buttons)", () => {
+    const cur = { ...neutral(), qam: true, menu: true };
+    expect(navStateToInputEvents(neutral(), cur)).toEqual([]);
   });
 });

--- a/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.ts
+++ b/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.ts
@@ -57,6 +57,12 @@ export interface DeckHidrawWatcherOptions {
    *  called while nav mode is off, so the idle wake path costs the same
    *  as before. */
   onNavEvents?: (events: InputEvent[]) => void;
+  /** Fires ONCE if the stream dies on its own (error/end) — NOT on stop().
+   *  When the watcher is the overlay's nav source (Deck strategy), a dead
+   *  stream means nav AND the wake button are gone while the strategy would
+   *  still freeze Steam on the next open; the caller must degrade or
+   *  restart. */
+  onDeath?: () => void;
 }
 
 export interface DeckHidrawWatcherHandle {
@@ -69,6 +75,9 @@ export interface DeckHidrawWatcherHandle {
    *  held from the opening press must not fire a nav action into the
    *  freshly-opened overlay. Deactivation clears all diff state. */
   setNavActive(active: boolean): void;
+  /** False once the stream has died (error/end) or stop() was called. The
+   *  strategy decision must not treat a dead watcher as a nav source. */
+  isAlive(): boolean;
   /** Path of the hidraw node we opened, for diagnostics. */
   path(): string;
   /** Tear down the stream. Idempotent. */
@@ -81,7 +90,18 @@ const DEFAULT_LOG = (msg: string) => console.log(`[deck-hidraw] ${msg}`);
  *  ADC noise on a resting stick doesn't emit a continuous event stream. */
 const STICK_QUANT = 128;
 
+/** Values within this of center clamp to exactly 0 BEFORE quantization.
+ *  Quantization alone can't silence a resting stick whose ADC noise
+ *  straddles a step boundary — it would alternate between two quantized
+ *  values at report rate (~250/s) and stream axis RPCs the whole time the
+ *  overlay is open. The evdev path gets this for free from kernel fuzz
+ *  filtering; the raw hidraw path must do its own. 0.10 comfortably covers
+ *  the ±0.04 rest drift measured on a worn Jupiter stick while staying far
+ *  below NavController's 0.5 nav deadzone and any deliberate scroll tilt. */
+const STICK_DEADBAND = 0.1;
+
 function quantize(v: number): number {
+  if (Math.abs(v) < STICK_DEADBAND) return 0;
   // `+ 0` normalizes -0 → 0 so a centered stick always compares equal.
   return Math.round(v * STICK_QUANT) / STICK_QUANT + 0;
 }
@@ -244,11 +264,13 @@ export async function startDeckHidrawWatcher(
     } catch {
       /* ignore */
     }
+    opts.onDeath?.();
   });
   stream.on("end", () => {
     if (stopped) return;
     log(`stream end on ${path} — watcher stopped.`);
     stopped = true;
+    opts.onDeath?.();
   });
 
   return {
@@ -272,6 +294,9 @@ export async function startDeckHidrawWatcher(
       // next frame latches silently (held wake button must not fire); on
       // exit stale state must not leak into the next overlay session.
       prevNav = null;
+    },
+    isAlive(): boolean {
+      return !stopped;
     },
     path(): string {
       return path;

--- a/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.ts
+++ b/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.ts
@@ -33,11 +33,14 @@ import {
   findDeckHidrawPath,
   findButton,
   splitReports,
+  decodeNavState,
   REPORT_ID_INPUT,
   REPORT_LEN,
   type DeckButton,
+  type DeckNavState,
 } from "@loadout/deck-hid";
 import type { WakeEvent } from "./input-intercept";
+import type { InputEvent } from "./nav-controller";
 
 export interface DeckHidrawWatcherOptions {
   /** Fires when the bound button transitions 0→1. Always passes
@@ -49,6 +52,11 @@ export interface DeckHidrawWatcherOptions {
   initialButton?: string | null;
   /** Optional log sink. Defaults to console.log with a [deck-hidraw] prefix. */
   log?: (msg: string) => void;
+  /** Fires with NavController-shaped InputEvents decoded from the full
+   *  gamepad report while nav mode is active (see setNavActive). Never
+   *  called while nav mode is off, so the idle wake path costs the same
+   *  as before. */
+  onNavEvents?: (events: InputEvent[]) => void;
 }
 
 export interface DeckHidrawWatcherHandle {
@@ -56,6 +64,11 @@ export interface DeckHidrawWatcherHandle {
   setBinding(button: string | null): void;
   /** Currently bound button name, or null. */
   getBinding(): string | null;
+  /** Toggle full nav decoding (overlay open ↔ closed). Activation latches
+   *  the first frame as a baseline WITHOUT emitting — a wake button still
+   *  held from the opening press must not fire a nav action into the
+   *  freshly-opened overlay. Deactivation clears all diff state. */
+  setNavActive(active: boolean): void;
   /** Path of the hidraw node we opened, for diagnostics. */
   path(): string;
   /** Tear down the stream. Idempotent. */
@@ -63,6 +76,62 @@ export interface DeckHidrawWatcherHandle {
 }
 
 const DEFAULT_LOG = (msg: string) => console.log(`[deck-hidraw] ${msg}`);
+
+/** Stick values are quantized to this many steps per unit before diffing so
+ *  ADC noise on a resting stick doesn't emit a continuous event stream. */
+const STICK_QUANT = 128;
+
+function quantize(v: number): number {
+  // `+ 0` normalizes -0 → 0 so a centered stick always compares equal.
+  return Math.round(v * STICK_QUANT) / STICK_QUANT + 0;
+}
+
+/** Pure: diff two decoded frames into NavController-shaped InputEvents.
+ *  Buttons map to the same names the evdev path produces; the d-pad becomes
+ *  synthetic Hat axes (−1/0/1) so NavController's axis→dpad edge/repeat
+ *  logic is reused unchanged; sticks are quantized and emitted on change.
+ *  View/Steam map to Select/Mode so NavController's modifier-suppression
+ *  semantics stay consistent with evdev controllers. `prev = null` means
+ *  "baseline frame" — nothing is emitted, the caller just stores it. */
+export function navStateToInputEvents(
+  prev: DeckNavState | null,
+  cur: DeckNavState,
+): InputEvent[] {
+  if (!prev) return [];
+  const out: InputEvent[] = [];
+
+  const button = (name: "A" | "B" | "X" | "Y" | "LB" | "RB" | "Mode" | "Select", p: boolean, c: boolean) => {
+    if (p !== c) out.push({ kind: "button", button: name, pressed: c });
+  };
+  button("A", prev.a, cur.a);
+  button("B", prev.b, cur.b);
+  button("X", prev.x, cur.x);
+  button("Y", prev.y, cur.y);
+  button("LB", prev.l1, cur.l1);
+  button("RB", prev.r1, cur.r1);
+  button("Select", prev.view, cur.view);
+  button("Mode", prev.steam, cur.steam);
+
+  const hat = (neg: boolean, pos: boolean): number => (pos ? 1 : neg ? -1 : 0);
+  const prevHatX = hat(prev.dpadLeft, prev.dpadRight);
+  const curHatX = hat(cur.dpadLeft, cur.dpadRight);
+  if (prevHatX !== curHatX) out.push({ kind: "axis", axis: "HatX", value: curHatX });
+  const prevHatY = hat(prev.dpadUp, prev.dpadDown);
+  const curHatY = hat(cur.dpadUp, cur.dpadDown);
+  if (prevHatY !== curHatY) out.push({ kind: "axis", axis: "HatY", value: curHatY });
+
+  const stick = (axis: "LeftStickX" | "LeftStickY" | "RightStickX" | "RightStickY", p: number, c: number) => {
+    const pq = quantize(p);
+    const cq = quantize(c);
+    if (pq !== cq) out.push({ kind: "axis", axis, value: cq });
+  };
+  stick("LeftStickX", prev.lx, cur.lx);
+  stick("LeftStickY", prev.ly, cur.ly);
+  stick("RightStickX", prev.rx, cur.rx);
+  stick("RightStickY", prev.ry, cur.ry);
+
+  return out;
+}
 
 /**
  * Start a watcher. Returns null when we can't or shouldn't run — non-Deck
@@ -114,6 +183,11 @@ export async function startDeckHidrawWatcher(
   let suppressNextEdge = true;
   let stopped = false;
   let buf: Buffer = Buffer.alloc(0);
+  /** Overlay-open nav decoding. `prevNav === null` while active means "next
+   *  frame is the baseline" — latch it without emitting (the wake button is
+   *  usually still held when the overlay opens). */
+  let navActive = false;
+  let prevNav: DeckNavState | null = null;
 
   log(`watching ${path}; initial binding = ${bound?.name ?? "<none>"}`);
 
@@ -140,6 +214,17 @@ export async function startDeckHidrawWatcher(
         }
         lastBitValue = cur;
         suppressNextEdge = false;
+      }
+      // Full nav decode — only while the overlay is open. Runs after the
+      // wake-bit chase so a wake press that CLOSES the overlay still fires
+      // even when nav mode is active for that same frame.
+      if (navActive && opts.onNavEvents) {
+        const nav = decodeNavState(report);
+        if (nav) {
+          const events = navStateToInputEvents(prevNav, nav);
+          prevNav = nav;
+          if (events.length > 0) opts.onNavEvents(events);
+        }
       }
     }
     // Keep only the trailing partial report (rare; defensive).
@@ -180,6 +265,13 @@ export async function startDeckHidrawWatcher(
     },
     getBinding(): string | null {
       return bound?.name ?? null;
+    },
+    setNavActive(active: boolean): void {
+      navActive = active;
+      // Entering OR leaving nav mode drops the diff baseline: on entry the
+      // next frame latches silently (held wake button must not fire); on
+      // exit stale state must not leak into the next overlay session.
+      prevNav = null;
     },
     path(): string {
       return path;

--- a/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.ts
+++ b/apps/loadout-overlay/src/bun/native/deck-hidraw-watcher.ts
@@ -34,10 +34,10 @@ import {
   findButton,
   splitReports,
   decodeNavState,
-  REPORT_ID_INPUT,
   REPORT_LEN,
   type DeckButton,
   type DeckNavState,
+  isDeckStateReport,
 } from "@loadout/deck-hid";
 import type { WakeEvent } from "./input-intercept";
 import type { InputEvent } from "./nav-controller";
@@ -220,7 +220,7 @@ export async function startDeckHidrawWatcher(
       // button state. Skip everything else WITHOUT touching edge state —
       // reading a non-input frame's bytes would both misfire and corrupt
       // lastBitValue, desyncing the next real press.
-      if (report[0] !== REPORT_ID_INPUT) continue;
+      if (!isDeckStateReport(report)) continue;
       // We track only the SINGLE bound bit's transitions. Decoding the full
       // button map per frame is unnecessary on the hot path — chase the one
       // bit and bail. (Less GC pressure than building a Map every report.)

--- a/apps/loadout-overlay/src/bun/native/devices.test.ts
+++ b/apps/loadout-overlay/src/bun/native/devices.test.ts
@@ -63,6 +63,32 @@ describe("parseDevices", () => {
     expect(pad.isSteamVirtual).toBe(true);
   });
 
+  it("flags Deck built-in nodes (28de:1205/1206) incl. mouse-only lizard nodes", () => {
+    // Mirrors a real Jupiter: hid-steam exposes a mouse emulation node and a
+    // keyboard emulation node under the controller's own vendor:product.
+    const deckFixture = `I: Bus=0003 Vendor=28de Product=1205 Version=0110
+N: Name="Valve Software Steam Controller"
+H: Handlers=event4 mouse1
+
+I: Bus=0003 Vendor=28de Product=1206 Version=0110
+N: Name="Valve Software Steam Controller"
+H: Handlers=sysrq kbd event10
+
+I: Bus=0003 Vendor=28de Product=11ff Version=0001
+N: Name="Microsoft X-Box 360 pad 0"
+H: Handlers=event12
+B: KEY=${CONTROLLER_KEY_LINE}
+`;
+    const [mouse, kbd, virt] = parseDevices(deckFixture);
+    expect(mouse.isDeckBuiltin).toBe(true); // LCD (1205), mouse-only node
+    expect(kbd.isDeckBuiltin).toBe(true); // OLED (1206), kbd node
+    expect(virt.isDeckBuiltin).toBe(false); // virtual pad is NOT built-in
+    expect(virt.isSteamVirtual).toBe(true);
+    // Non-Valve devices never flag.
+    const [xbox] = parseDevices(FIXTURE);
+    expect(xbox.isDeckBuiltin).toBe(false);
+  });
+
   it("populates a stable hash across reconnects", () => {
     const [a] = parseDevices(FIXTURE);
     const [b] = parseDevices(FIXTURE);

--- a/apps/loadout-overlay/src/bun/native/devices.ts
+++ b/apps/loadout-overlay/src/bun/native/devices.ts
@@ -51,6 +51,15 @@ const KEYBOARD_REQUIRED_KEYS = [KEY_LEFTCTRL, KEY_3, KEY_4] as const;
 const STEAM_VENDOR = 0x28de;
 const STEAM_PRODUCT = 0x11ff;
 
+/** Products of the Steam Deck's BUILT-IN controller (hid-steam): Jupiter
+ *  (LCD) and Galileo (OLED). The driver exposes several evdev nodes under
+ *  these ids — the raw gamepad node (controller caps; only present while
+ *  Steam Input hasn't claimed the hidraw) plus lizard-mode keyboard/mouse
+ *  emulation nodes. On the Deck overlay strategy all of them are grab-only:
+ *  nav comes from our own hidraw reader, and grabbing blocks lizard-mode
+ *  input leaking to desktop apps behind the overlay. */
+const DECK_BUILTIN_PRODUCTS = [0x1205, 0x1206];
+
 // ---- Types -----------------------------------------------------------------
 
 /** Deprecated — single-class view kept for callers that haven't moved to
@@ -84,6 +93,10 @@ export interface InputDevice {
    *  it — grabbing it would mean our overlay's own CEF Gamepad API and
    *  Steam's BPM nav both lose input. */
   isSteamVirtual: boolean;
+  /** True for any evdev node of the Deck's built-in controller (28de:1205 /
+   *  28de:1206) — the raw gamepad node and the lizard-mode keyboard/mouse
+   *  emulation nodes. See DECK_BUILTIN_PRODUCTS. */
+  isDeckBuiltin: boolean;
 }
 
 // ---- Enumeration -----------------------------------------------------------
@@ -108,9 +121,12 @@ export function parseDevices(raw: string): InputDevice[] {
     const keyLine = matchLine(block, /^B:\s+KEY=(.*)$/m) ?? "";
     const keyCaps = parseKeyBitmask(keyLine);
     const flags = classifyByCaps(name, keyCaps);
+    const vendorNum = parseInt(vendor, 16);
+    const productNum = parseInt(product, 16);
     const isSteamVirtual =
-      parseInt(vendor, 16) === STEAM_VENDOR &&
-      parseInt(product, 16) === STEAM_PRODUCT;
+      vendorNum === STEAM_VENDOR && productNum === STEAM_PRODUCT;
+    const isDeckBuiltin =
+      vendorNum === STEAM_VENDOR && DECK_BUILTIN_PRODUCTS.includes(productNum);
     devices.push({
       eventPath: `/dev/input/${eventName}`,
       name,
@@ -121,6 +137,7 @@ export function parseDevices(raw: string): InputDevice[] {
       hash: djb2(`${name}|${vendor}|${product}`),
       keyCaps,
       isSteamVirtual,
+      isDeckBuiltin,
     });
   }
   return devices;

--- a/apps/loadout-overlay/src/bun/native/devices.ts
+++ b/apps/loadout-overlay/src/bun/native/devices.ts
@@ -89,9 +89,13 @@ export interface InputDevice {
   /** Parsed EV_KEY capability bitmask. Empty if the B: KEY= line is absent
    *  (non-input devices). */
   keyCaps: Uint8Array;
-  /** True for Steam Input's virtual Xbox 360 pad. Interception MUST skip
-   *  it — grabbing it would mean our overlay's own CEF Gamepad API and
-   *  Steam's BPM nav both lose input. */
+  /** True for Steam Input's virtual Xbox 360 pad (28de:11ff). Decides
+   *  read-for-nav vs grab-only in input-intercept (never plain "skip"):
+   *  grabbing it silences the game underneath while Steam BPM keeps reading
+   *  the physical pad via hidraw. NOTE: the grab/release loops assume every
+   *  11ff node has controller caps (true in the field — it's always the
+   *  virtual X360 pad); a hypothetical 11ff keyboard-only node would now be
+   *  grabbed too. */
   isSteamVirtual: boolean;
   /** True for any evdev node of the Deck's built-in controller (28de:1205 /
    *  28de:1206) — the raw gamepad node and the lizard-mode keyboard/mouse

--- a/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
@@ -173,7 +173,12 @@ function mkDevice(
   path: string,
   name: string,
   flags: Partial<InputDevice["flags"]> = {},
-  opts: { isSteamVirtual?: boolean; vendor?: string; product?: string } = {},
+  opts: {
+    isSteamVirtual?: boolean;
+    isDeckBuiltin?: boolean;
+    vendor?: string;
+    product?: string;
+  } = {},
 ): InputDevice {
   return {
     eventPath: path,
@@ -193,6 +198,7 @@ function mkDevice(
     hash: name.split("").reduce((a, c) => a + c.charCodeAt(0), 0),
     keyCaps: new Uint8Array(0),
     isSteamVirtual: opts.isSteamVirtual ?? false,
+    isDeckBuiltin: opts.isDeckBuiltin ?? false,
   };
 }
 
@@ -799,6 +805,87 @@ describe("startInputIntercept — injectNavEvents (external nav sources)", () =>
       { kind: "button", button: "Y", pressed: false },
     ]);
     expect(actions).toEqual(["y"]); // no phantom on the new generation
+    h.shutdown();
+  });
+});
+
+describe("startInputIntercept — Deck built-in nodes (grabDeckBuiltinNodes)", () => {
+  const EVIOCGRAB_REQ = 0x40044590n;
+
+  it("ignores Deck emulation nodes entirely when the option is off (default)", async () => {
+    devicesOnSystem = [
+      mkDevice("/dev/input/event4", "Valve Software Steam Controller", {}, {
+        isDeckBuiltin: true, vendor: "28de", product: "1205",
+      }),
+    ];
+    const h = await startInputIntercept({ onWake: () => {}, onAction: () => {} });
+    // Mouse-only node: no controller/keyboard/qam caps → not even opened.
+    expect(ffiCalls.filter((c) => c.kind === "open")).toHaveLength(0);
+    h.shutdown();
+  });
+
+  it("opens + grabs Deck built-in nodes (incl. mouse-only and keyboard) during intercept, releases with null", async () => {
+    devicesOnSystem = [
+      // Lizard mouse node — no caps at all.
+      mkDevice("/dev/input/event4", "Valve Software Steam Controller", {}, {
+        isDeckBuiltin: true, vendor: "28de", product: "1205",
+      }),
+      // Lizard keyboard node — keyboard-classified AND deck-builtin.
+      mkDevice("/dev/input/event10", "Valve Software Steam Controller", { isKeyboard: true }, {
+        isDeckBuiltin: true, vendor: "28de", product: "1205",
+      }),
+      // Raw gamepad node (Steam not running) — controller-classified.
+      mkDevice("/dev/input/event20", "Valve Software Steam Controller", { isController: true }, {
+        isDeckBuiltin: true, vendor: "28de", product: "1205",
+      }),
+      // External keyboard must stay passive.
+      mkDevice("/dev/input/event19", "Apple Inc. Magic Keyboard", { isKeyboard: true }),
+    ];
+    const h = await startInputIntercept({
+      onWake: () => {},
+      onAction: () => {},
+      grabDeckBuiltinNodes: true,
+    });
+    const opens = ffiCalls.filter((c) => c.kind === "open");
+    expect(opens.map((c) => (c as { path: string }).path).sort()).toEqual([
+      "/dev/input/event10",
+      "/dev/input/event19",
+      "/dev/input/event4",
+    ].concat(["/dev/input/event20"]).sort());
+
+    h.grab();
+    const grabs = ffiCalls.filter(
+      (c) => c.kind === "ioctl" && c.request === EVIOCGRAB_REQ && c.argKind === "pointer",
+    );
+    // All three deck nodes grabbed; the external keyboard is not.
+    expect(grabs).toHaveLength(3);
+
+    h.release();
+    const releases = ffiCalls.filter(
+      (c) => c.kind === "ioctl" && c.request === EVIOCGRAB_REQ && c.argKind === "null",
+    );
+    expect(releases).toHaveLength(3);
+    h.shutdown();
+  });
+
+  it("keeps the raw Deck gamepad node grab-only (never a nav read source)", async () => {
+    // With hidraw nav active, reading the raw gamepad evdev node would
+    // double every input. onReady's controller count covers only nav-read
+    // controllers, so a deck-builtin controller node must not count.
+    devicesOnSystem = [
+      mkDevice("/dev/input/event20", "Valve Software Steam Controller", { isController: true }, {
+        isDeckBuiltin: true, vendor: "28de", product: "1205",
+      }),
+      mkDevice("/dev/input/event12", "DualSense Wireless Controller", { isController: true }),
+    ];
+    let counts: { controllers: number } | null = null;
+    const h = await startInputIntercept({
+      onWake: () => {},
+      onAction: () => {},
+      onReady: (c) => (counts = c),
+      grabDeckBuiltinNodes: true,
+    });
+    expect(counts!.controllers).toBe(1); // only the external DualSense
     h.shutdown();
   });
 });

--- a/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.test.ts
@@ -722,3 +722,83 @@ describe("__testing__.toInputEvents", () => {
 // iterated on with stricter config.
 void KEY_F16;
 void enqueueRead;
+
+describe("startInputIntercept — injectNavEvents (external nav sources)", () => {
+  it("drops events while not intercepting", async () => {
+    devicesOnSystem = [];
+    const actions: string[] = [];
+    const h = await startInputIntercept({
+      onWake: () => {},
+      onAction: (a) => actions.push(a),
+      externalNavSources: ["deck-hidraw"],
+    });
+    h.injectNavEvents("deck-hidraw", [
+      { kind: "button", button: "A", pressed: true },
+    ]);
+    expect(actions).toEqual([]);
+    h.shutdown();
+  });
+
+  it("routes events into NavController while intercepting", async () => {
+    devicesOnSystem = [];
+    const actions: string[] = [];
+    const h = await startInputIntercept({
+      onWake: () => {},
+      onAction: (a) => actions.push(a),
+      externalNavSources: ["deck-hidraw"],
+    });
+    h.grab();
+    h.injectNavEvents("deck-hidraw", [
+      { kind: "button", button: "A", pressed: true },
+    ]);
+    expect(actions).toEqual(["a"]);
+    // d-pad arrives as Hat axes and lands as directions.
+    h.injectNavEvents("deck-hidraw", [{ kind: "axis", axis: "HatY", value: 1 }]);
+    expect(actions).toEqual(["a", "down"]);
+    h.shutdown();
+  });
+
+  it("forwards right-stick axis events to onAxis for overlay scroll", async () => {
+    devicesOnSystem = [];
+    const axes: Array<[string, number]> = [];
+    const h = await startInputIntercept({
+      onWake: () => {},
+      onAction: () => {},
+      onAxis: (axis, value) => axes.push([axis, value]),
+      externalNavSources: ["deck-hidraw"],
+    });
+    h.grab();
+    h.injectNavEvents("deck-hidraw", [
+      { kind: "axis", axis: "RightStickY", value: 0.75 },
+    ]);
+    expect(axes).toEqual([["RightStickY", 0.75]]);
+    h.shutdown();
+  });
+
+  it("generation bump across release/grab isolates stale held state", async () => {
+    // A press injected in one overlay session must not produce a phantom
+    // action when its release arrives after a close→open cycle: the
+    // controller id embeds the grab generation, and nav.reset() on both
+    // transitions clears the rest.
+    devicesOnSystem = [];
+    const actions: string[] = [];
+    const h = await startInputIntercept({
+      onWake: () => {},
+      onAction: (a) => actions.push(a),
+      externalNavSources: ["deck-hidraw"],
+    });
+    h.grab();
+    h.injectNavEvents("deck-hidraw", [
+      { kind: "button", button: "Y", pressed: true },
+    ]);
+    expect(actions).toEqual(["y"]);
+    h.release();
+    h.grab();
+    // The stale release from the previous session's press.
+    h.injectNavEvents("deck-hidraw", [
+      { kind: "button", button: "Y", pressed: false },
+    ]);
+    expect(actions).toEqual(["y"]); // no phantom on the new generation
+    h.shutdown();
+  });
+});

--- a/apps/loadout-overlay/src/bun/native/input-intercept.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.ts
@@ -789,9 +789,31 @@ export async function startInputIntercept(
       // EVIOCGRAB so the game underneath gets nothing. We never feed their
       // events to NavController (the physical pads already drive overlay nav;
       // this mirrors them, so processing both would double every input) and
-      // never run wake detection on them. readRawEvents above already drained
-      // the fd so its buffer can't back up — just skip the rest.
-      if (t.grabOnly) continue;
+      // — on IP hosts — never run wake detection on them either (the physical
+      // pad already drives wake; processing the mirror would double-toggle).
+      // readRawEvents above already drained the fd so its buffer can't back up.
+      //
+      // Deck strategy exception: there the virtual pad (or the raw built-in
+      // gamepad node when Steam isn't running) is the ONLY evdev view of the
+      // built-in controller — no other device mirrors it — so combo wake
+      // detection (Guide+B etc.) must keep running or a Deck with no
+      // configured hidraw wake binding has no controller wake at all. Nav
+      // stays off (hidraw drives it; reading both would double).
+      if (t.grabOnly) {
+        if (grabDeckBuiltinNodes && t.dev.flags.isController && !pendingGrabs.has(t)) {
+          for (const e of events) {
+            if (e.type !== EV_KEY) continue;
+            const wake = processCombo(t.combo, e.code, e.value, now);
+            if (wake) {
+              trace(
+                `[input-intercept] wake=${wake} from grab-only '${t.dev.name}' (${t.path})`,
+              );
+              opts.onWake(wake);
+            }
+          }
+        }
+        continue;
+      }
 
       // A device with a still-deferred grab isn't ours yet — the app
       // underneath is reading it (that's the whole point of deferring, so it
@@ -888,9 +910,12 @@ export async function startInputIntercept(
       const rc = libc.symbols.ioctl(t.fd, EVIOCGRAB, ptr(intBuf));
       if (rc === 0) {
         t.grabbed = true;
-        console.log(
-          `[input-intercept] grabbed ${t.path} '${t.dev.name}'${t.grabOnly ? " (virtual, grab-only)" : ""}`,
-        );
+        const label = !t.grabOnly
+          ? ""
+          : t.dev.isSteamVirtual
+            ? " (virtual, grab-only)"
+            : " (deck-builtin, grab-only)";
+        console.log(`[input-intercept] grabbed ${t.path} '${t.dev.name}'${label}`);
       } else {
         // EBUSY is normal if another app (old overlay instance,
         // steamcompmgr) has it — log and move on.
@@ -983,7 +1008,7 @@ export async function startInputIntercept(
     }
     nav.reset();
     console.log(
-      `[input-intercept] released ${tracked.filter((t) => t.dev.flags.isController).length} controller(s)`,
+      `[input-intercept] released ${tracked.filter((t) => t.dev.flags.isController || t.grabOnly).length} device(s)`,
     );
     startTimer();
   }

--- a/apps/loadout-overlay/src/bun/native/input-intercept.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.ts
@@ -604,6 +604,11 @@ export interface InputInterceptOptions {
    *  mirror would double every input. index.ts sets this to "no IP composites".
    */
   readVirtualPadsForNav?: boolean;
+  /** Non-evdev nav sources (e.g. "deck-hidraw") that inject events via
+   *  injectNavEvents. Listed here so pollOnce pumps their NavController
+   *  state every active tick — key repeat then fires on our 25 ms cadence
+   *  instead of depending on the source's own report cadence. */
+  externalNavSources?: string[];
 }
 
 export interface InputInterceptHandle {
@@ -612,6 +617,12 @@ export interface InputInterceptHandle {
   grab(): void;
   /** Stop intercept — release grabs, narrow masks back to idle. */
   release(): void;
+  /** Feed NavController-shaped events from an external (non-evdev) source,
+   *  e.g. the Deck hidraw watcher. No-op unless intercepting. The source id
+   *  is suffixed with the live grab generation, so state from a previous
+   *  overlay session can never leak into the next (nav.reset() on grab and
+   *  release covers the rest). */
+  injectNavEvents(sourceId: string, events: InputEvent[]): void;
   /** Close all FDs, release any outstanding grabs. Call from shutdown. */
   shutdown(): void;
   /** For diagnostic logs. */
@@ -635,6 +646,7 @@ export async function startInputIntercept(
   // it. index.ts sets readVirtualPadsForNav = "no IP composites present", i.e.
   // the Deck-alone case reads; the external-IP-pad case stays grab-only.
   const readVirtualPadsForNav = opts.readVirtualPadsForNav ?? true;
+  const externalNavSources = opts.externalNavSources ?? [];
 
   // Track controllers including the virtual pad; isSteamVirtual only decides
   // read-for-nav vs grab-only below (via `grabOnly` in openAndTrack).
@@ -802,6 +814,16 @@ export async function startInputIntercept(
         const cid = `${t.dev.hash}_${generation}`;
         const input = toInputEvents(events, t.cal);
         nav.processEvents(cid, input);
+      }
+    }
+
+    // Pump external nav sources (Deck hidraw) with an empty batch each
+    // active tick so their held buttons key-repeat on our cadence — the
+    // source only pushes events on state CHANGES, which would otherwise
+    // leave repeat at the mercy of its report timing.
+    if (intercepting) {
+      for (const id of externalNavSources) {
+        nav.processEvents(`${id}_${generation}`, []);
       }
     }
   }
@@ -1062,6 +1084,13 @@ export async function startInputIntercept(
   return {
     grab: doGrab,
     release: doRelease,
+    injectNavEvents: (sourceId: string, events: InputEvent[]): void => {
+      // Closed-overlay events are dropped, not queued: the source keeps its
+      // own state and re-baselines on the next open, so a stale press here
+      // would only ever produce a phantom action.
+      if (!intercepting) return;
+      nav.processEvents(`${sourceId}_${generation}`, events);
+    },
     shutdown: () => {
       if (timer) clearInterval(timer);
       timer = null;

--- a/apps/loadout-overlay/src/bun/native/input-intercept.ts
+++ b/apps/loadout-overlay/src/bun/native/input-intercept.ts
@@ -609,6 +609,14 @@ export interface InputInterceptOptions {
    *  state every active tick — key repeat then fires on our 25 ms cadence
    *  instead of depending on the source's own report cadence. */
   externalNavSources?: string[];
+  /** Deck strategy: treat every evdev node of the Deck's built-in controller
+   *  (28de:1205/1206 — raw gamepad + lizard-mode keyboard/mouse emulation)
+   *  as grab-only during intercept. Nav comes from the hidraw reader instead
+   *  (reading the raw gamepad node too would double every input), and
+   *  grabbing the emulation nodes stops lizard-mode kbd/mouse leaking to
+   *  desktop apps behind the overlay — the desktop-mode capture, where
+   *  Steam isn't frozen and consumers read evdev. Default false. */
+  grabDeckBuiltinNodes?: boolean;
 }
 
 export interface InputInterceptHandle {
@@ -647,12 +655,20 @@ export async function startInputIntercept(
   // the Deck-alone case reads; the external-IP-pad case stays grab-only.
   const readVirtualPadsForNav = opts.readVirtualPadsForNav ?? true;
   const externalNavSources = opts.externalNavSources ?? [];
+  const grabDeckBuiltinNodes = opts.grabDeckBuiltinNodes ?? false;
+
+  /** Devices we open at all. Deck built-in nodes include a mouse-only
+   *  emulation node with no controller/keyboard/qam caps — eligible only
+   *  when the Deck strategy wants it for grab-only capture. */
+  const isEligible = (d: InputDevice): boolean =>
+    d.flags.isController ||
+    d.flags.isKeyboard ||
+    d.flags.isQam ||
+    (grabDeckBuiltinNodes && d.isDeckBuiltin);
 
   // Track controllers including the virtual pad; isSteamVirtual only decides
   // read-for-nav vs grab-only below (via `grabOnly` in openAndTrack).
-  const devices = (await enumerateDevices()).filter(
-    (d) => d.flags.isController || d.flags.isKeyboard || d.flags.isQam,
-  );
+  const devices = (await enumerateDevices()).filter(isEligible);
 
   const tracked: TrackedDevice[] = [];
 
@@ -667,7 +683,12 @@ export async function startInputIntercept(
     }
     // A virtual pad is read for nav (grabOnly=false) on the Deck-alone case,
     // or grab-only when an external IP-managed pad drives nav over DBus.
-    const grabOnly = dev.isSteamVirtual && !readVirtualPadsForNav;
+    // On the Deck hidraw-nav strategy, every built-in-controller node (raw
+    // gamepad + lizard kbd/mouse emulation) is also grab-only: hidraw drives
+    // nav, evdev grabs just silence what's underneath.
+    const grabOnly =
+      (dev.isSteamVirtual && !readVirtualPadsForNav) ||
+      (grabDeckBuiltinNodes && dev.isDeckBuiltin);
     // Grab-only virtual pads are never read for nav, so masks + axis
     // calibration are irrelevant — skip them.
     if (!grabOnly) applyIdleMasks(fd, dev);
@@ -686,7 +707,9 @@ export async function startInputIntercept(
     tracked.push(t);
     const kinds = [
       grabOnly
-        ? "virtual(grab-only)"
+        ? dev.isSteamVirtual
+          ? "virtual(grab-only)"
+          : "deck-builtin(grab-only)"
         : dev.flags.isController
           ? "controller"
           : null,
@@ -918,7 +941,9 @@ export async function startInputIntercept(
     nav.reset();
     pendingGrabs.clear();
     for (const t of tracked) {
-      if (!t.dev.flags.isController) continue;
+      // Controllers, plus grab-only non-controllers (Deck lizard kbd/mouse
+      // emulation nodes) — keyboards/qam otherwise stay passive.
+      if (!t.dev.flags.isController && !t.grabOnly) continue;
       // Fresh modifier state each cycle: a guide/select/ctrl release missed
       // last session must not leave guideHeld stuck (→ every B reads as
       // Guide+B → re-toggles the overlay). resyncDeviceState (in grabOrDefer)
@@ -938,7 +963,7 @@ export async function startInputIntercept(
     // Those devices were never grabbed, so the loop below leaves them be.
     pendingGrabs.clear();
     for (const t of tracked) {
-      if (!t.dev.flags.isController) continue;
+      if (!t.dev.flags.isController && !t.grabOnly) continue;
       if (t.grabbed) {
         // Kernel semantics (drivers/input/evdev.c): EVIOCGRAB treats the
         // ioctl arg as a pointer and only checks null-vs-non-null — any
@@ -986,11 +1011,7 @@ export async function startInputIntercept(
       return;
     }
     if (!fresh) return;
-    const eligible =
-      fresh.flags.isController ||
-      fresh.flags.isKeyboard ||
-      fresh.flags.isQam;
-    if (!eligible) return;
+    if (!isEligible(fresh)) return;
     const t = openAndTrack(fresh);
     if (!t) return;
     // If the overlay is open, the new controller has to participate in
@@ -998,7 +1019,7 @@ export async function startInputIntercept(
     // broaden masks + EVIOCGRAB (grab-only virtual pads just get the grab,
     // so a pad's Steam Input virtual node created on connect is silenced too).
     // Keyboards / qam don't get grabbed.
-    if (intercepting && t.dev.flags.isController) {
+    if (intercepting && (t.dev.flags.isController || t.grabOnly)) {
       if (!t.grabOnly) applyInterceptMasks(t.fd);
       grabOrDefer(t);
     }
@@ -1060,16 +1081,12 @@ export async function startInputIntercept(
     const trackedPaths = new Set(tracked.map((t) => t.path));
     for (const dev of all) {
       if (trackedPaths.has(dev.eventPath)) continue;
-      const eligible =
-        dev.flags.isController ||
-        dev.flags.isKeyboard ||
-        dev.flags.isQam;
-      if (!eligible) continue;
+      if (!isEligible(dev)) continue;
       console.log(
         `[input-intercept] reconcile: ${dev.eventPath} '${dev.name}' new — opening`,
       );
       const t = openAndTrack(dev);
-      if (t && intercepting && t.dev.flags.isController) {
+      if (t && intercepting && (t.dev.flags.isController || t.grabOnly)) {
         if (!t.grabOnly) applyInterceptMasks(t.fd);
         grabOrDefer(t);
       }

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "apps/loadout": {
       "name": "@loadout/loadout-server",
-      "version": "0.6.0",
+      "version": "0.7.1",
       "dependencies": {
         "@loadout/exec": "workspace:*",
         "@loadout/game-library": "workspace:*",
@@ -44,9 +44,10 @@
     },
     "apps/loadout-overlay": {
       "name": "@loadout/loadout-overlay",
-      "version": "0.6.0",
+      "version": "0.7.1",
       "dependencies": {
         "@loadout/deck-hid": "workspace:*",
+        "@loadout/devices": "workspace:*",
         "@loadout/exec": "workspace:*",
         "@loadout/plugin-storage": "workspace:*",
         "@loadout/steam-paths": "workspace:*",
@@ -274,6 +275,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@loadout/deck-hid": "workspace:*",
+        "@loadout/devices": "workspace:*",
         "@loadout/exec": "workspace:*",
         "@loadout/plugin-storage": "workspace:*",
         "@loadout/types": "workspace:*",

--- a/packages/deck-hid/src/index.test.ts
+++ b/packages/deck-hid/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   parseHidUEvent,
   isDeckGamepadInterface,
   decodeButtons,
+  decodeNavState,
   diffTransitions,
   splitReports,
   findButton,
@@ -205,5 +206,85 @@ describe("splitReports", () => {
 
   it("yields an empty array for a chunk shorter than one report", () => {
     expect(splitReports(Buffer.alloc(32))).toEqual([]);
+  });
+});
+
+describe("decodeNavState", () => {
+  it("returns null for non-input report ids and short buffers", () => {
+    const wrongId = Buffer.alloc(REPORT_LEN);
+    wrongId[0] = 0x09;
+    expect(decodeNavState(wrongId)).toBeNull();
+    expect(decodeNavState(Buffer.alloc(32))).toBeNull();
+  });
+
+  it("decodes a neutral frame to all-false / centered", () => {
+    const s = decodeNavState(makeReport())!;
+    for (const k of [
+      "a", "b", "x", "y", "l1", "r1",
+      "dpadUp", "dpadDown", "dpadLeft", "dpadRight",
+      "view", "menu", "steam", "qam",
+    ] as const) {
+      expect(s[k]).toBe(false);
+    }
+    expect(s.lx).toBe(0);
+    expect(s.ly).toBe(0);
+    expect(s.rx).toBe(0);
+    expect(s.ry).toBe(0);
+  });
+
+  it("decodes each face/shoulder button bit of byte 8 individually", () => {
+    expect(decodeNavState(makeReport({ 8: 1 << 2 }))!.r1).toBe(true);
+    expect(decodeNavState(makeReport({ 8: 1 << 3 }))!.l1).toBe(true);
+    expect(decodeNavState(makeReport({ 8: 1 << 4 }))!.y).toBe(true);
+    expect(decodeNavState(makeReport({ 8: 1 << 5 }))!.b).toBe(true);
+    expect(decodeNavState(makeReport({ 8: 1 << 6 }))!.x).toBe(true);
+    expect(decodeNavState(makeReport({ 8: 1 << 7 }))!.a).toBe(true);
+  });
+
+  it("decodes each d-pad / system button bit of byte 9 individually", () => {
+    expect(decodeNavState(makeReport({ 9: 1 << 0 }))!.dpadUp).toBe(true);
+    expect(decodeNavState(makeReport({ 9: 1 << 1 }))!.dpadRight).toBe(true);
+    expect(decodeNavState(makeReport({ 9: 1 << 2 }))!.dpadLeft).toBe(true);
+    expect(decodeNavState(makeReport({ 9: 1 << 3 }))!.dpadDown).toBe(true);
+    expect(decodeNavState(makeReport({ 9: 1 << 4 }))!.view).toBe(true);
+    expect(decodeNavState(makeReport({ 9: 1 << 5 }))!.steam).toBe(true);
+    expect(decodeNavState(makeReport({ 9: 1 << 6 }))!.menu).toBe(true);
+  });
+
+  it("decodes the Quick Access button (byte 14 bit 2)", () => {
+    expect(decodeNavState(makeReport({ 14: 1 << 2 }))!.qam).toBe(true);
+  });
+
+  it("agrees with decodeButtons on every overlapping bit", () => {
+    // Cross-validation: the wake table and the nav decoder must never drift.
+    const frame = makeReport({ 8: 0x80, 9: 0x70, 14: 0x04 }); // A, View+Steam+Menu, Qam
+    const wake = decodeButtons(frame)!;
+    const nav = decodeNavState(frame)!;
+    expect(nav.a).toBe(wake.get("A")!);
+    expect(nav.view).toBe(wake.get("View")!);
+    expect(nav.steam).toBe(wake.get("Steam")!);
+    expect(nav.menu).toBe(wake.get("Menu")!);
+    expect(nav.qam).toBe(wake.get("Qam")!);
+  });
+
+  it("normalizes sticks and flips Y to the evdev down-positive convention", () => {
+    const frame = makeReport();
+    frame.writeInt16LE(32767, 48);  // LX full right
+    frame.writeInt16LE(32767, 50);  // LY full up (HID convention)
+    frame.writeInt16LE(-32768, 52); // RX full left
+    frame.writeInt16LE(-32768, 54); // RY full down (HID convention)
+    const s = decodeNavState(frame)!;
+    expect(s.lx).toBeCloseTo(1, 3);
+    expect(s.ly).toBeCloseTo(-1, 3); // up → negative after flip
+    expect(s.rx).toBeCloseTo(-1, 2);
+    expect(s.ry).toBeCloseTo(1, 2);  // down → positive after flip
+    // int16 min overshoots -1 slightly before clamping; verify the clamp.
+    expect(s.rx).toBeGreaterThanOrEqual(-1);
+    expect(s.ry).toBeLessThanOrEqual(1);
+  });
+
+  it("leaves centered sticks at exactly 0", () => {
+    const frame = makeReport({ 8: 0xff });
+    expect(decodeNavState(frame)!.lx).toBe(0);
   });
 });

--- a/packages/deck-hid/src/index.test.ts
+++ b/packages/deck-hid/src/index.test.ts
@@ -20,6 +20,8 @@ import {
   DECK_BUTTONS,
   REPORT_LEN,
   REPORT_ID_INPUT,
+  REPORT_TYPE_DECK_STATE,
+  isDeckStateReport,
 } from "./index";
 
 const JUPITER_GAMEPAD_UEVENT = `\
@@ -113,9 +115,17 @@ describe("findButton", () => {
 /** Build a 64-byte report 0x01 with the given byte overrides. All other bytes
  *  are zero, so the only buttons "set" are the ones the test explicitly
  *  overrides. */
+/** A realistic Deck state frame. The header matters: a real frame is
+ *  `01 00 09 40` — version 0x0001, ucType 0x09 (ID_CONTROLLER_DECK_STATE),
+ *  payload length 0x40. Fixtures used to emit `01 00 00 00`, which no real
+ *  controller sends, so they could not catch the decoder accepting the wrong
+ *  report type. Pass `2: <other>` to forge a different ucType. */
 function makeReport(overrides: Record<number, number> = {}): Buffer {
   const buf = Buffer.alloc(REPORT_LEN);
   buf[0] = REPORT_ID_INPUT;
+  buf[1] = 0x00;
+  buf[2] = REPORT_TYPE_DECK_STATE;
+  buf[3] = 0x40;
   for (const [k, v] of Object.entries(overrides)) {
     buf[parseInt(k, 10)] = v;
   }
@@ -123,9 +133,13 @@ function makeReport(overrides: Record<number, number> = {}): Buffer {
 }
 
 describe("decodeButtons", () => {
-  it("returns null for a non-input report id", () => {
-    const buf = Buffer.alloc(REPORT_LEN);
-    buf[0] = 0x09; // some other report id
+  it("returns null for a non-state report type", () => {
+    // Forge ucType (byte 2), NOT byte 0. Byte 0 is the protocol version and
+    // is 0x01 on every Valve in-report, so a fixture that changed it was
+    // testing a case the hardware never produces — which is how the decoder
+    // shipped accepting every report type.
+    const buf = makeReport({ 2: 0x0b });
+    expect(buf[0]).toBe(REPORT_ID_INPUT); // still a valid-looking header
     expect(decodeButtons(buf)).toBeNull();
   });
 
@@ -210,10 +224,12 @@ describe("splitReports", () => {
 });
 
 describe("decodeNavState", () => {
-  it("returns null for non-input report ids and short buffers", () => {
-    const wrongId = Buffer.alloc(REPORT_LEN);
-    wrongId[0] = 0x09;
-    expect(decodeNavState(wrongId)).toBeNull();
+  it("returns null for non-state report types and short buffers", () => {
+    // A sensor/feature report carries a real header and real-looking payload
+    // bytes; only ucType tells it apart. Decoding one as gamepad state is
+    // what produced phantom presses / stick snaps on a real Deck.
+    const sensors = makeReport({ 2: 0x0b, 8: 0xff, 9: 0xff, 48: 0xff, 49: 0x7f });
+    expect(decodeNavState(sensors)).toBeNull();
     expect(decodeNavState(Buffer.alloc(32))).toBeNull();
   });
 
@@ -286,5 +302,31 @@ describe("decodeNavState", () => {
   it("leaves centered sticks at exactly 0", () => {
     const frame = makeReport({ 8: 0xff });
     expect(decodeNavState(frame)!.lx).toBe(0);
+  });
+});
+
+describe("isDeckStateReport", () => {
+  it("accepts a real state frame header (01 00 09 40)", () => {
+    expect(isDeckStateReport(makeReport())).toBe(true);
+  });
+
+  it("rejects every other ucType while byte 0 still reads 0x01", () => {
+    // The regression guard: byte 0 alone cannot discriminate, so each of
+    // these would have been decoded as gamepad state before the fix.
+    for (const ucType of [0x01, 0x02, 0x0b, 0x0f, 0xff]) {
+      if (ucType === REPORT_TYPE_DECK_STATE) continue;
+      const forged = makeReport({ 2: ucType });
+      expect(forged[0]).toBe(REPORT_ID_INPUT);
+      expect(isDeckStateReport(forged)).toBe(false);
+    }
+  });
+
+  it("rejects a wrong protocol version", () => {
+    expect(isDeckStateReport(makeReport({ 0: 0x02 }))).toBe(false);
+    expect(isDeckStateReport(makeReport({ 1: 0x01 }))).toBe(false);
+  });
+
+  it("rejects a short buffer", () => {
+    expect(isDeckStateReport(Buffer.alloc(REPORT_LEN - 1))).toBe(false);
   });
 });

--- a/packages/deck-hid/src/index.ts
+++ b/packages/deck-hid/src/index.ts
@@ -246,3 +246,83 @@ export function splitReports(chunk: Buffer): Buffer[] {
   }
   return out;
 }
+
+// ── Nav-state decoding (full frame, overlay navigation) ─────────────────────
+//
+// The wake path above only chases single picker-exposed bits. Overlay nav
+// needs the full gamepad-relevant state of report 0x01. Layout references:
+//   - SDL SDL_hidapi_steamdeck.c `SteamDeckStatePacket_t` + STEAMDECK_*BUTTON_*
+//   - InputPlumber drivers/steam_deck/hid_report.rs
+// Both agree with DECK_BUTTONS above on every overlapping bit (A, View,
+// Steam, Menu, L5, R5, L4, R4, Qam), which cross-validates the table.
+//
+// ulButtons is a u64 at offset 8 (little-endian):
+//   byte 8:  bit0 R2 bit1 L2 bit2 R1 bit3 L1 bit4 Y bit5 B bit6 X bit7 A
+//   byte 9:  bit0 Up bit1 Right bit2 Left bit3 Down
+//            bit4 View bit5 Steam bit6 Menu bit7 L5
+//   byte 14: bit2 Quick Access (…)
+// Sticks are int16 LE: LX@48 LY@50 RX@52 RY@54. HID Y is up-positive; the
+// decoder negates it so consumers get the evdev convention (down-positive)
+// the overlay's NavController expects.
+
+/** Full nav-relevant state of one input report. */
+export interface DeckNavState {
+  a: boolean;
+  b: boolean;
+  x: boolean;
+  y: boolean;
+  l1: boolean;
+  r1: boolean;
+  dpadUp: boolean;
+  dpadDown: boolean;
+  dpadLeft: boolean;
+  dpadRight: boolean;
+  view: boolean;
+  menu: boolean;
+  steam: boolean;
+  qam: boolean;
+  /** Left stick, normalized -1..1, evdev sign convention (down/right positive). */
+  lx: number;
+  ly: number;
+  /** Right stick, same conventions. */
+  rx: number;
+  ry: number;
+}
+
+function bit(report: Buffer, byte: number, bitPos: number): boolean {
+  return ((report[byte] ?? 0) & (1 << bitPos)) !== 0;
+}
+
+function stick(report: Buffer, offset: number, negate: boolean): number {
+  const raw = report.readInt16LE(offset);
+  const v = Math.max(-1, Math.min(1, raw / 32767));
+  // `+ 0` normalizes -0 → 0 so centered sticks compare cleanly.
+  return negate ? -v + 0 : v;
+}
+
+/** Decode a single 64-byte input report 0x01 into a DeckNavState. Other
+ *  report ids and short buffers return null so the caller can skip them. */
+export function decodeNavState(report: Buffer): DeckNavState | null {
+  if (report.length < REPORT_LEN) return null;
+  if (report[0] !== REPORT_ID_INPUT) return null;
+  return {
+    r1: bit(report, 8, 2),
+    l1: bit(report, 8, 3),
+    y: bit(report, 8, 4),
+    b: bit(report, 8, 5),
+    x: bit(report, 8, 6),
+    a: bit(report, 8, 7),
+    dpadUp: bit(report, 9, 0),
+    dpadRight: bit(report, 9, 1),
+    dpadLeft: bit(report, 9, 2),
+    dpadDown: bit(report, 9, 3),
+    view: bit(report, 9, 4),
+    steam: bit(report, 9, 5),
+    menu: bit(report, 9, 6),
+    qam: bit(report, 14, 2),
+    lx: stick(report, 48, false),
+    ly: stick(report, 50, true),
+    rx: stick(report, 52, false),
+    ry: stick(report, 54, true),
+  };
+}

--- a/packages/deck-hid/src/index.ts
+++ b/packages/deck-hid/src/index.ts
@@ -30,12 +30,50 @@ const PRODUCT_GALILEO = 0x1206;
  *  presents it that way. External Steam Controllers also bus 0x0003. */
 const BUS_USB = 0x0003;
 
-/** Steam Deck HID gamepad report ID. The hidraw stream interleaves a few
- *  report types; only 0x01 carries button + axis state. */
+/** Byte 0 of every Valve in-report: the low half of `unReportVersion`.
+ *
+ *  NOT a report-type discriminator — it is 0x01 on EVERY in-report the
+ *  controller emits, so testing it alone accepts all of them. The header is
+ *  (per drivers/hid/hid-steam.c):
+ *
+ *      0-1 | always 0x01, 0x00 — protocol version
+ *        2 | ucType — message type   ← the actual discriminator
+ *        3 | payload length
+ *
+ *  Use isDeckStateReport() to select gamepad state frames. */
 export const REPORT_ID_INPUT = 0x01;
+
+/** `ID_CONTROLLER_DECK_STATE` — ucType of the 64-byte gamepad state report.
+ *  Matches `ID_CONTROLLER_DECK_STATE = 9` in hid-steam.c and SDL's
+ *  `k_EDeckStateReport`. */
+export const REPORT_TYPE_DECK_STATE = 0x09;
 
 /** Every input report is 64 bytes. */
 export const REPORT_LEN = 64;
+
+/**
+ * True only for a Steam Deck gamepad-state frame.
+ *
+ * Mirrors the kernel's own gate, which is the authority on this stream:
+ *
+ *     if (size != 64 || data[0] != 1 || data[1] != 0) return 0;
+ *     switch (data[2]) { case ID_CONTROLLER_DECK_STATE: ... }
+ *
+ * Previously every caller tested `report[0] !== REPORT_ID_INPUT`, which is
+ * constant across report types — so any other 64-byte in-report the
+ * controller emitted (Steam Input drives feature reports on this endpoint
+ * concurrently) was decoded as button + stick state. On a real Deck that
+ * surfaces as phantom presses or a stick snap into a freshly-opened overlay,
+ * or a spurious wake toggle while it is closed.
+ */
+export function isDeckStateReport(report: Buffer): boolean {
+  return (
+    report.length >= REPORT_LEN &&
+    report[0] === REPORT_ID_INPUT &&
+    report[1] === 0x00 &&
+    report[2] === REPORT_TYPE_DECK_STATE
+  );
+}
 
 // ── Button bit map (issue #86, verified on a Jupiter Deck) ─────────────────
 
@@ -231,7 +269,7 @@ export interface DeckButtonTransition {
  *  report ids and short buffers return null so the caller can skip them. */
 export function decodeButtons(report: Buffer): Map<string, boolean> | null {
   if (report.length < REPORT_LEN) return null;
-  if (report[0] !== REPORT_ID_INPUT) return null;
+  if (!isDeckStateReport(report)) return null;
   const out = new Map<string, boolean>();
   for (const [byteIdx, defs] of DECK_BUTTONS_BY_BYTE) {
     const v = report[byteIdx] ?? 0;
@@ -325,7 +363,7 @@ function stick(report: Buffer, offset: number, negate: boolean): number {
  *  report ids and short buffers return null so the caller can skip them. */
 export function decodeNavState(report: Buffer): DeckNavState | null {
   if (report.length < REPORT_LEN) return null;
-  if (report[0] !== REPORT_ID_INPUT) return null;
+  if (!isDeckStateReport(report)) return null;
   return {
     r1: bit(report, 8, 2),
     l1: bit(report, 8, 3),

--- a/packages/deck-hid/src/index.ts
+++ b/packages/deck-hid/src/index.ts
@@ -69,6 +69,27 @@ export const DECK_BUTTONS: readonly DeckButton[] = [
   { name: "A", label: "A Button", byte: 8, bit: 7 },
 ];
 
+/** Buttons that must NEVER be bindable as the overlay wake button. Steam and
+ *  Quick Access drive the whole device (Steam menu, QAM, chords) and Steam
+ *  reads them via hidraw concurrently with us — a press reaches Steam live
+ *  before the overlay can freeze it, so binding them means Steam's own menu
+ *  fights the overlay on every wake. They stay in DECK_BUTTONS (the decoder
+ *  and legacy persisted bindings still need their bit positions); every
+ *  binding surface (picker, set, press-to-capture, persisted-state readers)
+ *  must go through BINDABLE_DECK_BUTTONS / isBindableDeckButton instead. */
+export const RESERVED_DECK_BUTTONS: readonly string[] = ["Steam", "Qam"];
+
+/** DECK_BUTTONS minus the reserved system buttons — the only valid wake
+ *  binding candidates. */
+export const BINDABLE_DECK_BUTTONS: readonly DeckButton[] = DECK_BUTTONS.filter(
+  (b) => !RESERVED_DECK_BUTTONS.includes(b.name),
+);
+
+export function isBindableDeckButton(name: string | null): boolean {
+  if (!name) return false;
+  return BINDABLE_DECK_BUTTONS.some((b) => b.name === name);
+}
+
 /** Lookup index for parsing — byte → list of (bit, name). Built once, reused
  *  by frame-decode hot path. */
 export const DECK_BUTTONS_BY_BYTE: ReadonlyMap<number, ReadonlyArray<{ bit: number; name: string }>> =

--- a/packages/devices/src/dmi.test.ts
+++ b/packages/devices/src/dmi.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "bun:test";
+import { isApexDmi, isSteamDeckDmi } from "./dmi";
+
+describe("isSteamDeckDmi", () => {
+  it("matches the Deck LCD (Jupiter)", () => {
+    expect(isSteamDeckDmi({ sysVendor: "Valve", productName: "Jupiter" })).toBe(true);
+  });
+
+  it("matches the Deck OLED (Galileo)", () => {
+    expect(isSteamDeckDmi({ sysVendor: "Valve", productName: "Galileo" })).toBe(true);
+  });
+
+  it("falls back to a Valve sys_vendor for unknown future products", () => {
+    expect(isSteamDeckDmi({ sysVendor: "Valve", productName: "Somethingnew" })).toBe(true);
+  });
+
+  it("rejects non-Deck handhelds", () => {
+    expect(
+      isSteamDeckDmi({ sysVendor: "ONE-NETBOOK", productName: "ONEXPLAYER APEX 1 ABXX" }),
+    ).toBe(false);
+    expect(isSteamDeckDmi({ sysVendor: "ASUSTeK COMPUTER INC.", productName: "RC73X" })).toBe(
+      false,
+    );
+  });
+
+  it("rejects empty DMI (unreadable /sys)", () => {
+    expect(isSteamDeckDmi({ sysVendor: "", productName: "" })).toBe(false);
+  });
+});
+
+describe("isApexDmi", () => {
+  it("still matches the APEX and rejects the Deck", () => {
+    expect(isApexDmi({ sysVendor: "ONE-NETBOOK", productName: "ONEXPLAYER APEX 1" })).toBe(true);
+    expect(isApexDmi({ sysVendor: "Valve", productName: "Jupiter" })).toBe(false);
+  });
+});

--- a/packages/devices/src/dmi.ts
+++ b/packages/devices/src/dmi.ts
@@ -42,3 +42,17 @@ export function isApexDmi(info: DmiInfo): boolean {
 export async function isApex(): Promise<boolean> {
   return isApexDmi(await readDmi());
 }
+
+/** Steam Deck DMI signatures (product_name): Jupiter = LCD, Galileo = OLED.
+ *  Same identifiers tdp-control uses. A Valve sys_vendor is accepted as a
+ *  belt-and-braces fallback for future Deck revisions. */
+const DECK_PRODUCTS = ["Jupiter", "Galileo"];
+
+export function isSteamDeckDmi(info: DmiInfo): boolean {
+  if (DECK_PRODUCTS.some((p) => info.productName.includes(p))) return true;
+  return info.sysVendor.includes("Valve");
+}
+
+export async function isSteamDeck(): Promise<boolean> {
+  return isSteamDeckDmi(await readDmi());
+}

--- a/plugins/input-plumber/lib/wake-trigger-deck.test.ts
+++ b/plugins/input-plumber/lib/wake-trigger-deck.test.ts
@@ -16,7 +16,12 @@ import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as exec from "@loadout/exec";
 import { EventEmitter } from "node:events";
-import { captureWakeButton, ensureDeckHidrawUaccess } from "./wake-trigger-deck";
+import {
+  captureWakeButton,
+  ensureDeckHidrawUaccess,
+  getWakeStatus,
+  setWakeButton,
+} from "./wake-trigger-deck";
 import {
   DECK_HIDRAW_UACCESS_RULE,
   DECK_HIDRAW_UACCESS_RULE_PATH,
@@ -79,11 +84,31 @@ describe("captureWakeButton (Deck)", () => {
     const p = captureWakeButton(5000);
     await tick();
     stream.push(frame()); // idle baseline
-    stream.push(frame({ 9: 0x20 })); // Steam press
+    stream.push(frame({ 13: 0x04 })); // R4 press
     const r = await p;
     expect(r.ok).toBe(true);
-    expect(r.capturedRaw).toBe("deck:Steam");
-    expect(store["input-plumber"].wake.selectedRaw).toBe("deck:Steam");
+    expect(r.capturedRaw).toBe("deck:R4");
+    expect(store["input-plumber"].wake.selectedRaw).toBe("deck:R4");
+    expect(storage.writePluginStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores reserved Steam/Qam presses and captures the next bindable press", async () => {
+    // Steam and Quick Access are system buttons — pressing them mid-capture
+    // must not bind them (Steam reacts to them live via its own hidraw fd,
+    // so a wake bound there fights Steam's menus on every open).
+    const stream = fakeStream();
+    setup(stream);
+    const p = captureWakeButton(5000);
+    await tick();
+    stream.push(frame()); // idle baseline
+    stream.push(frame({ 9: 0x20 })); // Steam press — reserved, ignored
+    stream.push(frame()); // release
+    stream.push(frame({ 14: 0x04 })); // Qam press — reserved, ignored
+    stream.push(frame()); // release
+    stream.push(frame({ 10: 0x01 })); // R5 press — bindable, captured
+    const r = await p;
+    expect(r.ok).toBe(true);
+    expect(r.capturedRaw).toBe("deck:R5");
     expect(storage.writePluginStorage).toHaveBeenCalledTimes(1);
   });
 
@@ -92,14 +117,14 @@ describe("captureWakeButton (Deck)", () => {
     setup(stream);
     const p = captureWakeButton(5000);
     await tick();
-    const nonInput = frame({ 9: 0x20 });
+    const nonInput = frame({ 13: 0x04 });
     nonInput[0] = 0x09; // not an input report
     stream.push(nonInput);
     // No capture yet — a real press still wins afterwards.
-    stream.push(frame({ 14: 0x04 })); // Qam press (real input report)
+    stream.push(frame({ 10: 0x01 })); // R5 press (real input report)
     const r = await p;
     expect(r.ok).toBe(true);
-    expect(r.capturedRaw).toBe("deck:Qam");
+    expect(r.capturedRaw).toBe("deck:R5");
   });
 
   it("ignores a second press after commit (no double write)", async () => {
@@ -108,11 +133,11 @@ describe("captureWakeButton (Deck)", () => {
     const p = captureWakeButton(5000);
     await tick();
     stream.push(frame()); // idle
-    stream.push(frame({ 9: 0x20 })); // Steam press → commit
+    stream.push(frame({ 13: 0x04 })); // R4 press → commit
     stream.push(frame()); // release
-    stream.push(frame({ 14: 0x04 })); // Qam press AFTER commit — ignored
+    stream.push(frame({ 10: 0x01 })); // R5 press AFTER commit — ignored
     const r = await p;
-    expect(r.capturedRaw).toBe("deck:Steam");
+    expect(r.capturedRaw).toBe("deck:R4");
     expect(storage.writePluginStorage).toHaveBeenCalledTimes(1);
   });
 
@@ -157,10 +182,10 @@ describe("captureWakeButton (Deck)", () => {
     const p2 = captureWakeButton(5000);
     await tick();
     stream.push(frame()); // idle baseline
-    stream.push(frame({ 9: 0x20 })); // Steam press
+    stream.push(frame({ 13: 0x04 })); // R4 press
     const [r1, r2] = await Promise.all([p1, p2]);
     expect(r1.ok).toBe(true);
-    expect(r1.capturedRaw).toBe("deck:Steam");
+    expect(r1.capturedRaw).toBe("deck:R4");
     // Both callers see the same result envelope (same object reference,
     // since the inner Promise is shared via the gate).
     expect(r2).toBe(r1);
@@ -277,5 +302,50 @@ describe("ensureDeckHidrawUaccess", () => {
     // load on local-dev runs (where the user isn't root).
     await expect(ensureDeckHidrawUaccess()).resolves.toBeUndefined();
     for (const s of spies) s.mockRestore();
+  });
+});
+
+describe("reserved system buttons (Steam / Qam)", () => {
+  it("the picker options exclude Steam and Qam but keep every other button", async () => {
+    const stream = fakeStream();
+    setup(stream);
+    const status = await getWakeStatus();
+    const names = status.devices[0]!.buttons.map((b) => b.name);
+    expect(names).not.toContain("Steam");
+    expect(names).not.toContain("Qam");
+    expect(names).toEqual(
+      expect.arrayContaining(["View", "Menu", "L4", "L5", "R4", "R5", "A"]),
+    );
+  });
+
+  it("setWakeButton rejects a reserved button with a friendly error", async () => {
+    const stream = fakeStream();
+    setup(stream);
+    for (const raw of ["deck:Steam", "deck:Qam"]) {
+      const r = await setWakeButton(raw);
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("reserved");
+    }
+    expect(storage.writePluginStorage).toHaveBeenCalledTimes(0);
+    // A bindable button still works.
+    const ok = await setWakeButton("deck:R4");
+    expect(ok.ok).toBe(true);
+    expect(store["input-plumber"].wake.selectedRaw).toBe("deck:R4");
+  });
+
+  it("getWakeStatus reports a stale persisted reserved binding as unbound", async () => {
+    // A user could have bound Steam/Qam before they were blocked. The stored
+    // value must read back as "nothing bound" (the overlay watcher filters it
+    // too) without rewriting storage from a read path.
+    const stream = fakeStream();
+    setup(stream);
+    store["input-plumber"] = {
+      wake: { selectedRaw: "deck:Steam", deviceName: "Steam Deck Controller" },
+    };
+    const status = await getWakeStatus();
+    expect(status.selectedRaw).toBeNull();
+    expect(storage.writePluginStorage).toHaveBeenCalledTimes(0);
+    // Storage itself is untouched (inert, not clobbered).
+    expect(store["input-plumber"].wake.selectedRaw).toBe("deck:Steam");
   });
 });

--- a/plugins/input-plumber/lib/wake-trigger-deck.test.ts
+++ b/plugins/input-plumber/lib/wake-trigger-deck.test.ts
@@ -2,7 +2,7 @@
  * Tests for the Deck press-to-capture path. Stubs findDeckHidrawPath +
  * createReadStream + plugin-storage so no real Deck / fs is needed. Covers:
  *   - a real 0→1 press captures and persists the binding
- *   - non-input (non-0x01) report frames are ignored even with the bit set
+ *   - non-state report types (ucType != 0x09) are ignored even with the bit set
  *   - a button already held when capture starts doesn't auto-fire
  *   - a second press after commit is ignored (no double write / re-entrancy)
  *   - timeout returns timedOut:true and leaves an existing binding intact
@@ -28,9 +28,13 @@ import {
 } from "./profile";
 
 /** Deck input report (id 0x01, REPORT_LEN bytes) with optional byte overrides. */
+/** Realistic Deck state frame — header `01 00 09 40`. */
 function frame(overrides: Record<number, number> = {}): Buffer {
   const b = Buffer.alloc(REPORT_LEN);
   b[0] = REPORT_ID_INPUT;
+  b[1] = 0x00;
+  b[2] = 0x09;
+  b[3] = 0x40;
   for (const [k, v] of Object.entries(overrides)) b[parseInt(k, 10)] = v;
   return b;
 }
@@ -112,13 +116,13 @@ describe("captureWakeButton (Deck)", () => {
     expect(storage.writePluginStorage).toHaveBeenCalledTimes(1);
   });
 
-  it("ignores non-input report frames even when the bit is set", async () => {
+  it("ignores non-state report types even when the bit is set", async () => {
     const stream = fakeStream();
     setup(stream);
     const p = captureWakeButton(5000);
     await tick();
-    const nonInput = frame({ 13: 0x04 });
-    nonInput[0] = 0x09; // not an input report
+    // Forge ucType (byte 2), not byte 0 — byte 0 is 0x01 on every in-report.
+    const nonInput = frame({ 13: 0x04, 2: 0x0b });
     stream.push(nonInput);
     // No capture yet — a real press still wins afterwards.
     stream.push(frame({ 10: 0x01 })); // R5 press (real input report)

--- a/plugins/input-plumber/lib/wake-trigger-deck.ts
+++ b/plugins/input-plumber/lib/wake-trigger-deck.ts
@@ -32,6 +32,8 @@ import { runFull } from "@loadout/exec";
 import { readPluginStorage, writePluginStorage } from "@loadout/plugin-storage";
 import {
   DECK_BUTTONS,
+  BINDABLE_DECK_BUTTONS,
+  isBindableDeckButton,
   findButton,
   findDeckHidrawPath,
   splitReports,
@@ -93,11 +95,12 @@ function rawToButton(raw: string | null | undefined): DeckButton | null {
   return findButton(raw.slice(DECK_RAW_PREFIX.length));
 }
 
-/** WakeButtonOption rows for the picker. All Deck candidates are
- *  recommended — the gameplay-buttons exclusion that exists for IP
- *  doesn't apply (DECK_BUTTONS already filters to safe choices). */
+/** WakeButtonOption rows for the picker. Only BINDABLE buttons are offered —
+ *  Steam/Qam are reserved system buttons (they drive Steam's own menus and
+ *  Steam sees their presses live via hidraw before any freeze). All
+ *  remaining candidates are recommended. */
 function deckButtonOptions(): WakeButtonOption[] {
-  return DECK_BUTTONS.map((b) => ({
+  return BINDABLE_DECK_BUTTONS.map((b) => ({
     raw: buttonToRaw(b),
     name: b.name,
     category: "deck",
@@ -113,6 +116,16 @@ export async function getWakeStatus(): Promise<WakeStatus> {
   const devices: WakeStatusDevice[] = [
     { name: DECK_DEVICE_NAME, buttons: deckButtonOptions() },
   ];
+  // Sanitize a stale reserved binding (Steam/Qam were bindable before they
+  // were blocked): report it as unbound so the picker shows "Set wake
+  // button" instead of a selection that no longer exists in the options.
+  // The overlay watcher applies the same filter, so the stored value is
+  // inert either way; we deliberately don't rewrite storage from a read.
+  const storedButton = rawToButton(wake?.selectedRaw);
+  const selectedRaw =
+    storedButton && !isBindableDeckButton(storedButton.name)
+      ? null
+      : (wake?.selectedRaw ?? null);
   // ipActive:true is a UI hint — it tells the picker that bind/capture are
   // immediately usable. There's no IP daemon involved; the field's contract
   // in shared.ts is "the picker can act", which is true here.
@@ -120,7 +133,7 @@ export async function getWakeStatus(): Promise<WakeStatus> {
     ipActive: true,
     isDeck: true,
     devices,
-    selectedRaw: wake?.selectedRaw ?? null,
+    selectedRaw,
     hasLegacyProfile: false,
   };
 }
@@ -194,6 +207,12 @@ export async function setWakeButton(raw: string): Promise<WakeOpResult> {
     return {
       ok: false,
       error: `Unknown Deck button identifier: ${raw}`,
+    };
+  }
+  if (!isBindableDeckButton(btn.name)) {
+    return {
+      ok: false,
+      error: `${btn.label} is reserved for Steam system functions and cannot be used as the wake button.`,
     };
   }
   await writeWake({ selectedRaw: buttonToRaw(btn), deviceName: DECK_DEVICE_NAME });
@@ -329,6 +348,9 @@ async function captureInner(timeoutMs: number): Promise<WakeCaptureResult> {
       for (const report of splitReports(buf)) {
         // Only report id 0x01 carries button state; skip interleaved frames.
         if (report[0] !== REPORT_ID_INPUT) continue;
+        // Edge state is tracked for ALL buttons (a reserved press must still
+        // update its held memory), but only BINDABLE ones can be captured —
+        // pressing Steam/Qam mid-capture is ignored and the wait continues.
         for (const b of DECK_BUTTONS) {
           // splitReports only yields full REPORT_LEN (64-byte) frames and
           // b.byte is always < 64, so this index is provably in-bounds;
@@ -336,7 +358,9 @@ async function captureInner(timeoutMs: number): Promise<WakeCaptureResult> {
           const cur = ((report[b.byte] ?? 0) & (1 << b.bit)) !== 0;
           const prevHeld = held.get(b.name) ?? false;
           held.set(b.name, cur);
-          if (cur && !prevHeld && !pressed) pressed = b;
+          if (cur && !prevHeld && !pressed && isBindableDeckButton(b.name)) {
+            pressed = b;
+          }
         }
         if (pressed) break;
       }

--- a/plugins/input-plumber/lib/wake-trigger-deck.ts
+++ b/plugins/input-plumber/lib/wake-trigger-deck.ts
@@ -37,9 +37,9 @@ import {
   findButton,
   findDeckHidrawPath,
   splitReports,
-  REPORT_ID_INPUT,
   REPORT_LEN,
   type DeckButton,
+  isDeckStateReport,
 } from "@loadout/deck-hid";
 import {
   DECK_HIDRAW_UACCESS_RULE,
@@ -347,7 +347,7 @@ async function captureInner(timeoutMs: number): Promise<WakeCaptureResult> {
       let pressed: DeckButton | null = null;
       for (const report of splitReports(buf)) {
         // Only report id 0x01 carries button state; skip interleaved frames.
-        if (report[0] !== REPORT_ID_INPUT) continue;
+        if (!isDeckStateReport(report)) continue;
         // Edge state is tracked for ALL buttons (a reserved press must still
         // update its held memory), but only BINDABLE ones can be captured —
         // pressing Steam/Qam mid-capture is ignored and the wait continues.

--- a/plugins/input-plumber/lib/wake-trigger.test.ts
+++ b/plugins/input-plumber/lib/wake-trigger.test.ts
@@ -328,9 +328,11 @@ describe("wake-trigger orchestration", () => {
     expect(status.devices).toHaveLength(1);
     expect(status.devices[0].name).toBe("Steam Deck Controller");
     const names = status.devices[0].buttons.map((b) => b.name).sort();
-    expect(names).toContain("Steam");
-    expect(names).toContain("Qam");
+    // Steam/Qam are reserved system buttons — never offered as bindings.
+    expect(names).not.toContain("Steam");
+    expect(names).not.toContain("Qam");
     expect(names).toContain("L4");
+    expect(names).toContain("R4");
     // All buttons are flagged as recommended on Deck.
     expect(status.devices[0].buttons.every((b) => b.recommended)).toBe(true);
     // No busctl/systemctl/udevadm — the Deck path is pure.
@@ -343,13 +345,13 @@ describe("wake-trigger orchestration", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     spawnSpy = spyOn(Bun, "spawn").mockImplementation(stub as any);
 
-    const r = await setWakeButton("deck:Steam");
+    const r = await setWakeButton("deck:R4");
     expect(r.ok).toBe(true);
 
     const persisted = storage.get("input-plumber") as {
       wake?: { selectedRaw?: string; deviceName?: string };
     };
-    expect(persisted.wake?.selectedRaw).toBe("deck:Steam");
+    expect(persisted.wake?.selectedRaw).toBe("deck:R4");
     expect(persisted.wake?.deviceName).toBe("Steam Deck Controller");
     // No profile file written, no busctl/systemctl/udevadm.
     expect(writtenFiles.size).toBe(0);

--- a/plugins/input-plumber/lib/wake-trigger.ts
+++ b/plugins/input-plumber/lib/wake-trigger.ts
@@ -79,24 +79,10 @@ async function writeWake(wake: WakeState["wake"]): Promise<void> {
 
 // ── device detection ────────────────────────────────────────────────────────
 
-/** Steam Deck DMI signatures (product_name). Same identifiers tdp-control
- *  uses. We also accept a Valve sys_vendor as a belt-and-braces fallback. */
-const DECK_PRODUCTS = ["Jupiter", "Galileo"];
-
-async function readSysAttr(path: string): Promise<string> {
-  try {
-    return (await readFile(path, "utf-8")).trim();
-  } catch {
-    return "";
-  }
-}
-
-export async function isSteamDeck(): Promise<boolean> {
-  const product = await readSysAttr("/sys/class/dmi/id/product_name");
-  if (DECK_PRODUCTS.some((p) => product.includes(p))) return true;
-  const vendor = await readSysAttr("/sys/class/dmi/id/sys_vendor");
-  return vendor.includes("Valve");
-}
+/** Canonical DMI probe lives in @loadout/devices; re-exported so backend.ts
+ *  and the Deck submodule keep importing from here unchanged. */
+import { isSteamDeck } from "@loadout/devices";
+export { isSteamDeck };
 
 // ── status ──────────────────────────────────────────────────────────────────
 

--- a/plugins/input-plumber/package.json
+++ b/plugins/input-plumber/package.json
@@ -10,7 +10,8 @@
     "@loadout/types": "workspace:*",
     "@loadout/exec": "workspace:*",
     "@loadout/plugin-storage": "workspace:*",
-    "@loadout/deck-hid": "workspace:*"
+    "@loadout/deck-hid": "workspace:*",
+    "@loadout/devices": "workspace:*"
   },
   "plugin": {
     "id": "input-plumber",


### PR DESCRIPTION
## Problem

On Steam Deck the overlay never captured the controller:

- Steam reads the built-in controller (and external pads) via **hidraw**, which `EVIOCGRAB` cannot intercept — Steam BPM / Steam-Input-fed games kept responding behind the open overlay.
- In BPM home there isn't even an evdev nav source: the virtual X360 pad (`28de:11ff`) only exists while a game runs, so the overlay opened with **zero nav** (`input intercept ready — 0 controller(s)`).
- The strategy was inferred from IP absence (`readVirtualPadsForNav = !ipHandle.available`) rather than platform detection.

## Fix

New pure `decideInputStrategy()` (`apps/loadout-overlay/src/bun/lib/input-strategy.ts`) picks per host:

| Host | Nav source | Capture | Freeze |
|---|---|---|---|
| IP-managed (OXP APEX…) | IP DBus stream | InterceptMode + grabs | ON (**unchanged**) |
| **Deck, watcher OK** | **our own hidraw read** | built-in nodes + virtual pad grab-only, Steam SIGSTOP in game mode | **ON** |
| Deck, watcher failed / `DECK_OVERLAY_DECK_CAPTURE=0` | virtual pad (legacy) | evdev grabs only | OFF (exact legacy) |
| other hosts | evdev read+grab | evdev grabs | OFF |

- `packages/deck-hid`: `decodeNavState()` — full 64-byte report decode (buttons, d-pad, sticks), offsets cross-validated against SDL `SteamDeckStatePacket_t` / InputPlumber `hid_report.rs` and the repo's Jupiter-verified `DECK_BUTTONS`.
- `deck-hidraw-watcher`: wake path untouched; new nav mode (`setNavActive`) emits NavController-shaped events with a silent first-frame baseline (held wake button can't fire into a fresh overlay).
- `input-intercept`: `injectNavEvents()` external-source entry with grab-generation isolation + 25 ms repeat pump; `grabDeckBuiltinNodes` makes every `28de:1205/1206` node grab-only (incl. mouse-only lizard nodes — **desktop-mode capture**, since desktop consumers read evdev; also prevents raw-gamepad-node double-fire when Steam isn't running).
- Steam freeze on Deck is gated on the hidraw watcher having actually opened — a failed watcher falls back wholesale to today's behavior.
- Steam/QAM are blocked as wake bindings (`d07a1af`): they're reserved system buttons that Steam sees live via hidraw before any freeze. The picker no longer offers them, `setWakeButton` rejects them, and a binding persisted before the block is treated as unbound. **Deck-only** — the IP capability picker is untouched.
- `isSteamDeck()` centralized in `@loadout/devices` (was private to the input-plumber plugin).

**Works in Steam menus (no game running), in-game, and desktop mode; external wireless pads keep the evdev grab+read path and are silenced behind the overlay by the freeze.** InputPlumber-managed hosts are behaviorally untouched.

Kill switches: `DECK_OVERLAY_DECK_CAPTURE=0` (whole Deck strategy), `DECK_OVERLAY_SUSPEND_STEAM=1/0` (freeze override, pre-existing).

## Hardening (`27fdbbb`, after the first review round)

1. **Resume-burst:** Steam's hidraw fd keeps the *first* ~64 reports after the SIGSTOP, so SIGCONT replayed the wake-release edge into the game. On a frozen-Deck close the evdev release is deferred until SIGCONT + 500 ms; reopen inside the window cancels + flushes. Steam-BPM-side replay is unblockable — paddle wake bindings (R4/L4/…) avoid it.
2. **Watcher death mid-session** left freeze+grab armed with zero nav. `isAlive()`/`onDeath` now force-close and exit so systemd restarts and startup re-derives the strategy.
3. **Guide+B wake on Deck** — combo wake detection keeps running on grab-only controller nodes under the Deck strategy only (IP hosts unchanged; a mirror would double-toggle).
4. **Right-stick jitter** — 0.10 dead-band before quantization (evdev gets this free from kernel fuzz filtering; raw hidraw must do its own).

## Verification

**Counts (measured, not estimated):** 8 commits. Across the 8 touched test files: **163 tests pass, 112 of which exist on `main` → 51 net-new.** (An earlier revision of this description said "66 new tests" — that was wrong.) `bun run typecheck` clean; `eslint` clean apart from 3 warnings in test files.

**On-device, OXP APEX / SteamOS (non-Deck, InputPlumber host) — built and installed from this branch:**

```
[overlay] ip intercept ready — 1 composite device(s)
[overlay] ip intercept ACTIVE — using InterceptMode + DBus nav
[overlay] input strategy: deckNav=OFF steam-freeze=ON readVirtualPads=false
          (isDeck=false, ipManaged=true, hidraw=false, env: suspend=auto, deckCapture=auto)
[overlay] input intercept ready — 0 controller(s), 4 keyboard(s), 4 qam device(s) (readVirtualPadsForNav=false)
```

Byte-identical device counts and freeze decision vs the pre-PR build on the same hardware. No `[deck-hidraw]` lines, no `deck-builtin(grab-only)` devices. Also verified live on that host: `findDeckHidrawPath()` → `null` in 2.7 ms, `isSteamDeck()` → `false`, and `decideInputStrategy` reduces to main's exact values both with IP up and with IP down.

**Not verified:** everything Deck-specific. The hidraw nav decode, the lizard-node grabs, the Steam freeze on Deck, and the resume-burst deferred release all need real Jupiter/Galileo hardware. That is where the risk in this PR lives.

## Known accepted (documented, not fixed)

- Overlay opened before startup discovery completes is touch-only until close/reopen (pre-existing on `main`; window slightly wider).
- A wake press inside the 600 ms toggle debounce can leak one nav edge.
- Steam's live reaction to the *opening* wake press for non-paddle bindings.
- The grab/release loops assume every `28de:11ff` node has controller capabilities. True in the field — verified on the APEX, which exposes exactly one `11ff` node (`Microsoft X-Box 360 pad 0`, controller caps). A hypothetical `11ff` keyboard-only node would now be grabbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQhZsmqN35EXd2XUoUzNWF