### PR TITLE
fix(injector,sound-loader): three webpack-patcher bugs and a test writing to real Steam

### DIFF
--- a/apps/loadout/src/injector/webpack-patcher.test.ts
+++ b/apps/loadout/src/injector/webpack-patcher.test.ts
@@ -1,0 +1,296 @@
+/**
+ * The patcher's output is a string of JavaScript that only ever runs inside
+ * Steam. So these tests *run it* — against a fake `window` carrying a fake
+ * `webpackChunksteamui` — rather than asserting on the text of the script.
+ * Asserting on the text is how a patcher passes its tests while silently
+ * patching nothing, which is exactly the failure this file was written after.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { MAX_MODULE_SOURCE, buildWebpackPatcherScript } from "./webpack-patcher";
+import type { WebpackPatchEntry } from "./webpack-patcher";
+
+interface FakeChunk {
+  0: string[];
+  1: Record<string, unknown>;
+}
+
+/** Run the generated script against a fake webpack chunk array. */
+function runPatcher(args: {
+  patches: WebpackPatchEntry[];
+  modules: Record<string, (...a: unknown[]) => unknown>;
+}) {
+  const { patches, modules } = args;
+  const chunk = [["chunk"], modules] as unknown as FakeChunk;
+  const chunks: FakeChunk[] = [chunk];
+
+  const win: Record<string, unknown> = { webpackChunksteamui: chunks };
+  const script = buildWebpackPatcherScript(patches);
+
+  // `window` and `globalThis` both resolve to the fake, so `$self` lookups and
+  // the installed-guard behave as they do in Steam.
+  const run = new Function("window", "globalThis", "console", script);
+  run(win, win, { log() {}, warn() {}, error() {} });
+
+  return { modules: chunk[1], win, chunks };
+}
+
+function patch(overrides: Partial<WebpackPatchEntry["patch"]> = {}): WebpackPatchEntry {
+  return {
+    pluginId: "collections",
+    patch: {
+      find: "MARKER_FIND",
+      replacement: { match: "return TABS", replace: "return TABS.concat(EXTRA)" },
+      ...overrides,
+    },
+  };
+}
+
+describe("webpack patcher — module size ceiling", () => {
+  it("patches Steam's library module, which is far larger than the old ceiling", () => {
+    // The regression that prompted this file. Steam's library module — the one
+    // holding the tab bar, and the only reason a UI patcher exists — measured
+    // 646,312 chars on the 2026-07 client. The ceiling was 200,000, so the
+    // module was skipped before the find pattern was ever consulted: the patch
+    // matched nothing and reported nothing.
+    const padding = "/*".concat("x".repeat(646_312), "*/");
+    const factory = new Function(
+      "module",
+      `${padding}; var MARKER_FIND = 1; var TABS = [1]; var EXTRA = [2]; return TABS;`,
+    ) as (...a: unknown[]) => unknown;
+
+    expect(Function.prototype.toString.call(factory).length).toBeGreaterThan(200_000);
+
+    const { modules } = runPatcher({ patches: [patch()], modules: { "97220": factory } });
+    expect(modules["97220"]).not.toBe(factory);
+    expect((modules["97220"] as () => unknown)()).toEqual([1, 2]);
+  });
+
+  it("still skips a module too large to be worth scanning", () => {
+    const huge = new Function(
+      "module",
+      `/*${"x".repeat(MAX_MODULE_SOURCE + 1000)}*/; var MARKER_FIND = 1; return TABS;`,
+    ) as (...a: unknown[]) => unknown;
+
+    const { modules } = runPatcher({ patches: [patch()], modules: { big: huge } });
+    expect(modules.big).toBe(huge);
+  });
+});
+
+describe("webpack patcher — matching", () => {
+  it("rewrites a module whose source matches the find pattern", () => {
+    const factory = new Function(
+      "module",
+      "var MARKER_FIND = 1; var TABS = ['a']; var EXTRA = ['b']; return TABS;",
+    ) as (...a: unknown[]) => unknown;
+
+    const { modules } = runPatcher({ patches: [patch()], modules: { m: factory } });
+    expect((modules.m as () => unknown)()).toEqual(["a", "b"]);
+  });
+
+  it("leaves a module the find pattern doesn't name alone", () => {
+    // A patcher that rewrites the wrong module is worse than one that does
+    // nothing — it corrupts a component nobody is looking at.
+    const other = new Function("module", "var TABS = ['a']; return TABS;") as (
+      ...a: unknown[]
+    ) => unknown;
+
+    const { modules } = runPatcher({ patches: [patch()], modules: { other } });
+    expect(modules.other).toBe(other);
+  });
+
+  it("requires every entry of an array find to be present", () => {
+    const factory = new Function(
+      "module",
+      "var MARKER_FIND = 1; var TABS = ['a']; var EXTRA=['b']; return TABS;",
+    ) as (...a: unknown[]) => unknown;
+
+    const { modules } = runPatcher({
+      patches: [patch({ find: ["MARKER_FIND", "NOT_PRESENT"] })],
+      modules: { m: factory },
+    });
+    expect(modules.m).toBe(factory);
+  });
+
+  it("does not rewrite a module when the replacement matched nothing", () => {
+    // Finding the right module but failing the replacement must leave Steam's
+    // own code intact rather than rebuilding it from an unchanged string.
+    const factory = new Function(
+      "module",
+      "var MARKER_FIND = 1; return 'untouched';",
+    ) as (...a: unknown[]) => unknown;
+
+    const { modules } = runPatcher({ patches: [patch()], modules: { m: factory } });
+    expect(modules.m).toBe(factory);
+  });
+});
+
+describe("webpack patcher — surviving a bad patch", () => {
+  it("keeps the original factory when the patched source won't compile", () => {
+    // The safety property that makes source patching preferable to patching
+    // React's dispatcher: a broken patch degrades to stock Steam instead of
+    // taking the library page down mid-render.
+    const factory = new Function(
+      "module",
+      "var MARKER_FIND = 1; var TABS = ['a']; return TABS;",
+    ) as (...a: unknown[]) => unknown;
+
+    const { modules } = runPatcher({
+      patches: [patch({ replacement: { match: "return TABS", replace: "return TABS(((" } })],
+      modules: { m: factory },
+    });
+    expect((modules.m as () => unknown)()).toEqual(["a"]);
+  });
+
+  it("reports which patches never matched, rather than failing silently", () => {
+    const { win } = runPatcher({ patches: [patch({ find: "NEVER" })], modules: {} });
+    expect(win.__LOADOUT_APPLIED_PATCHES).toEqual({});
+    expect(win.__LOADOUT_PATCH_LOG).toEqual([]);
+  });
+
+  it("records what it did apply, so a live client can be inspected", () => {
+    const factory = new Function(
+      "module",
+      "var MARKER_FIND = 1; var TABS = ['a']; var EXTRA=['b']; return TABS;",
+    ) as (...a: unknown[]) => unknown;
+
+    const { win } = runPatcher({ patches: [patch()], modules: { m: factory } });
+    expect(win.__LOADOUT_APPLIED_PATCHES).toEqual({ "collections:0": true });
+    expect((win.__LOADOUT_PATCH_LOG as unknown[]).length).toBe(1);
+  });
+});
+
+describe("webpack patcher — re-injection", () => {
+  it("adopts a new patch set instead of bailing out", () => {
+    // Steam's page outlives the daemon, so this script gets injected into the
+    // same page again on every daemon restart. The old guard returned early,
+    // which meant a just-fixed patch appeared to do nothing at all.
+    const factory = new Function(
+      "module",
+      "var MARKER_FIND = 1; var TABS = ['a']; var EXTRA = ['b']; return TABS;",
+    ) as (...a: unknown[]) => unknown;
+
+    const chunk = [["c"], { m: factory }] as unknown as FakeChunk;
+    const chunks: FakeChunk[] = [chunk];
+    const win: Record<string, unknown> = { webpackChunksteamui: chunks };
+    const console_ = { log() {}, warn() {}, error() {} };
+
+    // First injection: a patch that matches nothing.
+    new Function("window", "globalThis", "console", buildWebpackPatcherScript([patch({ find: "NOPE" })]))(
+      win,
+      win,
+      console_,
+    );
+    expect(chunk[1].m).toBe(factory);
+
+    // Second injection, same page, with a patch that does match.
+    new Function("window", "globalThis", "console", buildWebpackPatcherScript([patch()]))(
+      win,
+      win,
+      console_,
+    );
+    expect(chunk[1].m).not.toBe(factory);
+    expect((chunk[1].m as () => unknown)()).toEqual(["a", "b"]);
+  });
+
+  it("does not double-wrap push across injections", () => {
+    // Two layers of interception would scan every chunk twice forever.
+    const win: Record<string, unknown> = { webpackChunksteamui: [] as FakeChunk[] };
+    const console_ = { log() {}, warn() {}, error() {} };
+    const script = buildWebpackPatcherScript([patch()]);
+
+    new Function("window", "globalThis", "console", script)(win, win, console_);
+    const afterFirst = (win.webpackChunksteamui as FakeChunk[]).push;
+    new Function("window", "globalThis", "console", script)(win, win, console_);
+    expect((win.webpackChunksteamui as FakeChunk[]).push).toBe(afterFirst);
+  });
+});
+
+describe("webpack patcher — $self", () => {
+  it("resolves for a kebab-case plugin id", () => {
+    // Dot notation made `globalThis.__LOADOUT_PLUGIN_input-plumber` a
+    // subtraction, so every hyphenated plugin got a patch that compiled and
+    // then threw. Nearly every plugin id in this repo is hyphenated, so the
+    // id here must contain a hyphen or the test proves nothing.
+    const factory = new Function(
+      "module",
+      "var MARKER_FIND = 1; var TABS = ['a']; return TABS;",
+    ) as (...a: unknown[]) => unknown;
+
+    const { modules } = runPatcher({
+      patches: [
+        {
+          pluginId: "input-plumber",
+          patch: {
+            find: "MARKER_FIND",
+            replacement: { match: "return TABS", replace: "return $self.extend(TABS)" },
+          },
+        },
+      ],
+      modules: { m: factory },
+    });
+
+    // The rebuilt factory is created by `new Function` inside the patcher, so
+    // it resolves the real global scope — as it does in Steam.
+    const key = "__LOADOUT_PLUGIN_input-plumber";
+    (globalThis as Record<string, unknown>)[key] = {
+      extend: (t: string[]) => [...t, "injected"],
+    };
+    try {
+      expect((modules.m as () => unknown)()).toEqual(["a", "injected"]);
+    } finally {
+      delete (globalThis as Record<string, unknown>)[key];
+    }
+  });
+
+  it("degrades to an empty object when the plugin global is absent", () => {
+    // The bundle-eval loop that populated these was removed as dead code, so
+    // a missing global is the normal case, not an exceptional one. It must
+    // not take Steam's library down.
+    const factory = new Function(
+      "module",
+      "var MARKER_FIND = 1; var TABS = ['a']; return TABS;",
+    ) as (...a: unknown[]) => unknown;
+
+    const { modules } = runPatcher({
+      patches: [
+        patch({
+          replacement: {
+            match: "return TABS",
+            replace: "return ($self.extend || function(t){return t})(TABS)",
+          },
+        }),
+      ],
+      modules: { m: factory },
+    });
+    expect((modules.m as () => unknown)()).toEqual(["a"]);
+  });
+});
+
+describe("webpack patcher — no patches", () => {
+  it("does not hook webpack at all when nothing needs patching", () => {
+    // Most sessions register no patches. Wrapping `push` regardless would put
+    // us on the hot path of every chunk load for nothing.
+    const { chunks } = runPatcher({ patches: [], modules: {} });
+    expect(chunks.push).toBe(Array.prototype.push);
+  });
+
+  it("hooks push when there is something to patch", () => {
+    const { chunks } = runPatcher({ patches: [patch()], modules: {} });
+    expect(chunks.push).not.toBe(Array.prototype.push);
+  });
+
+  it("patches a chunk that arrives after the hook is installed", () => {
+    // Steam loads its library chunk lazily, so the chunks present at install
+    // time are not the interesting ones.
+    const { chunks } = runPatcher({ patches: [patch()], modules: {} });
+    const late = new Function(
+      "module",
+      "var MARKER_FIND = 1; var TABS = ['a']; var EXTRA=['b']; return TABS;",
+    ) as (...a: unknown[]) => unknown;
+    const lateChunk = [["late"], { late }] as unknown as FakeChunk;
+
+    chunks.push(lateChunk);
+    expect((lateChunk[1].late as () => unknown)()).toEqual(["a", "b"]);
+  });
+});

--- a/apps/loadout/src/injector/webpack-patcher.ts
+++ b/apps/loadout/src/injector/webpack-patcher.ts
@@ -18,6 +18,15 @@
 
 import type { PluginPatch } from "@loadout/types";
 
+/**
+ * Largest module source we will stringify and scan, in characters.
+ *
+ * Sized from the real client rather than guessed: Steam's library module is
+ * ~646 KB and is the one every UI patch cares about, so anything under about
+ * 1 MB excludes the whole point of having a patcher.
+ */
+export const MAX_MODULE_SOURCE = 2_000_000;
+
 export interface WebpackPatchEntry {
   /** Plugin ID that owns this patch */
   pluginId: string;
@@ -45,11 +54,18 @@ export function buildWebpackPatcherScript(patches: WebpackPatchEntry[]): string 
 (function() {
   "use strict";
 
-  if (window.__LOADOUT_WEBPACK_PATCHER) {
-    console.log("[loadout:wp] Webpack patcher already installed");
-    return;
+  var MAX_MODULE_SOURCE = ${MAX_MODULE_SOURCE};
+
+  // Re-injection must update the patch set, not bail.
+  //
+  // Steam's page outlives the Loadout daemon: restart the daemon, enable a
+  // plugin, or edit a patch, and this script is injected again into the same
+  // page. The old guard returned early, so the running client kept the patch
+  // set it booted with — and a freshly-fixed patch appeared to do nothing,
+  // which is a genuinely baffling thing to debug.
+  if (window.__LOADOUT_WEBPACK_PATCHER && window.__LOADOUT_WEBPACK_PATCHER.reload) {
+    return window.__LOADOUT_WEBPACK_PATCHER.reload(${patchesJson});
   }
-  window.__LOADOUT_WEBPACK_PATCHER = true;
 
   var PATCHES = ${patchesJson};
   var appliedPatches = {};
@@ -84,9 +100,14 @@ export function buildWebpackPatcherScript(patches: WebpackPatchEntry[]): string 
       var matchPattern = rep.match;
       var replaceStr = rep.replace;
 
-      // Support $self — reference to the plugin's global module
+      // Support $self — reference to the plugin's global module.
+      //
+      // Bracket notation, not dot: plugin ids are kebab-case, so
+      // \`globalThis.__LOADOUT_PLUGIN_input-plumber\` parses as a subtraction
+      // and every hyphenated plugin — which is most of them — got a patch that
+      // compiled and then threw at runtime. \`route-patcher.ts\` had this right.
       replaceStr = replaceStr.split("$self").join(
-        "(globalThis.__LOADOUT_PLUGIN_" + pluginId + " || {})"
+        '(globalThis[' + JSON.stringify("__LOADOUT_PLUGIN_" + pluginId) + '] || {})'
       );
 
       // Try as regex first (if it looks like /pattern/flags)
@@ -127,8 +148,16 @@ export function buildWebpackPatcherScript(patches: WebpackPatchEntry[]): string 
       return factory;
     }
 
-    // Skip very large modules (likely generated code) and tiny ones
-    if (source.length > 200000 || source.length < 10) return factory;
+    // Skip tiny modules, and ones so large that stringifying every chunk would
+    // cost more than any patch is worth.
+    //
+    // The ceiling was 200,000, which silently skipped the module we most need:
+    // Steam's library module (97220 on the 2026-07 client) holds the tab bar
+    // and is 646,312 chars. A patch against it matched nothing and reported
+    // nothing, because a skipped module never reaches the find check. Measured
+    // on device: 2449 modules across 54 chunks, and stringifying all of them
+    // is not the expensive part.
+    if (source.length > MAX_MODULE_SOURCE || source.length < 10) return factory;
 
     var wasPatched = false;
 
@@ -288,11 +317,47 @@ export function buildWebpackPatcherScript(patches: WebpackPatchEntry[]): string 
   window.__LOADOUT_PATCH_LOG = patchLog;
   window.__LOADOUT_APPLIED_PATCHES = appliedPatches;
 
-  if (PATCHES.length > 0) {
-    console.log("[loadout:wp] Installing webpack patcher with " + PATCHES.length + " patch(es)...");
+  var hooked = false;
+
+  function ensureHooked() {
+    if (hooked) return;
+    hooked = true;
     installHook();
     // Check for unmatched patches after Steam finishes loading
     setTimeout(checkUnmatchedPatches, 15000);
+  }
+
+  window.__LOADOUT_WEBPACK_PATCHER = {
+    /**
+     * Swap in a new patch set and re-scan the chunks already loaded.
+     *
+     * Modules webpack has already *executed* keep running their original
+     * factory — replacing it only affects the next require — so a patch that
+     * lands this way generally shows up after Steam restarts. Applying it
+     * anyway is still right: it costs one scan, and it means the patch is in
+     * place the moment anything re-requires the module.
+     */
+    reload: function (nextPatches) {
+      PATCHES = nextPatches || [];
+      // Clear the applied set: the same key may now mean a different patch.
+      for (var key in appliedPatches) delete appliedPatches[key];
+      patchLog.length = 0;
+      if (PATCHES.length === 0) return "no-patches";
+      ensureHooked();
+      var chunkArray = window.webpackChunksteamui;
+      if (chunkArray) {
+        for (var i = 0; i < chunkArray.length; i++) {
+          var chunk = chunkArray[i];
+          if (Array.isArray(chunk) && chunk.length >= 2) processChunkModules(chunk[1]);
+        }
+      }
+      return "reloaded:" + PATCHES.length;
+    },
+  };
+
+  if (PATCHES.length > 0) {
+    console.log("[loadout:wp] Installing webpack patcher with " + PATCHES.length + " patch(es)...");
+    ensureHooked();
   } else {
     console.log("[loadout:wp] No patches registered, skipping webpack patcher");
   }

--- a/plugins/sound-loader/lib/steam-injector.ts
+++ b/plugins/sound-loader/lib/steam-injector.ts
@@ -20,10 +20,22 @@ const HEALTH_INTERVAL_MS = 5000;
 const WEBPACK_READY_POLL_MS = 100;
 const WEBPACK_READY_TIMEOUT_MS = 5000;
 
-export const STEAM_SOUNDS_CUSTOM_DIR = join(
-  homedir(),
-  ".local/share/Steam/steamui/sounds_custom/loadout",
-);
+/**
+ * Where staged sound files go, resolved **per call**.
+ *
+ * A module-level `const` here read `homedir()` once at import time, so it
+ * ignored both `process.env.HOME` and any test sandbox that set it — which
+ * meant `backend.test.ts` wrote into the developer's real Steam install and
+ * failed outright on a machine where `sounds_custom/` happens to be owned by
+ * root (a previous root-run of the plugin leaves it that way). Every other
+ * path in this plugin is already lazy for the same reason.
+ */
+export function steamSoundsCustomDir(): string {
+  return join(
+    process.env.HOME ?? homedir(),
+    ".local/share/Steam/steamui/sounds_custom/loadout",
+  );
+}
 
 export interface PackEntry {
   manifest: {
@@ -291,7 +303,7 @@ function loopbackUrlFor(stagingDir: string, filename: string): string {
 export async function stagePackFiles(
   entry: PackEntry,
   deckyToSteamLoader: Record<string, string>,
-  stagingDir: string = STEAM_SOUNDS_CUSTOM_DIR,
+  stagingDir: string = steamSoundsCustomDir(),
 ): Promise<Record<string, string>> {
   await clearStagedFiles(stagingDir);
   await prepareStagingDir(stagingDir);
@@ -343,7 +355,7 @@ export async function stagePackFiles(
 }
 
 /** Remove the entire staging directory (best-effort). */
-export async function clearStagedFiles(stagingDir: string = STEAM_SOUNDS_CUSTOM_DIR): Promise<void> {
+export async function clearStagedFiles(stagingDir: string = steamSoundsCustomDir()): Promise<void> {
   try {
     await rm(stagingDir, { recursive: true, force: true });
   } catch {
@@ -352,7 +364,7 @@ export async function clearStagedFiles(stagingDir: string = STEAM_SOUNDS_CUSTOM_
 }
 
 /** True if the staging directory exists and contains files (debug helper). */
-export async function listStagedFiles(stagingDir: string = STEAM_SOUNDS_CUSTOM_DIR): Promise<string[]> {
+export async function listStagedFiles(stagingDir: string = steamSoundsCustomDir()): Promise<string[]> {
   try {
     return await readdir(stagingDir);
   } catch {

--- a/scripts/check-plugin-specs.sh
+++ b/scripts/check-plugin-specs.sh
@@ -99,6 +99,12 @@ for dir in $SPEC_SCOPED_LIB_DIRS; do
   [ -d "$dir" ] || continue
   for lib in $(find "$dir" -type f -name '*.ts' 2>/dev/null); do
     case "$lib" in
+      # A spec is not itself subject to the spec rule. `*.test.ts` used to
+      # fall through here and pass only by accident — test files usually
+      # have no `export`, so `is_type_only_module` waved them through.
+      # Adding one exported helper to a spec would then have demanded
+      # `foo.test.test.ts`. Skip them explicitly.
+      *.test.ts) continue ;;
       *.spec.ts) continue ;;
       */types.ts) continue ;;
     esac
@@ -130,6 +136,8 @@ for dir in $SPEC_SCOPED_PACKAGES; do
   [ -d "$dir" ] || continue
   for src in $(find "$dir" -type f -name '*.ts' 2>/dev/null); do
     case "$src" in
+      # See the note in the lib/ loop above.
+      *.test.ts) continue ;;
       *.spec.ts) continue ;;
       */types.ts) continue ;;
     esac


### PR DESCRIPTION
Split out of #236. None of this depends on the collections plugin — it all fixes existing code, and it was blocking nothing.

## The webpack patcher could not patch the one module worth patching

It skipped any module over 200,000 chars **before** consulting the find pattern. Steam's library module — the one holding the library tab bar, and the reason a UI patcher exists at all — is **646,312 chars** on the 2026-07 client.

So a patch against it matched nothing and warned nothing. From the outside that is indistinguishable from a wrong find pattern, which is a genuinely awful thing to debug.

Measured on device: 2449 module factories across 54 chunks. Stringifying all of them is not the expensive part.

## `$self` was broken for almost every plugin

It expanded via dot notation:

```js
globalThis.__LOADOUT_PLUGIN_input-plumber   // parses as a subtraction
```

Plugin ids are kebab-case, so any hyphenated id — nearly all of them — got a patch that compiled and then threw at runtime. `route-patcher.ts` already used bracket notation; this now matches.

## Re-injection was a no-op

Steam's page outlives the Loadout daemon, so this script is injected again into the same page on every daemon restart. The install guard returned early, so the running client kept whatever patch set it booted with — and a freshly-fixed patch appeared to do nothing.

It now swaps the patch set and re-scans already-loaded chunks, without double-wrapping `push`. (Modules webpack has already *executed* keep their original factory, so a patch landing this way generally shows up after Steam restarts; applying it anyway costs one scan and means it is in place the moment anything re-requires the module.)

## sound-loader was writing into the developer's real Steam install

`STEAM_SOUNDS_CUSTOM_DIR` was a module-level `const` evaluated once at **import** time from `homedir()`, so it ignored `process.env.HOME` and any test sandbox that sets it. `backend.test.ts` points HOME at a tmpdir, and its own header says every on-disk path resolves "lazily, per call". This one did not.

It presented as a flaky test. On my machine `~/.local/share/Steam/steamui/sounds_custom/` is owned by `root`, left that way by an earlier root-run of the plugin, so `stagePackFiles` got `EACCES` and returned before `refreshOverrides` — the call the test asserts on. On a machine where that directory happens to be writable, the test passes **and silently rewrites the developer's staged sound files**.

Now a function, matching `SOUND_PACKS_DIR()` and every other path in that plugin.

## Tests

The patcher had none. The new ones **execute** the generated script against a fake `webpackChunksteamui` rather than asserting on its text — asserting on the text is how a patcher passes its suite while silently patching nothing, which is precisely the failure that prompted them.

Covered: the 646KB module as a named regression; array-find AND semantics; chunks arriving after install; `$self` with a hyphenated id, and its degradation when the plugin global is absent; re-injection adopting a new patch set without double-wrapping; and the property that makes source patching preferable to patching React's dispatcher — a replacement producing uncompilable source leaves Steam's original factory in place, degrading to stock rather than killing the library mid-render.

Also fixes `check-plugin-specs.sh` treating `*.test.ts` as subject to the spec rule. They passed only by accident — a test file usually has no `export`, so `is_type_only_module` waved it through — and adding one exported helper to a spec would have demanded `foo.test.test.ts`.

## Verification

`typecheck`, `lint`, `check:specs`, `check:dead-code` all clean. `bun run test` → **2606 + 387 pass, 0 fail** — including the `sound-loader` case that was failing on this machine before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
