### PR TITLE
fix(tdp-control): respect custom TDP range in power profiles (#230)

### DIFF
--- a/plugins/tdp-control/app.spec.tsx
+++ b/plugins/tdp-control/app.spec.tsx
@@ -141,6 +141,45 @@ describe("tdp-control plugin", () => {
     });
   });
 
+  it("keeps presets & battery cap in an optional collapsed region", async () => {
+    const container = document.createElement("div");
+    const { mount } = await import("./app");
+    mount(container);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("15W");
+    });
+
+    // Open the custom-device form.
+    const gear = container.querySelector(
+      '[aria-label="Custom device settings"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(gear);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("CUSTOM DEVICE");
+    });
+
+    // Required fields are always visible; the presets/battery cap live in a
+    // collapsed "optional" region and aren't rendered until it's expanded.
+    expect(container.textContent).toContain("Min TDP");
+    expect(container.textContent).toContain("Max TDP");
+    expect(container.textContent).toContain("Power presets");
+    expect(container.textContent).not.toContain("Silent preset");
+
+    // Expanding the region reveals the optional preset fields.
+    const toggle = container.querySelector(
+      '[aria-label="Toggle power presets and battery cap"]',
+    ) as HTMLElement;
+    expect(toggle).toBeTruthy();
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Silent preset");
+      expect(container.textContent).toContain("Battery max TDP");
+    });
+  });
+
   it("calls getTdpInfo on mount", async () => {
     const container = document.createElement("div");
     const { mount } = await import("./app");

--- a/plugins/tdp-control/app.tsx
+++ b/plugins/tdp-control/app.tsx
@@ -14,12 +14,13 @@ import {
   SegmentedItem,
   Toggle,
   TextInput,
+  Collapse,
   PluginHeader,
   HeaderBackButton,
   IconButton,
 } from "@loadout/ui";
 import { steamArtworkUrls } from "@loadout/steam-paths/artwork";
-import type { CustomDevice } from "./lib/custom-device";
+import { deriveDeviceDefaults, type CustomDevice } from "./lib/custom-device";
 
 export const icon = FaBolt;
 
@@ -808,21 +809,21 @@ function CustomDeviceForm({ info }: { info: TdpInfo }) {
 
   const fillFromDetected = useCallback(() => {
     const i = infoRef.current;
+    // Seed only the required fields (name + range) from auto-detection. The
+    // optional battery cap and presets are left BLANK so they derive from the
+    // range the user enters. Seeding the battery cap from the detected value
+    // is what caused a raised Max TDP to still clamp to the old (~30W) cap.
     // `maxWatts` is the power-state-aware *effective* cap (== battery cap when
-    // on battery), so seed the true device ceiling from `pluggedMaxWatts` and
-    // the battery cap from `batteryMaxWatts`. Fall back to `maxWatts` for
-    // older backends that don't report the split ceilings.
+    // on battery), so seed the true device ceiling from `pluggedMaxWatts`,
+    // falling back to `maxWatts` for older backends without the split ceiling.
     const trueMax = i.pluggedMaxWatts ?? i.maxWatts;
-    const batteryMax = i.batteryMaxWatts ?? i.maxWatts;
     setName(i.deviceName && i.deviceName !== "Unknown" ? i.deviceName : "");
     setMinTdp(String(i.minWatts));
     setMaxTdp(String(trueMax));
-    setBatteryMaxTdp(String(batteryMax));
-    setSilent(String(i.profiles.Silent ?? i.minWatts));
-    setBalanced(
-      String(i.profiles.Balanced ?? Math.round((i.minWatts + trueMax) / 2)),
-    );
-    setPerformance(String(i.profiles.Performance ?? trueMax));
+    setBatteryMaxTdp("");
+    setSilent("");
+    setBalanced("");
+    setPerformance("");
   }, []);
 
   // Seed the form on mount: from the saved custom device if one exists,
@@ -847,6 +848,10 @@ function CustomDeviceForm({ info }: { info: TdpInfo }) {
   }, [call, fillFrom, fillFromDetected]);
 
   const parse = (v: string): number => (v.trim() === "" ? NaN : Number(v));
+  // Optional fields: blank → undefined (derived server-side); otherwise parsed
+  // (NaN for garbage, which the validator rejects with a clear message).
+  const parseOpt = (v: string): number | undefined =>
+    v.trim() === "" ? undefined : Number(v);
 
   const handleSave = useCallback(async () => {
     setBusy(true);
@@ -856,11 +861,11 @@ function CustomDeviceForm({ info }: { info: TdpInfo }) {
       name: name.trim(),
       minTdp: parse(minTdp),
       maxTdp: parse(maxTdp),
-      batteryMaxTdp: parse(batteryMaxTdp),
+      batteryMaxTdp: parseOpt(batteryMaxTdp),
       profiles: {
-        Silent: parse(silent),
-        Balanced: parse(balanced),
-        Performance: parse(performance),
+        Silent: parseOpt(silent),
+        Balanced: parseOpt(balanced),
+        Performance: parseOpt(performance),
       },
     };
     try {
@@ -910,13 +915,27 @@ function CustomDeviceForm({ info }: { info: TdpInfo }) {
     }
   }, [call, fillFromDetected]);
 
-  const numberFields: Array<[string, string, (v: string) => void]> = [
+  const requiredFields: Array<[string, string, (v: string) => void]> = [
     ["Min TDP (W)", minTdp, setMinTdp],
     ["Max TDP (W)", maxTdp, setMaxTdp],
-    ["Battery max TDP (W)", batteryMaxTdp, setBatteryMaxTdp],
-    ["Silent preset (W)", silent, setSilent],
-    ["Balanced preset (W)", balanced, setBalanced],
-    ["Performance preset (W)", performance, setPerformance],
+  ];
+
+  // Live preview of the deterministic defaults, surfaced as placeholders on the
+  // optional fields so the user can see what "leave blank" will produce.
+  const minNum = parse(minTdp);
+  const maxNum = parse(maxTdp);
+  const preview =
+    Number.isInteger(minNum) && Number.isInteger(maxNum) && minNum < maxNum
+      ? deriveDeviceDefaults(minNum, maxNum)
+      : null;
+
+  const optionalFields: Array<
+    [string, string, (v: string) => void, number | undefined]
+  > = [
+    ["Battery max TDP (W)", batteryMaxTdp, setBatteryMaxTdp, preview?.batteryMaxTdp],
+    ["Silent preset (W)", silent, setSilent, preview?.profiles.Silent],
+    ["Balanced preset (W)", balanced, setBalanced, preview?.profiles.Balanced],
+    ["Performance preset (W)", performance, setPerformance, preview?.profiles.Performance],
   ];
 
   return (
@@ -948,7 +967,7 @@ function CustomDeviceForm({ info }: { info: TdpInfo }) {
         </div>
 
         <div className="grid grid-cols-2 gap-x-3 gap-y-2.5">
-          {numberFields.map(([label, value, setter]) => (
+          {requiredFields.map(([label, value, setter]) => (
             <div key={label}>
               <div className="subsection-label" style={{ marginBottom: 4 }}>
                 {label}
@@ -962,6 +981,41 @@ function CustomDeviceForm({ info }: { info: TdpInfo }) {
               />
             </div>
           ))}
+        </div>
+
+        <div style={{ marginTop: 10 }}>
+          {/* Re-key on hasCustom so the region opens for an existing custom
+              device (loaded async) and closes again when cleared. */}
+          <Collapse
+            key={hasCustom ? "custom" : "detected"}
+            defaultOpen={hasCustom}
+            ariaLabel="Toggle power presets and battery cap"
+            title={
+              <div className="subsection-label">
+                Power presets &amp; battery cap (optional)
+              </div>
+            }
+          >
+            <div className="subsection-desc" style={{ marginBottom: 10 }}>
+              Leave any field blank to auto-calculate it from your TDP range.
+            </div>
+            <div className="grid grid-cols-2 gap-x-3 gap-y-2.5">
+              {optionalFields.map(([label, value, setter, derived]) => (
+                <div key={label}>
+                  <div className="subsection-label" style={{ marginBottom: 4 }}>
+                    {label}
+                  </div>
+                  <TextInput
+                    value={value}
+                    onChange={setter}
+                    inputMode="numeric"
+                    placeholder={derived != null ? String(derived) : "Auto"}
+                    disabled={busy}
+                  />
+                </div>
+              ))}
+            </div>
+          </Collapse>
         </div>
 
         {formError && (

--- a/plugins/tdp-control/backend.test.ts
+++ b/plugins/tdp-control/backend.test.ts
@@ -689,4 +689,73 @@ describe("TdpControlBackend", () => {
       expect(info).toHaveProperty("supportsGpuControl");
     });
   });
+
+  // ── custom device ─────────────────────────────────────────────────
+  //
+  // A user-defined device only requires a name + TDP range; the battery cap
+  // and power presets are optional and derived when omitted. The derived
+  // battery cap is the full max, so raising Max TDP is respected on battery
+  // (regression: a raised max still clamped to the low detected battery cap).
+
+  describe("custom device", () => {
+    let dir: string;
+    let prevXdg: string | undefined;
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), "tdp-custom-device-"));
+      prevXdg = process.env.XDG_CONFIG_HOME;
+      process.env.XDG_CONFIG_HOME = dir;
+    });
+
+    afterEach(() => {
+      if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = prevXdg;
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("derives the battery cap + presets and respects the custom max on battery", async () => {
+      const b = backend as unknown as { acPowerOnline: boolean | null };
+
+      const result = await backend.setCustomDevice({
+        name: "Big Handheld",
+        minTdp: 5,
+        maxTdp: 80,
+      });
+      expect(result.success).toBe(true);
+
+      // Stored device is complete: battery cap defaults to the full max (no
+      // throttle) and presets span the range.
+      expect(await backend.getCustomDevice()).toEqual({
+        name: "Big Handheld",
+        minTdp: 5,
+        maxTdp: 80,
+        batteryMaxTdp: 80,
+        profiles: { Silent: 5, Balanced: 43, Performance: 80 },
+      });
+
+      // The custom range becomes the active device. On battery the effective
+      // cap is the full 80W — the reported "80W clamps to ~30W" bug is gone.
+      b.acPowerOnline = false;
+      const info = await backend.getTdpInfo();
+      expect(info.minWatts).toBe(5);
+      expect(info.pluggedMaxWatts).toBe(80);
+      expect(info.batteryMaxWatts).toBe(80);
+      expect(info.maxWatts).toBe(80); // effective cap on battery
+      expect(info.usingCustomDevice).toBe(true);
+
+      // The UI was told the range changed.
+      expect(emittedEvents.some((e) => e.event === "deviceChanged")).toBe(true);
+    });
+
+    it("rejects an explicit battery cap above the max", async () => {
+      const result = await backend.setCustomDevice({
+        name: "Bad",
+        minTdp: 5,
+        maxTdp: 40,
+        batteryMaxTdp: 60,
+      });
+      expect(result.success).toBe(false);
+      expect(await backend.getCustomDevice()).toBeNull();
+    });
+  });
 });

--- a/plugins/tdp-control/lib/custom-device.test.ts
+++ b/plugins/tdp-control/lib/custom-device.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   validateCustomDevice,
+  deriveDeviceDefaults,
   readCustomDevice,
   writeCustomDevice,
   clearCustomDevice,
@@ -88,10 +89,75 @@ describe("validateCustomDevice", () => {
     ).toBe(true);
   });
 
-  test("rejects missing profiles", () => {
-    const { profiles, ...rest } = VALID;
-    void profiles;
+  test("derives battery cap and presets when omitted", () => {
+    // Only name + range supplied — the optional fields fall back to the
+    // deterministic formula (battery cap = maxTdp, no artificial throttle).
+    const result = validateCustomDevice({ name: "Bare", minTdp: 5, maxTdp: 80 });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.device).toEqual({
+        name: "Bare",
+        minTdp: 5,
+        maxTdp: 80,
+        batteryMaxTdp: 80,
+        profiles: { Silent: 5, Balanced: 43, Performance: 80 },
+      });
+    }
+  });
+
+  test("derives individual presets left blank, keeps supplied ones", () => {
+    // Balanced supplied, Silent/Performance omitted → derived from the range.
+    const result = validateCustomDevice({
+      name: "Partial",
+      minTdp: 5,
+      maxTdp: 80,
+      profiles: { Balanced: 30 },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.device.profiles).toEqual({
+        Silent: 5,
+        Balanced: 30,
+        Performance: 80,
+      });
+    }
+  });
+
+  test("still validates supplied optional fields", () => {
+    // A supplied battery cap above max is rejected, not silently derived.
+    expect(
+      validateCustomDevice({
+        name: "Bad battery",
+        minTdp: 5,
+        maxTdp: 40,
+        batteryMaxTdp: 60,
+      }).ok,
+    ).toBe(false);
+  });
+
+  test("rejects missing required range", () => {
+    const { minTdp, ...rest } = VALID;
+    void minTdp;
     expect(validateCustomDevice(rest).ok).toBe(false);
+  });
+});
+
+describe("deriveDeviceDefaults", () => {
+  test("battery cap defaults to the full max (no throttle)", () => {
+    expect(deriveDeviceDefaults(5, 80).batteryMaxTdp).toBe(80);
+  });
+
+  test("presets span the range with a rounded midpoint", () => {
+    expect(deriveDeviceDefaults(5, 80).profiles).toEqual({
+      Silent: 5,
+      Balanced: 43,
+      Performance: 80,
+    });
+    expect(deriveDeviceDefaults(4, 15).profiles).toEqual({
+      Silent: 4,
+      Balanced: 10, // round((4 + 15) / 2) = 9.5 → 10
+      Performance: 15,
+    });
   });
 });
 

--- a/plugins/tdp-control/lib/custom-device.ts
+++ b/plugins/tdp-control/lib/custom-device.ts
@@ -44,11 +44,42 @@ function isWholeNumber(n: unknown): n is number {
 }
 
 /**
+ * Derive the optional device fields (battery cap + power presets) from just the
+ * TDP range, so a user only has to enter Min and Max. Deterministic and pure —
+ * the single source of truth used both by the form (to preview) and by
+ * `validateCustomDevice` (to fill any field the user left blank).
+ *
+ * Battery max defaults to the full `maxTdp`: for an unlisted/custom device we
+ * have no thermal profile to justify a lower cap, and silently capping battery
+ * TDP below the entered max is exactly the bug users hit ("80W clamps to 30W").
+ * Users who want a lower battery cap can still set one explicitly.
+ */
+export function deriveDeviceDefaults(
+  minTdp: number,
+  maxTdp: number,
+): { batteryMaxTdp: number; profiles: CustomDevice["profiles"] } {
+  return {
+    batteryMaxTdp: maxTdp,
+    profiles: {
+      Silent: minTdp,
+      Balanced: Math.round((minTdp + maxTdp) / 2),
+      Performance: maxTdp,
+    },
+  };
+}
+
+/**
  * Validate an untrusted object into a `CustomDevice`, or return a
  * user-facing error string. Rules: non-empty name; whole-number watts in
- * [MIN_WATTS, MAX_WATTS]; `minTdp < maxTdp`; `minTdp <= batteryMaxTdp <=
- * maxTdp`; each preset within `[minTdp, maxTdp]`. Pure — reused by the
- * backend RPC and by `readCustomDevice` to reject corrupt stored data.
+ * [MIN_WATTS, MAX_WATTS]; `minTdp < maxTdp`.
+ *
+ * `batteryMaxTdp` and each `profiles` preset are OPTIONAL: any that is absent
+ * (`null`/`undefined`) is derived from the range via `deriveDeviceDefaults`, so
+ * the form only has to require name + Min + Max. When a value IS supplied it is
+ * validated as before (`minTdp <= batteryMaxTdp <= maxTdp`; each preset within
+ * `[minTdp, maxTdp]`; presets ascending). The returned device is always
+ * complete. Pure — reused by the backend RPC and by `readCustomDevice` to
+ * reject corrupt stored data.
  */
 export function validateCustomDevice(input: unknown): ValidationResult {
   if (!input || typeof input !== "object") {
@@ -65,12 +96,12 @@ export function validateCustomDevice(input: unknown): ValidationResult {
     };
   }
 
-  const ranges: Array<[string, unknown]> = [
+  // Min and Max TDP are the only required numeric fields.
+  const requiredRanges: Array<[string, unknown]> = [
     ["Min TDP", o.minTdp],
     ["Max TDP", o.maxTdp],
-    ["Battery max TDP", o.batteryMaxTdp],
   ];
-  for (const [label, value] of ranges) {
+  for (const [label, value] of requiredRanges) {
     if (!isWholeNumber(value)) {
       return { ok: false, error: `${label} must be a whole number` };
     }
@@ -83,25 +114,39 @@ export function validateCustomDevice(input: unknown): ValidationResult {
   }
   const minTdp = o.minTdp as number;
   const maxTdp = o.maxTdp as number;
-  const batteryMaxTdp = o.batteryMaxTdp as number;
 
   if (minTdp >= maxTdp) {
     return { ok: false, error: "Min TDP must be less than Max TDP" };
   }
-  if (batteryMaxTdp < minTdp || batteryMaxTdp > maxTdp) {
-    return {
-      ok: false,
-      error: "Battery max TDP must be between Min and Max TDP",
-    };
+
+  // Everything below is optional — fall back to the deterministic formula.
+  const derived = deriveDeviceDefaults(minTdp, maxTdp);
+
+  // Battery max TDP (optional).
+  let batteryMaxTdp = derived.batteryMaxTdp;
+  if (o.batteryMaxTdp != null) {
+    if (!isWholeNumber(o.batteryMaxTdp)) {
+      return { ok: false, error: "Battery max TDP must be a whole number" };
+    }
+    if (o.batteryMaxTdp < minTdp || o.batteryMaxTdp > maxTdp) {
+      return {
+        ok: false,
+        error: "Battery max TDP must be between Min and Max TDP",
+      };
+    }
+    batteryMaxTdp = o.batteryMaxTdp;
   }
 
-  if (!o.profiles || typeof o.profiles !== "object") {
-    return { ok: false, error: "Power presets are required" };
-  }
-  const rawProfiles = o.profiles as Record<string, unknown>;
-  const profiles = {} as CustomDevice["profiles"];
+  // Power presets (optional, per-field). Any preset the user left blank is
+  // derived from the range; supplied ones are validated.
+  const rawProfiles =
+    o.profiles && typeof o.profiles === "object"
+      ? (o.profiles as Record<string, unknown>)
+      : {};
+  const profiles = { ...derived.profiles };
   for (const key of PROFILE_KEYS) {
     const value = rawProfiles[key];
+    if (value == null) continue; // left blank → keep derived default
     if (!isWholeNumber(value)) {
       return { ok: false, error: `${key} preset must be a whole number` };
     }

--- a/plugins/tdp-control/lib/tdp-profiles.test.ts
+++ b/plugins/tdp-control/lib/tdp-profiles.test.ts
@@ -649,20 +649,32 @@ describe("TDP Profile Engine", () => {
   // -------------------------------------------------------------------------
 
   describe("TDP clamping", () => {
-    test("clamps TDP below minimum (3W) to 3", async () => {
+    // The engine's sanity bounds are 1-200 W (mirroring the custom-device
+    // absolute range) so custom devices above the old 80 W cap aren't clamped
+    // by the per-game path. The real per-device limit is applied downstream in
+    // the backend's applyTdp().
+    test("clamps TDP below minimum (1W) to 1", async () => {
       const engine = createEngine();
       await engine.loadProfiles();
 
-      await engine.setProfile(100, "Low Game", 1);
-      expect(engine.getProfile(100)?.tdpWatts).toBe(3);
+      await engine.setProfile(100, "Low Game", 0);
+      expect(engine.getProfile(100)?.tdpWatts).toBe(1);
     });
 
-    test("clamps TDP above maximum (80W) to 80", async () => {
+    test("clamps TDP above maximum (200W) to 200", async () => {
       const engine = createEngine();
       await engine.loadProfiles();
 
-      await engine.setProfile(200, "High Game", 100);
-      expect(engine.getProfile(200)?.tdpWatts).toBe(80);
+      await engine.setProfile(200, "High Game", 250);
+      expect(engine.getProfile(200)?.tdpWatts).toBe(200);
+    });
+
+    test("allows a high custom-device wattage (e.g. 100W) unchanged", async () => {
+      const engine = createEngine();
+      await engine.loadProfiles();
+
+      await engine.setProfile(300, "Big Handheld", 100);
+      expect(engine.getProfile(300)?.tdpWatts).toBe(100);
     });
 
     test("clamps default TDP to valid range", async () => {
@@ -670,10 +682,10 @@ describe("TDP Profile Engine", () => {
       await engine.loadProfiles();
 
       await engine.setDefaultTdp(0);
-      expect(engine.getDefaultTdp()).toBe(3);
+      expect(engine.getDefaultTdp()).toBe(1);
 
-      await engine.setDefaultTdp(100);
-      expect(engine.getDefaultTdp()).toBe(80);
+      await engine.setDefaultTdp(250);
+      expect(engine.getDefaultTdp()).toBe(200);
     });
 
     test("clamps values loaded from config file", async () => {
@@ -681,16 +693,16 @@ describe("TDP Profile Engine", () => {
         defaultTdp: 999,
         profiles: [
           { appId: 1, gameName: "Low", tdpWatts: -5 },
-          { appId: 2, gameName: "High", tdpWatts: 100 },
+          { appId: 2, gameName: "High", tdpWatts: 250 },
         ],
       });
 
       const engine = createEngine();
       await engine.loadProfiles();
 
-      expect(engine.getDefaultTdp()).toBe(80);
-      expect(engine.getProfile(1)?.tdpWatts).toBe(3);
-      expect(engine.getProfile(2)?.tdpWatts).toBe(80);
+      expect(engine.getDefaultTdp()).toBe(200);
+      expect(engine.getProfile(1)?.tdpWatts).toBe(1);
+      expect(engine.getProfile(2)?.tdpWatts).toBe(200);
     });
   });
 

--- a/plugins/tdp-control/lib/tdp-profiles.ts
+++ b/plugins/tdp-control/lib/tdp-profiles.ts
@@ -57,8 +57,13 @@ export interface TdpProfileEngineOptions {
 // Constants
 // ---------------------------------------------------------------------------
 
-const MIN_TDP_WATTS = 3;
-const MAX_TDP_WATTS = 80;
+// Sanity bounds for stored per-game/default TDP values. These are a guard
+// against corrupt data, NOT the per-device limit — the real clamp to the active
+// device's range happens in the backend's applyTdp(). They mirror the
+// custom-device absolute bounds (1-200 W) so a custom device above the old 80 W
+// cap isn't silently limited through the per-game path.
+const MIN_TDP_WATTS = 1;
+const MAX_TDP_WATTS = 200;
 const DEFAULT_TDP_WATTS = 15;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Custom devices now derive their battery cap and power presets from the
TDP range, so a user only has to enter a name plus Min/Max. The presets
and battery cap move into an optional collapsible region in the
custom-device form; anything left blank is filled by a deterministic
formula (Silent=min, Balanced=midpoint, Performance=max, battery cap=max).

This fixes the reported bug where a raised Max TDP (e.g. 80W) still
clamped to the low auto-detected battery cap (~30W) on an unknown device:
the form no longer seeds the battery cap from the detected value, and a
blank battery cap now defaults to the full max instead of throttling.

Also raise the per-game profile engine's sanity clamp from 3-80W to
1-200W (mirroring the custom-device bounds) so custom devices above 80W
aren't silently limited through the per-game path. The real per-device
clamp still happens in the backend's applyTdp().

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JQ3SbER5nvqs1LQXwWt48f