### PR TITLE
fix(injector,sound-loader): re-arm the patch report on reload, refuse to double-hook

### DIFF
--- a/apps/loadout/src/injector/webpack-patcher.test.ts
+++ b/apps/loadout/src/injector/webpack-patcher.test.ts
@@ -204,6 +204,71 @@ describe("webpack patcher — re-injection", () => {
     new Function("window", "globalThis", "console", script)(win, win, console_);
     expect((win.webpackChunksteamui as FakeChunk[]).push).toBe(afterFirst);
   });
+
+  it("re-arms the unmatched-patch report for the reloaded set", () => {
+    // The reload path exists so a just-fixed patch takes effect on daemon
+    // restart. If the 15s report is armed only when the hook is installed, the
+    // reloaded set never gets one — so the developer editing a patch is back to
+    // silence, which is the exact failure this whole path is about.
+    const win: Record<string, unknown> = { webpackChunksteamui: [] as FakeChunk[] };
+    const warnings: string[] = [];
+    const console_ = {
+      log() {},
+      warn: (...a: unknown[]) => warnings.push(a.join(" ")),
+      error() {},
+    };
+
+    // Capture the armed callbacks instead of waiting 15 real seconds.
+    const armed: Array<() => void> = [];
+    const fakeSetTimeout = (fn: () => void) => {
+      armed.push(fn);
+      return armed.length;
+    };
+    const run = (script: string) =>
+      new Function("window", "globalThis", "console", "setTimeout", "clearTimeout", script)(
+        win,
+        win,
+        console_,
+        fakeSetTimeout,
+        () => {},
+      );
+
+    run(buildWebpackPatcherScript([{ ...patch({ find: "NEVER_A" }), pluginId: "first-plugin" }]));
+    run(buildWebpackPatcherScript([{ ...patch({ find: "NEVER_B" }), pluginId: "second-plugin" }]));
+
+    expect(armed.length).toBeGreaterThan(1);
+
+    // Fire the most recently armed report: it must name the reloaded plugin.
+    armed[armed.length - 1]!();
+    expect(warnings.some((w) => w.includes("second-plugin"))).toBe(true);
+  });
+
+  it("declines rather than double-hooking when an older build is already installed", () => {
+    // Builds before `reload` existed set this global to a bare `true`, and
+    // their push hook is still live in the page. Falling through would leave
+    // two interceptors applying two different patch sets to every chunk.
+    const chunks: FakeChunk[] = [];
+    const win: Record<string, unknown> = {
+      webpackChunksteamui: chunks,
+      __LOADOUT_WEBPACK_PATCHER: true,
+    };
+    const warnings: string[] = [];
+    const console_ = {
+      log() {},
+      warn: (...a: unknown[]) => warnings.push(a.join(" ")),
+      error() {},
+    };
+
+    const pristinePush = chunks.push;
+    new Function("window", "globalThis", "console", buildWebpackPatcherScript([patch()]))(
+      win,
+      win,
+      console_,
+    );
+
+    expect(chunks.push).toBe(pristinePush);
+    expect(warnings.some((w) => w.includes("Restart Steam"))).toBe(true);
+  });
 });
 
 describe("webpack patcher — $self", () => {

--- a/apps/loadout/src/injector/webpack-patcher.ts
+++ b/apps/loadout/src/injector/webpack-patcher.ts
@@ -22,8 +22,9 @@ import type { PluginPatch } from "@loadout/types";
  * Largest module source we will stringify and scan, in characters.
  *
  * Sized from the real client rather than guessed: Steam's library module is
- * ~646 KB and is the one every UI patch cares about, so anything under about
- * 1 MB excludes the whole point of having a patcher.
+ * ~646 KB and is the one every UI patch cares about, so any ceiling below
+ * ~650 KB excludes the whole point of having a patcher. 2 MB leaves room for
+ * that module to grow without putting us back in the same hole.
  */
 export const MAX_MODULE_SOURCE = 2_000_000;
 
@@ -63,8 +64,22 @@ export function buildWebpackPatcherScript(patches: WebpackPatchEntry[]): string 
   // page. The old guard returned early, so the running client kept the patch
   // set it booted with — and a freshly-fixed patch appeared to do nothing,
   // which is a genuinely baffling thing to debug.
-  if (window.__LOADOUT_WEBPACK_PATCHER && window.__LOADOUT_WEBPACK_PATCHER.reload) {
-    return window.__LOADOUT_WEBPACK_PATCHER.reload(${patchesJson});
+  if (window.__LOADOUT_WEBPACK_PATCHER) {
+    var installed = window.__LOADOUT_WEBPACK_PATCHER;
+    if (typeof installed.reload === "function") {
+      return installed.reload(${patchesJson});
+    }
+    // A build from before \`reload\` existed left a bare \`true\` here, and its
+    // push hook is still live in this page. We cannot reach that closure to
+    // swap its patch set, and installing a second hook would leave two
+    // interceptors scanning every chunk and applying two different patch sets
+    // — with __LOADOUT_PATCH_LOG pointing at only one of them. Decline, which
+    // is what the old guard did anyway, but say why.
+    console.warn(
+      "[loadout:wp] A patcher from an older Loadout build is already installed " +
+      "in this page. Restart Steam to pick up the current patch set."
+    );
+    return;
   }
 
   var PATCHES = ${patchesJson};
@@ -323,8 +338,23 @@ export function buildWebpackPatcherScript(patches: WebpackPatchEntry[]): string 
     if (hooked) return;
     hooked = true;
     installHook();
-    // Check for unmatched patches after Steam finishes loading
-    setTimeout(checkUnmatchedPatches, 15000);
+  }
+
+  var unmatchedTimer = null;
+
+  /**
+   * Report unmatched patches once Steam has finished loading.
+   *
+   * Armed per *patch set*, not per hook: a reload adopts different patches and
+   * those need their own report. Keeping this inside \`ensureHooked\` meant it
+   * fired exactly once per page, so after a daemon restart a patch that matched
+   * nothing went back to being silent — the precise failure the reload path
+   * exists to fix. Re-arming replaces any pending check so two reloads in
+   * quick succession produce one report, not two.
+   */
+  function armUnmatchedCheck() {
+    if (unmatchedTimer !== null) clearTimeout(unmatchedTimer);
+    unmatchedTimer = setTimeout(checkUnmatchedPatches, 15000);
   }
 
   window.__LOADOUT_WEBPACK_PATCHER = {
@@ -344,6 +374,7 @@ export function buildWebpackPatcherScript(patches: WebpackPatchEntry[]): string 
       patchLog.length = 0;
       if (PATCHES.length === 0) return "no-patches";
       ensureHooked();
+      armUnmatchedCheck();
       var chunkArray = window.webpackChunksteamui;
       if (chunkArray) {
         for (var i = 0; i < chunkArray.length; i++) {
@@ -358,6 +389,7 @@ export function buildWebpackPatcherScript(patches: WebpackPatchEntry[]): string 
   if (PATCHES.length > 0) {
     console.log("[loadout:wp] Installing webpack patcher with " + PATCHES.length + " patch(es)...");
     ensureHooked();
+    armUnmatchedCheck();
   } else {
     console.log("[loadout:wp] No patches registered, skipping webpack patcher");
   }

--- a/plugins/sound-loader/lib/steam-injector.ts
+++ b/plugins/sound-loader/lib/steam-injector.ts
@@ -31,8 +31,15 @@ const WEBPACK_READY_TIMEOUT_MS = 5000;
  * path in this plugin is already lazy for the same reason.
  */
 export function steamSoundsCustomDir(): string {
+  // `||`, not `??`: an empty HOME has to fall back too. `??` only catches
+  // null/undefined, so `HOME=""` would join onto nothing and produce a
+  // relative path — staging sound files into the process CWD, which is a poor
+  // failure mode for the function whose whole bug was writing to the wrong
+  // place. Loadout ships a systemd unit, and units are exactly where
+  // empty-vs-unset HOME bites. Same guard `packages/external-cache` applies
+  // to XDG_CACHE_HOME.
   return join(
-    process.env.HOME ?? homedir(),
+    process.env.HOME || homedir(),
     ".local/share/Steam/steamui/sounds_custom/loadout",
   );
 }


### PR DESCRIPTION
Three gaps found reviewing #238 after it merged. The first two undercut that PR's own purpose, which was making a silently-unapplied patch visible.

## The unmatched-patch report fired once per page, not once per patch set

`setTimeout(checkUnmatchedPatches, 15000)` lived inside `ensureHooked()`, which is guarded by `hooked`. So `reload()` adopted a new patch set and never armed a report for it.

That breaks the exact loop the reload path exists to serve — edit a patch, restart the daemon, re-inject — and puts you back to silence when the patch matches nothing. #238 called that *"indistinguishable from a wrong find pattern, which is a genuinely awful thing to debug."*

Measured before the fix, by injecting twice against a fake chunk array with a captured `setTimeout`: **one** timer registration across two injections, and **zero** warnings naming the reloaded plugin.

Arming now happens per patch set, in both the install and reload paths, and replaces any pending check so two quick reloads report once rather than twice.

## A page carrying an older build's `true` sentinel got `push` double-wrapped

The guard requires `.reload`. Builds from before it existed set `window.__LOADOUT_WEBPACK_PATCHER = true`, and `true.reload` is undefined — so the guard fell through and `installHook()` wrapped `push` on top of the still-live wrapper from the old closure.

Two interceptors then scan every chunk, each applying its own patch set, with `__LOADOUT_PATCH_LOG` pointing at only one of them. Reachable by updating Loadout while Steam keeps running, which is the same page-outlives-daemon case the reload path was written for.

Verified by running the shipped script and then this one against one fake page: **one late chunk's factory was read twice.**

It now declines and says why. Same outcome as the old guard, minus the mystery, and it self-heals on a Steam restart. Not patching at all beats two live hooks.

## `??` did not guard an empty `HOME`

`process.env.HOME ?? homedir()` only falls back on null/undefined. `HOME=""` yields a relative path, staging sound files into the process CWD — a poor failure mode for the function whose whole bug in #238 was writing to the wrong place.

Loadout ships a systemd unit, and units are exactly where empty-vs-unset `HOME` bites. `packages/external-cache/src/index.ts:113` already guards `XDG_CACHE_HOME` this way.

Also corrects the `MAX_MODULE_SOURCE` comment: the library module is 646 KB, so the floor that matters is ~650 KB, not the 1 MB the comment claimed. Harmless in effect — it steers ceilings upward — but the arithmetic didn't support the sentence.

## Tests

Both patcher gaps get regression tests, and **both were confirmed to fail against the pre-fix source** before being fixed: reverting `webpack-patcher.ts` fails exactly those two and nothing else. A test that passes either way isn't a regression test.

They follow #238's approach of *executing* the generated script against a fake `webpackChunksteamui` rather than asserting on its text, and inject `setTimeout`/`clearTimeout` so the 15s report is observable without waiting.

## Verification

`typecheck`, `lint`, `check:specs`, `check:dead-code` clean.

`test:backend` **423 fail on this branch and 423 on `main`** — identical failure names, checked with `comm -13` on sorted `(fail)` lines, not just counts. That 423 is the standing macOS baseline for Linux-targeted code plus the `mock.module` leakage in `docs/test-mock-contamination.md`. Directly affected files: **39 pass, 0 fail**.

Not verified on hardware — these are page-lifecycle paths, and the double-hook case needs a daemon upgrade across #238 with Steam left running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)