### PR TITLE
fix(overlay): retry transient plugin-bundle fetches

### DIFF
--- a/apps/loadout-overlay/src/overlay/hooks/usePluginIcons.ts
+++ b/apps/loadout-overlay/src/overlay/hooks/usePluginIcons.ts
@@ -38,8 +38,14 @@ async function loadIcon(pluginId: string): Promise<PluginIconComponent | null> {
       iconCache.set(pluginId, icon);
       return icon;
     } catch (err) {
+      // Deliberately NOT cached. `iconCache` has no invalidation, so caching
+      // a failure here burns the icon to the letter fallback for the whole
+      // page lifetime — and the overlay window is shown/hidden, never
+      // reloaded, so that means the whole session. A transient fetch failure
+      // (see fetchBundleSource: a network-change socket-pool flush during
+      // boot) must stay retryable on the next sidebar mount. Only the success
+      // path caches, where `null` legitimately means "plugin exports no icon".
       console.warn(`[usePluginIcons] Failed to load icon for ${pluginId}:`, err);
-      iconCache.set(pluginId, null);
       return null;
     } finally {
       inFlight.delete(pluginId);

--- a/apps/loadout-overlay/src/overlay/hooks/usePlugins.ts
+++ b/apps/loadout-overlay/src/overlay/hooks/usePlugins.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { authHeaders, apiUrl } from "../lib/backend";
+import { exponentialDelays, retryAsync } from "../lib/retry";
 import { onConnect, subscribe } from "@loadout/ui/ws-client";
 
 export interface PluginInfo {
@@ -63,18 +64,24 @@ function usePluginList(path: string) {
 
   useEffect(() => {
     let cancelled = false;
-    let retryTimer: ReturnType<typeof setTimeout>;
 
-    async function fetchWithRetry(attempt = 0) {
-      if (cancelled) return;
-      const ok = await fetchPlugins();
-      if (!ok && !cancelled) {
-        const delay = Math.min(1000 * 2 ** attempt, 10000);
-        retryTimer = setTimeout(() => fetchWithRetry(attempt + 1), delay);
-      }
-    }
-
-    fetchWithRetry();
+    // Unbounded backoff: the sidebar is useless without a plugin list, so
+    // there's no failure path worth surfacing — keep waiting for the server.
+    // `shouldContinue` is what makes this safe in an effect: it's checked
+    // before every attempt AND after every wait, so an unmount stops the
+    // chain without firing another request.
+    void retryAsync({
+      label: "[overlay] plugin list",
+      delays: exponentialDelays({ base: 1000, cap: 10000 }),
+      isRetriable: () => true,
+      shouldContinue: () => !cancelled,
+      run: async () => {
+        if (!(await fetchPlugins())) throw new Error("plugin list fetch failed");
+      },
+    }).catch(() => {
+      // Only reachable via cancellation (unmount) — fetchPlugins already
+      // logged anything worth seeing.
+    });
 
     // Re-fetch whenever the WebSocket (re)connects — server is up
     const unsub = onConnect(() => {
@@ -93,7 +100,6 @@ function usePluginList(path: string) {
 
     return () => {
       cancelled = true;
-      clearTimeout(retryTimer);
       unsub();
       unsubChanged();
     };

--- a/apps/loadout-overlay/src/overlay/lib/backend.test.ts
+++ b/apps/loadout-overlay/src/overlay/lib/backend.test.ts
@@ -25,7 +25,13 @@ let calls: string[] = [];
 let origFetch: unknown;
 
 /** Queue a scripted sequence of outcomes, one per fetch attempt. Errors are
- *  thrown (network layer); Responses are returned (HTTP layer). */
+ *  thrown (network layer); Responses are returned (HTTP layer). The last
+ *  entry repeats forever, so "fails and keeps failing" is one entry.
+ *
+ *  Footgun: repeating an entry hands back the SAME Response object, so a
+ *  script whose repeated entry is an `ok()` would throw "Body already used"
+ *  on the second read. Only repeat entries whose body is never read (errors,
+ *  or non-2xx, which short-circuit before `.text()`). */
 function scriptFetch(results: FetchResult[]): void {
   let i = 0;
   (globalThis as { fetch: unknown }).fetch = (url: string) => {
@@ -115,10 +121,54 @@ describe("fetchBundleSource", () => {
     }
   });
 
-  it("waits the configured backoff between attempts", async () => {
-    scriptFetch([networkChanged(), ok("slow")]);
+  it("uses the ladder rungs in order, not some other index", async () => {
+    // Two rungs, far apart, with BOTH bounds asserted. A single-rung test
+    // can't catch an off-by-one: `delays[attempt]` would read past the end,
+    // and any fallback (or a re-read of the wrong rung) still "waits a bit".
+    // Failing twice forces both rungs to be paid — 40 + 250 = 290ms — so
+    // reading the wrong index lands outside the window.
+    scriptFetch([networkChanged(), networkChanged(), ok("third time")]);
     const t0 = performance.now();
-    await fetchBundleSource({ pluginId: "network-info", delays: [60] });
-    expect(performance.now() - t0).toBeGreaterThanOrEqual(50);
+    const text = await fetchBundleSource({
+      pluginId: "network-info",
+      delays: [40, 250],
+    });
+    const elapsed = performance.now() - t0;
+    expect(text).toBe("third time");
+    expect(elapsed).toBeGreaterThanOrEqual(280);
+    // Generous headroom for scheduler jitter, but far below 40+40 (wrong rung
+    // reused), 250+250, or a 1000ms fallback creeping in.
+    expect(elapsed).toBeLessThan(700);
+  });
+
+  it("keeps the HTTP status in the error when a 5xx exhausts the ladder", async () => {
+    // Guards the `lastErr = err` on the 5xx branch: without it the rejection
+    // degrades to "…: undefined" and the status — the only diagnostic the
+    // user ever sees — is lost.
+    scriptFetch([status(503)]);
+    await expect(
+      fetchBundleSource({ pluginId: "storage", delays: NO_DELAY }),
+    ).rejects.toThrow("HTTP 503");
+    expect(calls.length).toBe(NO_DELAY.length + 1);
+  });
+
+  it("retries a body that dies mid-stream after headers arrived", async () => {
+    const truncated = {
+      ok: true,
+      status: 200,
+      text: () => Promise.reject(new TypeError("Failed to fetch")),
+    } as unknown as Response;
+    scriptFetch([truncated, ok("intact")]);
+    const text = await fetchBundleSource({ pluginId: "hltb", delays: NO_DELAY });
+    expect(text).toBe("intact");
+    expect(calls.length).toBe(2);
+  });
+
+  it("makes exactly one attempt when the ladder is empty", async () => {
+    scriptFetch([networkChanged()]);
+    await expect(
+      fetchBundleSource({ pluginId: "apex", delays: [] }),
+    ).rejects.toThrow("Failed to fetch");
+    expect(calls.length).toBe(1);
   });
 });

--- a/apps/loadout-overlay/src/overlay/lib/backend.test.ts
+++ b/apps/loadout-overlay/src/overlay/lib/backend.test.ts
@@ -1,0 +1,124 @@
+// Unit tests for the plugin-bundle fetch retry in lib/backend.ts.
+//
+// The bug this covers: the overlay fires every plugin's bundle fetch in
+// parallel ~3 ms into page load. On a handheld booting straight into gaming
+// mode, Wi-Fi is often still associating right then — the interface goes
+// active, Chromium flushes its socket pool, and every in-flight request dies
+// with ERR_NETWORK_CHANGED (a bare `TypeError: Failed to fetch` in JS).
+// Nothing re-requested them, so those plugins' widgets and icons stayed dead
+// for the whole session. Observed live: 8 bundles landed before the flush, 17
+// died; the identical fetches all succeeded seconds later.
+//
+// importPluginBundle itself isn't unit-tested here — it evaluates the bundle
+// via `import()` of a blob: URL, which needs a real browser module loader.
+// fetchBundleSource holds all the retry logic, so it's the unit under test.
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { fetchBundleSource } from "./backend";
+
+// No real backoff — the ladder's *shape* is what matters, not the wall time.
+const NO_DELAY = [0, 0, 0] as const;
+
+type FetchResult = Response | Error;
+
+let calls: string[] = [];
+let origFetch: unknown;
+
+/** Queue a scripted sequence of outcomes, one per fetch attempt. Errors are
+ *  thrown (network layer); Responses are returned (HTTP layer). */
+function scriptFetch(results: FetchResult[]): void {
+  let i = 0;
+  (globalThis as { fetch: unknown }).fetch = (url: string) => {
+    calls.push(url);
+    const r = results[Math.min(i, results.length - 1)];
+    i++;
+    return r instanceof Error ? Promise.reject(r) : Promise.resolve(r);
+  };
+}
+
+const ok = (body: string) => new Response(body, { status: 200 });
+const status = (code: number) => new Response("", { status: code });
+/** What Chromium surfaces to JS when the socket pool is flushed. */
+const networkChanged = () => new TypeError("Failed to fetch");
+
+beforeEach(() => {
+  calls = [];
+  origFetch = (globalThis as { fetch?: unknown }).fetch;
+});
+
+afterEach(() => {
+  (globalThis as { fetch?: unknown }).fetch = origFetch;
+});
+
+describe("fetchBundleSource", () => {
+  it("returns the body without retrying when the first attempt succeeds", async () => {
+    scriptFetch([ok("export const x = 1")]);
+    const text = await fetchBundleSource({ pluginId: "battery-tracker", delays: NO_DELAY });
+    expect(text).toBe("export const x = 1");
+    expect(calls.length).toBe(1);
+  });
+
+  it("recovers from the ERR_NETWORK_CHANGED flush that broke the widgets", async () => {
+    scriptFetch([networkChanged(), ok("export const y = 2")]);
+    const text = await fetchBundleSource({ pluginId: "display-settings", delays: NO_DELAY });
+    expect(text).toBe("export const y = 2");
+    expect(calls.length).toBe(2);
+  });
+
+  it("keeps retrying up to the full ladder before giving up", async () => {
+    scriptFetch([networkChanged(), networkChanged(), networkChanged(), ok("late")]);
+    const text = await fetchBundleSource({ pluginId: "wifi", delays: NO_DELAY });
+    expect(text).toBe("late");
+    // 1 initial + 3 retries — the last retry is the one that lands.
+    expect(calls.length).toBe(4);
+  });
+
+  it("gives up after the ladder is exhausted and surfaces the last error", async () => {
+    scriptFetch([networkChanged()]);
+    await expect(
+      fetchBundleSource({ pluginId: "bluetooth", delays: NO_DELAY }),
+    ).rejects.toThrow("Failed to fetch");
+    expect(calls.length).toBe(NO_DELAY.length + 1);
+  });
+
+  it("retries a 5xx — a server hiccup usually clears on the next attempt", async () => {
+    scriptFetch([status(503), ok("recovered")]);
+    const text = await fetchBundleSource({ pluginId: "storage", delays: NO_DELAY });
+    expect(text).toBe("recovered");
+    expect(calls.length).toBe(2);
+  });
+
+  it("does NOT retry a 404 — the plugin is genuinely gone", async () => {
+    scriptFetch([status(404)]);
+    await expect(
+      fetchBundleSource({ pluginId: "ghost-plugin", delays: NO_DELAY }),
+    ).rejects.toThrow("HTTP 404");
+    expect(calls.length).toBe(1);
+  });
+
+  it("does NOT retry a 401 — re-asking without credentials repeats the answer", async () => {
+    scriptFetch([status(401)]);
+    await expect(
+      fetchBundleSource({ pluginId: "quick-links", delays: NO_DELAY }),
+    ).rejects.toThrow("HTTP 401");
+    expect(calls.length).toBe(1);
+  });
+
+  it("cache-busts per attempt so a retry can't be served the failed response", async () => {
+    scriptFetch([networkChanged(), networkChanged(), ok("fresh")]);
+    await fetchBundleSource({ pluginId: "rgb-control", delays: NO_DELAY });
+    expect(calls.length).toBe(3);
+    expect(new Set(calls).size).toBe(3);
+    for (const url of calls) {
+      expect(url).toContain("/plugins/rgb-control/app-bundle.js");
+      expect(url).toMatch(/\?t=\d+/);
+    }
+  });
+
+  it("waits the configured backoff between attempts", async () => {
+    scriptFetch([networkChanged(), ok("slow")]);
+    const t0 = performance.now();
+    await fetchBundleSource({ pluginId: "network-info", delays: [60] });
+    expect(performance.now() - t0).toBeGreaterThanOrEqual(50);
+  });
+});

--- a/apps/loadout-overlay/src/overlay/lib/backend.ts
+++ b/apps/loadout-overlay/src/overlay/lib/backend.ts
@@ -6,30 +6,45 @@
  */
 
 import { BACKEND_URL } from "./config";
+import {
+  HttpError,
+  exponentialDelays,
+  fetchTextNoCache,
+  fixedDelays,
+  retryAsync,
+} from "./retry";
 
 let sessionToken: string | null = null;
 
 /**
  * Fetch the session token from the Bun server.
- * Retries with exponential backoff until the server is reachable.
+ *
+ * Unbounded backoff on purpose: there is no meaningful failure path here.
+ * Without a token the overlay can't talk to the backend at all, so the only
+ * sane behaviour is to keep waiting for the server to come up. Every status
+ * is retried, including 4xx — a not-yet-ready server can answer oddly during
+ * startup, and giving up would strand the session.
  */
 export async function initBackend(): Promise<void> {
-  for (let attempt = 0; ; attempt++) {
-    try {
+  await retryAsync({
+    label: "[backend] token",
+    delays: exponentialDelays({ base: 1000, cap: 10000 }),
+    isRetriable: () => true,
+    run: async () => {
       const res = await fetch(`${BACKEND_URL}/api/token`);
-      if (res.ok) {
-        const data = await res.json();
-        sessionToken = data.token;
-        // Backward compat for ws-client.ts which reads from window
-        window.__LOADOUT_TOKEN__ = sessionToken ?? undefined;
-        console.log("[backend] Token acquired");
-        return;
+      if (!res.ok) {
+        throw new HttpError({
+          status: res.status,
+          message: `HTTP ${res.status} fetching session token`,
+        });
       }
-    } catch {}
-    const delay = Math.min(1000 * 2 ** attempt, 10000);
-    console.warn(`[backend] Server not ready, retrying in ${delay}ms...`);
-    await new Promise((r) => setTimeout(r, delay));
-  }
+      const data = await res.json();
+      sessionToken = data.token;
+      // Backward compat for ws-client.ts which reads from window
+      window.__LOADOUT_TOKEN__ = sessionToken ?? undefined;
+      console.log("[backend] Token acquired");
+    },
+  });
 }
 
 /** Get the current auth token. */
@@ -88,14 +103,6 @@ const bundleCache = new Map<string, Promise<Record<string, unknown>>>();
  *  nothing about whether an interface is about to come up and flush the pool. */
 const BUNDLE_RETRY_DELAYS_MS = [150, 400, 1000, 2500];
 
-/** Transient = worth retrying. A thrown fetch is a network-layer failure
- *  (ERR_NETWORK_CHANGED, connection reset, …) and 5xx is a server hiccup;
- *  both usually clear on the next attempt. A 4xx is a real answer — the
- *  plugin is gone or unauthorized — and retrying just repeats it. */
-function isRetriableStatus(status: number): boolean {
-  return status >= 500;
-}
-
 /** Fetch the bundle source, retrying transient failures.
  *
  *  Why this exists: the overlay fires every plugin's bundle fetch in
@@ -115,52 +122,15 @@ export async function fetchBundleSource({
   /** Overridable so tests don't pay the real backoff. */
   delays?: readonly number[];
 }): Promise<string> {
-  let lastErr: unknown;
-  for (let attempt = 0; attempt <= delays.length; attempt++) {
-    if (attempt > 0) {
-      // No `?? fallback`: attempt is bounded by delays.length, so this index
-      // is always in range. A fallback here would turn a future off-by-one
-      // into a silently different ladder instead of a loud failure.
-      const delay = delays[attempt - 1];
-      console.warn(
-        `[bundle] retry ${attempt}/${delays.length} for ${pluginId} in ${delay}ms (${lastErr instanceof Error ? lastErr.message : String(lastErr)})`,
-      );
-      await new Promise((r) => setTimeout(r, delay));
-    }
-    // Cache-bust per ATTEMPT, not per call: a retry must not be served the
-    // failed response out of the HTTP cache.
-    const url = `${pluginBundleUrl(pluginId)}?t=${Date.now()}`;
-
-    // Each stage is caught separately so the non-retriable throw below sits
-    // OUTSIDE any try that could swallow it. Sniffing the message to tell
-    // "the 4xx I just threw" from "a network error" would make correctness
-    // rest on a string prefix.
-    let res: Response;
-    try {
-      res = await fetch(url);
-    } catch (err) {
-      lastErr = err; // network layer: ERR_NETWORK_CHANGED, conn reset, …
-      continue;
-    }
-
-    if (!res.ok) {
-      const err = new Error(`HTTP ${res.status} loading ${pluginId} bundle`);
-      if (!isRetriableStatus(res.status)) throw err;
-      lastErr = err;
-      continue;
-    }
-
-    try {
-      // Retried on purpose: a body that dies mid-stream is the shape a flush
-      // takes when it lands after the response headers arrived.
-      return await res.text();
-    } catch (err) {
-      lastErr = err;
-    }
-  }
-  throw lastErr instanceof Error
-    ? lastErr
-    : new Error(`failed to load ${pluginId} bundle: ${String(lastErr)}`);
+  return retryAsync({
+    label: `[bundle] ${pluginId}`,
+    delays: fixedDelays(delays),
+    run: () =>
+      fetchTextNoCache({
+        url: pluginBundleUrl(pluginId),
+        what: `${pluginId} bundle`,
+      }),
+  });
 }
 
 export async function importPluginBundle(pluginId: string): Promise<Record<string, unknown>> {

--- a/apps/loadout-overlay/src/overlay/lib/backend.ts
+++ b/apps/loadout-overlay/src/overlay/lib/backend.ts
@@ -72,6 +72,69 @@ export function pluginBundleUrl(pluginId: string): string {
  */
 const bundleCache = new Map<string, Promise<Record<string, unknown>>>();
 
+/** Backoff before each retry of a transient bundle fetch, in ms. Sized for
+ *  the failure this exists for — a single socket-pool flush, where the very
+ *  next attempt already succeeds — while still covering a slower blip. The
+ *  server is known reachable by this point (initBackend blocks on /api/token
+ *  until it answers), so a long ladder would only delay a real error. */
+const BUNDLE_RETRY_DELAYS_MS = [150, 400, 1000];
+
+/** Transient = worth retrying. A thrown fetch is a network-layer failure
+ *  (ERR_NETWORK_CHANGED, connection reset, …) and 5xx is a server hiccup;
+ *  both usually clear on the next attempt. A 4xx is a real answer — the
+ *  plugin is gone or unauthorized — and retrying just repeats it. */
+function isRetriableStatus(status: number): boolean {
+  return status >= 500;
+}
+
+/** Fetch the bundle source, retrying transient failures.
+ *
+ *  Why this exists: the overlay fires every plugin's bundle fetch in
+ *  parallel ~3 ms into page load. On a handheld that boots straight into
+ *  gaming mode, Wi-Fi is often still associating at that moment — when the
+ *  interface activates, Chromium's network-change notifier flushes the
+ *  socket pool and every in-flight request dies with ERR_NETWORK_CHANGED
+ *  (surfaced to JS as a bare `TypeError: Failed to fetch`). Whichever
+ *  bundles had already landed were fine; the rest failed, and since nothing
+ *  re-requested them, their widgets and icons stayed broken for the whole
+ *  session — until someone restarted the overlay by hand. */
+export async function fetchBundleSource({
+  pluginId,
+  delays = BUNDLE_RETRY_DELAYS_MS,
+}: {
+  pluginId: string;
+  /** Overridable so tests don't pay the real backoff. */
+  delays?: readonly number[];
+}): Promise<string> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    if (attempt > 0) {
+      const delay = delays[attempt - 1] ?? 1000;
+      console.warn(
+        `[bundle] retry ${attempt}/${delays.length} for ${pluginId} in ${delay}ms (${lastErr instanceof Error ? lastErr.message : String(lastErr)})`,
+      );
+      await new Promise((r) => setTimeout(r, delay));
+    }
+    // Cache-bust per ATTEMPT, not per call: a retry must not be served the
+    // failed response out of the HTTP cache.
+    const url = `${pluginBundleUrl(pluginId)}?t=${Date.now()}`;
+    try {
+      const res = await fetch(url);
+      if (res.ok) return await res.text();
+      const err = new Error(`HTTP ${res.status} loading ${pluginId} bundle`);
+      if (!isRetriableStatus(res.status)) throw err;
+      lastErr = err;
+    } catch (err) {
+      // A non-retriable HTTP error thrown just above must not be retried.
+      if (err instanceof Error && err.message.startsWith("HTTP ")) throw err;
+      lastErr = err;
+    }
+  }
+  throw lastErr instanceof Error
+    ? lastErr
+    : new Error(`failed to load ${pluginId} bundle: ${String(lastErr)}`);
+}
+
 export async function importPluginBundle(pluginId: string): Promise<Record<string, unknown>> {
   const cached = bundleCache.get(pluginId);
   if (cached) {
@@ -82,10 +145,10 @@ export async function importPluginBundle(pluginId: string): Promise<Record<strin
   console.log(`[bundle] fetching: ${pluginId}`);
   const t0 = performance.now();
   const promise = (async () => {
-    const url = `${pluginBundleUrl(pluginId)}?t=${Date.now()}`;
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`HTTP ${res.status} loading ${pluginId} bundle`);
-    const text = await res.text();
+    // Only the fetch is retried. A bundle that downloads but fails to
+    // evaluate is a build error, not a blip — re-importing it would fail
+    // identically, so that error propagates on the first attempt.
+    const text = await fetchBundleSource({ pluginId });
     const blob = new Blob([text], { type: "application/javascript" });
     const blobUrl = URL.createObjectURL(blob);
     try {

--- a/apps/loadout-overlay/src/overlay/lib/backend.ts
+++ b/apps/loadout-overlay/src/overlay/lib/backend.ts
@@ -72,12 +72,21 @@ export function pluginBundleUrl(pluginId: string): string {
  */
 const bundleCache = new Map<string, Promise<Record<string, unknown>>>();
 
-/** Backoff before each retry of a transient bundle fetch, in ms. Sized for
- *  the failure this exists for — a single socket-pool flush, where the very
- *  next attempt already succeeds — while still covering a slower blip. The
- *  server is known reachable by this point (initBackend blocks on /api/token
- *  until it answers), so a long ladder would only delay a real error. */
-const BUNDLE_RETRY_DELAYS_MS = [150, 400, 1000];
+/** Backoff before each retry of a transient bundle fetch, in ms.
+ *
+ *  This is a ~4 s wall-clock budget, not "4 chances": a flushed request fails
+ *  instantly, so each attempt is exposed for only a single-digit-ms loopback
+ *  round trip. Surviving a flush needs a few ms of calm, which the first rung
+ *  already buys. The later rungs are there because NetworkChangeNotifierLinux
+ *  fires per netlink RTM_NEWADDR — v4 lease, v6 link-local, v6 SLAAC, and on a
+ *  host bringing up both eth0 and wlan0 those can spread over seconds. Nobody
+ *  is blocked on the outcome (a failure just renders a widget placeholder), so
+ *  the extra rungs cost nothing on the success path.
+ *
+ *  Note the ladder does NOT key off backend reachability: the server is on
+ *  loopback and answers with no network at all, so initBackend succeeding says
+ *  nothing about whether an interface is about to come up and flush the pool. */
+const BUNDLE_RETRY_DELAYS_MS = [150, 400, 1000, 2500];
 
 /** Transient = worth retrying. A thrown fetch is a network-layer failure
  *  (ERR_NETWORK_CHANGED, connection reset, …) and 5xx is a server hiccup;
@@ -109,7 +118,10 @@ export async function fetchBundleSource({
   let lastErr: unknown;
   for (let attempt = 0; attempt <= delays.length; attempt++) {
     if (attempt > 0) {
-      const delay = delays[attempt - 1] ?? 1000;
+      // No `?? fallback`: attempt is bounded by delays.length, so this index
+      // is always in range. A fallback here would turn a future off-by-one
+      // into a silently different ladder instead of a loud failure.
+      const delay = delays[attempt - 1];
       console.warn(
         `[bundle] retry ${attempt}/${delays.length} for ${pluginId} in ${delay}ms (${lastErr instanceof Error ? lastErr.message : String(lastErr)})`,
       );
@@ -118,15 +130,31 @@ export async function fetchBundleSource({
     // Cache-bust per ATTEMPT, not per call: a retry must not be served the
     // failed response out of the HTTP cache.
     const url = `${pluginBundleUrl(pluginId)}?t=${Date.now()}`;
+
+    // Each stage is caught separately so the non-retriable throw below sits
+    // OUTSIDE any try that could swallow it. Sniffing the message to tell
+    // "the 4xx I just threw" from "a network error" would make correctness
+    // rest on a string prefix.
+    let res: Response;
     try {
-      const res = await fetch(url);
-      if (res.ok) return await res.text();
+      res = await fetch(url);
+    } catch (err) {
+      lastErr = err; // network layer: ERR_NETWORK_CHANGED, conn reset, …
+      continue;
+    }
+
+    if (!res.ok) {
       const err = new Error(`HTTP ${res.status} loading ${pluginId} bundle`);
       if (!isRetriableStatus(res.status)) throw err;
       lastErr = err;
+      continue;
+    }
+
+    try {
+      // Retried on purpose: a body that dies mid-stream is the shape a flush
+      // takes when it lands after the response headers arrived.
+      return await res.text();
     } catch (err) {
-      // A non-retriable HTTP error thrown just above must not be retried.
-      if (err instanceof Error && err.message.startsWith("HTTP ")) throw err;
       lastErr = err;
     }
   }

--- a/apps/loadout-overlay/src/overlay/lib/pluginInit.ts
+++ b/apps/loadout-overlay/src/overlay/lib/pluginInit.ts
@@ -14,7 +14,12 @@
  */
 import type { PluginInfo } from "../hooks/usePlugins";
 import { authHeaders, apiUrl, importPluginBundle } from "./backend";
+import { fetchTextNoCache, fixedDelays, retryAsync } from "./retry";
 import { call as wsCall, subscribe } from "@loadout/ui/ws-client";
+
+/** Same ladder as the bundle fetches — this call shares their page-load
+ *  window and therefore their failure mode. */
+const STARTUP_LIST_RETRY_DELAYS_MS = [150, 400, 1000, 2500];
 
 export interface PluginInitAPI {
   /** Call a method on this plugin's backend. */
@@ -43,12 +48,22 @@ function makeApi(pluginId: string): PluginInitAPI {
 export async function runStartupInits(): Promise<void> {
   let plugins: PluginInfo[];
   try {
-    const res = await fetch(apiUrl("/api/plugins"), { headers: authHeaders() });
-    if (!res.ok) {
-      console.warn(`[pluginInit] /api/plugins HTTP ${res.status}`);
-      return;
-    }
-    plugins = (await res.json()) as PluginInfo[];
+    // Retried on the same ladder as the bundle fetches, and for the same
+    // reason: this call runs in the same page-load window, so the socket-pool
+    // flush that killed those kills this too. It's worse when it happens here
+    // — a single dropped list fetch meant NO startup plugin ever initialised,
+    // silently, for the whole session.
+    const body = await retryAsync({
+      label: "[pluginInit] /api/plugins",
+      delays: fixedDelays(STARTUP_LIST_RETRY_DELAYS_MS),
+      run: () =>
+        fetchTextNoCache({
+          url: apiUrl("/api/plugins"),
+          what: "plugin list",
+          headers: authHeaders(),
+        }),
+    });
+    plugins = JSON.parse(body) as PluginInfo[];
   } catch (err) {
     console.warn("[pluginInit] Failed to fetch plugin list:", err);
     return;

--- a/apps/loadout-overlay/src/overlay/lib/retry.test.ts
+++ b/apps/loadout-overlay/src/overlay/lib/retry.test.ts
@@ -1,0 +1,259 @@
+// Unit tests for the shared retry policy in lib/retry.ts.
+//
+// This replaced three hand-rolled retry loops in the overlay, so the tests
+// pin both shapes it has to serve: the bounded ladder used by plugin-bundle
+// and plugin-list fetches, and the unbounded backoff used by the startup
+// gates (session token, sidebar plugin list) where giving up is not an option.
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  HttpError,
+  exponentialDelays,
+  fetchTextNoCache,
+  fixedDelays,
+  isRetriableError,
+  retryAsync,
+} from "./retry";
+
+const NO_DELAY = [0, 0, 0] as const;
+
+describe("fixedDelays", () => {
+  it("hands back each rung in order, then null to stop", () => {
+    const policy = fixedDelays([10, 20, 30]);
+    expect(policy(0)).toBe(10);
+    expect(policy(1)).toBe(20);
+    expect(policy(2)).toBe(30);
+    expect(policy(3)).toBeNull();
+    expect(policy(99)).toBeNull();
+  });
+
+  it("gives up immediately when the ladder is empty", () => {
+    expect(fixedDelays([])(0)).toBeNull();
+  });
+
+  it("treats a literal 0 rung as a real delay, not as 'stop'", () => {
+    // Guards against a truthiness check creeping in — the test suites here
+    // pass 0-length ladders to skip real waiting.
+    expect(fixedDelays([0])(0)).toBe(0);
+  });
+});
+
+describe("exponentialDelays", () => {
+  it("doubles from the base and clamps at the cap, never stopping", () => {
+    const policy = exponentialDelays({ base: 100, cap: 800 });
+    expect([0, 1, 2, 3, 4, 50].map(policy)).toEqual([100, 200, 400, 800, 800, 800]);
+  });
+});
+
+describe("isRetriableError", () => {
+  it("retries network-layer failures", () => {
+    expect(isRetriableError(new TypeError("Failed to fetch"))).toBe(true);
+  });
+
+  it("retries 5xx", () => {
+    expect(isRetriableError(new HttpError({ status: 503, message: "x" }))).toBe(true);
+  });
+
+  it("retries 408 and 429, the conventional transient 4xx", () => {
+    expect(isRetriableError(new HttpError({ status: 408, message: "x" }))).toBe(true);
+    expect(isRetriableError(new HttpError({ status: 429, message: "x" }))).toBe(true);
+  });
+
+  it("does not retry 404 or 401 — those are real answers", () => {
+    expect(isRetriableError(new HttpError({ status: 404, message: "x" }))).toBe(false);
+    expect(isRetriableError(new HttpError({ status: 401, message: "x" }))).toBe(false);
+  });
+});
+
+describe("retryAsync", () => {
+  it("returns the first success without retrying", async () => {
+    let calls = 0;
+    const out = await retryAsync({
+      label: "t",
+      delays: fixedDelays(NO_DELAY),
+      run: async () => { calls++; return "ok"; },
+    });
+    expect(out).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  it("retries a transient failure and returns the eventual success", async () => {
+    let calls = 0;
+    const out = await retryAsync({
+      label: "t",
+      delays: fixedDelays(NO_DELAY),
+      run: async () => {
+        calls++;
+        if (calls < 3) throw new TypeError("Failed to fetch");
+        return "late";
+      },
+    });
+    expect(out).toBe("late");
+    expect(calls).toBe(3);
+  });
+
+  it("runs 1 + N attempts, then rethrows the last error", async () => {
+    let calls = 0;
+    await expect(
+      retryAsync({
+        label: "t",
+        delays: fixedDelays(NO_DELAY),
+        run: async () => { calls++; throw new TypeError("Failed to fetch"); },
+      }),
+    ).rejects.toThrow("Failed to fetch");
+    expect(calls).toBe(NO_DELAY.length + 1);
+  });
+
+  it("stops at the first non-retriable error without burning the ladder", async () => {
+    let calls = 0;
+    await expect(
+      retryAsync({
+        label: "t",
+        delays: fixedDelays(NO_DELAY),
+        run: async () => {
+          calls++;
+          throw new HttpError({ status: 404, message: "HTTP 404 loading x" });
+        },
+      }),
+    ).rejects.toThrow("HTTP 404");
+    expect(calls).toBe(1);
+  });
+
+  it("preserves the failing error's identity, not a wrapped copy", async () => {
+    const original = new HttpError({ status: 503, message: "HTTP 503 loading x" });
+    const err = await retryAsync({
+      label: "t",
+      delays: fixedDelays([]),
+      run: async () => { throw original; },
+    }).catch((e) => e);
+    expect(err).toBe(original);
+    expect((err as HttpError).status).toBe(503);
+  });
+
+  it("uses the ladder rungs in order", async () => {
+    let calls = 0;
+    const t0 = performance.now();
+    await retryAsync({
+      label: "t",
+      delays: fixedDelays([40, 250]),
+      run: async () => {
+        calls++;
+        if (calls < 3) throw new TypeError("Failed to fetch");
+        return "done";
+      },
+    });
+    const elapsed = performance.now() - t0;
+    // 40 + 250 = 290. Bounded above so reusing one rung (80 / 500) or a
+    // 1000ms fallback creeping back in would fail.
+    expect(elapsed).toBeGreaterThanOrEqual(280);
+    expect(elapsed).toBeLessThan(700);
+  });
+
+  it("keeps retrying past any fixed count under an unbounded policy", async () => {
+    let calls = 0;
+    const out = await retryAsync({
+      label: "t",
+      delays: exponentialDelays({ base: 0, cap: 0 }),
+      isRetriable: () => true,
+      run: async () => {
+        calls++;
+        if (calls < 12) throw new Error("not ready");
+        return "up";
+      },
+    });
+    expect(out).toBe("up");
+    expect(calls).toBe(12);
+  });
+
+  it("stops when shouldContinue goes false and fires no further attempt", async () => {
+    // Deliberately a BOUNDED ladder. The same assertion under an unbounded
+    // policy would hang forever if the in-loop shouldContinue check were
+    // removed, which is a useless way for a test to fail; bounded means a
+    // missing check shows up as calls === 4 instead of a wedged suite.
+    let calls = 0;
+    let live = true;
+    await expect(
+      retryAsync({
+        label: "t",
+        delays: fixedDelays(NO_DELAY),
+        isRetriable: () => true,
+        shouldContinue: () => live,
+        run: async () => {
+          calls++;
+          live = false; // e.g. the effect unmounted mid-flight
+          throw new Error("boom");
+        },
+      }),
+    ).rejects.toThrow("boom");
+    // Rejects with the real error, not a generic "cancelled" — a caller that
+    // failed then got cancelled should still see why it failed.
+    expect(calls).toBe(1);
+  });
+
+  it("does not run even once when cancelled before starting", async () => {
+    let calls = 0;
+    await expect(
+      retryAsync({
+        label: "t",
+        delays: fixedDelays(NO_DELAY),
+        shouldContinue: () => false,
+        run: async () => { calls++; return "never"; },
+      }),
+    ).rejects.toThrow("cancelled");
+    expect(calls).toBe(0);
+  });
+});
+
+describe("fetchTextNoCache", () => {
+  let origFetch: unknown;
+  let urls: string[] = [];
+
+  beforeEach(() => {
+    urls = [];
+    origFetch = (globalThis as { fetch?: unknown }).fetch;
+  });
+  afterEach(() => {
+    (globalThis as { fetch?: unknown }).fetch = origFetch;
+  });
+
+  function stub(res: Response | Error): void {
+    (globalThis as { fetch: unknown }).fetch = (url: string) => {
+      urls.push(url);
+      return res instanceof Error ? Promise.reject(res) : Promise.resolve(res);
+    };
+  }
+
+  it("returns the body on 2xx", async () => {
+    stub(new Response("export const x = 1", { status: 200 }));
+    expect(await fetchTextNoCache({ url: "http://h/b.js", what: "b" })).toBe(
+      "export const x = 1",
+    );
+  });
+
+  it("throws an HttpError carrying the status on non-2xx", async () => {
+    stub(new Response("", { status: 503 }));
+    const err = await fetchTextNoCache({ url: "http://h/b.js", what: "b" }).catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(503);
+    expect((err as HttpError).message).toBe("HTTP 503 loading b");
+  });
+
+  it("appends a cache-buster with ? when the url has no query", async () => {
+    stub(new Response("x", { status: 200 }));
+    await fetchTextNoCache({ url: "http://h/b.js", what: "b" });
+    expect(urls[0]).toMatch(/^http:\/\/h\/b\.js\?t=\d+$/);
+  });
+
+  it("appends with & when the url already has a query", async () => {
+    stub(new Response("x", { status: 200 }));
+    await fetchTextNoCache({ url: "http://h/api?installed=1", what: "b" });
+    expect(urls[0]).toMatch(/^http:\/\/h\/api\?installed=1&t=\d+$/);
+  });
+
+  it("propagates a network-layer throw untouched so the policy can classify it", async () => {
+    stub(new TypeError("Failed to fetch"));
+    await expect(
+      fetchTextNoCache({ url: "http://h/b.js", what: "b" }),
+    ).rejects.toThrow("Failed to fetch");
+  });
+});

--- a/apps/loadout-overlay/src/overlay/lib/retry.ts
+++ b/apps/loadout-overlay/src/overlay/lib/retry.ts
@@ -1,0 +1,147 @@
+/**
+ * Retry policy shared by the overlay's network calls.
+ *
+ * Why this exists: the overlay had three hand-rolled retry loops that had
+ * drifted apart (initBackend, usePlugins' fetchWithRetry, and the plugin
+ * bundle fetch), each re-deriving backoff and "is this worth retrying".
+ *
+ * They serve two genuinely different shapes, both expressed here:
+ *
+ *  - **Bounded ladder** (`fixedDelays`): a fixed list of waits, then give up
+ *    and surface the error. For work where failing is a real outcome the
+ *    caller must handle — a plugin bundle that never arrives renders a
+ *    placeholder.
+ *  - **Unbounded backoff** (`exponentialDelays`): retry forever. For startup
+ *    gates where there is no meaningful failure path — the session token
+ *    MUST eventually be acquired or the overlay is useless.
+ */
+
+/** A non-2xx HTTP response, carrying the status so retry policies can decide
+ *  structurally instead of sniffing an error message. */
+export class HttpError extends Error {
+  readonly status: number;
+
+  constructor({ status, message }: { status: number; message: string }) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+  }
+}
+
+/** ms to wait before the attempt after `attempt`, or null to stop retrying. */
+export type DelayPolicy = (attempt: number) => number | null;
+
+/** Bounded: wait each listed delay in turn, then give up.
+ *
+ *  Deliberately no `?? fallback` on the index — under noUncheckedIndexedAccess
+ *  an out-of-range read is a type error, so an off-by-one fails the build
+ *  instead of silently substituting a different ladder. */
+export function fixedDelays(delays: readonly number[]): DelayPolicy {
+  return (attempt) => {
+    const delay = delays[attempt];
+    return delay === undefined ? null : delay;
+  };
+}
+
+/** Unbounded: exponential backoff, capped. Never returns null — the caller
+ *  is expected to be a startup gate with no failure path, or to stop via
+ *  `shouldContinue`. */
+export function exponentialDelays({
+  base = 1000,
+  cap = 10000,
+}: { base?: number; cap?: number } = {}): DelayPolicy {
+  return (attempt) => Math.min(base * 2 ** attempt, cap);
+}
+
+/** Default: retry anything except a non-retriable HTTP status. A 4xx is a
+ *  real answer — the resource is gone or we're unauthorized — and asking
+ *  again just repeats it. 408 (timeout) and 429 (rate limit) are the
+ *  conventional exceptions and are retriable. */
+export function isRetriableError(err: unknown): boolean {
+  if (!(err instanceof HttpError)) return true; // network layer
+  if (err.status === 408 || err.status === 429) return true;
+  return err.status >= 500;
+}
+
+export interface RetryOptions<T> {
+  /** Prefix for retry logs, e.g. "[bundle] battery-tracker". */
+  label: string;
+  /** One attempt. Throw to signal failure; `attempt` is 0-based. */
+  run: (attempt: number) => Promise<T>;
+  delays: DelayPolicy;
+  /** Defaults to `isRetriableError`. */
+  isRetriable?: (err: unknown) => boolean;
+  /** Checked before each attempt and after each wait, so a caller whose
+   *  lifetime ended (an unmounted React effect) stops without firing another
+   *  request. Returning false rejects with the last error, or a cancellation
+   *  error if nothing has failed yet. */
+  shouldContinue?: () => boolean;
+}
+
+/**
+ * Run `run` until it succeeds, the delay policy gives up, the error is not
+ * retriable, or `shouldContinue` goes false.
+ *
+ * Note this is a wall-clock budget, not simply "N chances": a request killed
+ * by a socket-pool flush fails instantly, so each attempt's exposure is only
+ * as long as the request itself. What matters is that the ladder spans the
+ * window in which the disruption is happening.
+ */
+export async function retryAsync<T>({
+  label,
+  run,
+  delays,
+  isRetriable = isRetriableError,
+  shouldContinue,
+}: RetryOptions<T>): Promise<T> {
+  let lastErr: unknown;
+  let hasFailed = false;
+
+  for (let attempt = 0; ; attempt++) {
+    if (shouldContinue && !shouldContinue()) {
+      throw hasFailed ? lastErr : new Error(`${label}: cancelled`);
+    }
+
+    try {
+      return await run(attempt);
+    } catch (err) {
+      lastErr = err;
+      hasFailed = true;
+      if (!isRetriable(err)) throw err;
+    }
+
+    const delay = delays(attempt);
+    if (delay === null) throw lastErr;
+
+    console.warn(
+      `${label}: attempt ${attempt + 1} failed (${lastErr instanceof Error ? lastErr.message : String(lastErr)}), retrying in ${delay}ms`,
+    );
+    await new Promise((r) => setTimeout(r, delay));
+  }
+}
+
+/** Fetch a URL and read it as text, turning a non-2xx into an HttpError so
+ *  the retry policy can classify it. Cache-busts per call so a retry is never
+ *  served the failed response out of the HTTP cache. */
+export async function fetchTextNoCache({
+  url,
+  what,
+  headers,
+}: {
+  url: string;
+  /** Named in the error, e.g. "battery-tracker bundle". */
+  what: string;
+  headers?: HeadersInit;
+}): Promise<string> {
+  const busted = `${url}${url.includes("?") ? "&" : "?"}t=${Date.now()}`;
+  const res = await fetch(busted, headers ? { headers } : undefined);
+  if (!res.ok) {
+    throw new HttpError({
+      status: res.status,
+      message: `HTTP ${res.status} loading ${what}`,
+    });
+  }
+  // Retried by the caller on purpose: a body dying mid-stream is the shape a
+  // socket-pool flush takes when it lands after the headers arrived.
+  return await res.text();
+}


### PR DESCRIPTION
## Problem

The overlay fires **every** plugin's bundle fetch in parallel ~3 ms into page load. On a handheld that boots straight into gaming mode, Wi-Fi is often still associating at that exact moment — when the interface activates, Chromium's network-change notifier flushes the socket pool and every in-flight request dies with `net::ERR_NETWORK_CHANGED`, surfaced to JS as a bare `TypeError: Failed to fetch`.

Observed live on an OXP APEX (SteamOS), diagnosed via CEF DevTools on `:9222`:

```
15:35:53  overlay webview boots, fires all 25 bundle fetches at +3ms
15:35:54  wlan0: disconnected -> prepare -> config -> connected
15:35:55  wlan0: dhcp4 new lease 192.168.86.44 -> activated
```

The 8 bundles that had already landed were fine. The 17 still in flight — battery-tracker, display-settings, bluetooth, wifi, storage, network-info, rgb-control, quick-links and the rest — all failed, in fetch order. Nothing re-requested them, so those plugins' home widgets and sidebar icons stayed dead **for the entire session**; only a manual overlay restart cleared it.

`importPluginBundle` already dropped the failed promise from `bundleCache`, so a retry *would* have worked — confirmed by re-importing the identical bundles seconds later — but nothing ever retried.

## Fix

**1. Retry transient bundle fetches** on a `150 / 400 / 1000 / 2500` ms ladder.

| Outcome | Retried? | Why |
|---|---|---|
| thrown `fetch` (network layer) | yes | `ERR_NETWORK_CHANGED`, conn reset |
| 5xx, 408, 429 | yes | server hiccup / transient |
| other 4xx | **no** | a real answer: plugin gone (404) or unauthorized (401) |
| module `import()` failure | **no** | a build error; re-importing fails identically |

Cache-busts **per attempt**, so a retry is never handed the failed response out of the HTTP cache. The ladder is a ~4 s wall-clock budget, not "4 chances" — a flushed request fails instantly, so each attempt is exposed for only a loopback round trip. The later rungs exist because `NetworkChangeNotifierLinux` fires per netlink `RTM_NEWADDR` (v4 lease, v6 link-local, v6 SLAAC) and the affected host brings up both eth0 and wlan0.

**2. `usePluginIcons` no longer negative-caches failures.** `iconCache` has no invalidation and its guards short-circuit on `.has()`, so a failed icon load burned that plugin to the letter fallback for the whole page lifetime — and the overlay window is shown/hidden, never reloaded, so that meant the whole session. This was the same bug, unfixed by the retry. Only the success path caches now, where `null` legitimately means "exports no icon".

**3. `runStartupInits` had no retry at all** (`pluginInit.ts`). It fetched `/api/plugins` with a single attempt in the same page-load window, so the same flush killed it — and when it did, **no `loadOnStartup` plugin ever initialised**, silently, for the session. One dropped request took out every startup plugin.

**4. Four hand-rolled retry loops consolidated** into `lib/retry.ts`, covering both shapes the overlay needs:
- `fixedDelays` — bounded ladder, then surface the error (bundles, plugin list).
- `exponentialDelays` — unbounded, for startup gates with no failure path (session token, sidebar list).

`HttpError` carries the status, so retriability is a structural check rather than sniffing an error message. `usePlugins` keeps its effect-scoped cancellation via `shouldContinue`.

## Verification

**34 tests** — 22 for `retry.ts` (both policy shapes, cancellation, error-identity preservation, cache-buster `?`-vs-`&`), 12 for the bundle path. `typecheck` and `eslint` clean. `test:ui` 378/378; `test:backend` 2514 pass / 1 fail (a pre-existing `sound-loader` flake on `main`, untouched here). Full `bun run build` succeeds, so bundling is confirmed, not just types.

Mutation-tested rather than assumed. Eight mutations, each caught by the intended test: `fixedDelays` off-by-one, losing the original error on give-up, 404-treated-as-retriable, hoisting the `shouldContinue` check out of the loop, and four ladder variations. The `shouldContinue` one initially **hung** the suite instead of failing it, so that test was rewritten onto a bounded ladder to fail cleanly.

Note the 12 bundle tests pass unchanged across the `retry.ts` extraction, which is the evidence the refactor is behaviour-preserving — but they were added by this PR's own first commit, not inherited from `main`.

## Known gaps

- **Not exercised on-device.** Reproducing the original bug needs a boot-time network race; the test hardware is currently running another branch. Worth one cold boot before release.
- **`pluginInit` and `usePlugins` have no tests.** Replacing the startup ladder with `[]` — deleting the retry item 3 is named after — passes the suite. So does dropping `headers` from `fetchTextNoCache`, which would strip `Authorization` and 401 the plugin list. The 22 new tests all land on `retry.ts`, already the best-covered part.
- **`initBackend`'s "never rejects" is now configurational, not structural.** It relies on `isRetriable: () => true`; deleting that line passes the suite, and both boot callsites do `initBackend().then(…)` with no `.catch()`, so a rejection would take out the whole boot chain including the `__overlay/show` subscription. The old `for(;;) { try{}catch{} }` made that impossible by construction.
- **`exponentialDelays({ base: 0 })`** yields `NaN` at attempt ≥1024 and would spin. Unreachable from either production callsite (`base: 1000`), but the helper is exported.
- `fetchTextNoCache` appends the cache-buster with string concatenation, so a URL with a fragment would put it in the fragment. No current callsite produces one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQhZsmqN35EXd2XUoUzNWF