### PR TITLE
feat(achievement-hunter): Phase 0 — game-facts, Steam service caller, device probe

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "steam-loader",
@@ -31,7 +30,7 @@
     },
     "apps/loadout": {
       "name": "@loadout/loadout-server",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@loadout/exec": "workspace:*",
         "@loadout/game-library": "workspace:*",
@@ -44,7 +43,7 @@
     },
     "apps/loadout-overlay": {
       "name": "@loadout/loadout-overlay",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@loadout/deck-hid": "workspace:*",
         "@loadout/devices": "workspace:*",
@@ -96,6 +95,13 @@
         "@loadout/exec": "workspace:*",
       },
     },
+    "packages/game-facts": {
+      "name": "@loadout/game-facts",
+      "version": "0.0.1",
+      "dependencies": {
+        "@loadout/external-cache": "workspace:*",
+      },
+    },
     "packages/game-library": {
       "name": "@loadout/game-library",
       "version": "0.0.1",
@@ -130,6 +136,10 @@
     "packages/steam-cdp": {
       "name": "@loadout/steam-cdp",
       "version": "0.0.1",
+      "dependencies": {
+        "@loadout/external-cache": "workspace:*",
+        "@loadout/steam-paths": "workspace:*",
+      },
     },
     "packages/steam-cef-badges": {
       "name": "@loadout/steam-cef-badges",
@@ -174,6 +184,14 @@
     "packages/wake": {
       "name": "@loadout/wake",
       "version": "0.0.1",
+    },
+    "plugins/achievement-hunter": {
+      "name": "@loadout/plugin-achievement-hunter",
+      "version": "0.0.1",
+      "dependencies": {
+        "@loadout/steam-cdp": "workspace:*",
+        "@loadout/steam-paths": "workspace:*",
+      },
     },
     "plugins/apex": {
       "name": "@loadout/plugin-apex",
@@ -647,6 +665,8 @@
 
     "@loadout/file-picker": ["@loadout/file-picker@workspace:packages/file-picker"],
 
+    "@loadout/game-facts": ["@loadout/game-facts@workspace:packages/game-facts"],
+
     "@loadout/game-library": ["@loadout/game-library@workspace:packages/game-library"],
 
     "@loadout/loadout-overlay": ["@loadout/loadout-overlay@workspace:apps/loadout-overlay"],
@@ -654,6 +674,8 @@
     "@loadout/loadout-server": ["@loadout/loadout-server@workspace:apps/loadout"],
 
     "@loadout/per-game-profiles": ["@loadout/per-game-profiles@workspace:packages/per-game-profiles"],
+
+    "@loadout/plugin-achievement-hunter": ["@loadout/plugin-achievement-hunter@workspace:plugins/achievement-hunter"],
 
     "@loadout/plugin-apex": ["@loadout/plugin-apex@workspace:plugins/apex"],
 

--- a/knip.ts
+++ b/knip.ts
@@ -111,6 +111,21 @@ const config: KnipConfig = {
       project: "**/*.{ts,tsx,css}",
     },
 
+    // achievement-hunter ships a maintainer-only hardware probe on top of the
+    // standard plugin entries. It is run by hand on a device
+    // (`bun plugins/achievement-hunter/scripts/probe-achievements.ts`) to
+    // measure Steam's real service surface — batch caps, response shapes —
+    // and is never imported by the plugin itself.
+    "plugins/achievement-hunter": {
+      entry: [
+        "app.tsx",
+        "backend.ts",
+        "**/*.{test,spec}.{ts,tsx}",
+        "scripts/*.ts",
+      ],
+      project: "**/*.{ts,tsx,css}",
+    },
+
     // recomp additionally ships dynamic-loaded game/mod setup modules and
     // operator scripts on top of the standard plugin entries.
     "plugins/recomp": {

--- a/packages/game-facts/package.json
+++ b/packages/game-facts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@loadout/game-facts",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "@loadout/external-cache": "workspace:*"
+  }
+}

--- a/packages/game-facts/src/index.ts
+++ b/packages/game-facts/src/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Batched, throttled, cached resolution of per-game facts.
+ *
+ * A "fact" is one datum about one game that needs I/O: achievement
+ * completion, HowLongToBeat time, ProtonDB tier, is-a-friend-playing.
+ * This package owns the plumbing every such fact needs — the three-state
+ * value type, staleness policy, batch planning, and the sweep engine that
+ * paces requests and backs off when a source complains — so each consumer
+ * only writes the part that is actually specific to its source.
+ *
+ * Consumers:
+ *   - `plugins/achievement-hunter` — one resolver, batched over Steam's
+ *     authenticated CM transport.
+ *   - `plugins/library-tabs` — six planned resolvers feeding its rule
+ *     engine, which specified this interface before it was extracted
+ *     (see that plugin's `PLAN.md`, "async facts").
+ *
+ * See `types.ts` for why `FactValue` has three states and why
+ * `FactResolver` is generic over its key.
+ */
+
+export {
+  allUnavailable,
+  isOk,
+  missing,
+  unavailable,
+  type FactResolver,
+  type FactRow,
+  type FactValue,
+  type SweepProgress,
+} from "./types";
+
+export {
+  classify,
+  countFresh,
+  fixedTtl,
+  type Staleness,
+  type StalenessPolicy,
+} from "./staleness";
+
+export {
+  planBatches,
+  planCost,
+  type PlanBatchesOptions,
+} from "./plan";
+
+export {
+  createFactStore,
+  type CreateFactStoreOptions,
+  type FactStore,
+  type FactStoreSnapshot,
+} from "./store";
+
+export { createLimiter, type Limiter } from "./limiter";
+
+export {
+  createSweeper,
+  FactFetchError,
+  type BackoffState,
+  type BackoffStore,
+  type Sweeper,
+  type SweeperOptions,
+} from "./sweeper";

--- a/packages/game-facts/src/limiter.test.ts
+++ b/packages/game-facts/src/limiter.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+
+import { createLimiter } from "./limiter";
+
+/** A promise plus its resolver, so a test can hold tasks open deliberately. */
+function deferred<T = void>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("createLimiter", () => {
+  it("rejects a nonsensical cap", () => {
+    expect(() => createLimiter(0)).toThrow(/max/);
+    expect(() => createLimiter(-1)).toThrow(/max/);
+    expect(() => createLimiter(NaN)).toThrow(/max/);
+  });
+
+  it("runs a task and returns its value", async () => {
+    const limit = createLimiter(2);
+    expect(await limit(async () => 42)).toBe(42);
+  });
+
+  it("never exceeds the cap", async () => {
+    const limit = createLimiter(2);
+    let active = 0;
+    let peak = 0;
+    const gates = Array.from({ length: 6 }, () => deferred());
+
+    const tasks = gates.map((gate, i) =>
+      limit(async () => {
+        active++;
+        peak = Math.max(peak, active);
+        await gate.promise;
+        active--;
+        return i;
+      }),
+    );
+
+    // Let the first wave enter.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(peak).toBe(2);
+
+    for (const gate of gates) gate.resolve();
+    expect(await Promise.all(tasks)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(peak).toBe(2);
+    expect(active).toBe(0);
+  });
+
+  it("admits queued tasks in call order (FIFO, not LIFO)", async () => {
+    const limit = createLimiter(1);
+    const started: number[] = [];
+    const gates = [deferred(), deferred(), deferred()];
+
+    const tasks = gates.map((gate, i) =>
+      limit(async () => {
+        started.push(i);
+        await gate.promise;
+      }),
+    );
+
+    // Release one at a time so admission order is observable.
+    gates[0]!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    gates[1]!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    gates[2]!.resolve();
+    await Promise.all(tasks);
+
+    expect(started).toEqual([0, 1, 2]);
+  });
+
+  it("releases the slot when a task throws", async () => {
+    // The bug this guards: a rejection that leaks its slot permanently
+    // shrinks the pool, and enough of them deadlock every later caller.
+    const limit = createLimiter(1);
+
+    await expect(
+      limit(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    // The pool must be whole again.
+    expect(await limit(async () => "ok")).toBe("ok");
+    expect(await limit(async () => "ok again")).toBe("ok again");
+  });
+
+  it("survives a run of failures without deadlocking", async () => {
+    const limit = createLimiter(2);
+    const results = await Promise.allSettled(
+      Array.from({ length: 10 }, (_, i) =>
+        limit(async () => {
+          if (i % 2 === 0) throw new Error(`fail ${i}`);
+          return i;
+        }),
+      ),
+    );
+    expect(results.filter((r) => r.status === "rejected").length).toBe(5);
+    expect(await limit(async () => "still alive")).toBe("still alive");
+  });
+});

--- a/packages/game-facts/src/limiter.ts
+++ b/packages/game-facts/src/limiter.ts
@@ -1,0 +1,52 @@
+/**
+ * A FIFO concurrency limiter.
+ *
+ * Extracted because two shipped plugins already hand-roll it —
+ * `plugins/protondb-badges/backend.ts` (cap 4) and `plugins/hltb/backend.ts`
+ * (cap 3) are near-identical copies — and library-tabs' planned
+ * HTTP-backed fact resolvers need a third. Achievement Hunter's own sweep
+ * runs at concurrency 1, where a limiter is redundant; it lives here for the
+ * consumers that need N > 1, and so those two copies have somewhere to
+ * migrate onto.
+ *
+ * Deliberately not a rate limiter. This caps *simultaneity*, not requests
+ * per second. Pacing is the sweeper's job, because the right inter-request
+ * gap depends on the source and belongs next to the backoff policy.
+ */
+
+/** Run `fn` when a slot is free. Resolves/rejects with `fn`'s result. */
+export type Limiter = <T>(fn: () => Promise<T>) => Promise<T>;
+
+/**
+ * Create a limiter allowing `max` concurrent tasks.
+ *
+ * Queued tasks start in call order. A task that throws still releases its
+ * slot — without that, one rejection permanently shrinks the pool and a
+ * few of them deadlock the caller.
+ */
+export function createLimiter(max: number): Limiter {
+  if (!Number.isFinite(max) || max < 1) {
+    throw new Error(`createLimiter: max must be >= 1, got ${max}`);
+  }
+
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  return async function withSlot<T>(fn: () => Promise<T>): Promise<T> {
+    if (active >= max) {
+      await new Promise<void>((resolve) => {
+        queue.push(resolve);
+      });
+    }
+    active++;
+    try {
+      return await fn();
+    } finally {
+      active--;
+      // Hand the slot to the longest-waiting caller. `shift` is what makes
+      // this FIFO; a `pop` here would starve early callers under load.
+      const next = queue.shift();
+      if (next) next();
+    }
+  };
+}

--- a/packages/game-facts/src/plan.test.ts
+++ b/packages/game-facts/src/plan.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "bun:test";
+
+import { planBatches, planCost } from "./plan";
+import { fixedTtl } from "./staleness";
+import type { FactRow } from "./types";
+
+const HOUR = 60 * 60 * 1000;
+const policy = fixedTtl(24 * 60 * 60);
+const NOW = 1_700_000_000_000;
+
+function freshRows(appIds: string[], at = NOW): Map<string, FactRow<number>> {
+  return new Map(appIds.map((id) => [id, { at, value: 1 }]));
+}
+
+function ids(n: number, prefix = "app"): string[] {
+  return Array.from({ length: n }, (_, i) => `${prefix}${i}`);
+}
+
+describe("planBatches", () => {
+  it("returns an empty plan when everything is fresh", () => {
+    const appIds = ids(10);
+    const batches = planBatches({
+      appIds,
+      rows: freshRows(appIds),
+      batchSize: 50,
+      policy,
+      now: NOW,
+    });
+    expect(batches).toEqual([]);
+  });
+
+  it("batches every appId when the cache is cold", () => {
+    const batches = planBatches({
+      appIds: ids(137),
+      rows: new Map(),
+      batchSize: 50,
+      policy,
+      now: NOW,
+    });
+    // The plan's headline arithmetic: 137 apps at 50/batch is exactly 3.
+    expect(batches.length).toBe(3);
+    expect(batches[0]!.length).toBe(50);
+    expect(batches[1]!.length).toBe(50);
+    expect(batches[2]!.length).toBe(37);
+    expect(batches.flat().length).toBe(137);
+  });
+
+  it("preserves input order so recency-first batching reaches the hero row first", () => {
+    // Callers sort by last-played before calling; the planner must not re-sort.
+    const appIds = ["recent", "older", "oldest", "ancient"];
+    const batches = planBatches({
+      appIds,
+      rows: new Map(),
+      batchSize: 2,
+      policy,
+      now: NOW,
+    });
+    expect(batches).toEqual([
+      ["recent", "older"],
+      ["oldest", "ancient"],
+    ]);
+  });
+
+  it("skips fresh rows and keeps the survivors in order", () => {
+    const appIds = ["a", "b", "c", "d", "e"];
+    const batches = planBatches({
+      appIds,
+      rows: freshRows(["b", "d"]),
+      batchSize: 10,
+      policy,
+      now: NOW,
+    });
+    expect(batches).toEqual([["a", "c", "e"]]);
+  });
+
+  it("re-queues stale rows", () => {
+    const appIds = ["fresh", "stale"];
+    const rows = new Map<string, FactRow<number>>([
+      ["fresh", { at: NOW, value: 1 }],
+      ["stale", { at: NOW - 48 * HOUR, value: 1 }],
+    ]);
+    const batches = planBatches({ appIds, rows, batchSize: 10, policy, now: NOW });
+    expect(batches).toEqual([["stale"]]);
+  });
+
+  it("resumes a partial sweep without a persisted cursor", () => {
+    // Simulate a sweep that committed the first 16 of 40 batches, then died.
+    const appIds = ids(2000);
+    const done = appIds.slice(0, 16 * 50);
+    const batches = planBatches({
+      appIds,
+      rows: freshRows(done),
+      batchSize: 50,
+      policy,
+      now: NOW,
+    });
+    expect(batches.length).toBe(40 - 16);
+    // It picks up exactly where it left off, in order.
+    expect(batches[0]![0]).toBe(appIds[16 * 50]);
+  });
+
+  it("re-fetches everything when forced, ignoring freshness", () => {
+    const appIds = ids(10);
+    const batches = planBatches({
+      appIds,
+      rows: freshRows(appIds),
+      batchSize: 4,
+      policy,
+      now: NOW,
+      force: true,
+    });
+    expect(batches.flat()).toEqual(appIds);
+  });
+
+  it("still respects the current library when forced", () => {
+    // A cached row for a game no longer owned must not resurrect into a batch.
+    const batches = planBatches({
+      appIds: ["a"],
+      rows: freshRows(["a", "unowned"]),
+      batchSize: 10,
+      policy,
+      now: NOW,
+      force: true,
+    });
+    expect(batches).toEqual([["a"]]);
+  });
+
+  it("collapses duplicate appIds, keeping first position", () => {
+    // appStore.allApps can list the same appid twice (owned + family-shared).
+    const batches = planBatches({
+      appIds: ["a", "b", "a", "c", "b"],
+      rows: new Map(),
+      batchSize: 10,
+      policy,
+      now: NOW,
+    });
+    expect(batches).toEqual([["a", "b", "c"]]);
+  });
+
+  it("handles an empty library", () => {
+    expect(
+      planBatches({ appIds: [], rows: new Map(), batchSize: 50, policy, now: NOW }),
+    ).toEqual([]);
+  });
+
+  it("emits single-item batches when batchSize is 1", () => {
+    const batches = planBatches({
+      appIds: ["a", "b"],
+      rows: new Map(),
+      batchSize: 1,
+      policy,
+      now: NOW,
+    });
+    expect(batches).toEqual([["a"], ["b"]]);
+  });
+
+  it("rejects a nonsensical batch size rather than looping forever", () => {
+    const base = { appIds: ["a"], rows: new Map(), policy, now: NOW };
+    expect(() => planBatches({ ...base, batchSize: 0 })).toThrow(/batchSize/);
+    expect(() => planBatches({ ...base, batchSize: -5 })).toThrow(/batchSize/);
+    expect(() => planBatches({ ...base, batchSize: Infinity })).toThrow(/batchSize/);
+  });
+});
+
+describe("planCost", () => {
+  it("reports the request count the UI shows on the Rescan button", () => {
+    expect(
+      planCost({
+        appIds: ids(2000),
+        rows: new Map(),
+        batchSize: 50,
+        policy,
+        now: NOW,
+      }),
+    ).toBe(40);
+  });
+
+  it("is 0 when nothing is due", () => {
+    const appIds = ids(5);
+    expect(
+      planCost({ appIds, rows: freshRows(appIds), batchSize: 50, policy, now: NOW }),
+    ).toBe(0);
+  });
+});

--- a/packages/game-facts/src/plan.ts
+++ b/packages/game-facts/src/plan.ts
@@ -1,0 +1,92 @@
+/**
+ * Turning "here is my library" into "here are the batches to fetch".
+ *
+ * Pure: takes the appIds, the rows already cached, a clock reading and a
+ * staleness policy; returns the batches. No I/O, no state, so the whole
+ * scheduling decision is unit-testable at exact TTL boundaries.
+ *
+ * Two properties matter and both are load-bearing:
+ *
+ * 1. **Input order is preserved.** Callers sort `appIds` before calling —
+ *    for achievements that is recency-first, so the games on the dashboard's
+ *    hero row land in batch 1 and the view feels instant even though the
+ *    sweep runs for another twenty seconds. The planner must not re-sort.
+ *
+ * 2. **Resumability falls out.** There is no cursor to persist. Each batch
+ *    commits its rows to the store, so re-planning after a restart simply
+ *    finds those rows fresh and skips them. A sweep interrupted at batch 17
+ *    of 40 resumes at 17 because the first 16 are no longer stale — not
+ *    because anything wrote down "17".
+ */
+
+import { classify, type StalenessPolicy } from "./staleness";
+import type { FactRow } from "./types";
+
+export interface PlanBatchesOptions<V = unknown> {
+  /**
+   * The sweep universe, already in the order it should be fetched.
+   * Duplicates are collapsed, keeping first position.
+   */
+  appIds: readonly string[];
+  /** Rows already cached, keyed by appId. */
+  rows: ReadonlyMap<string, FactRow<V>>;
+  /** Max appIds per batch. Must be ≥ 1. */
+  batchSize: number;
+  policy: StalenessPolicy<V>;
+  /** Unix ms. Injected rather than read from the clock so tests are exact. */
+  now: number;
+  /**
+   * Ignore TTLs and re-fetch everything — the manual "Rescan" button.
+   * Note this still respects `appIds`, so it is a rescan of the current
+   * library, not of whatever the cache happens to remember.
+   */
+  force?: boolean;
+}
+
+/**
+ * The appIds that need fetching, chunked into batches.
+ *
+ * Returns `[]` when everything is fresh — callers can treat an empty plan
+ * as "nothing to do" without a separate check.
+ */
+export function planBatches<V = unknown>(
+  opts: PlanBatchesOptions<V>,
+): string[][] {
+  const { appIds, rows, batchSize, policy, now, force = false } = opts;
+
+  if (batchSize < 1 || !Number.isFinite(batchSize)) {
+    throw new Error(`planBatches: batchSize must be >= 1, got ${batchSize}`);
+  }
+
+  const due: string[] = [];
+  const seen = new Set<string>();
+
+  for (const appId of appIds) {
+    // Collapse duplicates rather than fetching the same app twice in one
+    // sweep. `appStore.allApps` can carry the same appid twice for a game
+    // that is both owned and family-shared.
+    if (seen.has(appId)) continue;
+    seen.add(appId);
+
+    if (force || classify(rows.get(appId), now, policy) !== "fresh") {
+      due.push(appId);
+    }
+  }
+
+  const batches: string[][] = [];
+  for (let i = 0; i < due.length; i += batchSize) {
+    batches.push(due.slice(i, i + batchSize));
+  }
+  return batches;
+}
+
+/**
+ * How many requests a plan will cost, without building it.
+ *
+ * Exposed so the UI can say "Rescan (40 requests)" on a button *before* the
+ * user commits to it. Showing the price up front is what turns a
+ * rate-limit worry into an informed choice.
+ */
+export function planCost<V = unknown>(opts: PlanBatchesOptions<V>): number {
+  return planBatches(opts).length;
+}

--- a/packages/game-facts/src/staleness.test.ts
+++ b/packages/game-facts/src/staleness.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test";
+
+import { classify, countFresh, fixedTtl } from "./staleness";
+import type { FactRow } from "./types";
+
+const HOUR = 60 * 60 * 1000;
+
+/** The achievement policy from the plan: no-achievements 30d, complete 7d,
+ *  partial 24h. Exercised here because the value-dependent case is the whole
+ *  reason this module isn't a bare number. */
+const achievements = {
+  ttlSecFor: (v: { unlocked: number; total: number }) => {
+    if (v.total === 0) return 30 * 24 * 60 * 60;
+    if (v.unlocked >= v.total) return 7 * 24 * 60 * 60;
+    return 24 * 60 * 60;
+  },
+};
+
+function row<V>(at: number, value: V): FactRow<V> {
+  return { at, value };
+}
+
+describe("classify", () => {
+  it("reports a missing row as missing, not stale", () => {
+    expect(classify(undefined, 1_000, fixedTtl(60))).toBe("missing");
+  });
+
+  it("is fresh strictly inside the window and stale at the boundary", () => {
+    const policy = fixedTtl(60);
+    const at = 1_000_000;
+    // 59.999s old — inside.
+    expect(classify(row(at, 1), at + 59_999, policy)).toBe("fresh");
+    // Exactly 60s old — the window is [0, ttl), so this is stale.
+    expect(classify(row(at, 1), at + 60_000, policy)).toBe("stale");
+    expect(classify(row(at, 1), at + 60_001, policy)).toBe("stale");
+  });
+
+  it("treats Infinity as never re-fetch", () => {
+    const policy = fixedTtl(Infinity);
+    const at = 0;
+    expect(classify(row(at, 1), at + 1_000 * HOUR, policy)).toBe("fresh");
+  });
+
+  it("treats a zero or negative TTL as always stale", () => {
+    const at = 5_000;
+    expect(classify(row(at, 1), at, fixedTtl(0))).toBe("stale");
+    expect(classify(row(at, 1), at, fixedTtl(-10))).toBe("stale");
+  });
+
+  it("reads a future-dated row as fresh so clock skew cannot spin the sweep", () => {
+    const now = 1_000_000;
+    expect(classify(row(now + 5 * HOUR, 1), now, fixedTtl(60))).toBe("fresh");
+  });
+
+  describe("value-dependent TTL", () => {
+    const at = 1_000_000_000;
+
+    it("keeps a no-achievements row fresh for 30 days", () => {
+      const r = row(at, { unlocked: 0, total: 0 });
+      expect(classify(r, at + 29 * 24 * HOUR, achievements)).toBe("fresh");
+      expect(classify(r, at + 31 * 24 * HOUR, achievements)).toBe("stale");
+    });
+
+    it("keeps a completed row fresh for 7 days", () => {
+      const r = row(at, { unlocked: 51, total: 51 });
+      expect(classify(r, at + 6 * 24 * HOUR, achievements)).toBe("fresh");
+      expect(classify(r, at + 8 * 24 * HOUR, achievements)).toBe("stale");
+    });
+
+    it("expires a partial row after 24 hours", () => {
+      const r = row(at, { unlocked: 26, total: 51 });
+      expect(classify(r, at + 23 * HOUR, achievements)).toBe("fresh");
+      expect(classify(r, at + 25 * HOUR, achievements)).toBe("stale");
+    });
+
+    it("gives the three buckets genuinely different lifetimes", () => {
+      // Guards against a refactor that collapses the policy to one TTL:
+      // at 10 days only the no-achievements row should still be fresh.
+      const now = at + 10 * 24 * HOUR;
+      expect(classify(row(at, { unlocked: 0, total: 0 }), now, achievements)).toBe("fresh");
+      expect(classify(row(at, { unlocked: 51, total: 51 }), now, achievements)).toBe("stale");
+      expect(classify(row(at, { unlocked: 26, total: 51 }), now, achievements)).toBe("stale");
+    });
+  });
+});
+
+describe("countFresh", () => {
+  const policy = fixedTtl(60);
+
+  it("counts only fresh rows, ignoring stale and missing", () => {
+    const now = 1_000_000;
+    const rows = new Map<string, FactRow<number>>([
+      ["a", row(now, 1)], // fresh
+      ["b", row(now - 10 * 60_000, 1)], // stale
+      // "c" missing entirely
+    ]);
+    expect(countFresh(["a", "b", "c"], rows, now, policy)).toBe(1);
+  });
+
+  it("ignores cached rows that are not in the requested universe", () => {
+    const now = 1_000_000;
+    const rows = new Map<string, FactRow<number>>([
+      ["a", row(now, 1)],
+      ["ghost", row(now, 1)],
+    ]);
+    // "ghost" is cached and fresh but no longer in the library.
+    expect(countFresh(["a"], rows, now, policy)).toBe(1);
+  });
+
+  it("returns 0 for an empty universe", () => {
+    expect(countFresh([], new Map(), 1_000, policy)).toBe(0);
+  });
+});

--- a/packages/game-facts/src/staleness.ts
+++ b/packages/game-facts/src/staleness.ts
@@ -1,0 +1,93 @@
+/**
+ * Deciding which cached rows are worth re-fetching.
+ *
+ * A single TTL per fact is the obvious design and it is wrong, because the
+ * *value* tells you how long it stays true. Achievement completion is the
+ * motivating case:
+ *
+ *   - a game with no achievements at all will never have any    → 30 days
+ *   - a game already at 100% cannot go up                        →  7 days
+ *   - a game part-way through changes every session              → 24 hours
+ *
+ * In a real Steam library 40–60% of entries are in the first bucket, so a
+ * value-dependent TTL is the difference between a cold sweep every day and
+ * a handful of requests. That is the whole reason this module exists rather
+ * than a `ttlSec` number.
+ *
+ * The policy is a function of the stored value, so it stays pure and
+ * testable at exact boundaries — no clock, no I/O.
+ */
+
+import type { FactRow } from "./types";
+
+/**
+ * How fresh a row is.
+ *
+ * `missing` and `stale` both mean "fetch it"; they are distinguished
+ * because the UI counts them differently — `scanned` is rows we have *ever*
+ * answered, so a stale row still counts and a missing one does not.
+ */
+export type Staleness = "fresh" | "stale" | "missing";
+
+export interface StalenessPolicy<V = unknown> {
+  /**
+   * Freshness window in seconds for a row holding `value`.
+   *
+   * Return `Infinity` for "never re-fetch once known" — the row is then
+   * permanently `fresh`, which is the correct answer for a genuinely
+   * immutable fact and the strongest possible rate-limit mitigation.
+   * Return `0` to force a re-fetch on every sweep.
+   */
+  ttlSecFor(value: V): number;
+}
+
+/** A policy with one TTL for every value — the degenerate case. */
+export function fixedTtl<V = unknown>(ttlSec: number): StalenessPolicy<V> {
+  return { ttlSecFor: () => ttlSec };
+}
+
+/**
+ * Classify one row against the clock.
+ *
+ * `row === undefined` is `missing`: nothing has been fetched. A row whose
+ * `at` is in the future (clock skew, a restored backup) is treated as
+ * fresh rather than stale — re-fetching on a skewed clock would spin.
+ */
+export function classify<V>(
+  row: FactRow<V> | undefined,
+  now: number,
+  policy: StalenessPolicy<V>,
+): Staleness {
+  if (!row) return "missing";
+
+  const ttlSec = policy.ttlSecFor(row.value);
+  if (!Number.isFinite(ttlSec)) return "fresh";
+  if (ttlSec <= 0) return "stale";
+
+  const ageMs = now - row.at;
+  // Future-dated rows (clock skew) read as fresh, never stale.
+  if (ageMs < 0) return "fresh";
+
+  return ageMs < ttlSec * 1000 ? "fresh" : "stale";
+}
+
+/**
+ * Count how many of `appIds` currently have a fresh row.
+ *
+ * This is the numerator behind "340 of 812 games scanned". It counts
+ * `fresh` only — a stale row is one we are about to re-ask about, and
+ * claiming it as scanned would make the progress bar go backwards when the
+ * sweep re-queues it.
+ */
+export function countFresh<V>(
+  appIds: readonly string[],
+  rows: ReadonlyMap<string, FactRow<V>>,
+  now: number,
+  policy: StalenessPolicy<V>,
+): number {
+  let n = 0;
+  for (const appId of appIds) {
+    if (classify(rows.get(appId), now, policy) === "fresh") n++;
+  }
+  return n;
+}

--- a/packages/game-facts/src/store.test.ts
+++ b/packages/game-facts/src/store.test.ts
@@ -1,0 +1,293 @@
+// Deliberately uses an in-memory ExternalCache double rather than the real
+// `@loadout/external-cache`.
+//
+// Two other specs — packages/sgdb-art/src/index.test.ts and
+// plugins/store-bridge/lib/stores/epic/index.test.ts — call
+// `mock.module("@loadout/external-cache", …)` with a partial double that
+// implements only `getOrFetch`. Those mocks leak across files despite
+// `--isolate` (see docs/test-mock-contamination.md), so importing the real
+// module here yields a cache whose `set` is undefined: green in isolation,
+// twelve failures in the full suite.
+//
+// Injecting a double is the fix rather than a workaround. `ExternalCache` is
+// a collaborator of `createFactStore`, not part of it, and the real one has
+// its own disk-backed specs. The double JSON round-trips on read and write so
+// it degrades exactly like disk does — a caller can never be handed a live
+// reference to what it wrote, which is what makes the detached-copy and
+// corrupt-document cases meaningful.
+
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import type { ExternalCache } from "@loadout/external-cache";
+
+import { createFactStore } from "./store";
+import type { FactRow } from "./types";
+
+const KEY = "progress:v1";
+const ME = "76561198000000001";
+const SOMEONE_ELSE = "76561198000000002";
+
+/** In-memory ExternalCache that serialises like the disk-backed one. */
+function fakeCache(): ExternalCache & { raw: Map<string, unknown> } {
+  const raw = new Map<string, unknown>();
+  const clone = <T>(v: T): T => JSON.parse(JSON.stringify(v)) as T;
+  return {
+    raw,
+    pluginId: "game-facts-test",
+    get dir() {
+      return "/fake/cache/game-facts-test";
+    },
+    async get<T>(key: string): Promise<T | undefined> {
+      return raw.has(key) ? clone(raw.get(key) as T) : undefined;
+    },
+    async set<T>(key: string, value: T): Promise<void> {
+      raw.set(key, clone(value));
+    },
+    async delete(key: string): Promise<void> {
+      raw.delete(key);
+    },
+    async clear(): Promise<void> {
+      raw.clear();
+    },
+    async clearExpired(): Promise<number> {
+      return 0;
+    },
+    async getOrFetch<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+      if (raw.has(key)) return clone(raw.get(key) as T);
+      const value = await fetcher();
+      raw.set(key, clone(value));
+      return value;
+    },
+  };
+}
+
+let cache: ExternalCache & { raw: Map<string, unknown> };
+
+beforeEach(() => {
+  cache = fakeCache();
+});
+
+function row(at: number, value: number): FactRow<number> {
+  return { at, value };
+}
+
+describe("createFactStore", () => {
+  it("reads empty on a cold cache and reports no match", async () => {
+    const snap = await createFactStore<number>(cache, KEY, ME).load();
+    expect(snap.matched).toBe(false);
+    expect(snap.rows.size).toBe(0);
+  });
+
+  it("round-trips rows through the cache to a fresh store instance", async () => {
+    const a = createFactStore<number>(cache, KEY, ME);
+    await a.commit(new Map([["620", row(1000, 26)]]));
+
+    // A second instance shares no memory with the first, so this proves the
+    // write was persisted rather than only landing in the in-process memo.
+    const b = createFactStore<number>(cache, KEY, ME);
+    const snap = await b.load();
+    expect(snap.matched).toBe(true);
+    expect(snap.rows.get("620")).toEqual({ at: 1000, value: 26 });
+  });
+
+  it("merges successive commits rather than replacing", async () => {
+    const store = createFactStore<number>(cache, KEY, ME);
+    await store.commit(new Map([["620", row(1, 1)]]));
+    await store.commit(new Map([["570", row(2, 2)]]));
+    const merged = await store.commit(new Map([["292030", row(3, 3)]]));
+
+    expect([...merged.keys()].sort()).toEqual(["292030", "570", "620"]);
+    const reread = await createFactStore<number>(cache, KEY, ME).load();
+    expect(reread.rows.size).toBe(3);
+  });
+
+  it("overwrites a row on re-commit", async () => {
+    const store = createFactStore<number>(cache, KEY, ME);
+    await store.commit(new Map([["620", row(1, 10)]]));
+    const after = await store.commit(new Map([["620", row(2, 20)]]));
+    expect(after.get("620")).toEqual({ at: 2, value: 20 });
+  });
+
+  it("writes once per commit, so a 40-batch sweep costs 40 writes not 1600", async () => {
+    let writes = 0;
+    const counting: ExternalCache = {
+      ...cache,
+      set: async (k, v, o) => {
+        writes++;
+        return cache.set(k, v, o);
+      },
+    };
+    const store = createFactStore<number>(counting, KEY, ME);
+    await store.commit(new Map([["a", row(1, 1)]]));
+    await store.commit(new Map([["b", row(2, 2)]]));
+    expect(writes).toBe(2);
+  });
+
+  it("reads the cache once, then serves later loads from memory", async () => {
+    let reads = 0;
+    const counting: ExternalCache = {
+      ...cache,
+      get: async (k) => {
+        reads++;
+        return cache.get(k);
+      },
+    };
+    const store = createFactStore<number>(counting, KEY, ME);
+    await store.load();
+    await store.load();
+    await store.commit(new Map([["a", row(1, 1)]]));
+    await store.load();
+    expect(reads).toBe(1);
+  });
+
+  it("returns a detached copy from load, so callers cannot corrupt the memo", async () => {
+    const store = createFactStore<number>(cache, KEY, ME);
+    await store.commit(new Map([["620", row(1, 1)]]));
+
+    const first = await store.load();
+    first.rows.delete("620");
+    first.rows.set("junk", row(9, 9));
+
+    const second = await store.load();
+    expect(second.rows.has("620")).toBe(true);
+    expect(second.rows.has("junk")).toBe(false);
+  });
+
+  describe("identity", () => {
+    it("treats another account's document as empty", async () => {
+      await createFactStore<number>(cache, KEY, ME).commit(
+        new Map([["620", row(1, 26)]]),
+      );
+
+      // Switching Steam users must not mix two people's progress into one
+      // ranking — the class of bug that is otherwise very hard to notice.
+      const snap = await createFactStore<number>(cache, KEY, SOMEONE_ELSE).load();
+      expect(snap.matched).toBe(false);
+      expect(snap.rows.size).toBe(0);
+    });
+
+    it("does not leak the previous identity's rows into a later commit", async () => {
+      await createFactStore<number>(cache, KEY, ME).commit(
+        new Map([["620", row(1, 26)]]),
+      );
+
+      const theirs = createFactStore<number>(cache, KEY, SOMEONE_ELSE);
+      await theirs.commit(new Map([["570", row(2, 5)]]));
+
+      const snap = await theirs.load();
+      expect(snap.rows.has("620")).toBe(false);
+      expect(snap.rows.size).toBe(1);
+
+      // And the original owner's rows are gone, not silently merged back in.
+      expect((await createFactStore<number>(cache, KEY, ME).load()).matched).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("resilience", () => {
+    it("treats a corrupt document as an empty cache", async () => {
+      // A hand-edited or truncated file must degrade to a re-fetch, never throw.
+      await cache.set(KEY, "not a document at all", { ttlSec: 1000 });
+      const snap = await createFactStore<number>(cache, KEY, ME).load();
+      expect(snap.matched).toBe(false);
+      expect(snap.rows.size).toBe(0);
+    });
+
+    it("survives a cache read that throws", async () => {
+      const hostile: ExternalCache = {
+        ...cache,
+        get: async () => {
+          throw new Error("EIO");
+        },
+      };
+      const snap = await createFactStore<number>(hostile, KEY, ME).load();
+      expect(snap.matched).toBe(false);
+      expect(snap.rows.size).toBe(0);
+    });
+
+    it("drops individual rows with a missing or non-numeric timestamp", async () => {
+      await cache.set(
+        KEY,
+        {
+          identity: ME,
+          rows: {
+            good: { at: 1000, value: 1 },
+            noAt: { value: 2 },
+            badAt: { at: "yesterday", value: 3 },
+            nanAt: { at: NaN, value: 4 },
+            nullRow: null,
+          },
+        },
+        { ttlSec: 1000 },
+      );
+
+      const snap = await createFactStore<number>(cache, KEY, ME).load();
+      // A row with no usable staleness is worse than absent: it would read as
+      // fresh-or-stale by accident. Only `good` survives.
+      expect([...snap.rows.keys()]).toEqual(["good"]);
+    });
+
+    it("survives a document with a missing rows object", async () => {
+      await cache.set(KEY, { identity: ME }, { ttlSec: 1000 });
+      const snap = await createFactStore<number>(cache, KEY, ME).load();
+      expect(snap.matched).toBe(false);
+      expect(snap.rows.size).toBe(0);
+    });
+  });
+
+  describe("prune", () => {
+    it("removes rows outside the keep set and reports the count", async () => {
+      const store = createFactStore<number>(cache, KEY, ME);
+      await store.commit(
+        new Map([
+          ["a", row(1, 1)],
+          ["b", row(1, 2)],
+          ["c", row(1, 3)],
+          ["d", row(1, 4)],
+        ]),
+      );
+
+      expect(await store.prune(new Set(["a", "c"]))).toBe(2);
+
+      const snap = await createFactStore<number>(cache, KEY, ME).load();
+      expect([...snap.rows.keys()].sort()).toEqual(["a", "c"]);
+    });
+
+    it("is a no-op when everything is kept", async () => {
+      const store = createFactStore<number>(cache, KEY, ME);
+      await store.commit(new Map([["a", row(1, 1)]]));
+      expect(await store.prune(new Set(["a"]))).toBe(0);
+      expect((await store.load()).rows.size).toBe(1);
+    });
+
+    it("does not write when nothing was removed", async () => {
+      let writes = 0;
+      const counting: ExternalCache = {
+        ...cache,
+        set: async (k, v, o) => {
+          writes++;
+          return cache.set(k, v, o);
+        },
+      };
+      const store = createFactStore<number>(counting, KEY, ME);
+      await store.commit(new Map([["a", row(1, 1)]]));
+      writes = 0;
+      await store.prune(new Set(["a"]));
+      expect(writes).toBe(0);
+    });
+  });
+
+  describe("clear", () => {
+    it("deletes the document and reads empty afterwards", async () => {
+      const store = createFactStore<number>(cache, KEY, ME);
+      await store.commit(new Map([["a", row(1, 1)]]));
+      await store.clear();
+
+      expect((await store.load()).rows.size).toBe(0);
+      expect((await createFactStore<number>(cache, KEY, ME).load()).matched).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/packages/game-facts/src/store.ts
+++ b/packages/game-facts/src/store.ts
@@ -1,0 +1,154 @@
+/**
+ * One-document cache for a whole library's worth of fact rows.
+ *
+ * ## Why one aggregate document, not a file per game
+ *
+ * `@loadout/external-cache` keys entries by SHA-1 of the key, which makes a
+ * point read cheap and an *enumeration* impossible — there is no
+ * `keys()` / `entries()` API, by design. But the question a sweep has to
+ * answer on every start is "which of my 2000 rows are stale, and in what
+ * order", which is a whole-corpus question. Per-app files would mean 2000
+ * point reads to plan one sweep.
+ *
+ * So breadth data lives in a single document: ~2000 rows is ~80 KB, one
+ * atomic read at start and one atomic write per committed batch. Per-app
+ * files remain the right shape for *depth* data (every achievement of one
+ * game, fetched only for games the user actually opened) — that stays on
+ * plain `cache.get`/`set`.
+ *
+ * ## Identity
+ *
+ * The document carries an `identity` string and any mismatch is treated as
+ * an empty cache. For achievements that is the Steam id: switching accounts
+ * on a shared device must not silently mix two people's progress into one
+ * ranking. It is a cheap, total invalidation for the class of bug that is
+ * otherwise very hard to notice.
+ */
+
+import type { ExternalCache } from "@loadout/external-cache";
+
+import type { FactRow } from "./types";
+
+/** On-disk shape. Versioned via the cache key, not a field. */
+interface FactDoc<V> {
+  identity: string;
+  rows: Record<string, FactRow<V>>;
+}
+
+export interface FactStoreSnapshot<V> {
+  /** `false` when the stored document belonged to a different identity (or
+   *  there was none) — the caller is starting from cold. */
+  matched: boolean;
+  rows: Map<string, FactRow<V>>;
+}
+
+export interface FactStore<V = unknown> {
+  /** Read the rows for the configured identity. A missing, corrupt or
+   *  foreign-identity document all read as empty. */
+  load(): Promise<FactStoreSnapshot<V>>;
+  /** Merge `updates` over the current rows and persist. Returns the merged
+   *  map so a caller can keep using it without re-reading. */
+  commit(updates: ReadonlyMap<string, FactRow<V>>): Promise<Map<string, FactRow<V>>>;
+  /** Drop rows whose appId is not in `keep` and persist. Returns the number
+   *  removed. Used when the library shrinks (uninstall, sharing revoked). */
+  prune(keep: ReadonlySet<string>): Promise<number>;
+  /** Delete the document entirely. */
+  clear(): Promise<void>;
+}
+
+export interface CreateFactStoreOptions {
+  /**
+   * TTL of the *document*, in seconds. Long by default (1 year): per-row
+   * freshness is decided by each row's `at` against a
+   * {@link StalenessPolicy}, so an expiry here would throw away good rows
+   * for no reason. It exists only so an abandoned plugin's cache is
+   * eventually swept by `clearExpired()`.
+   */
+  ttlSec?: number;
+}
+
+const ONE_YEAR_SEC = 365 * 24 * 60 * 60;
+
+/**
+ * Create a store over one cache key.
+ *
+ * Keeps an in-memory copy so a 40-batch sweep pays one disk read rather
+ * than 40. The copy is seeded on first `load()` and updated by `commit`, so
+ * it can never drift from what was written — every mutation goes through
+ * here.
+ */
+export function createFactStore<V = unknown>(
+  cache: ExternalCache,
+  key: string,
+  identity: string,
+  opts: CreateFactStoreOptions = {},
+): FactStore<V> {
+  const ttlSec = opts.ttlSec ?? ONE_YEAR_SEC;
+
+  /** Authoritative in-memory rows once loaded; `null` until first read. */
+  let memo: Map<string, FactRow<V>> | null = null;
+
+  async function readDoc(): Promise<FactStoreSnapshot<V>> {
+    if (memo) return { matched: true, rows: new Map(memo) };
+
+    let doc: FactDoc<V> | undefined;
+    try {
+      doc = await cache.get<FactDoc<V>>(key);
+    } catch {
+      // A corrupt or unreadable document is a cache miss, not an error —
+      // the whole point of this data is that it can be re-fetched.
+      doc = undefined;
+    }
+
+    const usable =
+      !!doc && doc.identity === identity && !!doc.rows && typeof doc.rows === "object";
+
+    memo = new Map<string, FactRow<V>>();
+    if (usable) {
+      for (const [appId, row] of Object.entries(doc!.rows)) {
+        // Defend against a hand-edited or truncated file: a row without a
+        // numeric `at` has no usable staleness and is worse than absent.
+        if (row && typeof row.at === "number" && Number.isFinite(row.at)) {
+          memo.set(appId, row);
+        }
+      }
+    }
+    return { matched: usable, rows: new Map(memo) };
+  }
+
+  async function writeDoc(rows: Map<string, FactRow<V>>): Promise<void> {
+    const doc: FactDoc<V> = { identity, rows: Object.fromEntries(rows) };
+    await cache.set(key, doc, { ttlSec });
+  }
+
+  return {
+    load: readDoc,
+
+    async commit(updates) {
+      if (!memo) await readDoc();
+      const rows = memo!;
+      for (const [appId, row] of updates) rows.set(appId, row);
+      await writeDoc(rows);
+      return new Map(rows);
+    },
+
+    async prune(keep) {
+      if (!memo) await readDoc();
+      const rows = memo!;
+      let removed = 0;
+      for (const appId of [...rows.keys()]) {
+        if (!keep.has(appId)) {
+          rows.delete(appId);
+          removed++;
+        }
+      }
+      if (removed > 0) await writeDoc(rows);
+      return removed;
+    },
+
+    async clear() {
+      memo = new Map();
+      await cache.delete(key);
+    },
+  };
+}

--- a/packages/game-facts/src/sweeper.test.ts
+++ b/packages/game-facts/src/sweeper.test.ts
@@ -1,0 +1,719 @@
+import { describe, expect, it } from "bun:test";
+
+import { fixedTtl, type StalenessPolicy } from "./staleness";
+import type { FactStore, FactStoreSnapshot } from "./store";
+import {
+  createSweeper,
+  FactFetchError,
+  type BackoffState,
+  type BackoffStore,
+  type SweeperOptions,
+} from "./sweeper";
+import type { FactRow, SweepProgress } from "./types";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/** In-memory FactStore. store.test.ts covers the real disk-backed one; here
+ *  we want precise control and zero I/O. */
+function memStore<V>(initial: Map<string, FactRow<V>> = new Map()): FactStore<V> & {
+  rows: Map<string, FactRow<V>>;
+  commits: number;
+} {
+  const rows = new Map(initial);
+  const self = {
+    rows,
+    commits: 0,
+    async load(): Promise<FactStoreSnapshot<V>> {
+      return { matched: true, rows: new Map(rows) };
+    },
+    async commit(updates: ReadonlyMap<string, FactRow<V>>) {
+      self.commits++;
+      for (const [k, v] of updates) rows.set(k, v);
+      return new Map(rows);
+    },
+    async prune() {
+      return 0;
+    },
+    async clear() {
+      rows.clear();
+    },
+  };
+  return self;
+}
+
+/** In-memory BackoffStore that records every write. */
+function memBackoff(initial?: BackoffState) {
+  let state = initial;
+  const writes: BackoffState[] = [];
+  const store: BackoffStore = {
+    async read() {
+      return state;
+    },
+    async write(next) {
+      state = next;
+      writes.push(next);
+    },
+  };
+  return { store, writes, get state() { return state; } };
+}
+
+/** A controllable clock. `sleep` advances it instead of waiting, so tests
+ *  exercise the real gap logic at zero wall-clock cost. */
+function fakeClock(start = 1_700_000_000_000) {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+function ids(n: number, prefix = "app"): string[] {
+  return Array.from({ length: n }, (_, i) => `${prefix}${i}`);
+}
+
+/** Rows for every appId, as if just fetched. */
+function fetchedRows(appIds: string[], at: number): Map<string, FactRow<number>> {
+  return new Map(appIds.map((id) => [id, { at, value: 1 }]));
+}
+
+interface HarnessOverrides<V = number> extends Partial<SweeperOptions<V>> {
+  policy?: StalenessPolicy<V>;
+}
+
+function harness(universe: string[], overrides: HarnessOverrides = {}) {
+  const clock = fakeClock();
+  const store = memStore<number>();
+  const calls: string[][] = [];
+  const base: SweeperOptions<number> = {
+    store,
+    policy: fixedTtl(24 * 60 * 60),
+    order: () => universe,
+    fetchBatch: async (appIds) => {
+      calls.push([...appIds]);
+      return fetchedRows(appIds, clock.now());
+    },
+    batchSize: 50,
+    gapMs: 300,
+    now: clock.now,
+    sleep: clock.sleep,
+    ...overrides,
+  };
+  const sweeper = createSweeper<number>(base);
+  return { sweeper, store, calls, clock };
+}
+
+describe("createSweeper", () => {
+  describe("batching", () => {
+    it("issues exactly ceil(N/batchSize) requests", async () => {
+      const { sweeper, calls } = harness(ids(137));
+      const final = await sweeper.start();
+
+      expect(calls.length).toBe(3);
+      expect(final.status).toBe("done");
+      expect(final.requests).toBe(3);
+      expect(final.total).toBe(137);
+      expect(final.scanned).toBe(137);
+    });
+
+    it("preserves the caller's order across batches", async () => {
+      const universe = ["recent", "older", "oldest"];
+      const { sweeper, calls } = harness(universe, { batchSize: 2 });
+      await sweeper.start();
+      expect(calls).toEqual([["recent", "older"], ["oldest"]]);
+    });
+
+    it("does nothing and reports done when everything is fresh", async () => {
+      const universe = ids(10);
+      const clock = fakeClock();
+      const store = memStore<number>(fetchedRows(universe, clock.now()));
+      const calls: string[][] = [];
+      const sweeper = createSweeper<number>({
+        store,
+        policy: fixedTtl(24 * 60 * 60),
+        order: () => universe,
+        fetchBatch: async (a) => {
+          calls.push(a);
+          return fetchedRows(a, clock.now());
+        },
+        batchSize: 50,
+        gapMs: 300,
+        now: clock.now,
+        sleep: clock.sleep,
+      });
+
+      const final = await sweeper.start();
+      expect(calls.length).toBe(0);
+      expect(final.status).toBe("done");
+      expect(final.scanned).toBe(10);
+    });
+
+    it("re-fetches everything when forced", async () => {
+      const universe = ids(10);
+      const clock = fakeClock();
+      const store = memStore<number>(fetchedRows(universe, clock.now()));
+      const calls: string[][] = [];
+      const sweeper = createSweeper<number>({
+        store,
+        policy: fixedTtl(24 * 60 * 60),
+        order: () => universe,
+        fetchBatch: async (a) => {
+          calls.push(a);
+          return fetchedRows(a, clock.now());
+        },
+        batchSize: 5,
+        gapMs: 0,
+        now: clock.now,
+        sleep: clock.sleep,
+      });
+
+      await sweeper.start({ force: true });
+      expect(calls.flat().length).toBe(10);
+    });
+  });
+
+  describe("throttling", () => {
+    it("never has two batches in flight at once", async () => {
+      // The invariant the whole rate-limit story rests on. A fetchBatch that
+      // records overlap proves it rather than trusting the loop's shape.
+      let inFlight = 0;
+      let peak = 0;
+      const clock = fakeClock();
+      const { sweeper } = harness(ids(200), {
+        batchSize: 10,
+        gapMs: 0,
+        now: clock.now,
+        sleep: clock.sleep,
+        fetchBatch: async (appIds) => {
+          inFlight++;
+          peak = Math.max(peak, inFlight);
+          await Promise.resolve();
+          await Promise.resolve();
+          inFlight--;
+          return fetchedRows(appIds, clock.now());
+        },
+      });
+
+      await sweeper.start();
+      expect(peak).toBe(1);
+      expect(inFlight).toBe(0);
+    });
+
+    it("waits gapMs between batches but not after the last", async () => {
+      const sleeps: number[] = [];
+      const clock = fakeClock();
+      const { sweeper } = harness(ids(30), {
+        batchSize: 10,
+        gapMs: 300,
+        now: clock.now,
+        sleep: async (ms) => {
+          sleeps.push(ms);
+          clock.advance(ms);
+        },
+      });
+
+      await sweeper.start();
+      // 3 batches → 2 gaps. A trailing gap would make every sweep look
+      // slower than it is and delays nothing useful.
+      expect(sleeps).toEqual([300, 300]);
+    });
+
+    it("skips sleeping entirely when gapMs is 0", async () => {
+      const sleeps: number[] = [];
+      const { sweeper } = harness(ids(30), {
+        batchSize: 10,
+        gapMs: 0,
+        sleep: async (ms) => {
+          sleeps.push(ms);
+        },
+      });
+      await sweeper.start();
+      expect(sleeps).toEqual([]);
+    });
+  });
+
+  describe("resumability", () => {
+    it("commits after every batch so an interrupted sweep resumes", async () => {
+      const universe = ids(100);
+      const clock = fakeClock();
+      const store = memStore<number>();
+      let call = 0;
+
+      const first = createSweeper<number>({
+        store,
+        policy: fixedTtl(24 * 60 * 60),
+        order: () => universe,
+        fetchBatch: async (appIds) => {
+          call++;
+          // Die partway through the third batch.
+          if (call === 3) throw new FactFetchError("crash", { fatal: true });
+          return fetchedRows(appIds, clock.now());
+        },
+        batchSize: 25,
+        gapMs: 0,
+        now: clock.now,
+        sleep: clock.sleep,
+      });
+
+      const stopped = await first.start();
+      expect(stopped.status).toBe("backoff");
+      // Two batches committed before the failure.
+      expect(store.rows.size).toBe(50);
+
+      // A fresh sweeper with no persisted cursor picks up the remainder.
+      const resumedCalls: string[][] = [];
+      const second = createSweeper<number>({
+        store,
+        policy: fixedTtl(24 * 60 * 60),
+        order: () => universe,
+        fetchBatch: async (appIds) => {
+          resumedCalls.push([...appIds]);
+          return fetchedRows(appIds, clock.now());
+        },
+        batchSize: 25,
+        gapMs: 0,
+        now: clock.now,
+        sleep: clock.sleep,
+      });
+
+      const done = await second.start();
+      expect(done.status).toBe("done");
+      expect(resumedCalls.flat().length).toBe(50);
+      expect(resumedCalls[0]![0]).toBe(universe[50]);
+      expect(store.rows.size).toBe(100);
+    });
+  });
+
+  describe("failure handling", () => {
+    it("tolerates a transient failure and carries on", async () => {
+      const clock = fakeClock();
+      let call = 0;
+      const { sweeper, store } = harness(ids(30), {
+        batchSize: 10,
+        gapMs: 0,
+        now: clock.now,
+        sleep: clock.sleep,
+        fetchBatch: async (appIds) => {
+          call++;
+          if (call === 2) throw new Error("timeout");
+          return fetchedRows(appIds, clock.now());
+        },
+      });
+
+      const final = await sweeper.start();
+      expect(final.status).toBe("done");
+      // Batch 2's appIds stay stale; the other 20 landed.
+      expect(store.rows.size).toBe(20);
+    });
+
+    it("gives up after maxConsecutiveFailures in a row", async () => {
+      const { sweeper } = harness(ids(100), {
+        batchSize: 10,
+        gapMs: 0,
+        maxConsecutiveFailures: 3,
+        fetchBatch: async () => {
+          throw new Error("source is down");
+        },
+      });
+
+      const final = await sweeper.start();
+      expect(final.status).toBe("error");
+      expect(final.reason).toBe("source is down");
+      expect(final.requests).toBe(3);
+    });
+
+    it("resets the consecutive counter after a success", async () => {
+      // Two failures, a success, then two more must NOT trip a limit of 3.
+      let call = 0;
+      const { sweeper } = harness(ids(60), {
+        batchSize: 10,
+        gapMs: 0,
+        maxConsecutiveFailures: 3,
+        fetchBatch: async (appIds) => {
+          call++;
+          if (call === 1 || call === 2 || call === 4 || call === 5) {
+            throw new Error("blip");
+          }
+          return fetchedRows(appIds, 1);
+        },
+      });
+
+      const final = await sweeper.start();
+      expect(final.status).toBe("done");
+      expect(final.requests).toBe(6);
+    });
+
+    it("stops immediately on a fatal error, without waiting for the limit", async () => {
+      // A rate-limit result must not be retried — that is how an account
+      // gets flagged.
+      const { sweeper, calls } = harness(ids(100), {
+        batchSize: 10,
+        gapMs: 0,
+        maxConsecutiveFailures: 3,
+        fetchBatch: async () => {
+          throw new FactFetchError("LimitExceeded", { fatal: true });
+        },
+      });
+
+      const final = await sweeper.start();
+      expect(final.status).toBe("backoff");
+      expect(final.reason).toBe("LimitExceeded");
+      expect(calls.length).toBe(0);
+      expect(final.requests).toBe(1);
+    });
+
+    it("treats a plain Error as transient, not fatal", async () => {
+      // An unexpected throw in a resolver is a bug, and must not silently
+      // disable sweeping for an hour.
+      const { sweeper } = harness(ids(10), {
+        batchSize: 10,
+        gapMs: 0,
+        maxConsecutiveFailures: 5,
+        fetchBatch: async () => {
+          throw new TypeError("undefined is not a function");
+        },
+      });
+      const final = await sweeper.start();
+      // One batch, one transient failure, under the limit → sweep completes.
+      expect(final.status).toBe("done");
+    });
+  });
+
+  describe("persisted backoff", () => {
+    it("writes an exponentially growing retryAt on failure", async () => {
+      const backoff = memBackoff();
+      const clock = fakeClock();
+      const { sweeper } = harness(ids(10), {
+        batchSize: 10,
+        gapMs: 0,
+        backoff: backoff.store,
+        backoffBaseMs: 1000,
+        now: clock.now,
+        sleep: clock.sleep,
+        fetchBatch: async () => {
+          throw new FactFetchError("LimitExceeded", { fatal: true });
+        },
+      });
+
+      await sweeper.start();
+      expect(backoff.state?.failures).toBe(1);
+      expect(backoff.state?.retryAt).toBe(clock.now() + 1000);
+      expect(backoff.state?.reason).toBe("LimitExceeded");
+    });
+
+    it("doubles the delay across restarts", async () => {
+      const backoff = memBackoff({ failures: 2, retryAt: 0 });
+      const clock = fakeClock();
+      const { sweeper } = harness(ids(10), {
+        batchSize: 10,
+        gapMs: 0,
+        backoff: backoff.store,
+        backoffBaseMs: 1000,
+        now: clock.now,
+        sleep: clock.sleep,
+        fetchBatch: async () => {
+          throw new FactFetchError("LimitExceeded", { fatal: true });
+        },
+      });
+
+      await sweeper.start();
+      // Third consecutive failure → base * 2^2.
+      expect(backoff.state?.failures).toBe(3);
+      expect(backoff.state?.retryAt).toBe(clock.now() + 4000);
+    });
+
+    it("caps the delay at backoffMaxMs", async () => {
+      const backoff = memBackoff({ failures: 30, retryAt: 0 });
+      const clock = fakeClock();
+      const { sweeper } = harness(ids(10), {
+        batchSize: 10,
+        gapMs: 0,
+        backoff: backoff.store,
+        backoffBaseMs: 1000,
+        backoffMaxMs: 5000,
+        now: clock.now,
+        sleep: clock.sleep,
+        fetchBatch: async () => {
+          throw new FactFetchError("nope", { fatal: true });
+        },
+      });
+
+      await sweeper.start();
+      expect(backoff.state?.retryAt).toBe(clock.now() + 5000);
+    });
+
+    it("refuses to sweep while a backoff is live, and says when it expires", async () => {
+      const clock = fakeClock();
+      const retryAt = clock.now() + HOUR_MS;
+      const backoff = memBackoff({ failures: 1, retryAt, reason: "LimitExceeded" });
+      const { sweeper, calls } = harness(ids(50), {
+        backoff: backoff.store,
+        now: clock.now,
+        sleep: clock.sleep,
+      });
+
+      const final = await sweeper.start();
+      expect(final.status).toBe("backoff");
+      expect(final.retryAt).toBe(retryAt);
+      expect(final.reason).toBe("LimitExceeded");
+      expect(calls.length).toBe(0);
+    });
+
+    it("sweeps once the backoff has expired", async () => {
+      const clock = fakeClock();
+      const backoff = memBackoff({ failures: 1, retryAt: clock.now() - 1 });
+      const { sweeper, calls } = harness(ids(20), {
+        batchSize: 10,
+        gapMs: 0,
+        backoff: backoff.store,
+        now: clock.now,
+        sleep: clock.sleep,
+      });
+
+      const final = await sweeper.start();
+      expect(final.status).toBe("done");
+      expect(calls.length).toBe(2);
+    });
+
+    it("clears the failure count after a successful batch", async () => {
+      const clock = fakeClock();
+      const backoff = memBackoff({ failures: 2, retryAt: clock.now() - 1 });
+      const { sweeper } = harness(ids(10), {
+        batchSize: 10,
+        gapMs: 0,
+        backoff: backoff.store,
+        now: clock.now,
+        sleep: clock.sleep,
+      });
+
+      await sweeper.start();
+      expect(backoff.state).toEqual({ failures: 0, retryAt: 0 });
+    });
+
+    it("does not touch the backoff store on a clean sweep from a clean state", async () => {
+      // A healthy source shouldn't cause a config write on every sweep.
+      const backoff = memBackoff();
+      const { sweeper } = harness(ids(10), {
+        batchSize: 10,
+        gapMs: 0,
+        backoff: backoff.store,
+      });
+
+      await sweeper.start();
+      expect(backoff.writes).toEqual([]);
+    });
+
+    it("works with no backoff store at all", async () => {
+      const { sweeper } = harness(ids(20), { batchSize: 10, gapMs: 0 });
+      const final = await sweeper.start();
+      expect(final.status).toBe("done");
+    });
+  });
+
+  describe("pause, resume and cancel", () => {
+    it("halts between batches when paused and continues when resumed", async () => {
+      const clock = fakeClock();
+      const calls: string[][] = [];
+      const { sweeper } = harness(ids(30), {
+        batchSize: 10,
+        gapMs: 0,
+        now: clock.now,
+        sleep: clock.sleep,
+        fetchBatch: async (appIds) => {
+          calls.push([...appIds]);
+          if (calls.length === 1) sweeper.pause();
+          return fetchedRows(appIds, clock.now());
+        },
+      });
+
+      const running = sweeper.start();
+      // Let the first batch land and the loop reach the pause gate.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(sweeper.progress.status).toBe("paused");
+      expect(calls.length).toBe(1);
+
+      sweeper.resume();
+      const final = await running;
+      expect(final.status).toBe("done");
+      expect(calls.length).toBe(3);
+    });
+
+    it("stops with status cancelled and leaves committed rows intact", async () => {
+      const clock = fakeClock();
+      const calls: string[][] = [];
+      const { sweeper, store } = harness(ids(50), {
+        batchSize: 10,
+        gapMs: 0,
+        now: clock.now,
+        sleep: clock.sleep,
+        fetchBatch: async (appIds) => {
+          calls.push([...appIds]);
+          if (calls.length === 2) sweeper.cancel();
+          return fetchedRows(appIds, clock.now());
+        },
+      });
+
+      const final = await sweeper.start();
+      expect(final.status).toBe("cancelled");
+      expect(calls.length).toBe(2);
+      // Cancelling is not rolling back — what was fetched stays cached.
+      expect(store.rows.size).toBe(20);
+    });
+
+    it("releases a paused sweep when cancelled", async () => {
+      // Without this, cancel() on a paused sweep would hang forever.
+      const clock = fakeClock();
+      const calls: string[][] = [];
+      const { sweeper } = harness(ids(30), {
+        batchSize: 10,
+        gapMs: 0,
+        now: clock.now,
+        sleep: clock.sleep,
+        fetchBatch: async (appIds) => {
+          calls.push([...appIds]);
+          if (calls.length === 1) sweeper.pause();
+          return fetchedRows(appIds, clock.now());
+        },
+      });
+
+      const running = sweeper.start();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(sweeper.progress.status).toBe("paused");
+
+      sweeper.cancel();
+      const final = await running;
+      expect(final.status).toBe("cancelled");
+      expect(calls.length).toBe(1);
+    });
+
+    it("ignores resume when not paused and pause when not running", async () => {
+      const { sweeper } = harness(ids(10), { batchSize: 10, gapMs: 0 });
+      sweeper.pause();
+      expect(sweeper.progress.status).toBe("idle");
+      sweeper.resume();
+      expect(sweeper.progress.status).toBe("idle");
+      expect((await sweeper.start()).status).toBe("done");
+    });
+  });
+
+  describe("concurrent starts", () => {
+    it("returns the in-flight sweep rather than starting a second", async () => {
+      const clock = fakeClock();
+      const calls: string[][] = [];
+      const { sweeper } = harness(ids(30), {
+        batchSize: 10,
+        gapMs: 0,
+        now: clock.now,
+        sleep: clock.sleep,
+        fetchBatch: async (appIds) => {
+          calls.push([...appIds]);
+          return fetchedRows(appIds, clock.now());
+        },
+      });
+
+      const a = sweeper.start();
+      const b = sweeper.start();
+      expect(a).toBe(b);
+      await Promise.all([a, b]);
+      // 3 batches, not 6.
+      expect(calls.length).toBe(3);
+    });
+
+    it("can be started again after finishing", async () => {
+      const { sweeper, calls } = harness(ids(10), { batchSize: 10, gapMs: 0 });
+      await sweeper.start();
+      expect(calls.length).toBe(1);
+      // Everything is fresh now, so a second sweep is a no-op...
+      await sweeper.start();
+      expect(calls.length).toBe(1);
+      // ...unless forced.
+      await sweeper.start({ force: true });
+      expect(calls.length).toBe(2);
+    });
+  });
+
+  describe("progress reporting", () => {
+    it("reports scanned rising monotonically to total", async () => {
+      const seen: SweepProgress[] = [];
+      const { sweeper } = harness(ids(50), { batchSize: 10, gapMs: 0 });
+      sweeper.onProgress((p) => seen.push(p));
+
+      await sweeper.start();
+
+      const scanned = seen.map((p) => p.scanned);
+      for (let i = 1; i < scanned.length; i++) {
+        expect(scanned[i]!).toBeGreaterThanOrEqual(scanned[i - 1]!);
+      }
+      expect(scanned.at(-1)).toBe(50);
+      expect(seen.at(-1)!.status).toBe("done");
+    });
+
+    it("counts a partially-answered batch honestly", async () => {
+      // A source that answers 6 of 10 must not report 10 scanned.
+      const clock = fakeClock();
+      const { sweeper } = harness(ids(10), {
+        batchSize: 10,
+        gapMs: 0,
+        now: clock.now,
+        sleep: clock.sleep,
+        fetchBatch: async (appIds) =>
+          fetchedRows(appIds.slice(0, 6), clock.now()),
+      });
+
+      const final = await sweeper.start();
+      expect(final.scanned).toBe(6);
+      expect(final.total).toBe(10);
+    });
+
+    it("dedupes the total so N-of-M matches what is swept", async () => {
+      const { sweeper, calls } = harness(["a", "b", "a", "c"], {
+        batchSize: 10,
+        gapMs: 0,
+      });
+      const final = await sweeper.start();
+      expect(final.total).toBe(3);
+      expect(calls[0]).toEqual(["a", "b", "c"]);
+    });
+
+    it("accumulates elapsedMs from the injected clock", async () => {
+      const clock = fakeClock();
+      const { sweeper } = harness(ids(30), {
+        batchSize: 10,
+        gapMs: 300,
+        now: clock.now,
+        sleep: clock.sleep,
+      });
+      const final = await sweeper.start();
+      // Two 300ms gaps between three batches.
+      expect(final.elapsedMs).toBe(600);
+    });
+
+    it("keeps sweeping when a progress subscriber throws", async () => {
+      const { sweeper } = harness(ids(20), { batchSize: 10, gapMs: 0 });
+      sweeper.onProgress(() => {
+        throw new Error("bad subscriber");
+      });
+      expect((await sweeper.start()).status).toBe("done");
+    });
+
+    it("stops notifying after unsubscribe", async () => {
+      const seen: SweepProgress[] = [];
+      const { sweeper } = harness(ids(20), { batchSize: 10, gapMs: 0 });
+      const off = sweeper.onProgress((p) => seen.push(p));
+      off();
+      await sweeper.start();
+      expect(seen).toEqual([]);
+    });
+  });
+});

--- a/packages/game-facts/src/sweeper.ts
+++ b/packages/game-facts/src/sweeper.ts
@@ -1,0 +1,374 @@
+/**
+ * Drives a batched, throttled, resumable sweep over a library's facts.
+ *
+ * This is the piece that makes "don't hammer the source" a property of the
+ * system rather than a promise in a comment. It owns:
+ *
+ *   - **one request in flight**, inherent in awaiting each batch in a loop;
+ *   - **a gap between batches**, so other consumers of a shared transport
+ *     get a real window rather than being starved for the sweep's duration;
+ *   - **exponential backoff that survives a restart**, so a source saying
+ *     "slow down" isn't re-provoked every time the app relaunches;
+ *   - **resumability with no cursor** — each batch commits its rows, so a
+ *     re-plan naturally skips what's already fresh (see `plan.ts`);
+ *   - **an honest progress record**, including the raw request count, so a
+ *     user worried about rate limits can see the cost instead of being
+ *     reassured about it.
+ *
+ * Everything time-related is injectable (`now`, `sleep`) so the whole engine
+ * is testable without real delays.
+ *
+ * ## Failure policy
+ *
+ * Two kinds of failure, because conflating them is either too brittle or too
+ * reckless:
+ *
+ *   - **fatal** (`FactFetchError` with `fatal: true`) — the source told us
+ *     to stop, e.g. a rate-limit result. Abort the sweep now and back off.
+ *     Retrying into a rate limit is how an account gets flagged.
+ *   - **transient** (anything else) — a timeout or a blip. Tolerated:
+ *     the batch's appIds stay stale and the next sweep picks them up. Only
+ *     after `maxConsecutiveFailures` in a row does the sweep give up, which
+ *     is the circuit breaker for a source that's down but not saying so.
+ */
+
+import { planBatches } from "./plan";
+import { countFresh, type StalenessPolicy } from "./staleness";
+import type { FactStore } from "./store";
+import type { FactRow, SweepProgress } from "./types";
+
+/**
+ * Thrown by a `fetchBatch` implementation to say *how* it failed.
+ *
+ * Plain `Error`s are treated as transient, which is the safe default for an
+ * unexpected throw — a bug in a resolver shouldn't silently disable sweeping
+ * for hours.
+ */
+export class FactFetchError extends Error {
+  readonly fatal: boolean;
+
+  constructor(message: string, opts: { fatal?: boolean; cause?: unknown } = {}) {
+    super(message);
+    this.name = "FactFetchError";
+    this.fatal = opts.fatal ?? false;
+    if (opts.cause !== undefined) this.cause = opts.cause;
+  }
+}
+
+/** Persisted backoff, so a rate limit outlives the process that hit it. */
+export interface BackoffState {
+  /** Consecutive sweep-level failures. Drives the exponential delay. */
+  failures: number;
+  /** Unix ms before which no sweep should start. */
+  retryAt: number;
+  /** User-facing reason for the most recent failure. */
+  reason?: string;
+}
+
+/**
+ * Where backoff is persisted. Injected rather than assumed so this package
+ * stays free of any particular config mechanism — a plugin wires this to
+ * `@loadout/plugin-storage`, a test to a plain object.
+ */
+export interface BackoffStore {
+  read(): Promise<BackoffState | undefined>;
+  write(state: BackoffState): Promise<void>;
+}
+
+export interface SweeperOptions<V = unknown> {
+  store: FactStore<V>;
+  policy: StalenessPolicy<V>;
+  /**
+   * The sweep universe, in the order it should be fetched. Re-read on every
+   * `start()` so a library change is picked up without recreating the
+   * sweeper. Callers sort this — recency-first for achievements.
+   */
+  order: () => Promise<readonly string[]> | readonly string[];
+  /**
+   * Fetch one batch. Return a row per appId answered; appIds omitted from
+   * the result are simply left stale. Throw {@link FactFetchError} to
+   * signal failure.
+   */
+  fetchBatch: (appIds: string[]) => Promise<ReadonlyMap<string, FactRow<V>>>;
+  batchSize: number;
+  /** Delay between batches, ms. Not applied after the final batch. */
+  gapMs: number;
+  backoff?: BackoffStore;
+  /** First backoff delay; doubles per consecutive failure. Default 60s. */
+  backoffBaseMs?: number;
+  /** Ceiling for the backoff delay. Default 1 hour. */
+  backoffMaxMs?: number;
+  /** Consecutive transient failures before giving up. Default 3. */
+  maxConsecutiveFailures?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface Sweeper {
+  /** Run a sweep. Resolves when it ends for any reason. Calling while a
+   *  sweep is running returns the in-flight promise rather than starting a
+   *  second one. */
+  start(opts?: { force?: boolean }): Promise<SweepProgress>;
+  pause(): void;
+  resume(): void;
+  cancel(): void;
+  readonly progress: SweepProgress;
+  /** Subscribe to progress changes. Returns an unsubscribe function. */
+  onProgress(cb: (progress: SweepProgress) => void): () => void;
+}
+
+const DEFAULT_BACKOFF_BASE_MS = 60_000;
+const DEFAULT_BACKOFF_MAX_MS = 60 * 60_000;
+const DEFAULT_MAX_CONSECUTIVE_FAILURES = 3;
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** A latch the sweep loop waits on while paused. */
+interface PauseGate {
+  promise: Promise<void>;
+  release: () => void;
+}
+
+export function createSweeper<V = unknown>(opts: SweeperOptions<V>): Sweeper {
+  const {
+    store,
+    policy,
+    order,
+    fetchBatch,
+    batchSize,
+    gapMs,
+    backoff,
+    backoffBaseMs = DEFAULT_BACKOFF_BASE_MS,
+    backoffMaxMs = DEFAULT_BACKOFF_MAX_MS,
+    maxConsecutiveFailures = DEFAULT_MAX_CONSECUTIVE_FAILURES,
+    now = Date.now,
+    sleep = defaultSleep,
+  } = opts;
+
+  let progress: SweepProgress = {
+    status: "idle",
+    scanned: 0,
+    total: 0,
+    requests: 0,
+    elapsedMs: 0,
+  };
+
+  const listeners = new Set<(p: SweepProgress) => void>();
+  let inFlight: Promise<SweepProgress> | null = null;
+  let cancelled = false;
+  /** Non-null while paused; resolving it releases the loop. */
+  let pauseGate: PauseGate | null = null;
+
+  /**
+   * Read `pauseGate` through a function with a declared return type.
+   *
+   * `pause()` assigns the gate from outside `run()`'s control-flow graph, so
+   * TypeScript narrows the bare variable to `null` inside the sweep loop and
+   * then to `never` at the property access. Going through an annotated
+   * accessor is what keeps the union honest.
+   */
+  function currentPauseGate(): PauseGate | null {
+    return pauseGate;
+  }
+
+  function emit(patch: Partial<SweepProgress>): void {
+    progress = { ...progress, ...patch };
+    // Hand each listener its own frozen read so a subscriber can't mutate
+    // shared state for the others.
+    const snapshot = progress;
+    for (const cb of listeners) {
+      try {
+        cb(snapshot);
+      } catch {
+        // A throwing subscriber must not abort the sweep.
+      }
+    }
+  }
+
+  function makeGate(): PauseGate {
+    let release = () => {};
+    const promise = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return { promise, release };
+  }
+
+  function backoffDelayMs(failures: number): number {
+    const exponent = Math.max(0, failures - 1);
+    // `2 ** exponent` overflows to Infinity long before this matters, and
+    // Math.min pins it to the ceiling, so no guard is needed.
+    return Math.min(backoffBaseMs * 2 ** exponent, backoffMaxMs);
+  }
+
+  async function recordFailure(reason: string): Promise<number> {
+    const prior = (await backoff?.read())?.failures ?? 0;
+    const failures = prior + 1;
+    const retryAt = now() + backoffDelayMs(failures);
+    await backoff?.write({ failures, retryAt, reason });
+    return retryAt;
+  }
+
+  async function clearFailures(): Promise<void> {
+    const current = await backoff?.read();
+    // Only write when there's something to clear — a successful sweep on a
+    // healthy source shouldn't touch the config file at all.
+    if (current && (current.failures > 0 || current.retryAt > 0)) {
+      await backoff?.write({ failures: 0, retryAt: 0 });
+    }
+  }
+
+  async function run(force: boolean): Promise<SweepProgress> {
+    const startedAt = now();
+    cancelled = false;
+    pauseGate = null;
+
+    // A live backoff wins over any request to sweep. Surfaced rather than
+    // silently ignored so the UI can say when it will retry.
+    const persisted = await backoff?.read();
+    if (persisted && persisted.retryAt > startedAt) {
+      emit({
+        status: "backoff",
+        reason: persisted.reason ?? "Waiting before contacting the source again.",
+        retryAt: persisted.retryAt,
+        elapsedMs: 0,
+      });
+      return progress;
+    }
+
+    const universe = await order();
+    const { rows } = await store.load();
+
+    // Dedupe for the denominator so "N of M" matches what's actually swept.
+    const total = new Set(universe).size;
+    emit({
+      status: "running",
+      total,
+      requests: 0,
+      scanned: countFresh(universe, rows, startedAt, policy),
+      elapsedMs: 0,
+      reason: undefined,
+      retryAt: undefined,
+    });
+
+    const batches = planBatches({
+      appIds: universe,
+      rows,
+      batchSize,
+      policy,
+      now: startedAt,
+      force,
+    });
+
+    if (batches.length === 0) {
+      emit({ status: "done", elapsedMs: now() - startedAt });
+      return progress;
+    }
+
+    let live = rows;
+    let consecutiveFailures = 0;
+    let requests = 0;
+
+    for (let i = 0; i < batches.length; i++) {
+      if (cancelled) {
+        emit({ status: "cancelled", elapsedMs: now() - startedAt });
+        return progress;
+      }
+      const gate = currentPauseGate();
+      if (gate) {
+        await gate.promise;
+        // `cancel()` releases the gate too, so re-check rather than assuming
+        // a release means "resumed".
+        if (cancelled) {
+          emit({ status: "cancelled", elapsedMs: now() - startedAt });
+          return progress;
+        }
+      }
+
+      const batch = batches[i]!;
+      try {
+        const fetched = await fetchBatch(batch);
+        requests++;
+        live = await store.commit(fetched);
+        consecutiveFailures = 0;
+        await clearFailures();
+        emit({
+          requests,
+          scanned: countFresh(universe, live, now(), policy),
+          elapsedMs: now() - startedAt,
+        });
+      } catch (err) {
+        requests++;
+        const fatal = err instanceof FactFetchError && err.fatal;
+        const reason = err instanceof Error ? err.message : String(err);
+        consecutiveFailures++;
+
+        if (fatal || consecutiveFailures >= maxConsecutiveFailures) {
+          const retryAt = await recordFailure(reason);
+          emit({
+            status: fatal ? "backoff" : "error",
+            reason,
+            retryAt,
+            requests,
+            elapsedMs: now() - startedAt,
+          });
+          return progress;
+        }
+        // Transient: leave this batch's appIds stale and carry on. The next
+        // sweep re-queues them, so nothing is lost.
+        emit({ requests, elapsedMs: now() - startedAt });
+      }
+
+      const isLast = i === batches.length - 1;
+      if (!isLast && gapMs > 0) await sleep(gapMs);
+    }
+
+    emit({
+      status: cancelled ? "cancelled" : "done",
+      scanned: countFresh(universe, live, now(), policy),
+      elapsedMs: now() - startedAt,
+    });
+    return progress;
+  }
+
+  return {
+    start(startOpts) {
+      if (inFlight) return inFlight;
+      inFlight = run(startOpts?.force ?? false).finally(() => {
+        inFlight = null;
+      });
+      return inFlight;
+    },
+
+    pause() {
+      if (progress.status !== "running" || pauseGate) return;
+      pauseGate = makeGate();
+      emit({ status: "paused" });
+    },
+
+    resume() {
+      if (!pauseGate) return;
+      const gate = pauseGate;
+      pauseGate = null;
+      emit({ status: "running" });
+      gate.release();
+    },
+
+    cancel() {
+      cancelled = true;
+      // Release the loop so it can observe the cancellation rather than
+      // sitting on the pause gate forever.
+      const gate = pauseGate;
+      pauseGate = null;
+      gate?.release();
+    },
+
+    get progress() {
+      return progress;
+    },
+
+    onProgress(cb) {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+  };
+}

--- a/packages/game-facts/src/types.test.ts
+++ b/packages/game-facts/src/types.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+
+import { allUnavailable, isOk, missing, unavailable, type FactValue } from "./types";
+
+describe("isOk", () => {
+  it("narrows the ok variant", () => {
+    const fact: FactValue = { state: "ok", value: 42 };
+    expect(isOk(fact)).toBe(true);
+    if (isOk(fact)) {
+      // Compile-time narrowing is the point; assert the runtime read too.
+      expect(fact.value).toBe(42);
+    }
+  });
+
+  it("rejects loading, missing, unavailable and undefined alike", () => {
+    expect(isOk({ state: "loading" })).toBe(false);
+    expect(isOk(missing())).toBe(false);
+    expect(isOk(unavailable("Steam is not running"))).toBe(false);
+    expect(isOk(undefined)).toBe(false);
+  });
+
+  it("does not treat a falsy ok value as not-ok", () => {
+    // The trap this guard exists to avoid: `fact?.value` reads false/0 as absent.
+    expect(isOk({ state: "ok", value: false })).toBe(true);
+    expect(isOk({ state: "ok", value: 0 })).toBe(true);
+    expect(isOk({ state: "ok", value: "" })).toBe(true);
+  });
+});
+
+describe("missing", () => {
+  it("is a distinct state, not an ok carrying a sentinel", () => {
+    // `{state:"ok", value:-1}` would claim a real measurement of -1 and force
+    // every consumer to know the sentinel. `plugins/collections` pays for this
+    // distinction in its evaluator: `loading` and `unavailable` are
+    // indeterminate, `missing` is a definite no routed through the range's
+    // includeUnknown escape hatch (lib/rules.ts:118).
+    expect(missing()).toEqual({ state: "missing" });
+    expect(isOk(missing())).toBe(false);
+  });
+
+  it("is not the same answer as loading", () => {
+    // Collapsing these is the bug that made every unscanned game *match*
+    // under a "pass" indeterminate policy, silently and with no diagnostic.
+    expect(missing()).not.toEqual({ state: "loading" });
+  });
+
+  it("carries no reason, because the source is fine", () => {
+    // A reason belongs on `unavailable` — the source being down is the
+    // user-actionable case. "This game has no achievements" needs no excuse.
+    expect(Object.keys(missing())).toEqual(["state"]);
+  });
+});
+
+describe("unavailable", () => {
+  it("carries the user-facing reason verbatim for empty states to quote", () => {
+    const reason = "Achievement data hasn't been scanned yet.";
+    expect(unavailable(reason)).toEqual({ state: "unavailable", reason });
+  });
+
+  it("is distinct from missing: one source is down, one game has no data", () => {
+    expect(unavailable("Steam is not running")).not.toEqual(missing());
+  });
+});
+
+describe("allUnavailable", () => {
+  it("answers for every appId, honouring the resolve-never-reject contract", () => {
+    const map = allUnavailable(["620", "570"], "Steam is not running");
+    expect(map.size).toBe(2);
+    expect(map.get("620")).toEqual({
+      state: "unavailable",
+      reason: "Steam is not running",
+    });
+    expect(map.get("570")).toEqual({
+      state: "unavailable",
+      reason: "Steam is not running",
+    });
+  });
+
+  it("returns an empty map for an empty batch", () => {
+    expect(allUnavailable([], "nope").size).toBe(0);
+  });
+});

--- a/packages/game-facts/src/types.ts
+++ b/packages/game-facts/src/types.ts
@@ -1,0 +1,162 @@
+/**
+ * The vocabulary for per-game facts that need I/O to answer.
+ *
+ * A "fact" is one datum about one game that cannot be read from local
+ * metadata: achievement completion, HowLongToBeat time, ProtonDB tier,
+ * whether a friend is playing it right now. Facts are resolved *outside*
+ * whatever consumes them — batched over the library, cached, then handed
+ * over as a plain map — so the consumer stays synchronous.
+ *
+ * ## Why the four-state {@link FactValue}
+ *
+ * A fact is not `T | undefined`. There are four genuinely different
+ * answers, and collapsing any of them is the standard way this class of
+ * feature lies to users:
+ *
+ *   - `ok`          — we asked and got an answer.
+ *   - `loading`     — we have not asked yet. **Not** a failure, and not
+ *                     zero. The first render of any view necessarily
+ *                     precedes every resolver.
+ *   - `missing`     — we asked, and this particular game has no answer.
+ *                     No ProtonDB report; no achievements at all. Endemic,
+ *                     not exceptional, and a *definite* no rather than an
+ *                     unknown.
+ *   - `unavailable` — the whole source is down, with a user-facing `reason`
+ *                     so an empty state can quote it. "Friends Playing
+ *                     needs Steam running" beats a silent zero.
+ *
+ * The `loading` / `missing` split is the load-bearing one, and it was paid
+ * for in a real bug. `plugins/collections` originally had three states, and
+ * folding per-game absence into the indeterminate bucket made every
+ * unanswered game **match** under its default `"pass"` policy — silently,
+ * with no diagnostic. Its `lib/types.ts:263` now carries the same four, and
+ * `factNumber` (`lib/rules.ts:118`) routes `missing` through the range's
+ * `includeUnknown` escape hatch.
+ *
+ * That plugin still declares `FactValue` locally, and the two declarations
+ * are deliberately kept structurally identical: TypeScript is structural, so
+ * a fact payload crosses the plugin RPC boundary with neither side importing
+ * the other. The duplication is scheduled for removal — when collections
+ * lands its resolver layer, its local declaration becomes a re-export from
+ * here. It is not accidental.
+ *
+ * ## Why {@link FactResolver} is generic over its key
+ *
+ * A consumer's set of fact keys is its own vocabulary — library-tabs ties
+ * `FactKey` to its `RuleKind` union, and hoisting that here would drag the
+ * whole rule engine along. So the key is a type parameter defaulting to
+ * `string`: producers that own a single fact ignore it, and a consumer with
+ * a closed key union instantiates `FactResolver<FactKey>` with no change
+ * to this package.
+ */
+
+/**
+ * One resolved fact for one game.
+ *
+ * The `value` union is deliberately narrow — these cross an RPC boundary
+ * as JSON, so no `Date`, no `bigint`, no nested objects. Timestamps travel
+ * as unix-ms numbers and 64-bit ids as strings.
+ */
+export type FactValue =
+  | { state: "ok"; value: number | string | boolean | string[] }
+  | { state: "loading" }
+  | { state: "missing" }
+  | { state: "unavailable"; reason: string };
+
+/** Narrow a {@link FactValue} to its `ok` variant. */
+export function isOk(
+  fact: FactValue | undefined,
+): fact is { state: "ok"; value: number | string | boolean | string[] } {
+  return fact?.state === "ok";
+}
+
+/**
+ * Build a `missing` fact: the source answered, and this game has nothing.
+ *
+ * A helper rather than an inline literal so the choice is deliberate at the
+ * call site. Reach for this over `{state:"ok", value:-1}` — an `ok` carrying
+ * a sentinel claims we have a real measurement when we do not, and it
+ * obliges every consumer to know the sentinel.
+ */
+export function missing(): FactValue {
+  return { state: "missing" };
+}
+
+/**
+ * Build an `unavailable` fact. A helper rather than an inline literal
+ * because the `reason` is user-facing copy and every call site forgetting
+ * it is a silently empty view.
+ */
+export function unavailable(reason: string): FactValue {
+  return { state: "unavailable", reason };
+}
+
+/**
+ * Build a map of the same `unavailable` fact for every appId.
+ *
+ * The shape a failing {@link FactResolver} returns: the contract is
+ * "resolve, never reject", so a source that is wholesale unreachable
+ * still has to answer for each appId it was asked about.
+ */
+export function allUnavailable(
+  appIds: readonly string[],
+  reason: string,
+): Map<string, FactValue> {
+  const out = new Map<string, FactValue>();
+  for (const appId of appIds) out.set(appId, unavailable(reason));
+  return out;
+}
+
+/**
+ * A cached fact, with the timestamp that decides its staleness.
+ *
+ * `V` is the *stored* value, which is not necessarily a {@link FactValue}
+ * — an achievement resolver stores `{unlocked, total}` and projects a
+ * percentage on read. Keeping the stored shape open is what lets one
+ * cache serve both a rich dashboard and a thin fact wire.
+ */
+export interface FactRow<V = unknown> {
+  /** Unix ms of the last *successful* fetch. Never written on failure. */
+  at: number;
+  value: V;
+}
+
+/**
+ * Resolves one fact for a batch of games.
+ *
+ * `resolve` **must not reject.** A source that is down returns
+ * {@link allUnavailable} for the whole batch, because one dead source
+ * must not abort a sweep that is also feeding five healthy ones.
+ */
+export interface FactResolver<K extends string = string> {
+  key: K;
+  /** Default freshness window. Resolvers with a value-dependent TTL
+   *  should express that as a {@link StalenessPolicy} instead. */
+  ttlSec: number;
+  resolve(appIds: string[]): Promise<Map<string, FactValue>>;
+}
+
+/** What a sweep is doing right now. Drives the progress UI verbatim. */
+export interface SweepProgress {
+  status:
+    | "idle"
+    | "running"
+    | "paused"
+    | "backoff"
+    | "done"
+    | "cancelled"
+    | "error";
+  /** appIds with a fresh row — the honest numerator for "N of M scanned". */
+  scanned: number;
+  /** Size of the sweep universe. */
+  total: number;
+  /** Batches actually issued this sweep. Surfaced so a user worried about
+   *  rate limits can *see* the cost rather than be reassured about it. */
+  requests: number;
+  /** ms since the current sweep started, 0 when idle. */
+  elapsedMs: number;
+  /** Present for `backoff` and `error` — user-facing, quote it directly. */
+  reason?: string;
+  /** Unix ms the backoff expires. Present only for `backoff`. */
+  retryAt?: number;
+}

--- a/packages/steam-cdp/package.json
+++ b/packages/steam-cdp/package.json
@@ -7,5 +7,9 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "@loadout/external-cache": "workspace:*",
+    "@loadout/steam-paths": "workspace:*"
+  }
 }

--- a/packages/steam-cdp/src/index.ts
+++ b/packages/steam-cdp/src/index.ts
@@ -16,6 +16,11 @@
  *
  * For the per-plugin "I need to call one Steam API once" pattern, prefer
  * `withSteamClient(fn)` — it lazy-connects, runs your callback, closes.
+ *
+ * Separately, `callSteamService` reaches Valve's *authenticated protobuf
+ * services* from inside Steam's page (see `./services.ts`) — a much wider
+ * surface than `window.SteamClient`, and the only way to answer questions
+ * about games the user owns but hasn't installed.
  */
 
 export { CDPClient, type CDPResponse, type CDPEvent } from "./cdp-client";
@@ -35,3 +40,17 @@ export {
   withSteamClient,
   type SteamClientOptions,
 } from "./steam-client";
+
+export {
+  buildCallExpression,
+  callSteamService,
+  chunkCacheKey,
+  clearServiceModuleCache,
+  findModuleIdInSource,
+  resolveServiceModuleId,
+  SteamServiceError,
+  type CallServiceOptions,
+  type ResolveOptions,
+  type SteamServiceErrorCode,
+  type SteamServiceSpec,
+} from "./services";

--- a/packages/steam-cdp/src/services.test.ts
+++ b/packages/steam-cdp/src/services.test.ts
@@ -1,0 +1,491 @@
+// Real disk I/O against a per-test temp dir via XDG_CACHE_HOME — the pattern
+// packages/external-cache and packages/plugin-storage use, to avoid the
+// `mock.module("fs/promises", …)` cross-file leakage documented in
+// docs/test-mock-contamination.md. The page itself is stubbed through the
+// `evaluate` seam, so nothing here needs Steam.
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  buildCallExpression,
+  callSteamService,
+  chunkCacheKey,
+  clearServiceModuleCache,
+  findModuleIdInSource,
+  resolveServiceModuleId,
+  SteamServiceError,
+  type SteamServiceSpec,
+} from "./services";
+
+const SPEC: SteamServiceSpec = {
+  namespace: "Player",
+  method: "GetAchievementsProgress",
+};
+const LITERAL = '"Player.GetAchievementsProgress#1"';
+
+let tempDir: string;
+let prevXdg: string | undefined;
+
+beforeEach(async () => {
+  prevXdg = process.env.XDG_CACHE_HOME;
+  tempDir = mkdtempSync(join(tmpdir(), "steam-services-"));
+  process.env.XDG_CACHE_HOME = tempDir;
+  // The module-id memo is process-global; clear it so tests don't leak into
+  // each other through it.
+  await clearServiceModuleCache();
+});
+
+afterEach(() => {
+  if (prevXdg === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = prevXdg;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ── findModuleIdInSource ─────────────────────────────────────────────────
+
+describe("findModuleIdInSource", () => {
+  it("finds a modern arrow-form module header", () => {
+    const src = `64295:(e,t,r)=>{r.d(t,{xtC:()=>x});const m=${LITERAL};}`;
+    expect(findModuleIdInSource(src, src.indexOf(LITERAL))).toBe(64295);
+  });
+
+  it("finds a legacy function-form module header", () => {
+    const src = `12345:function(e,t,r){const m=${LITERAL};}`;
+    expect(findModuleIdInSource(src, src.indexOf(LITERAL))).toBe(12345);
+  });
+
+  it("tolerates whitespace in the header", () => {
+    const src = `999 : ( e , t , r ) => { const m=${LITERAL};}`;
+    expect(findModuleIdInSource(src, src.indexOf(LITERAL))).toBe(999);
+  });
+
+  it("returns the NEAREST preceding header, not the first in the file", () => {
+    // The whole point of walking backwards. Getting this wrong resolves to
+    // some unrelated module hundreds of kilobytes earlier and the call fails
+    // with a confusing no-namespace.
+    const src = [
+      `1111:(e,t,r)=>{ const other = "Wishlist.GetWishlistItemCount#1"; }`,
+      `2222:(e,t,r)=>{ const other = "Store.GetItems#1"; }`,
+      `3333:(e,t,r)=>{ const m = ${LITERAL}; }`,
+    ].join(",");
+    expect(findModuleIdInSource(src, src.indexOf(LITERAL))).toBe(3333);
+  });
+
+  it("ignores headers that appear AFTER the match", () => {
+    const src = [
+      `7777:(e,t,r)=>{ const m = ${LITERAL}; }`,
+      `8888:(e,t,r)=>{ const later = "Nope#1"; }`,
+    ].join(",");
+    expect(findModuleIdInSource(src, src.indexOf(LITERAL))).toBe(7777);
+  });
+
+  it("returns null when no header precedes the match", () => {
+    // e.g. the literal appeared in a sourcemap comment before any module.
+    const src = `/* ${LITERAL} */`;
+    expect(findModuleIdInSource(src, src.indexOf(LITERAL))).toBeNull();
+  });
+
+  it("does not mistake a bare digit run for a module header", () => {
+    const src = `const version = 42; const m=${LITERAL};`;
+    expect(findModuleIdInSource(src, src.indexOf(LITERAL))).toBeNull();
+  });
+
+  it("does not mistake a two-argument factory for a module header", () => {
+    // Webpack module factories always take exactly three params.
+    const src = `55:(a,b)=>{ const m=${LITERAL}; }`;
+    expect(findModuleIdInSource(src, src.indexOf(LITERAL))).toBeNull();
+  });
+
+  it("handles a header at offset 0", () => {
+    const src = `1:(e,t,r)=>{${LITERAL}}`;
+    expect(findModuleIdInSource(src, src.indexOf(LITERAL))).toBe(1);
+  });
+});
+
+// ── chunkCacheKey ────────────────────────────────────────────────────────
+
+describe("chunkCacheKey", () => {
+  it("is independent of readdir order", () => {
+    const a = chunkCacheKey(["/s/chunk~a.js", "/s/chunk~b.js"]);
+    const b = chunkCacheKey(["/s/chunk~b.js", "/s/chunk~a.js"]);
+    expect(a).toBe(b);
+  });
+
+  it("is independent of the directory the chunks live in", () => {
+    // Only the content-hashed basenames identify a build.
+    expect(chunkCacheKey(["/one/chunk~a.js"])).toBe(
+      chunkCacheKey(["/completely/other/chunk~a.js"]),
+    );
+  });
+
+  it("changes when a chunk's content hash changes", () => {
+    const before = chunkCacheKey(["/s/chunk~2c8f1a.js"]);
+    const after = chunkCacheKey(["/s/chunk~9d3e77.js"]);
+    expect(after).not.toBe(before);
+  });
+
+  it("changes when a chunk is added", () => {
+    const one = chunkCacheKey(["/s/chunk~a.js"]);
+    const two = chunkCacheKey(["/s/chunk~a.js", "/s/chunk~b.js"]);
+    expect(two).not.toBe(one);
+  });
+
+  it("is a stable fixed-width hex string", () => {
+    const key = chunkCacheKey(["/s/chunk~a.js"]);
+    expect(key).toMatch(/^[0-9a-f]{8}$/);
+    expect(chunkCacheKey(["/s/chunk~a.js"])).toBe(key);
+  });
+});
+
+// ── buildCallExpression ──────────────────────────────────────────────────
+
+describe("buildCallExpression", () => {
+  const expr = buildCallExpression(64295, "GetAchievementsProgress", {
+    steamid: "76561198000000001",
+    appids: [620, 570],
+  }, 8000);
+
+  it("embeds the in-page timeout race", () => {
+    // Non-negotiable: without it a never-settling CM call holds the
+    // per-target evaluate chain and blocks every other consumer of Steam.
+    expect(expr).toContain("Promise.race");
+    expect(expr).toContain("setTimeout");
+    expect(expr).toContain("8000");
+    expect(expr).toContain("in-page timeout");
+  });
+
+  it("self-bootstraps webpack require rather than trusting the injector", () => {
+    expect(expr).toContain("__STEAM_WP_REQUIRE");
+    expect(expr).toContain("webpackChunksteamui");
+  });
+
+  it("duck-types the namespace instead of a minified export key", () => {
+    expect(expr).toContain("Object.values(mod)");
+    expect(expr).not.toContain("xtC");
+  });
+
+  it("serialises the request as JSON, preserving a 64-bit id as a string", () => {
+    expect(expr).toContain('"steamid":"76561198000000001"');
+    expect(expr).toContain('"appids":[620,570]');
+  });
+
+  it("reads the EResult both ways Steam exposes it", () => {
+    expect(expr).toContain("GetEResult");
+    expect(expr).toContain("response.eresult");
+  });
+
+  it("normalises Longs and round-trips through JSON before the clone", () => {
+    expect(expr).toContain("normaliseLongs");
+    expect(expr).toContain("JSON.parse(JSON.stringify(");
+  });
+
+  it("returns a tagged union covering every failure mode", () => {
+    for (const tag of [
+      "no-wp",
+      "no-transport",
+      "no-namespace",
+      "timeout",
+      "malformed",
+      "ok",
+    ]) {
+      expect(expr).toContain(`tag: "${tag}"`);
+    }
+  });
+
+  it("is a syntactically valid expression", () => {
+    // Cheapest possible guard against a template-literal typo shipping.
+    expect(() => new Function(`return ${expr};`)).not.toThrow();
+  });
+});
+
+// ── resolveServiceModuleId ───────────────────────────────────────────────
+
+describe("resolveServiceModuleId", () => {
+  it("greps the chunks and returns the enclosing module id", async () => {
+    const id = await resolveServiceModuleId(SPEC, {
+      listChunks: async () => ["/s/chunk~a.js"],
+      readChunk: async () => `64295:(e,t,r)=>{const m=${LITERAL};}`,
+    });
+    expect(id).toBe(64295);
+  });
+
+  it("searches later chunks when the first does not match", async () => {
+    const read: string[] = [];
+    const id = await resolveServiceModuleId(SPEC, {
+      listChunks: async () => ["/s/chunk~a.js", "/s/chunk~b.js"],
+      readChunk: async (p) => {
+        read.push(p);
+        return p.endsWith("b.js")
+          ? `777:(e,t,r)=>{const m=${LITERAL};}`
+          : `111:(e,t,r)=>{const nope="Other#1";}`;
+      },
+    });
+    expect(id).toBe(777);
+    expect(read).toEqual(["/s/chunk~a.js", "/s/chunk~b.js"]);
+  });
+
+  it("accepts single-quoted literals", async () => {
+    const id = await resolveServiceModuleId(SPEC, {
+      listChunks: async () => ["/s/chunk~a.js"],
+      readChunk: async () =>
+        `4242:(e,t,r)=>{const m='Player.GetAchievementsProgress#1';}`,
+    });
+    expect(id).toBe(4242);
+  });
+
+  it("skips a chunk that vanishes mid-read", async () => {
+    // Steam updating underneath us must not fail the whole resolution.
+    const id = await resolveServiceModuleId(SPEC, {
+      listChunks: async () => ["/s/gone.js", "/s/chunk~b.js"],
+      readChunk: async (p) => {
+        if (p.endsWith("gone.js")) throw new Error("ENOENT");
+        return `31337:(e,t,r)=>{const m=${LITERAL};}`;
+      },
+    });
+    expect(id).toBe(31337);
+  });
+
+  it("throws unresolved, naming the literal, when nothing matches", async () => {
+    const err = await resolveServiceModuleId(SPEC, {
+      listChunks: async () => ["/s/chunk~a.js"],
+      readChunk: async () => "nothing interesting here",
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(SteamServiceError);
+    expect((err as SteamServiceError).code).toBe("unresolved");
+    // Diagnosable from the log line alone after a Valve rename.
+    expect((err as SteamServiceError).message).toContain(
+      "Player.GetAchievementsProgress#1",
+    );
+  });
+
+  it("throws unresolved when Steam is not installed", async () => {
+    const err = await resolveServiceModuleId(SPEC, {
+      listChunks: async () => [],
+    }).catch((e) => e);
+    expect((err as SteamServiceError).code).toBe("unresolved");
+    expect((err as SteamServiceError).message).toMatch(/Is Steam installed/);
+  });
+
+  it("caches so a second call does not re-read the bundle", async () => {
+    let reads = 0;
+    const opts = {
+      listChunks: async () => ["/s/chunk~a.js"],
+      readChunk: async () => {
+        reads++;
+        return `500:(e,t,r)=>{const m=${LITERAL};}`;
+      },
+    };
+
+    expect(await resolveServiceModuleId(SPEC, opts)).toBe(500);
+    expect(await resolveServiceModuleId(SPEC, opts)).toBe(500);
+    expect(reads).toBe(1);
+  });
+
+  it("re-greps when the chunk filenames change, i.e. Steam updated", async () => {
+    let reads = 0;
+    const first = await resolveServiceModuleId(SPEC, {
+      listChunks: async () => ["/s/chunk~OLD.js"],
+      readChunk: async () => {
+        reads++;
+        return `100:(e,t,r)=>{const m=${LITERAL};}`;
+      },
+    });
+    expect(first).toBe(100);
+
+    // Fresh memo, as after a restart; the disk cache is keyed on the names.
+    await clearServiceModuleCache();
+
+    const second = await resolveServiceModuleId(SPEC, {
+      listChunks: async () => ["/s/chunk~NEW.js"],
+      readChunk: async () => {
+        reads++;
+        return `200:(e,t,r)=>{const m=${LITERAL};}`;
+      },
+    });
+    // The id moved between builds — exactly the reason nothing is hardcoded.
+    expect(second).toBe(200);
+    expect(reads).toBe(2);
+  });
+});
+
+// ── callSteamService ─────────────────────────────────────────────────────
+
+/** Resolve to module 64295 without touching disk twice. */
+const resolveOpts = {
+  listChunks: async () => ["/s/chunk~a.js"],
+  readChunk: async () => `64295:(e,t,r)=>{const m=${LITERAL};}`,
+};
+
+function callWith(result: unknown, extra: { timeoutMs?: number } = {}) {
+  return callSteamService(SPEC, { appids: [620] }, {
+    ...resolveOpts,
+    ...extra,
+    evaluate: async () => result,
+  });
+}
+
+describe("callSteamService", () => {
+  it("returns the response data on ok", async () => {
+    const data = {
+      achievement_progress: [
+        { appid: 620, unlocked: 26, total: 51, percentage: 50.98 },
+      ],
+    };
+    expect(await callWith({ tag: "ok", eresult: 1, data })).toEqual(data);
+  });
+
+  it("accepts an ok response with no EResult at all", async () => {
+    // Not every response object exposes one; treating that as failure would
+    // reject perfectly good data.
+    expect(await callWith({ tag: "ok", data: { ok: true } })).toEqual({ ok: true });
+  });
+
+  it("passes the resolved module id and request into the expression", async () => {
+    let seen = "";
+    await callSteamService(SPEC, { appids: [620, 570] }, {
+      ...resolveOpts,
+      evaluate: async (expr) => {
+        seen = expr;
+        return { tag: "ok", eresult: 1, data: null };
+      },
+    });
+    expect(seen).toContain("64295");
+    expect(seen).toContain('"appids":[620,570]');
+  });
+
+  const tagCases: Array<[string, string, RegExp]> = [
+    ["no-wp", "no-wp", /webpack require/],
+    ["no-transport", "no-transport", /GetServiceTransport/],
+    ["no-namespace", "no-namespace", /does not export/],
+    ["timeout", "timeout", /did not respond/],
+    ["malformed", "malformed", /unusable response/],
+  ];
+
+  for (const [tag, code, messageMatch] of tagCases) {
+    it(`maps the ${tag} tag to a typed ${code} error`, async () => {
+      const err = await callWith({ tag }).catch((e) => e);
+      expect(err).toBeInstanceOf(SteamServiceError);
+      expect((err as SteamServiceError).code).toBe(code);
+      expect((err as SteamServiceError).message).toMatch(messageMatch);
+    });
+  }
+
+  it("includes the in-page detail in a malformed error", async () => {
+    const err = await callWith({
+      tag: "malformed",
+      detail: "body.constructor is undefined",
+    }).catch((e) => e);
+    expect((err as SteamServiceError).message).toContain(
+      "body.constructor is undefined",
+    );
+  });
+
+  it("throws eresult, carrying the numeric code, on a non-OK EResult", async () => {
+    const err = await callWith({ tag: "ok", eresult: 84, data: {} }).catch((e) => e);
+    expect(err).toBeInstanceOf(SteamServiceError);
+    expect((err as SteamServiceError).code).toBe("eresult");
+    expect((err as SteamServiceError).eresult).toBe(84);
+  });
+
+  it("rejects an unrecognised payload rather than returning undefined data", async () => {
+    for (const junk of [null, undefined, "surprise", 42, {}]) {
+      const err = await callWith(junk).catch((e) => e);
+      expect((err as SteamServiceError).code).toBe("malformed");
+    }
+  });
+
+  it("times out on the JS side when the page never settles", async () => {
+    // The backstop: an in-page timer cannot fire if the page is wedged, and
+    // a stuck evaluate blocks every other consumer of that target.
+    const err = await callSteamService(SPEC, {}, {
+      ...resolveOpts,
+      timeoutMs: 5,
+      evaluate: () => new Promise(() => {}),
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(SteamServiceError);
+    expect((err as SteamServiceError).code).toBe("timeout");
+  });
+
+  it("propagates a resolution failure without evaluating anything", async () => {
+    let evaluated = false;
+    const err = await callSteamService(SPEC, {}, {
+      listChunks: async () => ["/s/chunk~a.js"],
+      readChunk: async () => "no match",
+      evaluate: async () => {
+        evaluated = true;
+        return { tag: "ok", data: null };
+      },
+    }).catch((e) => e);
+
+    expect((err as SteamServiceError).code).toBe("unresolved");
+    expect(evaluated).toBe(false);
+  });
+
+  it("surfaces an evaluate rejection rather than swallowing it", async () => {
+    const err = await callSteamService(SPEC, {}, {
+      ...resolveOpts,
+      evaluate: async () => {
+        throw new Error("CDP connection closed");
+      },
+    }).catch((e) => e);
+    expect((err as Error).message).toBe("CDP connection closed");
+  });
+});
+
+// ── the in-page Long normaliser ──────────────────────────────────────────
+
+describe("normaliseLongs (executed from the generated source)", () => {
+  /** Pull the helper out of the generated expression and run it for real, so
+   *  the 64-bit conversion is tested rather than assumed. */
+  function loadNormaliser(): (v: unknown) => unknown {
+    const expr = buildCallExpression(1, "M", {}, 1000);
+    const start = expr.indexOf("function normaliseLongs");
+    const end = expr.indexOf("\n    }", start) + "\n    }".length;
+    const src = expr.slice(start, end);
+    return new Function(`${src}; return normaliseLongs;`)() as (v: unknown) => unknown;
+  }
+
+  const normalise = loadNormaliser();
+
+  it("passes primitives and null through untouched", () => {
+    expect(normalise(42)).toBe(42);
+    expect(normalise("x")).toBe("x");
+    expect(normalise(null)).toBeNull();
+    expect(normalise(true)).toBe(true);
+  });
+
+  it("converts a 17-digit Steam id without precision loss", () => {
+    // 76561198000000001 = high 17825793, low 512 (unsigned).
+    const steamId = 76561198000000001n;
+    const long = {
+      low: Number(steamId & 0xffffffffn) | 0,
+      high: Number((steamId >> 32n) & 0xffffffffn) | 0,
+      unsigned: true,
+    };
+    expect(normalise(long)).toBe("76561198000000001");
+    // Why a decimal string and not a number: the value exceeds 2^53, so the
+    // number path silently drops the last digit.
+    expect(String(Number("76561198000000001"))).toBe("76561198000000000");
+  });
+
+  it("converts a small unsigned Long", () => {
+    expect(normalise({ low: 1294, high: 0, unsigned: true })).toBe("1294");
+  });
+
+  it("converts a negative signed Long via two's complement", () => {
+    expect(normalise({ low: -1, high: -1, unsigned: false })).toBe("-1");
+  });
+
+  it("recurses through arrays and nested objects", () => {
+    const out = normalise({
+      rows: [{ id: { low: 5, high: 0, unsigned: true }, name: "a" }],
+    }) as { rows: Array<{ id: unknown; name: string }> };
+    expect(out.rows[0]!.id).toBe("5");
+    expect(out.rows[0]!.name).toBe("a");
+  });
+});

--- a/packages/steam-cdp/src/services.ts
+++ b/packages/steam-cdp/src/services.ts
@@ -1,0 +1,529 @@
+/**
+ * Calling Valve's own authenticated service RPCs from inside Steam's page.
+ *
+ * ## What this unlocks
+ *
+ * Steam's client UI can call Valve's protobuf services **as the logged-in
+ * user**, over the CM connection Steam already holds. No API key, no HTTP
+ * endpoint, no third party, no scraping — `window.App.cm.GetServiceTransport()`
+ * hands out a transport that is already authenticated, and the shipped bundle
+ * contains ~949 service methods across ~110 namespaces. That is how a feature
+ * can answer questions about a user's *whole library* (including games that
+ * aren't installed) rather than just what's on disk.
+ *
+ * The one that motivated this module is `Player.GetAchievementsProgress`,
+ * which takes an **array** of appids and returns `{appid, unlocked, total,
+ * percentage}` for each. Batched, that turns "scan a 2000-game library" from
+ * 2000 requests into ~40.
+ *
+ * ## Why module ids are resolved by grepping the bundle
+ *
+ * The obvious call is `__STEAM_WP_REQUIRE(64295)["xtC"]` — and it works,
+ * until the next Steam update, because **webpack module ids change on every
+ * build**. Method *names* don't: `Player.GetAchievementsProgress#1` is
+ * versioned by Valve and stable across builds.
+ *
+ * So the id is discovered rather than hardcoded: text-search
+ * `~/.local/share/Steam/steamui/chunk~*.js` for the literal method name and
+ * walk backwards to the enclosing module header. The result is cached under a
+ * key derived from the chunk filenames, which webpack content-hashes — so the
+ * cache invalidates itself exactly once per Steam UI update, and never
+ * needlessly.
+ *
+ * Note we deliberately do **not** grep for the export key (`"xtC"` above):
+ * that *is* minified per build, and searching for it would be the fragile
+ * thing we just avoided. Instead the in-page expression duck-types the right
+ * export out of the already-resolved module. One module, a handful of
+ * exports — cheap, and self-healing across renames.
+ *
+ * ## Why every call is raced against a timeout, twice
+ *
+ * `CDPClient` serialises evaluates per target (see the `evaluateChains`
+ * comment in `./cdp-client.ts`), because Steam's CEF IPC crashes
+ * `steamwebhelper` if two clients drive one target concurrently. That makes a
+ * hung in-page promise a *shared* problem: it doesn't just fail this call, it
+ * head-of-line blocks every other plugin's access to Steam for as long as it
+ * hangs. Several `SteamClient` methods are known to hang forever rather than
+ * reject.
+ *
+ * So: the generated expression races the service call against an in-page
+ * `setTimeout`, guaranteeing the awaited promise always settles and the
+ * evaluate returns normally. A second race on the JS side is the backstop for
+ * the page itself being wedged, where no in-page timer can fire.
+ */
+
+import { basename } from "node:path";
+
+import { createExternalCache } from "@loadout/external-cache";
+import { listSteamUiChunks } from "@loadout/steam-paths";
+
+import { withSteamClient } from "./steam-client";
+
+/** Identifies one service method, e.g. `Player.GetAchievementsProgress#1`. */
+export interface SteamServiceSpec {
+  /** Service namespace, e.g. `"Player"`. */
+  namespace: string;
+  /** Method name, e.g. `"GetAchievementsProgress"`. */
+  method: string;
+  /** Valve's method version suffix. Effectively always 1. */
+  version?: number;
+}
+
+/**
+ * Why a service call failed. The codes exist so callers can react
+ * differently — in particular, `eresult` must never be cached and
+ * `unresolved` means a Steam update probably renamed something.
+ */
+export type SteamServiceErrorCode =
+  /** No chunk contained the method literal. Steam updated, or bad spec. */
+  | "unresolved"
+  /** Couldn't get webpack's require from the page. */
+  | "no-wp"
+  /** `App.cm.GetServiceTransport()` unavailable — Steam not signed in yet. */
+  | "no-transport"
+  /** The resolved module didn't export anything with this method. */
+  | "no-namespace"
+  /** The call didn't settle in time. */
+  | "timeout"
+  /** Steam answered with a non-OK EResult. */
+  | "eresult"
+  /** The response didn't look like a protobuf response object. */
+  | "malformed";
+
+export class SteamServiceError extends Error {
+  readonly code: SteamServiceErrorCode;
+  /** Valve's numeric EResult, when `code === "eresult"`. */
+  readonly eresult?: number;
+
+  constructor(
+    code: SteamServiceErrorCode,
+    message: string,
+    opts: { eresult?: number; cause?: unknown } = {},
+  ) {
+    super(message);
+    this.name = "SteamServiceError";
+    this.code = code;
+    if (opts.eresult !== undefined) this.eresult = opts.eresult;
+    if (opts.cause !== undefined) this.cause = opts.cause;
+  }
+}
+
+/** `EResult.OK`. Everything else is a failure worth surfacing. */
+const ERESULT_OK = 1;
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+/** Slack between the in-page deadline and the JS-side backstop. */
+const JS_RACE_SLACK_MS = 1_500;
+/** The key already guarantees correctness; the TTL is just a janitor. */
+const MODULE_CACHE_TTL_SEC = 30 * 24 * 60 * 60;
+
+/** Full method literal as it appears in the bundle. */
+function methodLiteral(spec: SteamServiceSpec): string {
+  return `${spec.namespace}.${spec.method}#${spec.version ?? 1}`;
+}
+
+/**
+ * Find the webpack module id that encloses `index` in `source`.
+ *
+ * Walks **backwards** to the *nearest preceding* module header, which is the
+ * whole point — the first header in the file would be some unrelated module
+ * hundreds of kilobytes earlier. Handles both shapes webpack emits:
+ *
+ *   modern:  `64295:(e,t,r)=>{`
+ *   legacy:  `64295:function(e,t,r){`
+ *
+ * Returns `null` when no header precedes the match, which in practice means
+ * the literal appeared outside any module (e.g. in a source-map comment).
+ */
+export function findModuleIdInSource(source: string, index: number): number | null {
+  const head = source.slice(0, index);
+
+  // Scan for all headers and keep the last. A single global regex pass is
+  // simpler and faster than repeated backwards `lastIndexOf` probing, and
+  // avoids the classic bug of matching a digit run that isn't a header.
+  const header = /(\d+)\s*:\s*(?:\(\s*\w+\s*,\s*\w+\s*,\s*\w+\s*\)\s*=>|function\s*\(\s*\w+\s*,\s*\w+\s*,\s*\w+\s*\))\s*\{/g;
+
+  let lastId: number | null = null;
+  let match: RegExpExecArray | null;
+  while ((match = header.exec(head)) !== null) {
+    lastId = Number(match[1]);
+  }
+  return lastId;
+}
+
+/**
+ * A cache key that changes exactly when Steam's UI bundle changes.
+ *
+ * Webpack content-hashes chunk filenames, so the *set* of basenames is a
+ * fingerprint of the build. Sorted first so readdir order can't affect it.
+ *
+ * Preferred over `SteamClient.System.GetSystemInfo().nSteamVersion` for two
+ * reasons: that call is on the known-to-hang list, and this works with Steam
+ * closed.
+ */
+export function chunkCacheKey(chunkPaths: readonly string[]): string {
+  const names = chunkPaths.map((p) => basename(p)).sort().join(",");
+  // Bun ships a global `Bun.hash`, but this module is also imported by tests
+  // under plain node resolution, so use a tiny stable hash rather than a
+  // runtime-specific API. FNV-1a is plenty — this is a cache key, not a
+  // security boundary.
+  let h = 0x811c9dc5;
+  for (let i = 0; i < names.length; i++) {
+    h ^= names.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
+}
+
+/**
+ * Recursively convert protobuf.js `Long` objects to decimal strings.
+ *
+ * Runs **inside the page** (this is source text, not a live function) for two
+ * reasons: a `{low, high, unsigned}` wrapper survives the structured clone as
+ * a meaningless object, and a 64-bit id coerced to a JS number is silently
+ * corrupted past 2^53. Steam ids are 17 digits, so that matters.
+ */
+const NORMALISE_LONGS_SRC = `function normaliseLongs(value) {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(normaliseLongs);
+  if (typeof value.low === "number" && typeof value.high === "number") {
+    // Two's-complement 64-bit reassembly. Read both halves as unsigned, then
+    // subtract 2^64 when the signed interpretation of the high word is
+    // negative. Returned as a decimal string: a 17-digit Steam id loses
+    // precision the moment it touches a JS number.
+    let big = (BigInt(value.high >>> 0) << 32n) | BigInt(value.low >>> 0);
+    if (value.unsigned !== true && (value.high | 0) < 0) big -= 1n << 64n;
+    return big.toString();
+  }
+  const out = {};
+  for (const key of Object.keys(value)) out[key] = normaliseLongs(value[key]);
+  return out;
+}`;
+
+/**
+ * Build the in-page expression for one service call.
+ *
+ * Returns a tagged union, matching the house style in `./steam-client.ts`, so
+ * every failure mode is distinguishable from a legitimate `null` in the
+ * response body.
+ */
+export function buildCallExpression(
+  moduleId: number,
+  method: string,
+  request: object,
+  timeoutMs: number,
+): string {
+  return `(async () => {
+    ${NORMALISE_LONGS_SRC}
+
+    // Self-bootstrap webpack's require rather than depending on the
+    // injector having run: apps/loadout/src/injector/steam-react.ts sets
+    // __STEAM_WP_REQUIRE, but it early-outs if __STEAM_REACT is already
+    // set, so the global is not guaranteed to exist even in an injected page.
+    let wp = globalThis.__STEAM_WP_REQUIRE;
+    if (typeof wp !== "function") {
+      try {
+        if (Array.isArray(window.webpackChunksteamui)) {
+          window.webpackChunksteamui.push([[Symbol()], {}, (r) => { wp = r; }]);
+          if (typeof wp === "function") globalThis.__STEAM_WP_REQUIRE = wp;
+        }
+      } catch (e) { /* fall through to the no-wp tag */ }
+    }
+    if (typeof wp !== "function") return { tag: "no-wp" };
+
+    let mod;
+    try { mod = wp(${JSON.stringify(moduleId)}); }
+    catch (e) { return { tag: "no-namespace", detail: String(e) }; }
+    if (!mod || typeof mod !== "object") return { tag: "no-namespace" };
+
+    // Duck-type the namespace out of the module. The export key is minified
+    // per build, so grepping for it would reintroduce the fragility that
+    // resolving the module id by method name exists to avoid.
+    const method = ${JSON.stringify(method)};
+    let ns = typeof mod[method] === "function" ? mod : null;
+    if (!ns) {
+      for (const value of Object.values(mod)) {
+        if (value && typeof value[method] === "function") { ns = value; break; }
+      }
+    }
+    if (!ns) return { tag: "no-namespace" };
+
+    const transport = window.App?.cm?.GetServiceTransport?.();
+    if (!transport) return { tag: "no-transport" };
+
+    let response;
+    try {
+      // Race in-page so the awaited promise ALWAYS settles. Without this a
+      // never-resolving CM call holds the per-target evaluate chain for the
+      // full CDP timeout and blocks every other consumer of Steam.
+      response = await Promise.race([
+        ns[method](transport, ${JSON.stringify(request)}),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("in-page timeout")), ${JSON.stringify(timeoutMs)})
+        ),
+      ]);
+    } catch (e) {
+      const message = String(e && e.message ? e.message : e);
+      if (message.indexOf("in-page timeout") !== -1) return { tag: "timeout" };
+      return { tag: "malformed", detail: message };
+    }
+
+    if (!response) return { tag: "malformed", detail: "empty response" };
+
+    const eresult =
+      typeof response.GetEResult === "function"
+        ? response.GetEResult()
+        : typeof response.eresult === "number"
+          ? response.eresult
+          : undefined;
+
+    let data = null;
+    try {
+      const body = typeof response.Body === "function" ? response.Body() : null;
+      if (body && body.constructor && typeof body.constructor.toObject === "function") {
+        data = body.constructor.toObject(false, body);
+      } else if (body) {
+        data = body;
+      }
+      // Round-trip through JSON so a protobuf wrapper can never reach the
+      // structured clone, after flattening any Long to a decimal string.
+      data = JSON.parse(JSON.stringify(normaliseLongs(data)));
+    } catch (e) {
+      return { tag: "malformed", detail: String(e), eresult };
+    }
+
+    return { tag: "ok", eresult, data };
+  })()`;
+}
+
+/** Shape the in-page expression returns. */
+interface CallResult {
+  tag: "ok" | "no-wp" | "no-transport" | "no-namespace" | "timeout" | "malformed";
+  eresult?: number;
+  data?: unknown;
+  detail?: string;
+}
+
+/** Process-lifetime memo, so a 40-batch sweep pays no repeat disk reads. */
+const moduleIdMemo = new Map<string, number>();
+
+export interface ResolveOptions {
+  /** Override the chunk list. Test seam. */
+  listChunks?: () => Promise<string[]>;
+  /** Override chunk reading. Test seam. */
+  readChunk?: (path: string) => Promise<string>;
+}
+
+async function defaultReadChunk(path: string): Promise<string> {
+  return await Bun.file(path).text();
+}
+
+/**
+ * Resolve the current webpack module id exporting a service namespace.
+ *
+ * Cached in-memory for the process and on disk under a key derived from the
+ * chunk filenames, so this greps the bundle at most once per Steam update.
+ */
+export async function resolveServiceModuleId(
+  spec: SteamServiceSpec,
+  opts: ResolveOptions = {},
+): Promise<number> {
+  const listChunks = opts.listChunks ?? listSteamUiChunks;
+  const readChunk = opts.readChunk ?? defaultReadChunk;
+  const literal = methodLiteral(spec);
+
+  const chunks = await listChunks();
+  if (chunks.length === 0) {
+    throw new SteamServiceError(
+      "unresolved",
+      `No Steam UI chunks found — looked for ${literal} in Steam's steamui directory. Is Steam installed?`,
+    );
+  }
+
+  const cacheKey = `modules:${chunkCacheKey(chunks)}`;
+  const memoKey = `${cacheKey}:${literal}`;
+
+  const memoised = moduleIdMemo.get(memoKey);
+  if (memoised !== undefined) return memoised;
+
+  const cache = createExternalCache("steam-cdp");
+  let table: Record<string, number> | undefined;
+  try {
+    table = await cache.get<Record<string, number>>(cacheKey);
+  } catch {
+    table = undefined;
+  }
+  const cached = table?.[literal];
+  if (typeof cached === "number") {
+    moduleIdMemo.set(memoKey, cached);
+    return cached;
+  }
+
+  // Both quote flavours, because the bundle's minifier picks either.
+  const needles = [`"${literal}"`, `'${literal}'`];
+
+  for (const path of chunks) {
+    let source: string;
+    try {
+      source = await readChunk(path);
+    } catch {
+      continue; // Chunk vanished mid-read (Steam updating). Try the next.
+    }
+
+    for (const needle of needles) {
+      const index = source.indexOf(needle);
+      if (index === -1) continue;
+      const moduleId = findModuleIdInSource(source, index);
+      if (moduleId === null) continue;
+
+      moduleIdMemo.set(memoKey, moduleId);
+      try {
+        await cache.set(
+          cacheKey,
+          { ...(table ?? {}), [literal]: moduleId },
+          { ttlSec: MODULE_CACHE_TTL_SEC },
+        );
+      } catch {
+        // A cache write failure costs a re-grep next launch, nothing more.
+      }
+      return moduleId;
+    }
+  }
+
+  throw new SteamServiceError(
+    "unresolved",
+    `Could not find ${literal} in any of ${chunks.length} Steam UI chunks — Valve may have renamed or removed it.`,
+  );
+}
+
+export interface CallServiceOptions extends ResolveOptions {
+  /** In-page deadline, ms. Default 8000. */
+  timeoutMs?: number;
+  /**
+   * Evaluate an expression in Steam's page. Defaults to a one-shot
+   * `withSteamClient` session, which inherits the global session
+   * serialisation. Injected by tests, and by callers that already hold a
+   * session and want their batches to share it.
+   */
+  evaluate?: (expression: string) => Promise<unknown>;
+}
+
+async function defaultEvaluate(expression: string): Promise<unknown> {
+  return await withSteamClient((sc) => sc._evaluateAsync(expression));
+}
+
+/**
+ * Call a Steam protobuf service and return its response body as a plain
+ * object.
+ *
+ * Throws {@link SteamServiceError} for every failure mode. Callers must not
+ * cache on a throw — in particular a `timeout` or `eresult` says nothing
+ * about the data, and caching it would turn a transient hiccup into a
+ * long-lived wrong answer.
+ */
+export async function callSteamService<T = unknown>(
+  spec: SteamServiceSpec,
+  request: object,
+  opts: CallServiceOptions = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const evaluate = opts.evaluate ?? defaultEvaluate;
+
+  const moduleId = await resolveServiceModuleId(spec, opts);
+  const expression = buildCallExpression(moduleId, spec.method, request, timeoutMs);
+
+  // Backstop race: the in-page timer cannot fire if the page itself is
+  // wedged, and a stuck evaluate blocks every other consumer of this target.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let result: unknown;
+  try {
+    result = await Promise.race([
+      evaluate(expression),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new SteamServiceError(
+                "timeout",
+                `${methodLiteral(spec)} did not settle within ${timeoutMs + JS_RACE_SLACK_MS}ms`,
+              ),
+            ),
+          timeoutMs + JS_RACE_SLACK_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+
+  const payload = result as CallResult | null | undefined;
+  const literal = methodLiteral(spec);
+
+  switch (payload?.tag) {
+    case "ok":
+      break;
+    case "no-wp":
+      throw new SteamServiceError(
+        "no-wp",
+        `Could not obtain webpack require from Steam's page while calling ${literal}.`,
+      );
+    case "no-transport":
+      throw new SteamServiceError(
+        "no-transport",
+        `App.cm.GetServiceTransport() is unavailable while calling ${literal} — is Steam signed in?`,
+      );
+    case "no-namespace":
+      throw new SteamServiceError(
+        "no-namespace",
+        `Module ${moduleId} does not export ${spec.namespace}.${spec.method}${
+          payload.detail ? ` (${payload.detail})` : ""
+        }.`,
+      );
+    case "timeout":
+      throw new SteamServiceError(
+        "timeout",
+        `${literal} did not respond within ${timeoutMs}ms.`,
+      );
+    case "malformed":
+      throw new SteamServiceError(
+        "malformed",
+        `${literal} returned an unusable response${
+          payload.detail ? `: ${payload.detail}` : ""
+        }.`,
+      );
+    default:
+      throw new SteamServiceError(
+        "malformed",
+        `${literal} returned an unexpected value: ${JSON.stringify(result)}`,
+      );
+  }
+
+  // An EResult we can read and which isn't OK is a real failure. An absent
+  // EResult is not: not every response object exposes one, and treating
+  // "couldn't read it" as failure would reject perfectly good data.
+  if (typeof payload.eresult === "number" && payload.eresult !== ERESULT_OK) {
+    throw new SteamServiceError(
+      "eresult",
+      `${literal} failed with EResult ${payload.eresult}.`,
+      { eresult: payload.eresult },
+    );
+  }
+
+  return payload.data as T;
+}
+
+/**
+ * Forget every resolved module id, in memory and on disk.
+ *
+ * Only needed if a resolution is somehow wrong while the chunk filenames are
+ * unchanged — the content-hashed cache key means an ordinary Steam update
+ * invalidates itself.
+ */
+export async function clearServiceModuleCache(): Promise<void> {
+  moduleIdMemo.clear();
+  try {
+    await createExternalCache("steam-cdp").clear();
+  } catch {
+    // Nothing to clear, or the dir is already gone.
+  }
+}

--- a/packages/steam-paths/src/index.ts
+++ b/packages/steam-paths/src/index.ts
@@ -1,6 +1,6 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { readdir, readFile } from "node:fs/promises";
+import { readdir, readFile, stat } from "node:fs/promises";
 
 export { isGamescopeRunning } from "./gaming-mode";
 
@@ -38,6 +38,63 @@ export function getSteamAppsDir(): string {
  */
 export function getAppCacheLibraryDir(): string {
   return join(getSteamDir(), "appcache", "librarycache");
+}
+
+/**
+ * Steam's shipped client UI bundle — the webpack output that renders Big
+ * Picture / Gaming Mode.
+ *
+ * Read-only, and only ever *text-searched*: `@loadout/steam-cdp`'s service
+ * caller greps these chunks for a literal like `"Player.GetAchievementsProgress#1"`
+ * to discover which webpack module id currently exports that service, because
+ * the ids change on every Steam build and hardcoding one is a guaranteed
+ * breakage. Never write here.
+ */
+export function getSteamUiDir(): string {
+  return join(getSteamDir(), "steamui");
+}
+
+/**
+ * List the `chunk~*.js` files of Steam's UI bundle, newest first.
+ *
+ * Newest-first because a service literal is overwhelmingly likely to live in
+ * a recently-built chunk, so callers that stop at the first hit do less I/O.
+ *
+ * The filenames are content-hashed by webpack, which makes the *set* of names
+ * a free cache key for "has Steam's UI changed?" — see
+ * `chunkCacheKey` in `@loadout/steam-cdp`. Returns `[]` when Steam isn't
+ * installed rather than throwing; a caller with no chunks to search reports
+ * that as an unresolved service, which is the more useful error.
+ */
+export async function listSteamUiChunks(): Promise<string[]> {
+  const dir = getSteamUiDir();
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const chunks = names.filter((n) => n.startsWith("chunk~") && n.endsWith(".js"));
+
+  // stat every candidate up front so the sort comparator stays pure — an
+  // async comparator would silently not sort.
+  const withMtime = await Promise.all(
+    chunks.map(async (name) => {
+      const path = join(dir, name);
+      try {
+        return { path, mtimeMs: (await stat(path)).mtimeMs };
+      } catch {
+        // Vanished between readdir and stat (Steam updating underneath us).
+        return null;
+      }
+    }),
+  );
+
+  return withMtime
+    .filter((entry): entry is { path: string; mtimeMs: number } => entry !== null)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .map((entry) => entry.path);
 }
 
 /**

--- a/plugins/achievement-hunter/package.json
+++ b/plugins/achievement-hunter/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@loadout/plugin-achievement-hunter",
+  "version": "0.0.1",
+  "type": "module",
+  "dependencies": {
+    "@loadout/steam-cdp": "workspace:*",
+    "@loadout/steam-paths": "workspace:*"
+  },
+  "plugin": {
+    "id": "achievement-hunter",
+    "name": "Achievement Hunter",
+    "description": "A library-wide achievement completion dashboard. Answers \"which games am I 3 achievements away from 100%?\" across your whole library — including games you haven't installed — plus per-game detail, an unlock timeline and a rarest-unlocked view. Big Picture has no equivalent.",
+    "permissions": {
+      "network": ["localhost", "127.0.0.1"],
+      "filesystem": [
+        "read:~/.local/share/Steam",
+        "write:~/.config/loadout/plugins",
+        "write:~/.cache/loadout"
+      ]
+    },
+    "category": "Steam",
+    "subtitle": "Achievement completion dashboard",
+    "target": { "type": "overlay" }
+  }
+}

--- a/plugins/achievement-hunter/scripts/probe-achievements.ts
+++ b/plugins/achievement-hunter/scripts/probe-achievements.ts
@@ -1,0 +1,643 @@
+#!/usr/bin/env bun
+/**
+ * Maintainer tool. Measures Steam's real achievement surface on a real
+ * device, so Phases 1–3 are written against measurements rather than guesses.
+ *
+ *   bun plugins/achievement-hunter/scripts/probe-achievements.ts > docs/steam-achievements-probe.md
+ *
+ * **Why this exists.** Loadout is developed on machines with no Steam install,
+ * and the plan's cost model rests on numbers nobody has measured:
+ *
+ * 1. **The server-side appid cap on `Player.GetAchievementsProgress`.** The
+ *    whole "40 requests for a 2000-game library" argument assumes a batch of
+ *    ~50 is accepted. If the real cap is 25 the sweep doubles; if it's 400 it
+ *    shrinks fivefold. This single number sets `DEFAULT_BATCH_SIZE`, so it is
+ *    measured by escalation rather than assumed.
+ * 2. **Whether `GetMyAchievementsForApp` already carries global rarity.** If
+ *    it does, the whole Tier-3 `GetTopAchievementsForGames` layer is
+ *    unnecessary and Phase 3 gets materially smaller.
+ * 3. **Which steamid expression actually resolves.** Nothing in the repo
+ *    resolves a steamid today; the plan lists four candidate in-page
+ *    expressions and none is verified.
+ * 4. **The `RegisterForAchievementChanges` payload** — per-unlock or
+ *    per-session decides whether the unlock timeline can stay live for free.
+ * 5. **Whether the recency fields the dashboard sorts by actually exist** on
+ *    `appStore` overviews. `rt_last_time_played` and friends are inferred
+ *    from reading TabMaster's source, not verified.
+ *
+ * Read-only. It evaluates expressions in Steam's context and reads bytes off
+ * disk. It writes no config, changes no achievement, and calls no mutator.
+ *
+ * Rate-limit note: the batch-cap probe deliberately issues a handful of
+ * escalating requests with a gap between them. That is a few tens of
+ * requests total — far below anything a normal library scan does — but it is
+ * the one part of this script that talks to Valve repeatedly, so it is
+ * ordered last and can be skipped with `--no-batch-probe`.
+ */
+
+import { CDPClient, findSharedJsTab } from "@loadout/steam-cdp";
+import { listSteamUiChunks } from "@loadout/steam-paths";
+import { findModuleIdInSource } from "@loadout/steam-cdp";
+
+/** Namespaces whose module ids we need to resolve. */
+const NAMESPACES = [
+  { namespace: "Player", method: "GetAchievementsProgress" },
+  { namespace: "Player", method: "GetTopAchievementsForGames" },
+  { namespace: "Player", method: "GetOwnedGames" },
+] as const;
+
+/** Batch sizes to escalate through when finding the server-side cap. */
+const BATCH_LADDER = [25, 50, 100, 200, 400] as const;
+
+/** Gap between batch-cap probes, ms. Deliberately generous. */
+const PROBE_GAP_MS = 1_000;
+
+/** The recency and shape fields Phase 1 sorts and filters by. */
+const WANTED_OVERVIEW_FIELDS = [
+  "appid",
+  "app_type",
+  "display_name",
+  "sort_as",
+  "rt_last_time_played",
+  "minutes_playtime_forever",
+  "minutes_playtime_last_two_weeks",
+  "rt_purchased_time",
+  "size_on_disk",
+  "library_capsule_filename",
+] as const;
+
+/** What the "which exports carry this method" expression returns. */
+type ExportProbe =
+  | { tag: "no-wp" | "no-mod" }
+  | { tag: "throw"; detail: string }
+  | { tag: "ok"; direct: boolean; via: string[]; allKeys: string[] };
+
+function heading(text: string): void {
+  console.log(`\n## ${text}\n`);
+}
+
+function subheading(text: string): void {
+  console.log(`\n### ${text}\n`);
+}
+
+function fence(body: string, lang = "json"): void {
+  console.log("```" + lang);
+  console.log(body.trimEnd());
+  console.log("```");
+}
+
+function note(text: string): void {
+  console.log(`> ${text}\n`);
+}
+
+function json(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Evaluate in Steam's SharedJSContext via `CDPClient` rather than
+ * `SteamClient`: the latter is a typed facade over specific APIs, and this
+ * script's whole job is to look at surfaces nobody has typed yet.
+ *
+ * One client is reused for the whole run — reconnecting per expression would
+ * mean dozens of transient CDP connections, which is exactly what Steam's CEF
+ * IPC dislikes.
+ */
+let client: CDPClient | null = null;
+
+/** Read through an annotated accessor: TypeScript otherwise narrows the
+ *  closure variable to `null` at the teardown site, since every assignment
+ *  happens inside `connect()`. */
+function currentClient(): CDPClient | null {
+  return client;
+}
+
+async function connect(): Promise<CDPClient> {
+  const existing = currentClient();
+  if (existing) return existing;
+  const tab = await findSharedJsTab();
+  if (!tab) {
+    throw new Error(
+      "SharedJSContext tab not found — is Steam running with its CEF debug port open?",
+    );
+  }
+  const created = new CDPClient(tab.webSocketDebuggerUrl);
+  await created.connect();
+  client = created;
+  return created;
+}
+
+async function evaluate<T>(expression: string, awaitPromise = true): Promise<T> {
+  const c = await connect();
+  return (await c.evaluate(expression, { awaitPromise })) as T;
+}
+
+// ── 1. Module id resolution ──────────────────────────────────────────────
+
+/**
+ * Resolve each namespace by grepping the shipped bundle, and report the
+ * module's export key names.
+ *
+ * The export key is the one thing the production resolver deliberately does
+ * NOT grep for (it is minified per build, so it duck-types instead). Dumping
+ * the real key names here confirms the duck-typing has something to find.
+ */
+async function probeModuleResolution(): Promise<Map<string, number>> {
+  heading("Service module resolution");
+
+  const chunks = await listSteamUiChunks();
+  note(
+    `Found ${chunks.length} \`chunk~*.js\` files. Filenames are content-hashed, ` +
+      "so the sorted set of basenames is the cache key that invalidates once " +
+      "per Steam UI update.",
+  );
+
+  const resolved = new Map<string, number>();
+  const rows: string[] = [
+    "| Namespace.Method | Module id | Chunk | Export keys with this method |",
+    "|---|---|---|---|",
+  ];
+
+  for (const spec of NAMESPACES) {
+    const literal = `${spec.namespace}.${spec.method}#1`;
+    let found: { moduleId: number; chunk: string } | null = null;
+
+    for (const path of chunks) {
+      let source: string;
+      try {
+        source = await Bun.file(path).text();
+      } catch {
+        continue;
+      }
+      const index =
+        source.indexOf(`"${literal}"`) !== -1
+          ? source.indexOf(`"${literal}"`)
+          : source.indexOf(`'${literal}'`);
+      if (index === -1) continue;
+      const moduleId = findModuleIdInSource(source, index);
+      if (moduleId === null) continue;
+      found = { moduleId, chunk: path.slice(path.lastIndexOf("/") + 1) };
+      break;
+    }
+
+    if (!found) {
+      rows.push(`| \`${literal}\` | **NOT FOUND** | — | — |`);
+      continue;
+    }
+
+    resolved.set(`${spec.namespace}.${spec.method}`, found.moduleId);
+
+    // Ask the page which exports of that module carry the method.
+    const keys = await evaluate<ExportProbe>(
+      `(() => {
+        let wp = globalThis.__STEAM_WP_REQUIRE;
+        if (typeof wp !== "function" && Array.isArray(window.webpackChunksteamui)) {
+          window.webpackChunksteamui.push([[Symbol()], {}, (r) => { wp = r; }]);
+        }
+        if (typeof wp !== "function") return { tag: "no-wp" };
+        let mod; try { mod = wp(${found.moduleId}); } catch (e) { return { tag: "throw", detail: String(e) }; }
+        if (!mod) return { tag: "no-mod" };
+        const method = ${JSON.stringify(spec.method)};
+        const direct = typeof mod[method] === "function";
+        const via = Object.keys(mod).filter((k) => mod[k] && typeof mod[k][method] === "function");
+        return { tag: "ok", direct, via, allKeys: Object.keys(mod).slice(0, 30) };
+      })()`,
+      false,
+    );
+
+    const keyDesc =
+      keys.tag === "ok"
+        ? `\`${JSON.stringify(keys.via)}\` (direct: ${keys.direct})`
+        : `\`${json(keys)}\``;
+
+    rows.push(`| \`${literal}\` | \`${found.moduleId}\` | \`${found.chunk}\` | ${keyDesc} |`);
+  }
+
+  console.log(rows.join("\n"));
+  console.log("");
+  note(
+    "Module ids change on every Steam build — these are a snapshot for " +
+      "cross-checking the resolver, never values to hardcode.",
+  );
+  return resolved;
+}
+
+// ── 2. Steam id ──────────────────────────────────────────────────────────
+
+/**
+ * Try every candidate in-page steamid expression and report which resolve.
+ *
+ * Whichever wins becomes path 1 of `lib/steam-id.ts`'s three-path resolver.
+ * A steamid is a 17-digit value, so anything shorter is a different kind of
+ * id and must not be accepted.
+ */
+async function probeSteamId(): Promise<string | null> {
+  heading("Steam id resolution");
+
+  const result = await evaluate<{
+    candidates: Array<{ expr: string; value: string | null; looksValid: boolean }>;
+  }>(
+    `(() => {
+      const probes = {
+        "App.m_CurrentUser.strSteamID": () => window.App?.m_CurrentUser?.strSteamID,
+        "App.cm.steamid": () => window.App?.cm?.steamid,
+        "App.cm.m_steamid": () => window.App?.cm?.m_steamid,
+        "LoginStore.m_strAccountName": () => window.LoginStore?.m_strAccountName,
+        "g_steamID": () => globalThis.g_steamID,
+        "App.GetCurrentUser().strSteamID": () => window.App?.GetCurrentUser?.()?.strSteamID,
+        "SteamClient.User.GetSteamID": () => window.SteamClient?.User?.GetSteamID?.(),
+      };
+      const candidates = [];
+      for (const [expr, fn] of Object.entries(probes)) {
+        let value = null;
+        try {
+          const raw = fn();
+          value = raw === undefined || raw === null ? null : String(raw);
+        } catch (e) { value = "threw: " + String(e); }
+        candidates.push({
+          expr,
+          value,
+          looksValid: typeof value === "string" && /^\\d{17}$/.test(value),
+        });
+      }
+      return { candidates };
+    })()`,
+    false,
+  );
+
+  const rows = ["| Expression | Value | 17-digit? |", "|---|---|---|"];
+  let winner: string | null = null;
+  for (const c of result.candidates) {
+    // Redact all but the last 4 digits: this output gets committed.
+    const shown =
+      c.looksValid && c.value ? `…${c.value.slice(-4)}` : (c.value ?? "_(absent)_");
+    rows.push(`| \`${c.expr}\` | ${shown} | ${c.looksValid ? "**yes**" : "no"} |`);
+    if (c.looksValid && !winner) winner = c.value;
+  }
+  console.log(rows.join("\n"));
+  console.log("");
+  note(
+    winner
+      ? "At least one expression resolves — use the first `yes` row as path 1 " +
+          "of the resolver. Values are redacted to the last 4 digits."
+      : "**No expression resolved a 17-digit id.** The resolver must fall back " +
+          "to `loginusers.vdf`. Investigate before building Phase 1.",
+  );
+  return winner;
+}
+
+// ── 3. appStore recency fields ───────────────────────────────────────────
+
+/** PRESENT/MISSING table for the fields the dashboard sorts and filters by. */
+async function probeOverviewFields(): Promise<void> {
+  heading("`appStore` overview fields the dashboard needs");
+
+  const result = await evaluate<
+    | { tag: "no-store" }
+    | {
+        tag: "ok";
+        total: number;
+        byType: Record<string, number>;
+        fields: Array<{ field: string; present: number; type: string; sample: string }>;
+      }
+  >(
+    `(() => {
+      const store = window.appStore;
+      if (!store || !Array.isArray(store.allApps)) return { tag: "no-store" };
+      const apps = store.allApps.filter(Boolean);
+      const wanted = ${JSON.stringify(WANTED_OVERVIEW_FIELDS)};
+      const byType = {};
+      for (const a of apps) {
+        const k = String(a.app_type);
+        byType[k] = (byType[k] || 0) + 1;
+      }
+      const fields = wanted.map((field) => {
+        let present = 0, type = "—", sample = "—";
+        for (const a of apps) {
+          const v = a[field];
+          if (v !== undefined && v !== null) {
+            present++;
+            if (type === "—") {
+              type = Array.isArray(v) ? "array" : typeof v;
+              sample = String(v).slice(0, 40);
+            }
+          }
+        }
+        return { field, present, type, sample };
+      });
+      return { tag: "ok", total: apps.length, byType, fields };
+    })()`,
+    false,
+  );
+
+  if (result.tag === "no-store") {
+    note(
+      "**`window.appStore.allApps` is unavailable.** Steam's library UI has " +
+        "not booted this session — open the library once and re-run.",
+    );
+    return;
+  }
+
+  note(
+    `${result.total} entries in \`allApps\`. Counts by \`app_type\`: ` +
+      `\`${json(result.byType)}\`. Note the plan deliberately does NOT filter to ` +
+      "`app_type === 1` the way `getAllApps()` does — demos and some " +
+      "applications carry achievements.",
+  );
+
+  const rows = ["| Field | Present | Type | Sample |", "|---|---|---|---|"];
+  for (const f of result.fields) {
+    const status =
+      f.present === 0 ? "**MISSING**" : `${f.present}/${result.total}`;
+    rows.push(`| \`${f.field}\` | ${status} | ${f.type} | \`${f.sample}\` |`);
+  }
+  console.log(rows.join("\n"));
+}
+
+// ── 4. GetMyAchievementsForApp ───────────────────────────────────────────
+
+/**
+ * Dump the full key set of the per-game detail call for a game that has
+ * partial-progress achievements.
+ *
+ * The question that matters: **is global rarity in here?** If yes, Tier 3 is
+ * unnecessary and "rarest unlocked" becomes free.
+ */
+async function probeAchievementDetail(appIds: string[]): Promise<void> {
+  heading("`SteamClient.Apps.GetMyAchievementsForApp` shape");
+
+  if (appIds.length === 0) {
+    note("No candidate appids with achievements were found — skipping.");
+    return;
+  }
+
+  for (const appId of appIds.slice(0, 2)) {
+    subheading(`appid ${appId}`);
+    const result = await evaluate<unknown>(
+      `(async () => {
+        const api = window.SteamClient?.Apps?.GetMyAchievementsForApp;
+        if (!api) return { tag: "no-api" };
+        try {
+          // Race in-page: several SteamClient getters hang forever rather
+          // than rejecting, and a hang blocks the whole evaluate chain.
+          const res = await Promise.race([
+            api(${JSON.stringify(appId)}),
+            new Promise((_, rej) => setTimeout(() => rej(new Error("timeout")), 5000)),
+          ]);
+          const list = res?.data?.rgAchievements ?? res?.rgAchievements ?? res;
+          const arr = Array.isArray(list) ? list : null;
+          if (!arr) return { tag: "unexpected", raw: JSON.stringify(res).slice(0, 800) };
+          const keyUnion = [...new Set(arr.flatMap((a) => Object.keys(a || {})))];
+          const partial = arr.find(
+            (a) => a && a.flMaxProgress && a.flCurrentProgress > 0 && a.flCurrentProgress < a.flMaxProgress
+          );
+          return {
+            tag: "ok",
+            count: arr.length,
+            achieved: arr.filter((a) => a && a.bAchieved).length,
+            keyUnion,
+            firstAchieved: arr.find((a) => a && a.bAchieved) ?? null,
+            firstLocked: arr.find((a) => a && !a.bAchieved) ?? null,
+            partialProgressExample: partial ?? null,
+          };
+        } catch (e) { return { tag: "throw", detail: String(e) }; }
+      })()`,
+    );
+    fence(json(result));
+  }
+
+  note(
+    "**Decision this drives:** if the key union contains a global-rarity " +
+      "field (something like `flAchieved` / `flAchievedPercent`), drop Tier 3 " +
+      "(`GetTopAchievementsForGames`) entirely and cut Phase 3's scope.",
+  );
+}
+
+// ── 5. RegisterForAchievementChanges ────────────────────────────────────
+
+/**
+ * Register the live-unlock callback and report its payload shape.
+ *
+ * Cannot force an unlock from here, so this reports whether registration
+ * succeeds and installs a recorder the operator can inspect after playing.
+ */
+async function probeAchievementEvents(): Promise<void> {
+  heading("`Apps.RegisterForAchievementChanges`");
+
+  const result = await evaluate<unknown>(
+    `(() => {
+      const api = window.SteamClient?.Apps?.RegisterForAchievementChanges;
+      if (!api) return { tag: "no-api" };
+      try {
+        globalThis.__ah_probe_events = globalThis.__ah_probe_events || [];
+        if (!globalThis.__ah_probe_reg) {
+          globalThis.__ah_probe_reg = api((...args) => {
+            globalThis.__ah_probe_events.push({
+              at: Date.now(),
+              argCount: args.length,
+              args: args.map((a) => {
+                try { return JSON.parse(JSON.stringify(a)); } catch (e) { return String(a); }
+              }),
+            });
+          });
+        }
+        return {
+          tag: "ok",
+          registrationType: typeof globalThis.__ah_probe_reg,
+          hasUnregister: typeof globalThis.__ah_probe_reg?.unregister === "function",
+          eventsSoFar: globalThis.__ah_probe_events.length,
+        };
+      } catch (e) { return { tag: "throw", detail: String(e) }; }
+    })()`,
+    false,
+  );
+
+  fence(json(result));
+  note(
+    "A recorder is now installed in the page. Play a game, unlock something, " +
+      "then read `globalThis.__ah_probe_events` over CDP (DevTools on " +
+      "`localhost:9222`). **The question:** does it fire once per unlock " +
+      "(the timeline stays live for free) or once per session?",
+  );
+}
+
+// ── 6. Batch cap ────────────────────────────────────────────────────────
+
+/**
+ * Escalate batch sizes against `Player.GetAchievementsProgress` and record
+ * where it errors, truncates, or slows non-linearly.
+ *
+ * This is the number the whole cost model turns on, so it is measured rather
+ * than assumed. Ordered last, and skippable, because it is the only part of
+ * this script that talks to Valve repeatedly.
+ */
+async function probeBatchCap(
+  moduleId: number,
+  steamId: string,
+  appIds: string[],
+): Promise<void> {
+  heading("`Player.GetAchievementsProgress` batch cap");
+
+  if (appIds.length < BATCH_LADDER[0]) {
+    note(
+      `Only ${appIds.length} candidate appids available — need at least ` +
+        `${BATCH_LADDER[0]} to probe the ladder. Skipping.`,
+    );
+    return;
+  }
+
+  const rows = [
+    "| Requested | Returned | Truncated? | ms | EResult | Outcome |",
+    "|---|---|---|---|---|---|",
+  ];
+
+  for (const size of BATCH_LADDER) {
+    if (appIds.length < size) {
+      rows.push(`| ${size} | — | — | — | — | _skipped: library too small_ |`);
+      continue;
+    }
+
+    const batch = appIds.slice(0, size).map((id) => Number(id));
+    const started = Date.now();
+    const result = await evaluate<{
+      tag: string;
+      eresult?: number;
+      count?: number;
+      detail?: string;
+    }>(
+      `(async () => {
+        let wp = globalThis.__STEAM_WP_REQUIRE;
+        if (typeof wp !== "function" && Array.isArray(window.webpackChunksteamui)) {
+          window.webpackChunksteamui.push([[Symbol()], {}, (r) => { wp = r; }]);
+        }
+        if (typeof wp !== "function") return { tag: "no-wp" };
+        const mod = wp(${moduleId});
+        const method = "GetAchievementsProgress";
+        let ns = typeof mod?.[method] === "function" ? mod : null;
+        if (!ns) for (const v of Object.values(mod || {})) {
+          if (v && typeof v[method] === "function") { ns = v; break; }
+        }
+        if (!ns) return { tag: "no-namespace" };
+        const tp = window.App?.cm?.GetServiceTransport?.();
+        if (!tp) return { tag: "no-transport" };
+        try {
+          const res = await Promise.race([
+            ns[method](tp, {
+              steamid: ${JSON.stringify(steamId)},
+              language: "english",
+              appids: ${JSON.stringify(batch)},
+            }),
+            new Promise((_, rej) => setTimeout(() => rej(new Error("timeout")), 20000)),
+          ]);
+          const eresult = typeof res?.GetEResult === "function" ? res.GetEResult() : res?.eresult;
+          const body = typeof res?.Body === "function" ? res.Body() : null;
+          const obj = body?.constructor?.toObject ? body.constructor.toObject(false, body) : body;
+          const list = obj?.achievement_progress;
+          return { tag: "ok", eresult, count: Array.isArray(list) ? list.length : -1 };
+        } catch (e) { return { tag: "throw", detail: String(e && e.message ? e.message : e) }; }
+      })()`,
+    );
+    const ms = Date.now() - started;
+
+    if (result.tag !== "ok") {
+      rows.push(
+        `| ${size} | — | — | ${ms} | — | **${result.tag}**${
+          result.detail ? ` — ${result.detail}` : ""
+        } |`,
+      );
+      // A failure at this size is the cap; escalating further tells us nothing.
+      break;
+    }
+
+    const returned = result.count ?? -1;
+    const truncated = returned >= 0 && returned < size;
+    rows.push(
+      `| ${size} | ${returned} | ${truncated ? "**yes**" : "no"} | ${ms} | ` +
+        `${result.eresult ?? "—"} | ${
+          result.eresult === 1 ? "ok" : `**EResult ${result.eresult}**`
+        } |`,
+    );
+
+    if (truncated || result.eresult !== 1) break;
+    await sleep(PROBE_GAP_MS);
+  }
+
+  console.log(rows.join("\n"));
+  console.log("");
+  note(
+    "**Decision this drives:** `DEFAULT_BATCH_SIZE` is the largest row that " +
+      "returned all requested appids with EResult 1 and no non-linear slowdown. " +
+      "Note that `returned < requested` is expected for games with no " +
+      "achievements — cross-check against the detail probe before reading it " +
+      "as truncation.",
+  );
+}
+
+/** Candidate appids, most-recently-played first — the sweep's real order. */
+async function recentAppIds(limit: number): Promise<string[]> {
+  const result = await evaluate<{ tag: string; appIds?: string[] }>(
+    `(() => {
+      const store = window.appStore;
+      if (!store || !Array.isArray(store.allApps)) return { tag: "no-store" };
+      const appIds = store.allApps
+        .filter((a) => a && a.appid)
+        .slice()
+        .sort((a, b) => (b.rt_last_time_played || 0) - (a.rt_last_time_played || 0))
+        .map((a) => String(a.appid))
+        .slice(0, ${limit});
+      return { tag: "ok", appIds };
+    })()`,
+    false,
+  );
+  return result.appIds ?? [];
+}
+
+async function main(): Promise<void> {
+  const skipBatch = process.argv.includes("--no-batch-probe");
+
+  console.log("# Steam achievements probe");
+  console.log("");
+  console.log(
+    "Generated by `plugins/achievement-hunter/scripts/probe-achievements.ts` " +
+      "on a real device. Read-only. Steam ids are redacted to their last 4 digits.",
+  );
+
+  const modules = await probeModuleResolution();
+  const steamId = await probeSteamId();
+  await probeOverviewFields();
+
+  const appIds = await recentAppIds(Math.max(...BATCH_LADDER));
+  await probeAchievementDetail(appIds);
+  await probeAchievementEvents();
+
+  const progressModule = modules.get("Player.GetAchievementsProgress");
+  if (skipBatch) {
+    heading("`Player.GetAchievementsProgress` batch cap");
+    note("Skipped via `--no-batch-probe`.");
+  } else if (progressModule === undefined) {
+    heading("`Player.GetAchievementsProgress` batch cap");
+    note("Skipped: the module id did not resolve, so there is nothing to call.");
+  } else if (!steamId) {
+    heading("`Player.GetAchievementsProgress` batch cap");
+    note("Skipped: no steamid resolved, and the call requires one.");
+  } else {
+    await probeBatchCap(progressModule, steamId, appIds);
+  }
+
+  console.log("");
+  console.log("---");
+  console.log("");
+  console.log(
+    "Open questions this run should have closed: batch cap → " +
+      "`DEFAULT_BATCH_SIZE`; global rarity present → drop Tier 3; steamid path " +
+      "→ `lib/steam-id.ts` path 1; event granularity → live timeline or not.",
+  );
+}
+
+try {
+  await main();
+} finally {
+  currentClient()?.close();
+}

--- a/scripts/check-plugin-specs.sh
+++ b/scripts/check-plugin-specs.sh
@@ -129,9 +129,15 @@ done
 
 # Shared workspace packages — same rule, scoped to a list of
 # package src/ trees the ratchet has been applied to.
-# Empty: sgdb-art/steam-shortcut/file-picker are removed from the minimal
-# PoC. Re-scope when those packages return with their plugins.
-SPEC_SCOPED_PACKAGES=""
+# sgdb-art/steam-shortcut/file-picker are removed from the minimal PoC;
+# re-scope when those packages return with their plugins.
+# game-facts is scoped from its first commit rather than ratcheted on
+# afterwards, so the gate holds by construction for a package whose whole job
+# is scheduling logic that must be proven at exact boundaries.
+# steam-cdp is free to scope: cdp-client.ts and steam-client.ts already have
+# siblings, tabs.ts and index.ts are under the floor. Scoping it now stops the
+# next addition to Steam's most breakage-prone surface arriving untested.
+SPEC_SCOPED_PACKAGES="packages/game-facts/src packages/steam-cdp/src"
 for dir in $SPEC_SCOPED_PACKAGES; do
   [ -d "$dir" ] || continue
   for src in $(find "$dir" -type f -name '*.ts' 2>/dev/null); do

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,8 @@
       "@loadout/external-cache/*": ["./packages/external-cache/src/*"],
       "@loadout/file-picker": ["./packages/file-picker/src"],
       "@loadout/file-picker/*": ["./packages/file-picker/src/*"],
+      "@loadout/game-facts": ["./packages/game-facts/src"],
+      "@loadout/game-facts/*": ["./packages/game-facts/src/*"],
       "@loadout/game-library": ["./packages/game-library/src"],
       "@loadout/game-library/*": ["./packages/game-library/src/*"],
       "@loadout/per-game-profiles": ["./packages/per-game-profiles/src"],


### PR DESCRIPTION
Groundwork for the Achievement Hunter dashboard from #237 §2.1 — *"which games am I 3 achievements away from 100%?"*, across the whole library including games that aren't installed. Big Picture has no equivalent view.

**No user-visible feature yet, deliberately.** The next step is a hardware probe whose output decides two design questions. Building Phase 1 first would mean guessing at numbers the device can just tell us.

---

## 👉 What I need from the handheld

```
bun plugins/achievement-hunter/scripts/probe-achievements.ts > docs/steam-achievements-probe.md
```

Read-only. Steam ids are redacted to their last four digits so the output is safe to commit. `--no-batch-probe` skips the only section that talks to Valve more than once.

Two answers change the design:

1. **The server-side appid cap** on `Player.GetAchievementsProgress`. The whole cost model rests on ~50 per batch being accepted. If the real cap is 25 the sweep doubles; if it's 400 it shrinks fivefold. The probe binary-searches 25/50/100/200/400 and stops at the first error, truncation or non-linear slowdown.
2. **Whether `GetMyAchievementsForApp` already carries global rarity.** If it does, a whole planned tier (`GetTopAchievementsForGames`) disappears and "rarest unlocked" becomes free.

It also pins down which steamid expression actually resolves (nothing in the repo resolves one today), whether `RegisterForAchievementChanges` fires per unlock or per session, and a PRESENT/MISSING table for the `appStore` recency fields the dashboard sorts by — currently inferred from reading TabMaster's source, not verified.

---

## The rate-limit question, since it shaped everything

The instinct to worry is right, applied to the wrong cost model. `Player.GetAchievementsProgress` takes an **array** of appids over the CM connection Steam already holds — no API key, no HTTP endpoint, no third party.

| Library | This, batched | `protondb-badges` today, same library |
|---|---|---|
| 500 games cold | **10 requests** | 500 HTTP GETs |
| 2000 games cold | **40 requests** | 2000 HTTP GETs |
| 2000 games, day 2 | **~6–12 requests** | 2000 again unless cached |

So a throttled full sweep costs under a twentieth of what an already-shipped plugin does to the same library, against Valve's own authenticated RPC. What is *not* defensible is `GetMyAchievementsForApp` at library scale — one app per call on the globally serialised CDP evaluate chain. That one stays lazy.

Day 2 being cheap comes from a value-dependent TTL: 40–60% of a real library has no achievements at all, and those rows get 30 days rather than 24 hours.

---

## `packages/game-facts`

A "fact" is one datum about one game that needs I/O. Every one needs the same plumbing, so it lives in one package instead of being written twice.

**Two consumers, which clears the repo's reuse bar before either duplicates anything.** Achievement Hunter needs one resolver; `plugins/collections` (#239) has six fact keys waiting on exactly this interface and specified it to the signature.

Six modules, sibling test each:

| | |
|---|---|
| `types.ts` | four-state `FactValue`, `FactResolver<K>`, `SweepProgress` |
| `staleness.ts` | value-dependent TTL — the single biggest cost reducer |
| `plan.ts` | batch planning; preserves caller order, resumes with no cursor |
| `sweeper.ts` | one in flight, inter-batch gap, persisted backoff, pause/resume/cancel |
| `store.ts` | one aggregate doc — "which rows are stale" is a whole-corpus question and `external-cache` has no enumerate API |
| `limiter.ts` | FIFO semaphore, so the copies in protondb-badges and hltb have somewhere to migrate |

`FactValue` has **four** states. `missing` (source answered, this game has nothing) is distinct from `loading` (nobody asked yet) and `unavailable` (source is down). Collapsing the first into the others is a bug `plugins/collections` already paid for: it made every unanswered game *match* under a default pass policy, silently and with no diagnostic. This replaces an earlier `-1` sentinel in my own design — `{state:"ok", value:-1}` claims a real measurement of minus one percent and forces every consumer to learn the sentinel.

Failures are split fatal vs transient. A rate-limit result stops the sweep immediately, because retrying into a rate limit is how an account gets flagged. A timeout is tolerated and that batch's appIds simply stay stale for next time.

Resumability has no cursor: each batch commits, so committed rows are no longer stale and a re-plan skips them. A sweep that dies at batch 17 of 40 resumes at 17 because of what's in the cache, not because anything wrote down "17".

---

## `packages/steam-cdp/src/services.ts`

Module ids are resolved by grepping the shipped bundle for the versioned method literal, **never hardcoded** — webpack ids change on every Steam build, method names don't. The result caches under a key derived from the content-hashed `chunk~*.js` filenames, so it re-resolves exactly once per Steam UI update and works with Steam closed. `nSteamVersion` would do the same job but needs a `SteamClient` call that's on the known-to-hang list.

The export key is **deliberately not grepped** — that one *is* minified per build, so searching for it would reintroduce the fragility that resolving by method name exists to avoid. The generated expression duck-types it out of the resolved module.

Every call is raced against a timeout **twice**: in-page so the awaited promise always settles, and again in JS in case the page itself is wedged. Not defensive padding — `CDPClient` serialises evaluates per target because Steam's CEF IPC crashes `steamwebhelper` if two clients drive one target concurrently, so a hung in-page promise head-of-line blocks every other plugin's Steam access for as long as it hangs.

64-bit ids travel as decimal strings in both directions; a 17-digit steamid loses its last digit the moment it touches a JS number.

---

## Testing

`typecheck`, `lint`, `check:specs`, `check:dead-code` clean. **141 pass** across the two new packages.

`test:backend` **423 fail on this branch and 423 on `main`** — identical failure names, compared with `comm -13` on sorted `(fail)` lines rather than counts. That 423 is the standing macOS baseline for Linux-targeted code plus the `mock.module` leakage in `docs/test-mock-contamination.md`. Test count 2553 → 2692: **+139 passing, zero new failures.** `test:ui` 115 fail, unchanged.

Everything is tested through an injected clock, an injected `evaluate`, or an injected cache, so none of it needs Steam. The sweeper's one-in-flight invariant is asserted by a `fetchBatch` that records overlap rather than by trusting the loop's shape.

`store.test.ts` injects an `ExternalCache` double rather than importing the real module. `packages/sgdb-art/src/index.test.ts:14` and `plugins/store-bridge/lib/stores/epic/index.test.ts:60` both mock that module with a partial lacking `set`, and it leaks across files despite `--isolate` — green in isolation, twelve failures in the full suite. Injecting is the fix rather than a workaround: the cache is a collaborator and has its own disk-backed specs.

`check-plugin-specs.sh` scopes both new package trees in from the first commit rather than ratcheting them on afterwards.

---

## Notes for review

- **Nothing runs on `onLoad`** — no CM calls, no CDP calls, asserted by a test. The sweep starts on page open, which is the literal reading of "don't load it all up front" at the process level while still allowing a library-wide answer at the feature level.
- **`plugins/collections` is not touched.** It's unmerged on #239, so the fact contract crosses by structural typing with neither plugin importing the other. `FactValue` is declared in both places on purpose; when #239 lands, its local copy becomes a re-export. The package header says so.
- Stacked on #240 conceptually but not in git — both branch off `main` independently and touch different files.

Closes nothing yet; #237 stays open until the dashboard ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)