### PR TITLE
fix(collections): the second review round, including two fixes that didn't hold

### DIFF
--- a/packages/steam-cdp/src/collections.test.ts
+++ b/packages/steam-cdp/src/collections.test.ts
@@ -15,6 +15,7 @@ import {
   createCollection,
   deleteCollection,
   listCollections,
+  editCollectionApps,
   renameCollection,
   setCollectionApps,
 } from "./collections";
@@ -159,6 +160,39 @@ describe("createCollection", () => {
         appIds: [],
       }),
     ).rejects.toBeInstanceOf(SteamClientUnreachableError);
+  });
+});
+
+describe("editCollectionApps", () => {
+  it("touches only the ids it was given", async () => {
+    // The difference from `setCollectionApps`, and the reason it exists: that
+    // one computes `have − want` in-page, so an app added by EmuDeck between
+    // the caller's read and this evaluate is removed. It is also the only safe
+    // way to edit a collection holding ids the caller cannot resolve — dead
+    // shortcut ids, invisible to a library read.
+    // 4294901760 stands in for a dead non-Steam shortcut id: present in the
+    // collection, unknown to any library read, and silently dropped by a
+    // whole-membership write.
+    const target = collection({ m_setApps: new Set([10, 4294901760]) });
+    const { store, saved } = fakeStore([target]);
+    await editCollectionApps(clientFor({ collectionStore: store }), {
+      collectionId: "uc-1",
+      add: ["20"],
+      remove: ["10"],
+    });
+    expect([...target.m_setApps!].sort((a, b) => a - b)).toEqual([20, 4294901760]);
+    expect(saved).toHaveLength(1);
+  });
+
+  it("refuses a dynamic collection, like every other write here", async () => {
+    const target = collection({ m_setApps: new Set([10]), m_bIsDynamic: true });
+    const { store } = fakeStore([target]);
+    await expect(
+      editCollectionApps(clientFor({ collectionStore: store }), {
+        collectionId: "uc-1",
+        add: ["20"],
+      }),
+    ).rejects.toThrow(/dynamic|editable/);
   });
 });
 

--- a/packages/steam-cdp/src/collections.ts
+++ b/packages/steam-cdp/src/collections.ts
@@ -183,6 +183,62 @@ export async function setCollectionApps(
   return unwrap<SteamCollectionInfo>(await client._evaluateAsync(expr), "setCollectionApps");
 }
 
+/**
+ * Add and/or remove specific apps, leaving everything else in the collection
+ * alone.
+ *
+ * The difference from {@link setCollectionApps} is what happens to entries the
+ * caller has never heard of. That one computes `have − want` in-page, so an app
+ * added by EmuDeck between the caller's read and this evaluate is *removed*;
+ * this one touches only the ids it was given, so a hand edit can't take
+ * somebody else's write with it. It is also the only safe way to edit a
+ * collection holding ids the caller cannot resolve — dead non-Steam shortcut
+ * ids, which are invisible to a library read and would otherwise be silently
+ * dropped by a whole-membership write.
+ *
+ * Refuses dynamic collections for the same reason as `setCollectionApps`.
+ */
+export async function editCollectionApps(
+  client: SteamClient,
+  args: { collectionId: string; add?: readonly string[]; remove?: readonly string[] },
+): Promise<SteamCollectionInfo> {
+  const { collectionId, add = [], remove = [] } = args;
+  const expr = `(async () => {
+    const cs = window.collectionStore;
+    if (!cs) return { tag: "no-store" };
+    if (typeof cs.SaveCollection !== "function") return { tag: "no-api" };
+    ${HELPERS}
+    try {
+      const col = findById(cs, ${JSON.stringify(collectionId)});
+      if (!col) return { tag: "error", error: "no collection with id " + ${JSON.stringify(collectionId)} };
+      const info = infoOf(col);
+      if (info.isDynamic || !info.isEditable) {
+        return { tag: "error", error: "collection is dynamic or not editable" };
+      }
+
+      const have = new Set(info.appIds);
+      // Only ids that would actually change anything: asking Steam to remove
+      // what it doesn't hold, or add what it does, is a write for nothing.
+      const toRemove = ${JSON.stringify([...remove].map(String))}.filter((id) => have.has(id));
+      const toAdd = ${JSON.stringify([...add].map(String))}.filter((id) => !have.has(id));
+
+      // Remove first: on a collection at Steam's size limit, adding before
+      // removing can throw and leave the write half-applied.
+      if (toRemove.length && typeof col.RemoveApps === "function") {
+        col.RemoveApps(toRemove.map((id) => ({ appid: Number(id) })));
+      }
+      if (toAdd.length && typeof col.AddApps === "function") {
+        col.AddApps(toAdd.map((id) => ({ appid: Number(id) })));
+      }
+      if (!toRemove.length && !toAdd.length) return { tag: "ok", value: info };
+
+      await cs.SaveCollection(col);
+      return { tag: "ok", value: infoOf(col) };
+    } catch (e) { return { tag: "error", error: String(e && e.message) }; }
+  })()`;
+  return unwrap<SteamCollectionInfo>(await client._evaluateAsync(expr), "editCollectionApps");
+}
+
 /** Rename in place. The id — and so the mirror's claim on it — is unchanged. */
 export async function renameCollection(
   client: SteamClient,

--- a/packages/steam-cdp/src/collections.ts
+++ b/packages/steam-cdp/src/collections.ts
@@ -221,16 +221,22 @@ export async function editCollectionApps(
       // what it doesn't hold, or add what it does, is a write for nothing.
       const toRemove = ${JSON.stringify([...remove].map(String))}.filter((id) => have.has(id));
       const toAdd = ${JSON.stringify([...add].map(String))}.filter((id) => !have.has(id));
+      if (!toRemove.length && !toAdd.length) return { tag: "ok", value: info };
+
+      // Missing either primitive is reported, not saved over: saving an
+      // unmodified collection and returning ok tells the caller an edit landed
+      // that never happened.
+      if (toRemove.length && typeof col.RemoveApps !== "function") {
+        return { tag: "error", error: "this Steam build has no RemoveApps" };
+      }
+      if (toAdd.length && typeof col.AddApps !== "function") {
+        return { tag: "error", error: "this Steam build has no AddApps" };
+      }
 
       // Remove first: on a collection at Steam's size limit, adding before
       // removing can throw and leave the write half-applied.
-      if (toRemove.length && typeof col.RemoveApps === "function") {
-        col.RemoveApps(toRemove.map((id) => ({ appid: Number(id) })));
-      }
-      if (toAdd.length && typeof col.AddApps === "function") {
-        col.AddApps(toAdd.map((id) => ({ appid: Number(id) })));
-      }
-      if (!toRemove.length && !toAdd.length) return { tag: "ok", value: info };
+      if (toRemove.length) col.RemoveApps(toRemove.map((id) => ({ appid: Number(id) })));
+      if (toAdd.length) col.AddApps(toAdd.map((id) => ({ appid: Number(id) })));
 
       await cs.SaveCollection(col);
       return { tag: "ok", value: infoOf(col) };

--- a/packages/steam-cdp/src/index.ts
+++ b/packages/steam-cdp/src/index.ts
@@ -45,6 +45,7 @@ export {
 export {
   listCollections,
   createCollection,
+  editCollectionApps,
   setCollectionApps,
   renameCollection,
   deleteCollection,

--- a/packages/ui/src/components/HeaderBackButton.tsx
+++ b/packages/ui/src/components/HeaderBackButton.tsx
@@ -37,7 +37,7 @@ export interface HeaderBackButtonProps {
   title?: string;
   ariaLabel?: string;
   /** Optional icon-size override. Matches the existing inline pattern
-   *  (13, matching `IconButton`) by default. */
+   *  (13, matching the glyphs plugin headers put inside `IconButton`) by default. */
   iconSize?: number;
 }
 

--- a/plugins/collections/README.md
+++ b/plugins/collections/README.md
@@ -12,10 +12,11 @@ Manages your Steam collections from the overlay — the ones you already have, a
 | What's in it | whatever the rules match, re-evaluated on every sync | an explicit list of games |
 | Rules | yes | **never** — pointing rules at a set somebody else curated would replace their work |
 | Editing its contents | change the rules | add and remove games directly |
-| Rename / delete | yes | yes, behind a two-step confirm |
+| Rename / delete | yes, behind a two-step confirm | yes, behind a two-step confirm |
 
-Everything on the grid syncs. There is no per-collection opt-in: what you see
-here is what Steam has.
+Every rule-built collection syncs — there is no per-collection opt-in, so what
+you see here is what Steam gets. The ones that already live in Steam are not
+"synced" at all: they *are* Steam's, and editing one writes to it directly.
 
 ## A rule collection can drop a game, and that's the point
 
@@ -27,10 +28,10 @@ it, and a sync reports what changed by name: *"Barely started — 1 removed
 
 ## Syncing
 
-Editing never writes to Steam on its own. A sync is a full library evaluation
-plus a batch of Cloud writes, and this runs on a handheld — doing that while
-you are still working made the plugin look frozen. So it happens where nothing
-is waiting on it:
+Editing a **rule-built** collection never writes to Steam on its own. A sync is
+a full library evaluation plus a batch of Cloud writes, and this runs on a
+handheld — doing that while you are still working made the plugin look frozen.
+So it happens where nothing is waiting on it:
 
 - the sync button in the header, whenever you want it;
 - when you leave the plugin, if **Sync when I leave** is on;
@@ -38,6 +39,12 @@ is waiting on it:
 
 A collection with no rules yet is never written — an empty rule tree matches
 your whole library, and nobody wants that in Steam.
+
+Editing a collection that is **already in Steam** is the other way round: adding
+or removing games, renaming, deleting and cleaning up all write immediately,
+because there is nothing to compute — Steam already holds the answer. Deleting a
+rule-built collection also removes its Steam collection on the spot, rather than
+leaving it there until the next sync.
 
 ## Entries Steam can no longer resolve
 
@@ -82,9 +89,12 @@ collection somebody else built.
 
 - **Steam's library tabs are a different thing.** This manages collections —
   the data. The tab strip along the top of Steam's library is built inline in
-  Steam's own bundle and isn't data-driven, so it can only be changed by
-  patching Steam at runtime. That was tried and abandoned as too fragile to
-  maintain; collections reach the same place through a supported door.
+  Steam's own bundle rather than from data, so reaching it means patching Steam
+  at runtime. That was tried: the patch applied but the tabs never rendered,
+  most likely because webpack had already executed and cached the module —
+  unproven, and other explanations were left unexamined. It was abandoned on
+  cost rather than impossibility; collections reach the same place through a
+  supported door.
 - Collections Steam derives for itself (Uncategorized, Favorites, Locally
   Installed, the `type-*` sets) are left out. Steam already provides them.
 - Dynamic collections — the ones Steam recomputes from a filter — are shown but

--- a/plugins/collections/README.md
+++ b/plugins/collections/README.md
@@ -35,10 +35,22 @@ So it happens where nothing is waiting on it:
 
 - the sync button in the header, whenever you want it;
 - when you leave the plugin, if **Sync when I leave** is on;
-- at startup, if a sync was owed from a session where Steam was closed.
+- at startup, if a sync was owed from a session where Steam was closed. That
+  one is the earliest Steam could be up, so it is also the most likely to find
+  the library still loading — it waits and tries again a few times rather than
+  syncing against a library that isn't there.
 
 A collection with no rules yet is never written — an empty rule tree matches
-your whole library, and nobody wants that in Steam.
+your whole library, and nobody wants that in Steam. Nor is one whose rules this
+build can't answer: a rule reading data no plugin supplies matches *everything*
+under the default policy, so it is refused for the same reason. Setting the
+collection to exclude what it can't check makes it narrower rather than wider,
+and it syncs normally after that.
+
+A sync never runs against a library that came back empty or half-loaded either.
+Both sources degrade to empty on failure, and because a sync rewrites whole
+memberships across every mirrored collection at once, a thin read wouldn't
+produce a smaller sync — it would empty all of them.
 
 Editing a collection that is **already in Steam** is the other way round: adding
 or removing games, renaming, deleting and cleaning up all write immediately,

--- a/plugins/collections/app.spec.tsx
+++ b/plugins/collections/app.spec.tsx
@@ -406,8 +406,10 @@ describe("editing a collection's rules", () => {
     fireEvent.click(screen.getByRole("button", { name: /Sega Genesis/ }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Remove collection" })).toBeTruthy());
 
+    // Arm, then confirm on the *renamed* button: the two used to share a name
+    // and a slot, so a double-press deleted.
     fireEvent.click(screen.getByRole("button", { name: "Remove collection" }));
-    fireEvent.click(screen.getByRole("button", { name: "Remove collection" }));
+    fireEvent.click(screen.getByText(/Delete .*Sega Genesis/));
 
     await waitFor(() => expect(screen.queryByText("Sega Genesis")).toBeNull());
     // Back on the grid, with everything else still there.
@@ -444,12 +446,14 @@ describe("editing a collection's rules", () => {
     fireEvent.click(screen.getByRole("button", { name: /Sega Genesis/ }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Remove collection" })).toBeTruthy());
 
-    // The bin spells out what it would do rather than doing it: an icon cannot
-    // name the collection it is about to destroy.
+    // The bin spells out what it would do rather than doing it — and the
+    // confirmation is a differently named button in a different place, so
+    // pressing twice in the same spot cannot delete.
     fireEvent.click(screen.getByRole("button", { name: "Remove collection" }));
     expect(calls.some((c) => c.method === "deleteLinked")).toBe(false);
+    expect(screen.queryByRole("button", { name: "Remove collection" })).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Remove collection" }));
+    fireEvent.click(screen.getByText(/Delete .*Sega Genesis/));
     await waitFor(() => expect(calls.some((c) => c.method === "deleteLinked")).toBe(true));
   });
 

--- a/plugins/collections/app.spec.tsx
+++ b/plugins/collections/app.spec.tsx
@@ -14,6 +14,13 @@ let mirrorState = { autoSync: false, pendingSync: false };
  */
 let releaseListGames: (() => void) | null = null;
 let holdListGames = false;
+/**
+ * Make `editLinked` reject — but only when released, so the rollback can be
+ * made to land *after* the user has moved to another collection. Rejecting
+ * immediately resolves the race before it exists.
+ */
+let failEditLinked = false;
+let rejectEditLinked: (() => void) | null = null;
 let summaries: unknown[] = [];
 let steamReachable = true;
 let games: string[] = [];
@@ -75,9 +82,17 @@ const callMock = mock((method: string, ...args: unknown[]) => {
       });
     case "setCollections":
       return Promise.resolve({ collections: managedCollections });
+    case "editLinked":
+      if (!failEditLinked) return Promise.resolve({ count: 0 });
+      return new Promise((_resolve, reject) => {
+        rejectEditLinked = () => reject(new Error("Steam went away (test stub)"));
+      });
     case "listGames": {
+      // Per-collection, so a response landing in the wrong collection is
+      // visible rather than coincidentally identical.
+      const forId = String((args as string[])[0] ?? "");
       const answer = {
-        games: games.map((appId) => ({ appId, name: `Game ${appId}` })),
+        games: games.map((appId) => ({ appId, name: `${forId} game ${appId}` })),
         kind: "linked",
         staleAppIds: [],
       };
@@ -139,6 +154,8 @@ beforeEach(() => {
   mirrorState = { autoSync: false, pendingSync: false };
   releaseListGames = null;
   holdListGames = false;
+  failEditLinked = false;
+  rejectEditLinked = null;
   summaries = [];
   steamReachable = true;
   games = [];
@@ -333,6 +350,38 @@ describe("editing a collection's rules", () => {
     fireEvent.click(screen.getByRole("button", { name: "Options" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Rename" })).toBeTruthy());
     expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+  });
+
+  it("doesn't paint one collection's games under another's header", async () => {
+    // Every edit path writes `games` after an await. Without a request token a
+    // rollback lands in whichever collection is open by then — and the edit
+    // paths write against what is on screen, so the next removal would aim at
+    // the wrong collection's members.
+    summaries = [summary(), summary({ id: "srm-2", label: "Nintendo 64" })];
+    games = ["10", "20"];
+    failEditLinked = true;
+    ({ unmount } = renderApp());
+    await waitFor(() => expect(screen.getByText("Sega Genesis")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: /Sega Genesis/ }));
+    await waitFor(() => expect(screen.getByText("srm-1 game 10")).toBeTruthy());
+
+    // Start a removal, then leave for the other collection before it fails.
+    fireEvent.click(screen.getByRole("button", { name: "Edit collection" }));
+    fireEvent.click(screen.getByText("srm-1 game 10"));
+    fireEvent.click(screen.getByText(/Remove 1 from collection/));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    await waitFor(() => expect(screen.getByText("Nintendo 64")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: /Nintendo 64/ }));
+
+    await waitFor(() => expect(screen.getByText("srm-2 game 10")).toBeTruthy());
+
+    // Only now does the earlier edit fail. Its rollback belongs to the
+    // collection we left, and must not land in this one.
+    rejectEditLinked?.();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(screen.queryByText("srm-1 game 10")).toBeNull();
+    expect(screen.getByText("srm-2 game 10")).toBeTruthy();
   });
 
   it("won't offer adding until it knows what is already in the collection", async () => {

--- a/plugins/collections/app.spec.tsx
+++ b/plugins/collections/app.spec.tsx
@@ -26,6 +26,8 @@ let summaries: unknown[] = [];
 let steamReachable = true;
 /** The library read comes back empty, as it does while Steam hydrates. */
 let libraryDegraded = false;
+/** Make the *next* `getConfig` reject, once. */
+let failNextGetConfig = false;
 let games: string[] = [];
 let managedCollections: unknown[] = [];
 
@@ -64,6 +66,13 @@ const callMock = mock((method: string, ...args: unknown[]) => {
           : { games: LIBRARY, providers: appStoreProviders(true), generatedAt: 0 },
       );
     case "getConfig":
+      // Fails once, on demand: the config and the library are fetched by the
+      // same effect, and a config that threw used to take the library's answer
+      // down with it and never be asked for again.
+      if (failNextGetConfig) {
+        failNextGetConfig = false;
+        return Promise.reject(new Error("config read failed (test stub)"));
+      }
       // A *whole* config, built from the real default. It used to be
       // `{collections, mirror}` alone — a shape the real `setConfig` rejects
       // outright ("settings are missing", "collectionOrder must be a list of
@@ -173,6 +182,7 @@ beforeEach(() => {
   summaries = [];
   steamReachable = true;
   libraryDegraded = false;
+  failNextGetConfig = false;
   games = [];
   managedCollections = [];
   container = document.createElement("div");
@@ -288,6 +298,32 @@ describe("editing a collection's rules", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "New collection" }));
     await waitFor(() => expect(screen.queryByText(/Reading your library/)).toBeNull());
+  }, 10_000);
+
+  it("asks for the config again when its first read fails", async () => {
+    // The config and the library are fetched by the same effect. They shared a
+    // `Promise.all`, so a config that threw discarded a library that had
+    // arrived perfectly well — and once the library gained a retry, the config
+    // was left outside it and never asked for again, leaving the rules screen
+    // on a spinner for the rest of the session.
+    managedCollections = [managed("backlog", "Backlog")];
+    summaries = [
+      summary({ id: "backlog", label: "Backlog", kind: "managed", autoMaintained: true }),
+    ];
+    failNextGetConfig = true;
+    ({ unmount } = renderApp());
+
+    await waitFor(
+      () => expect(calls.filter((c) => c.method === "getConfig").length).toBeGreaterThan(1),
+      { timeout: 4000 },
+    );
+    // And the rules screen has what it needs, rather than the spinner it shows
+    // when `collections` never arrived.
+    await waitFor(() => expect(screen.getByText("Backlog")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: /Backlog/ }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Options" })).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: "Options" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save" })).toBeTruthy());
   }, 10_000);
 
   it("locks the gallery while a preset is being built", async () => {

--- a/plugins/collections/app.spec.tsx
+++ b/plugins/collections/app.spec.tsx
@@ -3,6 +3,7 @@ import * as actualUi from "@loadout/ui";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { LIBRARY } from "./test/fixtures/library";
 import { defaultConfig, validateConfig } from "./lib/config";
+import { appStoreProviders, phase1Providers } from "./lib/adapt";
 
 const calls: Array<{ method: string; args: unknown[] }> = [];
 let mirrorState = { autoSync: false, pendingSync: false };
@@ -23,6 +24,8 @@ let failEditLinked = false;
 let rejectEditLinked: (() => void) | null = null;
 let summaries: unknown[] = [];
 let steamReachable = true;
+/** The library read comes back empty, as it does while Steam hydrates. */
+let libraryDegraded = false;
 let games: string[] = [];
 let managedCollections: unknown[] = [];
 
@@ -48,7 +51,18 @@ const callMock = mock((method: string, ...args: unknown[]) => {
       // A real library, not an empty one: the preset gallery greys out any
       // preset whose data source is missing, so with no games every preset
       // would be unpickable.
-      return Promise.resolve({ games: LIBRARY, providers: {}, generatedAt: 0 });
+      //
+      // Providers come from the real helpers rather than a hand-written `{}`.
+      // That field is how the UI tells "the library is loaded" from "the call
+      // returned" — `getSnapshot` never rejects, since both its sources
+      // degrade to empty — so a fake that omitted it described a snapshot the
+      // backend cannot produce, and every screen under test believed a
+      // library it should have been waiting for.
+      return Promise.resolve(
+        libraryDegraded
+          ? { games: [], providers: phase1Providers(false), generatedAt: 0 }
+          : { games: LIBRARY, providers: appStoreProviders(true), generatedAt: 0 },
+      );
     case "getConfig":
       // A *whole* config, built from the real default. It used to be
       // `{collections, mirror}` alone — a shape the real `setConfig` rejects
@@ -158,6 +172,7 @@ beforeEach(() => {
   rejectEditLinked = null;
   summaries = [];
   steamReachable = true;
+  libraryDegraded = false;
   games = [];
   managedCollections = [];
   container = document.createElement("div");
@@ -238,6 +253,42 @@ describe("opening a collection", () => {
 describe("editing a collection's rules", () => {
   /** A managed collection with the shape the rule builder needs. */
   const managed = fullCollection;
+
+  it("won't price the presets against a library that hasn't loaded", async () => {
+    // `getSnapshot` never rejects — both its sources degrade to empty — so a
+    // Steam still hydrating answers with a well-formed snapshot of nothing.
+    // Deciding on `snapshot !== null` treats that as a loaded library, and the
+    // page then greys out every preset blaming the user's play history for an
+    // outage of ours. The backend refuses to sync or prune on this same
+    // signal; the UI has to read it the same way.
+    libraryDegraded = true;
+    ({ unmount } = renderApp());
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "New collection" })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "New collection" }));
+    await waitFor(() => expect(screen.getByText("Or start from a preset")).toBeTruthy());
+
+    expect(screen.getByText(/Reading your library/)).toBeTruthy();
+    expect(screen.queryByText(/Needs play history/)).toBeNull();
+  });
+
+  it("asks again rather than settling for the empty answer", async () => {
+    // One fetch would leave every screen priced against that empty snapshot
+    // for the rest of the session, and nothing else re-reads the library.
+    libraryDegraded = true;
+    ({ unmount } = renderApp());
+    await waitFor(() => expect(calls.some((c) => c.method === "getSnapshot")).toBe(true));
+
+    libraryDegraded = false;
+    await waitFor(
+      () => expect(calls.filter((c) => c.method === "getSnapshot").length).toBeGreaterThan(1),
+      { timeout: 4000 },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "New collection" }));
+    await waitFor(() => expect(screen.queryByText(/Reading your library/)).toBeNull());
+  }, 10_000);
 
   it("locks the gallery while a preset is being built", async () => {
     // Creating one takes a beat, and a press that shows no sign of having

--- a/plugins/collections/app.tsx
+++ b/plugins/collections/app.tsx
@@ -193,19 +193,31 @@ export function Collections() {
       // and one fetch would leave every screen priced against it for the rest
       // of the session. Bounded: this is a webview waiting on a library, not a
       // poller.
+      let haveConfig = false;
       for (let attempt = 0; attempt < SNAPSHOT_ATTEMPTS && !cancelled; attempt++) {
         if (attempt > 0) {
           await new Promise((r) => setTimeout(r, SNAPSHOT_RETRY_MS * attempt));
           if (cancelled) return;
         }
+        // Separately, so one failing doesn't discard the other's answer. They
+        // used to share a `Promise.all`: a config read that threw dropped a
+        // library that had arrived perfectly well, and — once this became a
+        // loop — the config was never asked for again, leaving the rules
+        // screen on a spinner for the rest of the session.
+        if (!haveConfig) {
+          try {
+            await loadConfig();
+            haveConfig = true;
+          } catch {
+            // Retried on the next pass, like the snapshot.
+          }
+        }
+        if (cancelled) return;
         try {
-          const [snap] = await Promise.all([
-            call("getSnapshot") as Promise<GameMetadataSnapshot>,
-            attempt === 0 ? loadConfig() : Promise.resolve(),
-          ]);
+          const snap = (await call("getSnapshot")) as GameMetadataSnapshot;
           if (cancelled) return;
           setSnapshot(snap);
-          if (snapshotIsUsable(snap)) return;
+          if (haveConfig && snapshotIsUsable(snap)) return;
         } catch {
           // The grid still works without these; only rule editing needs them.
         }
@@ -373,6 +385,7 @@ export function Collections() {
         <RuleBuilder
           collection={editing}
           games={evalGames}
+          libraryLoaded={snapshotIsUsable(snapshot)}
           onCancel={() => void openCollection(editing)}
           onSave={(next) => void saveCollection(next)}
           onDelete={() => void removeCollection(editing.id)}

--- a/plugins/collections/app.tsx
+++ b/plugins/collections/app.tsx
@@ -281,6 +281,7 @@ export function Collections() {
         <NewCollectionPage
           existingNames={(summaries ?? []).map((c) => c.label)}
           games={evalGames}
+          libraryLoaded={snapshot !== null}
           onBack={() => setView({ kind: "grid" })}
           onPickPreset={(preset) => void createCollection(preset.label, preset)}
           onCreate={(label) => void createCollection(label)}
@@ -548,6 +549,7 @@ export function Collections() {
 
   /** Drop every entry Steam can no longer resolve — see `listGames`. */
   async function cleanUpLinked(id: string) {
+    const request = openRequest.current;
     const before = staleCount;
     setStaleCount(0);
     try {
@@ -560,7 +562,10 @@ export function Collections() {
       );
       await loadGrid();
     } catch (err) {
-      setStaleCount(before);
+      // Same token as `openCollection`: by the time this lands the user may be
+      // looking at a different collection, and painting this one's state under
+      // that one's header is how an edit gets aimed at the wrong thing.
+      if (request === openRequest.current) setStaleCount(before);
       notify(err instanceof Error ? err.message : "Couldn't clean that collection up", {
         kind: "error",
       });
@@ -568,6 +573,7 @@ export function Collections() {
   }
 
   async function addToLinked(id: string, label: string, appIds: string[]) {
+    const request = openRequest.current;
     const before = games ?? [];
     const nameOf = new Map((snapshot?.games ?? []).map((g) => [g.appId, g.name] as const));
     const added = appIds.map((appId) => ({ appId, name: nameOf.get(appId) ?? appId }));
@@ -581,7 +587,7 @@ export function Collections() {
       await call("editLinked", id, { add: appIds });
       await loadGrid();
     } catch (err) {
-      setGames(before);
+      if (request === openRequest.current) setGames(before);
       notify(err instanceof Error ? err.message : "Couldn't update that collection", {
         kind: "error",
       });
@@ -589,6 +595,7 @@ export function Collections() {
   }
 
   async function removeFromLinked(id: string, appIds: readonly string[]) {
+    const request = openRequest.current;
     const before = games ?? [];
     const dropped = new Set(appIds);
     const next = before.filter((g) => !dropped.has(g.appId));
@@ -599,7 +606,7 @@ export function Collections() {
       await call("editLinked", id, { remove: [...appIds] });
       await loadGrid();
     } catch (err) {
-      setGames(before);
+      if (request === openRequest.current) setGames(before);
       notify(err instanceof Error ? err.message : "Couldn't update that collection", {
         kind: "error",
       });

--- a/plugins/collections/app.tsx
+++ b/plugins/collections/app.tsx
@@ -43,6 +43,28 @@ import type { ManagedCollection } from "./lib/types";
 
 export { FaLayerGroup as icon };
 
+/** How many times to ask for the library before settling for what we got. */
+const SNAPSHOT_ATTEMPTS = 4;
+/** Multiplied by the attempt number, so 1s, 2s, 3s. */
+const SNAPSHOT_RETRY_MS = 1000;
+
+/**
+ * Whether the library snapshot can be *believed* — not merely whether the call
+ * came back.
+ *
+ * `getSnapshot` never rejects on a bad read: both its sources degrade to empty,
+ * so a Steam that hasn't finished hydrating answers with a well-formed snapshot
+ * of nothing. Testing `snapshot !== null` treats that as a loaded library and
+ * the screens priced against it then state it as fact — "every game in your
+ * library is already in this collection", twelve presets greyed out blaming
+ * play history. This is the same condition the backend refuses to sync or
+ * prune on, for the same reason.
+ */
+function snapshotIsUsable(snapshot: GameMetadataSnapshot | null): boolean {
+  if (snapshot === null) return false;
+  return snapshot.providers.appstore?.status === "ok" && snapshot.games.length > 0;
+}
+
 interface CollectionSummary {
   id: string;
   label: string;
@@ -163,17 +185,35 @@ export function Collections() {
   useEffect(() => {
     if (!ready) return;
     void loadGrid();
+    let cancelled = false;
     void (async () => {
-      try {
-        const [snap] = await Promise.all([
-          call("getSnapshot") as Promise<GameMetadataSnapshot>,
-          loadConfig(),
-        ]);
-        setSnapshot(snap);
-      } catch {
-        // The grid still works without these; only rule editing needs them.
+      // Retried while the answer is one we can't believe. `getSnapshot` never
+      // *fails* — both its sources degrade to empty — so a Steam that hasn't
+      // finished hydrating returns a perfectly well-formed snapshot of nothing,
+      // and one fetch would leave every screen priced against it for the rest
+      // of the session. Bounded: this is a webview waiting on a library, not a
+      // poller.
+      for (let attempt = 0; attempt < SNAPSHOT_ATTEMPTS && !cancelled; attempt++) {
+        if (attempt > 0) {
+          await new Promise((r) => setTimeout(r, SNAPSHOT_RETRY_MS * attempt));
+          if (cancelled) return;
+        }
+        try {
+          const [snap] = await Promise.all([
+            call("getSnapshot") as Promise<GameMetadataSnapshot>,
+            attempt === 0 ? loadConfig() : Promise.resolve(),
+          ]);
+          if (cancelled) return;
+          setSnapshot(snap);
+          if (snapshotIsUsable(snap)) return;
+        } catch {
+          // The grid still works without these; only rule editing needs them.
+        }
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [ready, loadGrid, loadConfig, call]);
 
   /**
@@ -264,7 +304,7 @@ export function Collections() {
     // row windowing measures against.
     return (
       <AddGamesPage
-        libraryLoaded={snapshot !== null}
+        libraryLoaded={snapshotIsUsable(snapshot)}
         label={view.label}
         candidates={(snapshot?.games ?? [])
           .filter((g) => !already.has(g.appId))
@@ -282,7 +322,7 @@ export function Collections() {
         <NewCollectionPage
           existingNames={(summaries ?? []).map((c) => c.label)}
           games={evalGames}
-          libraryLoaded={snapshot !== null}
+          libraryLoaded={snapshotIsUsable(snapshot)}
           onBack={() => setView({ kind: "grid" })}
           onPickPreset={(preset) => void createCollection(preset.label, preset)}
           onCreate={(label) => void createCollection(label)}

--- a/plugins/collections/app.tsx
+++ b/plugins/collections/app.tsx
@@ -264,10 +264,11 @@ export function Collections() {
     // row windowing measures against.
     return (
       <AddGamesPage
-          label={view.label}
-          candidates={(snapshot?.games ?? [])
-            .filter((g) => !already.has(g.appId))
-            .map((g) => ({ appId: g.appId, name: g.name, installed: g.installed }))}
+        libraryLoaded={snapshot !== null}
+        label={view.label}
+        candidates={(snapshot?.games ?? [])
+          .filter((g) => !already.has(g.appId))
+          .map((g) => ({ appId: g.appId, name: g.name, installed: g.installed }))}
         onBack={() => setView({ kind: "detail", id: view.id, label: view.label })}
         onAdd={(appIds) => void addToLinked(view.id, view.label, appIds)}
       />

--- a/plugins/collections/backend.test.ts
+++ b/plugins/collections/backend.test.ts
@@ -22,6 +22,10 @@ let hangSteam = false;
  * in every test and the "half the sync landed" branch had no coverage at all.
  */
 let failNextWrite: string | null = null;
+/** The library read comes back empty, as it does while Steam hydrates. */
+let emptyLibrary = false;
+/** Which Steam write primitive was last used — a whole-list write is a bug. */
+let steamWrites: string[] = [];
 /** Hold a write open so an edit can provably land mid-sync. */
 let releaseWrite: (() => void) | null = null;
 let holdWrite = false;
@@ -86,6 +90,7 @@ mock.module("@loadout/steam-cdp", () => ({
     _c: unknown,
     { collectionId, add = [], remove = [] }: { collectionId: string; add?: string[]; remove?: string[] },
   ) => {
+    steamWrites.push("editCollectionApps");
     if (failNextWrite === "setApps") {
       failNextWrite = null;
       throw new Error("Steam went away mid-write (test stub)");
@@ -105,6 +110,13 @@ mock.module("@loadout/steam-cdp", () => ({
     return { ...found, appIds: [...found.appIds] };
   },
   setCollectionApps: async (_c: unknown, { collectionId, appIds }: { collectionId: string; appIds: string[] }) => {
+    steamWrites.push("setCollectionApps");
+    if (holdWrite) {
+      holdWrite = false;
+      await new Promise<void>((resolve) => {
+        releaseWrite = resolve;
+      });
+    }
     if (failNextWrite === "setApps") {
       failNextWrite = null;
       throw new Error("Steam went away mid-write (test stub)");
@@ -136,6 +148,12 @@ beforeEach(() => {
   steamUp = true;
   hangSteam = false;
   failNextWrite = null;
+  emptyLibrary = false;
+  steamWrites = [];
+  releaseWrite = null;
+  holdWrite = false;
+  releaseSteamRead = null;
+  hangSteamOnce = false;
   fakeCollections = [];
   prevXdg = process.env.XDG_CONFIG_HOME;
   tempDir = mkdtempSync(join(tmpdir(), "collections-backend-"));
@@ -153,7 +171,7 @@ afterEach(() => {
  * real one is — through `callPlugin` to the game-library service — so
  * `listGames` and the rule engine see it exactly as they would on a device.
  */
-function libraryOf(games: Array<{ appId: string; name: string }>) {
+function libraryOf(games: Array<{ appId: string; name: string; source?: string }>) {
   return async (_plugin: string, method: string) =>
     method === "getGames"
       ? games.map((g) => ({
@@ -163,15 +181,20 @@ function libraryOf(games: Array<{ appId: string; name: string }>) {
           headerUrl: "",
           capsuleUrl: "",
           installed: true,
-          source: "steam",
+          // Shortcuts matter: pruning refuses to drop shortcut-shaped ids
+          // unless the library proves it has listed shortcuts at all.
+          source: g.source ?? "steam",
           tags: [],
         }))
       : null;
 }
 
-async function loaded(games: Array<{ appId: string; name: string }> = []) {
+async function loaded(games: Array<{ appId: string; name: string; source?: string }> = []) {
   const backend = new CollectionsBackend();
-  (backend as unknown as { callPlugin: unknown }).callPlugin = libraryOf(games);
+  (backend as unknown as { callPlugin: unknown }).callPlugin = (
+    plugin: string,
+    method: string,
+  ) => libraryOf(emptyLibrary ? [] : games)(plugin, method);
   await backend.onLoad();
   return backend;
 }
@@ -249,26 +272,29 @@ describe("entries Steam can no longer resolve", () => {
     // empty a collection somebody else built.
     // A library that answered with *something*, but nothing this collection
     // holds — the shape of a half-loaded read rather than a dead collection.
-    withDeadIds();
+    // Ordinary ids, so the shortcut guard doesn't fire first.
+    fakeCollections = [
+      { id: "uc-rh", name: "Recomp Hub", appIds: ["10", "20"], isDynamic: false, isEditable: true },
+    ];
     const backend = await loaded([{ appId: "999", name: "Something else" }]);
     await expect(backend.pruneLinked("uc-rh")).rejects.toThrow(/unreadable/);
-    expect(fakeCollections[0]!.appIds).toHaveLength(3);
+    expect(fakeCollections[0]!.appIds).toHaveLength(2);
   });
 
-  it("removes only the dead ids, naming them rather than rewriting the list", async () => {
+  it("prunes them on request, naming the dead ids rather than rewriting the list", async () => {
     withDeadIds();
-    const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
+    const backend = await loaded([
+      { appId: "620", name: "Portal 2" },
+      { appId: "3000000001", name: "Some ROM", source: "shortcut" },
+    ]);
     const result = await backend.pruneLinked("uc-rh");
     expect(result).toEqual({ removed: 2, kept: 1 });
     expect(fakeCollections[0]!.appIds).toEqual(["620"]);
-  });
-
-  it("prunes them on request, keeping everything real", async () => {
-    withDeadIds();
-    const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
-    const result = await backend.pruneLinked("uc-rh");
-    expect(result).toEqual({ removed: 2, kept: 1 });
-    expect(fakeCollections[0]!.appIds).toEqual(["620"]);
+    // A targeted removal, not a membership rewrite. Both land on the same
+    // list here, so the primitive is the only thing that distinguishes them —
+    // and a rewrite takes the collection's unresolvable ids with it, which is
+    // exactly what this is meant to avoid.
+    expect(steamWrites).toEqual(["editCollectionApps"]);
   });
 
   it("does nothing when there is nothing dead", async () => {
@@ -276,7 +302,7 @@ describe("entries Steam can no longer resolve", () => {
       { id: "uc-rh", name: "Recomp Hub", appIds: ["620"], isDynamic: false, isEditable: true },
     ];
     const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
-    expect(await backend.pruneLinked("uc-rh")).toEqual({ removed: 0, kept: 0 });
+    expect(await backend.pruneLinked("uc-rh")).toEqual({ removed: 0, kept: 1 });
     expect(fakeCollections[0]!.appIds).toEqual(["620"]);
   });
 
@@ -336,6 +362,10 @@ describe("editing a Steam collection by hand", () => {
     expect(fakeCollections[0]!.appIds).toContain("999999");
     expect(fakeCollections[0]!.appIds).toContain("400");
     expect(fakeCollections[0]!.appIds).toContain("620");
+    // Named explicitly: with only the *delta* fake honouring the latch, a
+    // reverted `editLinked` finishes before the concurrent push and the
+    // assertions above hold anyway. The primitive is the thing under test.
+    expect(steamWrites).toEqual(["editCollectionApps"]);
   });
 
   it("won't add the same game twice", async () => {
@@ -387,6 +417,74 @@ describe("a sync that writes nothing", () => {
     const report = await backend.syncMirror();
     expect(report.created).toBe(0);
     expect(report.blocked[0]!.reason).toMatch(/whole library/);
+  });
+});
+
+describe("state the UI depends on", () => {
+  // Each of these was changed in response to a review and shipped without a
+  // test that fails when the change is reverted.
+
+  it("keeps a ledger written mid-sync, rather than restoring the pre-sync one", async () => {
+    // `_markSyncOwed` captures the mirror before its own disk write and
+    // enqueues after it. Handing `_setMirrorState` a finished object let that
+    // late write restore a ledger the sync had just replaced — orphaning the
+    // collection it had created in Steam.
+    const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
+    await backend.createCollection("Backlog");
+    const { config } = await backend.getConfig();
+    await backend.setCollections([
+      {
+        ...config.collections[0]!,
+        root: {
+          kind: "group",
+          id: "backlog-root",
+          combinator: "all",
+          children: [{ id: "r1", kind: "installed" }],
+        },
+      },
+    ]);
+
+    holdWrite = true;
+    const syncing = backend.syncMirror();
+    await new Promise((r) => setTimeout(r, 10));
+    // Deliberately not awaited, so the edit's own "a sync is owed" write races
+    // the sync's ledger write. This pins the invariant rather than proving the
+    // ordering — the interleaving that used to clobber the ledger needs the
+    // two writes to land in one specific order, which a test can't force here.
+    // The fix (an updater, resolved inside the lock) makes the order moot.
+    const editing = backend.createCollection("Made mid-sync");
+    releaseWrite?.();
+    await Promise.all([syncing, editing]);
+    await new Promise((r) => setTimeout(r, 20));
+
+    const after = (await backend.getConfig()).config.mirror.ledger.entries;
+    expect(after.map((e) => e.managedId)).toContain("backlog");
+  });
+
+  it("reports the membership a created collection was given", async () => {
+    // The fake used to drop `appIds` on create, so a plan that created a
+    // collection holding the wrong games was indistinguishable from one that
+    // got it right.
+    const backend = await loaded([
+      { appId: "620", name: "Portal 2" },
+      { appId: "400", name: "Portal" },
+    ]);
+    await backend.createCollection("Installed");
+    const { config } = await backend.getConfig();
+    await backend.setCollections([
+      {
+        ...config.collections[0]!,
+        root: {
+          kind: "group",
+          id: "installed-root",
+          combinator: "all",
+          children: [{ id: "r1", kind: "installed" }],
+        },
+      },
+    ]);
+
+    await backend.syncMirror();
+    expect(fakeCollections[0]!.appIds.sort()).toEqual(["400", "620"]);
   });
 });
 
@@ -501,6 +599,69 @@ describe("things happening at once", () => {
     await syncing;
 
     expect((await backend.getConfig()).config.mirror.pendingSync).toBe(true);
+  });
+});
+
+describe("a sync against a library that didn't load", () => {
+  // Both library sources degrade to empty on failure, and a sync rewrites
+  // whole memberships — so a half-loaded library doesn't produce a smaller
+  // sync, it empties every collection we own. Every sync test in this file
+  // used to run in exactly that state without anyone noticing.
+  it("refuses rather than emptying every mirrored collection", async () => {
+    const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
+    await backend.createCollection("Backlog");
+    const { config } = await backend.getConfig();
+    await backend.setCollections([
+      {
+        ...config.collections[0]!,
+        root: {
+          kind: "group",
+          id: "backlog-root",
+          combinator: "all",
+          children: [{ id: "r1", kind: "installed" }],
+        },
+      },
+    ]);
+    await backend.syncMirror();
+    expect(fakeCollections[0]!.appIds).toEqual(["620"]);
+
+    // Now the library read comes back empty, the way it does while Steam is
+    // still hydrating — the moment `onLoad`'s owed sync fires.
+    emptyLibrary = true;
+    await expect(backend.syncMirror()).rejects.toThrow(/library isn't loaded/);
+
+    expect(fakeCollections[0]!.appIds).toEqual(["620"]);
+    expect((await backend.getConfig()).config.mirror.pendingSync).toBe(true);
+  });
+});
+
+describe("a collection whose rules this build can't check", () => {
+  it("is refused rather than mirrored as the whole library", async () => {
+    // An unresolvable fact evaluates to `indeterminate`, which the default
+    // policy counts as a match — so the collection matches everything and,
+    // without this, Steam gets a copy of the library.
+    const backend = await loaded([
+      { appId: "620", name: "Portal 2" },
+      { appId: "400", name: "Portal" },
+    ]);
+    await backend.createCollection("Short games");
+    const { config } = await backend.getConfig();
+    await backend.setCollections([
+      {
+        ...config.collections[0]!,
+        root: {
+          kind: "group",
+          id: "short-games-root",
+          combinator: "all",
+          children: [{ id: "r1", kind: "hltbMain", hours: { max: 10 } }],
+        },
+      },
+    ]);
+
+    const report = await backend.syncMirror();
+    expect(report.created).toBe(0);
+    expect(fakeCollections).toHaveLength(0);
+    expect(report.blocked[0]!.reason).toMatch(/can't check/);
   });
 });
 
@@ -688,7 +849,7 @@ describe("editing never syncs on its own", () => {
   it("still writes when asked to", async () => {
     // The manual path is the whole point of the above: the work is the same,
     // it just happens when nobody is waiting on it.
-    const backend = await loaded();
+    const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
     await backend.createCollection("Backlog");
     await backend.setCollections([
       {
@@ -740,7 +901,7 @@ describe("deleteCollection", () => {
     // batch of writes. A delete is one targeted call, and leaving it to the
     // next sync meant the collection vanished from the plugin while Steam
     // still listed it — which reads exactly like a delete that did not work.
-    const backend = await loaded();
+    const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
     await mirrored(backend);
     expect(fakeCollections).toHaveLength(1);
 
@@ -750,7 +911,7 @@ describe("deleteCollection", () => {
   });
 
   it("keeps the ledger row when Steam can't be reached, so the sync finishes it", async () => {
-    const backend = await loaded();
+    const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
     await mirrored(backend);
 
     steamUp = false;

--- a/plugins/collections/backend.test.ts
+++ b/plugins/collections/backend.test.ts
@@ -309,6 +309,23 @@ describe("entries Steam can no longer resolve", () => {
     expect(fakeCollections[0]!.appIds).toHaveLength(2);
   });
 
+  it("doesn't tell somebody to wait for a shortcut list that is never coming", async () => {
+    // The shortcut guard cannot tell a shortcut source that failed from a
+    // library that genuinely has none — somebody who removed EmuDeck and kept
+    // the collection. Refusing is still the right way round, since pruning is
+    // the only irreversible move here; promising that waiting fixes it is not,
+    // because for that user it never does.
+    withDeadIds();
+    const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
+    const err = await backend.pruneLinked("uc-rh").catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/lists none at all/);
+    expect((err as Error).message).not.toMatch(/in a moment|hasn't listed .* yet/);
+    // And it names the way out, rather than leaving the collection stuck.
+    expect((err as Error).message).toMatch(/delete/i);
+    expect(fakeCollections[0]!.appIds).toHaveLength(3);
+  });
+
   it("prunes them on request, naming the dead ids rather than rewriting the list", async () => {
     withDeadIds();
     const backend = await loaded([

--- a/plugins/collections/backend.test.ts
+++ b/plugins/collections/backend.test.ts
@@ -32,6 +32,19 @@ let holdWrite = false;
 /** Hold the *read* open, to land an edit between evaluating and planning. */
 let releaseSteamRead: (() => void) | null = null;
 let hangSteamOnce = false;
+
+/**
+ * Wait until a latch has actually been reached, rather than sleeping and
+ * hoping. A missed latch used to hang the test to the suite timeout instead of
+ * saying what it was waiting for.
+ */
+async function until(what: string, ready: () => boolean, ms = 2000) {
+  const deadline = Date.now() + ms;
+  while (!ready()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
 let fakeCollections: Array<{
   id: string;
   name: string;
@@ -354,7 +367,7 @@ describe("editing a Steam collection by hand", () => {
 
     holdWrite = true;
     const editing = backend.editLinked("uc-rh", { add: ["400"] });
-    await new Promise((r) => setTimeout(r, 10));
+    await until("the edit's Steam write", () => releaseWrite !== null);
     fakeCollections[0]!.appIds.push("999999"); // EmuDeck, mid-write
     releaseWrite?.();
     await editing;
@@ -446,7 +459,7 @@ describe("state the UI depends on", () => {
 
     holdWrite = true;
     const syncing = backend.syncMirror();
-    await new Promise((r) => setTimeout(r, 10));
+    await until("the sync's Steam write", () => releaseWrite !== null);
     // Deliberately not awaited, so the edit's own "a sync is owed" write races
     // the sync's ledger write. This pins the invariant rather than proving the
     // ordering — the interleaving that used to clobber the ledger needs the
@@ -571,7 +584,7 @@ describe("things happening at once", () => {
     // evaluation and the planning — the exact window.
     hangSteamOnce = true;
     const syncing = backend.syncMirror();
-    await new Promise((r) => setTimeout(r, 10));
+    await until("the plan's Steam read", () => releaseSteamRead !== null);
     await backend.setCollections([ruled]);
     releaseSteamRead?.();
     await syncing;
@@ -593,7 +606,7 @@ describe("things happening at once", () => {
     // whenever the scheduler happens to run it.
     holdWrite = true;
     const syncing = backend.syncMirror();
-    await new Promise((r) => setTimeout(r, 10));
+    await until("the sync's Steam write", () => releaseWrite !== null);
     await backend.createCollection("Made mid-sync");
     releaseWrite?.();
     await syncing;

--- a/plugins/collections/backend.test.ts
+++ b/plugins/collections/backend.test.ts
@@ -24,6 +24,13 @@ let hangSteam = false;
 let failNextWrite: string | null = null;
 /** The library read comes back empty, as it does while Steam hydrates. */
 let emptyLibrary = false;
+/** Library reads so far — `getSnapshot` is uncached, so this counts them. */
+let libraryReads = 0;
+/**
+ * Degrade the library from this read onward (1-based), so a test can put a
+ * failure *between* two reads inside one operation. `null` never degrades.
+ */
+let degradeLibraryFromRead: number | null = null;
 /** Which Steam write primitive was last used — a whole-list write is a bug. */
 let steamWrites: string[] = [];
 /** Hold a write open so an edit can provably land mid-sync. */
@@ -162,6 +169,8 @@ beforeEach(() => {
   hangSteam = false;
   failNextWrite = null;
   emptyLibrary = false;
+  libraryReads = 0;
+  degradeLibraryFromRead = null;
   steamWrites = [];
   releaseWrite = null;
   holdWrite = false;
@@ -207,7 +216,13 @@ async function loaded(games: Array<{ appId: string; name: string; source?: strin
   (backend as unknown as { callPlugin: unknown }).callPlugin = (
     plugin: string,
     method: string,
-  ) => libraryOf(emptyLibrary ? [] : games)(plugin, method);
+  ) => {
+    if (method !== "getGames") return libraryOf(games)(plugin, method);
+    libraryReads += 1;
+    const degraded =
+      emptyLibrary || (degradeLibraryFromRead !== null && libraryReads >= degradeLibraryFromRead);
+    return libraryOf(degraded ? [] : games)(plugin, method);
+  };
   await backend.onLoad();
   return backend;
 }
@@ -325,6 +340,16 @@ describe("entries Steam can no longer resolve", () => {
     const backend = await loaded();
     await backend.createCollection("Backlog");
     expect((await backend.listGames("backlog")).staleAppIds).toEqual([]);
+  });
+
+  it("has nothing to do for one built from rules either", async () => {
+    // Reading Steam directly rather than going through `listGames` lost the
+    // managed case, and a managed id then reached the "no collection with that
+    // id in Steam" error — reporting a collection the user is looking at as
+    // gone. Nothing in the UI asks for this, and it still must not lie.
+    const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
+    await backend.createCollection("Backlog");
+    expect(await backend.pruneLinked("backlog")).toEqual({ removed: 0, kept: 0 });
   });
 });
 
@@ -646,6 +671,43 @@ describe("a sync against a library that didn't load", () => {
     expect(fakeCollections[0]!.appIds).toEqual(["620"]);
     expect((await backend.getConfig()).config.mirror.pendingSync).toBe(true);
   });
+
+  it("plans against the very reading its guard checked, not a later one", async () => {
+    // `getSnapshot` is uncached, and the guard and the plan used to call it
+    // separately. A `getGames` failure or a CDP timeout between the two left
+    // the guard inspecting a healthy read while every membership was computed
+    // from a broken one — the same two-reads mistake `pruneLinked` had, in the
+    // one path that rewrites every mirrored collection at once. Measured: the
+    // guard passed, the sync reported success, and the collection came back
+    // empty.
+    const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
+    await backend.createCollection("Backlog");
+    const { config } = await backend.getConfig();
+    await backend.setCollections([
+      {
+        ...config.collections[0]!,
+        root: {
+          kind: "group",
+          id: "backlog-root",
+          combinator: "all",
+          children: [{ id: "r1", kind: "installed" }],
+        },
+      },
+    ]);
+    await backend.syncMirror();
+    expect(fakeCollections[0]!.appIds).toEqual(["620"]);
+
+    // Healthy for the first read of the sync, empty for every read after it.
+    libraryReads = 0;
+    degradeLibraryFromRead = 2;
+    await backend.syncMirror();
+
+    expect(fakeCollections[0]!.appIds).toEqual(["620"]);
+    // And one read is all a sync should take: three full library reads per
+    // sync — guard, plan, and naming the changes — is both the bug above and
+    // two extra `getGames` round trips on a handheld.
+    expect(libraryReads).toBe(1);
+  });
 });
 
 describe("a collection whose rules this build can't check", () => {
@@ -675,6 +737,43 @@ describe("a collection whose rules this build can't check", () => {
     expect(report.created).toBe(0);
     expect(fakeCollections).toHaveLength(0);
     expect(report.blocked[0]!.reason).toMatch(/can't check/);
+  });
+
+  it("syncs one whose policy already excludes what it can't check", async () => {
+    // Under `"fail"` an unchecked rule matches *nothing*, so the collection
+    // cannot be the whole library — it is narrower than intended, not wider.
+    // Refusing it anyway would contradict `diagnoseCollection`, which offers
+    // exactly this policy as the fix for the refusal above: the user would
+    // apply the suggested fix and the sync would go on refusing.
+    const backend = await loaded([
+      { appId: "620", name: "Portal 2" },
+      { appId: "400", name: "Portal" },
+    ]);
+    await backend.createCollection("Short or installed");
+    const { config } = await backend.getConfig();
+    await backend.setCollections([
+      {
+        ...config.collections[0]!,
+        indeterminatePolicy: "fail",
+        root: {
+          kind: "group",
+          id: "short-games-root",
+          // ANY, so the collection still has members once the unchecked rule
+          // contributes nothing — the case where refusing costs the user a
+          // collection that was perfectly correct.
+          combinator: "any",
+          children: [
+            { id: "r1", kind: "hltbMain", hours: { max: 10 } },
+            { id: "r2", kind: "installed" },
+          ],
+        },
+      },
+    ]);
+
+    const report = await backend.syncMirror();
+    expect(report.blocked).toEqual([]);
+    expect(report.created).toBe(1);
+    expect(fakeCollections[0]!.appIds.sort()).toEqual(["400", "620"]);
   });
 });
 
@@ -826,6 +925,96 @@ describe("createCollection", () => {
     const backend = await loaded();
     const config = await backend.createCollection("New");
     expect(config.collections[0]!.root.children).toEqual([]);
+  });
+});
+
+describe("the sync owed from a previous session", () => {
+  it("waits for the library rather than giving up in the first seconds of boot", async () => {
+    // Plugin load is the earliest moment Steam could be up, which makes it the
+    // moment the library is least likely to have hydrated — exactly what the
+    // sync guard refuses on. Load is also the only automatic sync left, so
+    // without a retry the owed one gives up at every boot and waits for the
+    // user to open the plugin and press the button.
+    const first = await loaded([{ appId: "620", name: "Portal 2" }]);
+    await first.setConfig({
+      ...(await first.getConfig()).config,
+      mirror: { ...(await first.getConfig()).config.mirror, autoSync: true },
+    });
+    await first.createCollection("Backlog");
+    await first.setCollections([
+      {
+        ...(await first.getConfig()).config.collections[0]!,
+        root: {
+          kind: "group",
+          id: "backlog-root",
+          combinator: "all",
+          children: [{ id: "r1", kind: "installed" }],
+        },
+      },
+    ]);
+    expect((await first.getConfig()).config.mirror.pendingSync).toBe(true);
+    expect(fakeCollections).toEqual([]);
+
+    // A fresh backend over the same config on disk — a reboot, with Steam's
+    // library not there yet.
+    emptyLibrary = true;
+    const second = new CollectionsBackend();
+    (second as unknown as { callPlugin: unknown }).callPlugin = (
+      plugin: string,
+      method: string,
+    ) => libraryOf(emptyLibrary ? [] : [{ appId: "620", name: "Portal 2" }])(plugin, method);
+    (second as unknown as { owedRetryDelays: readonly number[] }).owedRetryDelays = [10, 10, 10];
+    await second.onLoad();
+
+    // Refused, and still owed.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fakeCollections).toEqual([]);
+    expect((await second.getConfig()).config.mirror.pendingSync).toBe(true);
+
+    // Steam finishes loading. The retry is what turns that into a sync.
+    emptyLibrary = false;
+    await until("the owed sync to land", () => fakeCollections.length === 1);
+    expect(fakeCollections[0]!.appIds).toEqual(["620"]);
+    await second.onUnload();
+  });
+
+  it("gives up rather than retrying for the life of the session", async () => {
+    // A backend that keeps retrying forever is one quietly writing to Steam
+    // long after anybody expected it to.
+    const first = await loaded([{ appId: "620", name: "Portal 2" }]);
+    await first.setConfig({
+      ...(await first.getConfig()).config,
+      mirror: { ...(await first.getConfig()).config.mirror, autoSync: true },
+    });
+    await first.createCollection("Backlog");
+    await first.setCollections([
+      {
+        ...(await first.getConfig()).config.collections[0]!,
+        root: {
+          kind: "group",
+          id: "backlog-root",
+          combinator: "all",
+          children: [{ id: "r1", kind: "installed" }],
+        },
+      },
+    ]);
+
+    emptyLibrary = true;
+    const second = new CollectionsBackend();
+    (second as unknown as { callPlugin: unknown }).callPlugin = (
+      plugin: string,
+      method: string,
+    ) => libraryOf(emptyLibrary ? [] : [{ appId: "620", name: "Portal 2" }])(plugin, method);
+    (second as unknown as { owedRetryDelays: readonly number[] }).owedRetryDelays = [5, 5];
+    await second.onLoad();
+
+    // Well past the last delay, with the library still absent.
+    await new Promise((r) => setTimeout(r, 60));
+    emptyLibrary = false;
+    await new Promise((r) => setTimeout(r, 40));
+    expect(fakeCollections).toEqual([]);
+    expect((await second.getConfig()).config.mirror.pendingSync).toBe(true);
+    await second.onUnload();
   });
 });
 

--- a/plugins/collections/backend.test.ts
+++ b/plugins/collections/backend.test.ts
@@ -25,6 +25,9 @@ let failNextWrite: string | null = null;
 /** Hold a write open so an edit can provably land mid-sync. */
 let releaseWrite: (() => void) | null = null;
 let holdWrite = false;
+/** Hold the *read* open, to land an edit between evaluating and planning. */
+let releaseSteamRead: (() => void) | null = null;
+let hangSteamOnce = false;
 let fakeCollections: Array<{
   id: string;
   name: string;
@@ -41,12 +44,18 @@ mock.module("@loadout/steam-cdp", () => ({
   readSteamLibrary: async () => ({ entries: [], installedCount: 0, resolvedTagCount: 0 }),
   listCollections: async () => {
     if (hangSteam) await new Promise((r) => setTimeout(r, 20_000));
+    if (hangSteamOnce) {
+      hangSteamOnce = false;
+      await new Promise<void>((resolve) => {
+        releaseSteamRead = resolve;
+      });
+    }
     return fakeCollections.map((c) => ({ ...c, appIds: [...c.appIds] }));
   },
   // Stateful, so a test can ask what Steam ended up holding. A fake that
   // accepts every call and remembers nothing cannot tell "wrote it" from
   // "thought about writing it".
-  createCollection: async (_c: unknown, { name }: { name: string }) => {
+  createCollection: async (_c: unknown, { name, appIds = [] }: { name: string; appIds?: string[] }) => {
     if (failNextWrite === "create") {
       failNextWrite = null;
       throw new Error("Steam went away mid-write (test stub)");
@@ -57,9 +66,43 @@ mock.module("@loadout/steam-cdp", () => ({
         releaseWrite = resolve;
       });
     }
-    const made = { id: `uc-${fakeCollections.length + 1}`, name, appIds: [], isDynamic: false, isEditable: true };
+    // Honour the membership it was handed. Dropping it meant every created
+    // collection was empty in the fake, so a plan that created one holding the
+    // wrong games looked identical to one that got it right.
+    const made = {
+      id: `uc-${fakeCollections.length + 1}`,
+      name,
+      appIds: [...appIds],
+      isDynamic: false,
+      isEditable: true,
+    };
     fakeCollections.push(made);
     return { ...made };
+  },
+  // A true delta, like the real one: only the named ids move, so an entry the
+  // caller never knew about — a dead shortcut id, or something EmuDeck added
+  // in between — is left where it is.
+  editCollectionApps: async (
+    _c: unknown,
+    { collectionId, add = [], remove = [] }: { collectionId: string; add?: string[]; remove?: string[] },
+  ) => {
+    if (failNextWrite === "setApps") {
+      failNextWrite = null;
+      throw new Error("Steam went away mid-write (test stub)");
+    }
+    if (holdWrite) {
+      holdWrite = false;
+      await new Promise<void>((resolve) => {
+        releaseWrite = resolve;
+      });
+    }
+    const found = fakeCollections.find((c) => c.id === collectionId);
+    if (!found) throw new Error("no collection with id " + collectionId);
+    const dropped = new Set(remove);
+    const kept = found.appIds.filter((id) => !dropped.has(id));
+    const present = new Set(kept);
+    found.appIds = [...kept, ...add.filter((id) => !present.has(id))];
+    return { ...found, appIds: [...found.appIds] };
   },
   setCollectionApps: async (_c: unknown, { collectionId, appIds }: { collectionId: string; appIds: string[] }) => {
     if (failNextWrite === "setApps") {
@@ -187,16 +230,37 @@ describe("entries Steam can no longer resolve", () => {
     expect(result.staleAppIds).toEqual(["2924527325", "3541813501"]);
   });
 
+  it("refuses to prune when Steam answered but the library came back empty", async () => {
+    // `appstore: "ok"` only means the call returned. Steam answers with an
+    // empty list while its stores hydrate, and every owned-but-uninstalled
+    // game then looks dead. The old fake made *every* test run with a healthy
+    // provider, so this guard could be deleted with the suite still green.
+    withDeadIds();
+    const backend = await loaded([]);
+    await expect(backend.pruneLinked("uc-rh")).rejects.toThrow(/isn't fully loaded/);
+    expect(fakeCollections[0]!.appIds).toHaveLength(3);
+  });
+
   it("refuses to prune when the library can't vouch for the ids", async () => {
     // "Stale" means the library doesn't know the id, which is only safe to act
     // on when the library is trustworthy. Both sources degrade to empty on
     // failure, and a thin snapshot makes every ROM in an EmuDeck collection
     // look dead — shortcuts have no appmanifest. Confirming that dialog would
     // empty a collection somebody else built.
+    // A library that answered with *something*, but nothing this collection
+    // holds — the shape of a half-loaded read rather than a dead collection.
     withDeadIds();
-    const backend = await loaded([]);
-    await expect(backend.pruneLinked("uc-rh")).rejects.toThrow(/isn't fully loaded|unreadable/);
+    const backend = await loaded([{ appId: "999", name: "Something else" }]);
+    await expect(backend.pruneLinked("uc-rh")).rejects.toThrow(/unreadable/);
     expect(fakeCollections[0]!.appIds).toHaveLength(3);
+  });
+
+  it("removes only the dead ids, naming them rather than rewriting the list", async () => {
+    withDeadIds();
+    const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
+    const result = await backend.pruneLinked("uc-rh");
+    expect(result).toEqual({ removed: 2, kept: 1 });
+    expect(fakeCollections[0]!.appIds).toEqual(["620"]);
   });
 
   it("prunes them on request, keeping everything real", async () => {
@@ -254,14 +318,24 @@ describe("editing a Steam collection by hand", () => {
     expect(fakeCollections[0]!.appIds).toEqual(["620", "2924527325", "400"]);
   });
 
-  it("keeps what somebody else added between the read and the write", async () => {
-    // The UI's copy is always a moment old. A delta cannot lose what it never
-    // knew about.
+  it("keeps what somebody else added while the write was in flight", async () => {
+    // The window that matters is between our read and Steam applying the
+    // write. The old version pushed its entry in *before* the read, which a
+    // whole-membership write survived too — so it proved nothing about the
+    // delta. Held open here, so the concurrent add genuinely interleaves.
     collectionOf(["620"]);
     const backend = await loaded([{ appId: "620", name: "Portal 2" }]);
-    fakeCollections[0]!.appIds.push("999999"); // EmuDeck, mid-edit
-    await backend.editLinked("uc-rh", { add: ["400"] });
-    expect(fakeCollections[0]!.appIds).toEqual(["620", "999999", "400"]);
+
+    holdWrite = true;
+    const editing = backend.editLinked("uc-rh", { add: ["400"] });
+    await new Promise((r) => setTimeout(r, 10));
+    fakeCollections[0]!.appIds.push("999999"); // EmuDeck, mid-write
+    releaseWrite?.();
+    await editing;
+
+    expect(fakeCollections[0]!.appIds).toContain("999999");
+    expect(fakeCollections[0]!.appIds).toContain("400");
+    expect(fakeCollections[0]!.appIds).toContain("620");
   });
 
   it("won't add the same game twice", async () => {
@@ -369,6 +443,46 @@ describe("things happening at once", () => {
     await Promise.all([backend.createCollection("Backlog"), backend.createCollection("Backlog")]);
     const ids = (await backend.getConfig()).config.collections.map((c) => c.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("never pairs one reading of the rules with another reading of the config", async () => {
+    // The plan used to read `this.config.collections` twice with awaits in
+    // between: once to evaluate, once to plan. A rule saved in that window
+    // paired the *new* tree with the *old* evaluation — and a collection with
+    // no rules evaluates to the whole library, so it stopped being skipped and
+    // went to Steam holding everything. Reverting the capture-once change must
+    // fail here.
+    const backend = await loaded([
+      { appId: "620", name: "Portal 2" },
+      { appId: "400", name: "Portal" },
+      { appId: "500", name: "Left 4 Dead" },
+    ]);
+    await backend.createCollection("Backlog"); // no rules: matches everything
+    const { config } = await backend.getConfig();
+    const ruled = {
+      ...config.collections[0]!,
+      root: {
+        kind: "group" as const,
+        id: "backlog-root",
+        combinator: "all" as const,
+        children: [{ id: "r1", kind: "installed" as const, invert: true }],
+      },
+    };
+
+    // The plan's Steam read is held open, so the rule save lands between the
+    // evaluation and the planning — the exact window.
+    hangSteamOnce = true;
+    const syncing = backend.syncMirror();
+    await new Promise((r) => setTimeout(r, 10));
+    await backend.setCollections([ruled]);
+    releaseSteamRead?.();
+    await syncing;
+
+    // Either it was skipped as rule-less, or it was written with the
+    // membership its rules actually produce. What it must never be is present
+    // in Steam holding the whole library.
+    const written = fakeCollections.find((c) => c.name === "Backlog");
+    expect(written?.appIds.length ?? 0).toBeLessThan(3);
   });
 
   it("keeps the sync owed when an edit lands while it is writing", async () => {

--- a/plugins/collections/backend.ts
+++ b/plugins/collections/backend.ts
@@ -636,13 +636,27 @@ export default class CollectionsBackend implements PluginBackend {
     // EmuDeck collection reads dead. If the ids being dropped are
     // shortcut-shaped, the snapshot has to show it knows about shortcuts at
     // all before we act on that.
+    //
+    // What this cannot do is tell that apart from a library that genuinely has
+    // no shortcuts — somebody who removed EmuDeck and kept the collection. Two
+    // independent sources feed `source: "shortcut"` (the on-disk
+    // `shortcuts.vdf` scan and Steam's own `type-shortcut`/`type-rom` sets),
+    // so both would have to be wrong at once for the guard to fire on a real
+    // library; but when it does fire, refusing is still the right way round —
+    // the ids are inert either way, and pruning them is the only irreversible
+    // move available. So the message says what is true and what to do, rather
+    // than promising that waiting will fix it. It said "yet" and "in a
+    // moment", which for that user is never.
     const looksLikeShortcut = (appId: string) => Number(appId) > 2 ** 31;
     if (
       staleAppIds.some(looksLikeShortcut) &&
       !snapshot.games.some((g) => g.source === "shortcut")
     ) {
       throw new Error(
-        "Steam hasn't listed your non-Steam shortcuts yet, and most of what looks dead here is one. Try again in a moment.",
+        "Most of what looks dead here is a non-Steam shortcut, and your library lists none at all — " +
+          "so this can't tell entries left behind by a removed shortcut from a shortcut list that " +
+          "didn't load. If Steam is still starting up, try again once it has. If you removed those " +
+          "shortcuts for good, the collection itself is what to delete.",
       );
     }
     // Everything unknown and nothing known is what a broken read looks like,

--- a/plugins/collections/backend.ts
+++ b/plugins/collections/backend.ts
@@ -57,6 +57,22 @@ const STEAM_READ_TIMEOUT_MS = 8000;
 const GAME_LIBRARY_SERVICE = "__core:game-library";
 const PLAYTIME_PLUGIN = "playtime";
 
+/**
+ * How long the owed sync waits before trying again, per attempt. Backs off
+ * because the thing it is waiting for — Steam finishing its library load —
+ * takes seconds on a warm boot and can take a minute on a cold one, and gives
+ * up after the last entry rather than retrying for the session's lifetime.
+ */
+const OWED_RETRY_DELAYS_MS: readonly number[] = [5_000, 20_000, 60_000];
+
+/**
+ * The sync refused because the library read came back empty or degraded.
+ *
+ * A distinct type rather than a message match, so the owed-sync retry can wait
+ * out a hydrating Steam without also retrying failures that waiting cannot
+ * fix — Steam closed, the config read-only, a write rejected.
+ */
+class LibraryNotLoadedError extends Error {}
 
 /** What a sync did to one collection, for reporting it back. */
 export interface SyncChange {
@@ -127,6 +143,10 @@ export default class CollectionsBackend implements PluginBackend {
    * the user's edit from memory and from disk.
    */
   private configChain: Promise<unknown> = Promise.resolve();
+  /** The pending owed-sync retry, so unloading cancels it. */
+  private owedRetry: ReturnType<typeof setTimeout> | undefined;
+  /** Overridden in tests, which cannot wait out a real boot's worth of delay. */
+  private owedRetryDelays: readonly number[] = OWED_RETRY_DELAYS_MS;
 
   async onLoad(): Promise<void> {
     const result = await loadConfig();
@@ -141,15 +161,51 @@ export default class CollectionsBackend implements PluginBackend {
     if (this.config.mirror.autoSync && this.config.mirror.pendingSync) {
       // Load is the one automatic sync left, and it is safe here precisely
       // because nothing is on screen waiting for this backend yet.
-      void this.syncMirror().catch((err) => {
-        this.log?.warn(
-          `[collections] Owed sync still can't run: ${err instanceof Error ? err.message : err}`,
-        );
-      });
+      this._runOwedSync();
     }
   }
 
-  async onUnload(): Promise<void> {}
+  async onUnload(): Promise<void> {
+    clearTimeout(this.owedRetry);
+    this.owedRetry = undefined;
+  }
+
+  /**
+   * The owed sync, retried a few times while the library is still arriving.
+   *
+   * Plugin load is the *earliest* Steam could be up, which makes it the moment
+   * the library is least likely to have hydrated — and that is precisely what
+   * `_syncOnce`'s guard refuses on. Without a retry the one automatic sync
+   * left would give up in the first seconds of every boot and wait for the
+   * user to open the plugin.
+   *
+   * Only that one refusal is retried, and only a handful of times. Steam being
+   * *closed* is not a transient we can wait out on a handheld, and a backend
+   * that keeps retrying forever is a backend quietly writing to Steam long
+   * after anyone expected it to.
+   */
+  private _runOwedSync(attempt = 0): void {
+    void this.syncMirror().catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      const delay =
+        err instanceof LibraryNotLoadedError ? this.owedRetryDelays[attempt] : undefined;
+      if (delay === undefined) {
+        this.log?.warn(`[collections] Owed sync still can't run: ${message}`);
+        return;
+      }
+      this.log?.info(`[collections] Owed sync deferred (${message}) — retrying in ${delay}ms`);
+      this.owedRetry = setTimeout(() => {
+        this.owedRetry = undefined;
+        // Somebody may have synced by hand in the meantime, or turned
+        // auto-sync off. Either way this retry is no longer wanted.
+        if (this.config.mirror.autoSync && this.config.mirror.pendingSync) {
+          this._runOwedSync(attempt + 1);
+        }
+      }, delay);
+      // Never a reason to hold the process open.
+      (this.owedRetry as { unref?: () => void }).unref?.();
+    });
+  }
 
   // ── Config ───────────────────────────────────────────────────────────
 
@@ -365,7 +421,7 @@ export default class CollectionsBackend implements PluginBackend {
 
   // ── The grid ─────────────────────────────────────────────────────────
 
-    /**
+  /**
    * Read Steam, but never wait on it indefinitely.
    *
    * Steam being *down* is already handled — `withSteamClient` throws and the
@@ -528,11 +584,19 @@ export default class CollectionsBackend implements PluginBackend {
    *
    * Returns how many went, so the UI can report it rather than leaving the
    * user to count. Reads the collection again rather than trusting a list the
-   * UI captured: this writes the *whole* membership, and doing that from a
-   * stale copy is how you lose the entries somebody added in between.
+   * UI captured — that copy is always a moment old, and the ids named here are
+   * the ones about to be deleted. The write itself is a targeted removal
+   * (`editCollectionApps`), so entries added between the read and the write
+   * survive, as do the collection's own unresolvable ids that we did not judge
+   * dead.
    */
   async pruneLinked(id: string): Promise<{ removed: number; kept: number }> {
     this._assertWritable();
+    // A managed collection has no Steam id of its own to prune and can never
+    // hold a dead reference — its membership is recomputed from the library
+    // every time. Nothing in the UI offers this for one, but answering "there
+    // was nothing to do" beats "that collection no longer exists".
+    if (this.config.collections.some((c) => c.id === id)) return { removed: 0, kept: 0 };
     // **One** library read, used both to decide what is stale and to decide
     // whether that decision can be trusted. Reading twice — once here, once
     // inside `listGames` — meant the guard interrogated a healthy snapshot
@@ -705,7 +769,7 @@ export default class CollectionsBackend implements PluginBackend {
     summary: string;
     labels: Record<string, string>;
   }> {
-    const { plan } = await this._buildMirrorPlan();
+    const { plan } = await this._buildMirrorPlan(await this.getSnapshot());
     return {
       plan,
       summary: summarizePlan(plan),
@@ -741,7 +805,7 @@ export default class CollectionsBackend implements PluginBackend {
     const snapshot = await this.getSnapshot();
     if (snapshot.providers.appstore?.status !== "ok" || snapshot.games.length === 0) {
       await this._rememberPendingSync();
-      throw new Error(
+      throw new LibraryNotLoadedError(
         "Steam's library isn't loaded yet, so syncing now would empty your collections. It stays owed and will run once the library is there.",
       );
     }
@@ -749,7 +813,9 @@ export default class CollectionsBackend implements PluginBackend {
     let plan: MirrorPlan;
     let result: MirrorSyncResult;
     try {
-      const built = await this._buildMirrorPlan();
+      // The guarded snapshot, not a fresh one: the check above is only worth
+      // anything if it inspected the very reading these memberships come from.
+      const built = await this._buildMirrorPlan(snapshot);
       plan = built.plan;
       result = await withSteamClient(async (client) =>
         applyMirrorPlan({
@@ -807,7 +873,7 @@ export default class CollectionsBackend implements PluginBackend {
       renamed,
       deleted,
       failures,
-      changes: await this._describeChanges(plan),
+      changes: this._describeChanges(plan, snapshot),
       blocked,
     };
   }
@@ -819,16 +885,21 @@ export default class CollectionsBackend implements PluginBackend {
    * away. Surfacing them is the whole answer to "why did that game disappear":
    * a rules-driven collection dropping a game is correct, and only feels
    * arbitrary when it happens in silence.
+   *
+   * Named from the sync's own snapshot rather than a fresh read: a third
+   * reading of the library costs another `getGames` plus another CDP round
+   * trip on a handheld, and a name resolved from a *different* reading is how
+   * "3 removed" comes back as three bare app ids.
    */
-  private async _describeChanges(plan: MirrorPlan): Promise<SyncChange[]> {
+  private _describeChanges(plan: MirrorPlan, snapshot: GameMetadataSnapshot): SyncChange[] {
     const label = new Map(this.config.collections.map((c) => [c.id, c.label] as const));
     const changes: SyncChange[] = [];
 
-    // Only resolve names if something actually moved — this is a full library
-    // read, and most syncs are no-ops.
+    // Still only built when something actually moved: most syncs are no-ops,
+    // and this is a map over the whole library.
     const needsNames = plan.updates.some((u) => u.add.length + u.remove.length > 0);
     const nameOf = needsNames
-      ? new Map((await this.getSnapshot()).games.map((g) => [g.appId, g.name] as const))
+      ? new Map(snapshot.games.map((g) => [g.appId, g.name] as const))
       : new Map<string, string>();
     const names = (ids: readonly string[]) =>
       ids.slice(0, 5).map((id) => nameOf.get(id) ?? id);
@@ -877,14 +948,12 @@ export default class CollectionsBackend implements PluginBackend {
   }
 
   /**
-   * Evaluate every managed collection and diff against Steam.
+   * The plan, built against **one** reading of the config and **one** reading
+   * of the library.
    *
-   * Uses the same `evaluateCollection` the webview renders from — a second
-   * implementation here is how a collection comes to mean one thing on screen
-   * and another in Steam.
-   */
-  /**
-   * The plan, built against **one** reading of the config.
+   * Evaluates with the same `evaluateCollection` the webview renders from — a
+   * second implementation here is how a collection comes to mean one thing on
+   * screen and another in Steam.
    *
    * `this.config` used to be read twice here — once to evaluate, once to plan
    * — with two awaits in between, and this backend keeps serving RPCs across
@@ -894,9 +963,17 @@ export default class CollectionsBackend implements PluginBackend {
    * time we plan is no longer skipped, so the whole library gets written into
    * Steam under it. That is exactly the accident the `unbuilt` guard exists to
    * prevent, arriving through the back door.
+   *
+   * The library snapshot is passed **in** for the same reason, one level up:
+   * `getSnapshot` is uncached, so fetching our own here meant the caller's
+   * degraded-library guard interrogated one reading while memberships were
+   * computed from another. A `getGames` failure or a CDP timeout between the
+   * two emptied every mirrored collection with the guard reporting nothing —
+   * the same two-reads mistake `pruneLinked` had.
    */
-  private async _buildMirrorPlan(): Promise<{ plan: MirrorPlan; ledger: CollectionsConfig["mirror"]["ledger"] }> {
-    const snapshot = await this.getSnapshot();
+  private async _buildMirrorPlan(
+    snapshot: GameMetadataSnapshot,
+  ): Promise<{ plan: MirrorPlan; ledger: CollectionsConfig["mirror"]["ledger"] }> {
     const evalGames = buildEvalGames(snapshot.games);
     const now = Date.now();
 
@@ -915,7 +992,15 @@ export default class CollectionsBackend implements PluginBackend {
     for (const c of collections) {
       const result = evaluateCollection(c, evalGames, { now });
       evaluated.set(c.id, result.matched.map((g) => g.appId));
-      if (result.blockedFacts.length > 0) unevaluable.add(c.id);
+      // Only under a policy that turns `indeterminate` into a match. Under
+      // `"fail"` an unchecked rule matches *nothing*, so the collection is
+      // narrower than intended rather than wider — and refusing it there would
+      // contradict `diagnoseCollection`, which offers "exclude games we
+      // couldn't check" as the fix for exactly this and would then leave the
+      // user applying a fix that doesn't unblock the sync.
+      if (result.blockedFacts.length > 0 && c.indeterminatePolicy !== "fail") {
+        unevaluable.add(c.id);
+      }
     }
 
     const steamCollections: SteamCollectionInfo[] = await withSteamClient((client) =>

--- a/plugins/collections/backend.ts
+++ b/plugins/collections/backend.ts
@@ -543,10 +543,14 @@ export default class CollectionsBackend implements PluginBackend {
     const found = steamCollections.find((c) => c.id === id);
     if (!found) throw new Error("That collection no longer exists");
 
+    if (found.isDynamic || !found.isEditable) {
+      throw new Error("Steam works this collection out for itself, so its contents can't be edited here.");
+    }
+
     const known = new Set(snapshot.games.map((g) => g.appId));
     const staleAppIds = found.appIds.filter((appId) => !known.has(appId));
     const live = found.appIds.filter((appId) => known.has(appId));
-    if (staleAppIds.length === 0) return { removed: 0, kept: 0 };
+    if (staleAppIds.length === 0) return { removed: 0, kept: live.length };
 
     // "Stale" means *the library doesn't know this id* — which is only a safe
     // thing to act on when the library itself is trustworthy. Both sources
@@ -561,6 +565,20 @@ export default class CollectionsBackend implements PluginBackend {
     if (snapshot.providers.appstore?.status !== "ok" || snapshot.games.length === 0) {
       throw new Error(
         "Steam's library isn't fully loaded, so this can't tell a dead entry from an unread one. Try again in a moment.",
+      );
+    }
+    // A *partly* loaded library is the dangerous one: real Steam games present
+    // so the check above passes, non-Steam shortcuts absent so every ROM in an
+    // EmuDeck collection reads dead. If the ids being dropped are
+    // shortcut-shaped, the snapshot has to show it knows about shortcuts at
+    // all before we act on that.
+    const looksLikeShortcut = (appId: string) => Number(appId) > 2 ** 31;
+    if (
+      staleAppIds.some(looksLikeShortcut) &&
+      !snapshot.games.some((g) => g.source === "shortcut")
+    ) {
+      throw new Error(
+        "Steam hasn't listed your non-Steam shortcuts yet, and most of what looks dead here is one. Try again in a moment.",
       );
     }
     // Everything unknown and nothing known is what a broken read looks like,
@@ -712,6 +730,21 @@ export default class CollectionsBackend implements PluginBackend {
   private async _syncOnce(): Promise<SyncReport> {
     this._assertWritable();
     const editsBefore = this.editSeq;
+
+    // Both library sources degrade to empty on failure, and a sync rewrites
+    // whole memberships across every mirrored collection at once — so a
+    // half-loaded library doesn't produce a smaller sync, it produces one that
+    // empties every collection we own. `pruneLinked` refuses on the same
+    // signal for a far more targeted write; this is the path that needed it
+    // most, and the automatic owed-sync at load fires at exactly the moment
+    // Steam is least likely to have finished hydrating.
+    const snapshot = await this.getSnapshot();
+    if (snapshot.providers.appstore?.status !== "ok" || snapshot.games.length === 0) {
+      await this._rememberPendingSync();
+      throw new Error(
+        "Steam's library isn't loaded yet, so syncing now would empty your collections. It stays owed and will run once the library is there.",
+      );
+    }
 
     let plan: MirrorPlan;
     let result: MirrorSyncResult;
@@ -874,11 +907,15 @@ export default class CollectionsBackend implements PluginBackend {
     const namePrefix = this.config.settings.namePrefix;
 
     const evaluated = new Map<string, string[]>();
+    // Collections whose rules this build cannot answer. An unresolvable fact
+    // evaluates to `indeterminate`, which the default policy counts as a
+    // match, so the collection matches everything — the planner refuses those
+    // rather than writing a copy of the library into Steam.
+    const unevaluable = new Set<string>();
     for (const c of collections) {
-      evaluated.set(
-        c.id,
-        evaluateCollection(c, evalGames, { now }).matched.map((g) => g.appId),
-      );
+      const result = evaluateCollection(c, evalGames, { now });
+      evaluated.set(c.id, result.matched.map((g) => g.appId));
+      if (result.blockedFacts.length > 0) unevaluable.add(c.id);
     }
 
     const steamCollections: SteamCollectionInfo[] = await withSteamClient((client) =>
@@ -887,7 +924,10 @@ export default class CollectionsBackend implements PluginBackend {
 
     // The ledger travels with the plan. Applying against a second, later read
     // meant `applyToLedger` patched a ledger the plan was never built from.
-    return { plan: planMirror({ collections, evaluated, ledger, steamCollections, namePrefix }), ledger };
+    return {
+      plan: planMirror({ collections, evaluated, ledger, steamCollections, namePrefix, unevaluable }),
+      ledger,
+    };
   }
 
   // ── Internals ────────────────────────────────────────────────────────

--- a/plugins/collections/backend.ts
+++ b/plugins/collections/backend.ts
@@ -25,6 +25,7 @@ import type {
 import {
   createCollection,
   deleteCollection,
+  editCollectionApps,
   listCollections,
   readSteamLibrary,
   renameCollection,
@@ -294,13 +295,13 @@ export default class CollectionsBackend implements PluginBackend {
       return this.config;
     }
 
-    await this._setMirrorState({
-      ...this.config.mirror,
+    await this._setMirrorState((mirror) => ({
+      ...mirror,
       ledger: {
-        ...this.config.mirror.ledger,
-        entries: this.config.mirror.ledger.entries.filter((e) => e.managedId !== id),
+        ...mirror.ledger,
+        entries: mirror.ledger.entries.filter((e) => e.managedId !== id),
       },
-    });
+    }));
     return this.config;
   }
 
@@ -314,11 +315,24 @@ export default class CollectionsBackend implements PluginBackend {
     return run;
   }
 
-  private async _setMirrorState(mirror: CollectionsConfig["mirror"]): Promise<void> {
+  /**
+   * Update the mirror state, deciding what it becomes **inside** the lock.
+   *
+   * It used to take a finished `mirror` object built by the caller. That is
+   * fine when the caller snapshots and enqueues in one synchronous block, and
+   * wrong for `_markSyncOwed`, which captures before its own disk write and
+   * enqueues after it: a sync landing in that gap had its freshly-written
+   * ledger overwritten by the pre-sync copy, orphaning a collection it had
+   * just created in Steam. Taking an updater means the ledger is always the
+   * one on disk right now.
+   */
+  private async _setMirrorState(
+    update: (mirror: CollectionsConfig["mirror"]) => CollectionsConfig["mirror"],
+  ): Promise<void> {
     await this._mutateConfig(async () => {
       // Read inside the lock: a `setConfig` that landed while the sync ran is
       // already applied, and its edits must survive.
-      const next: CollectionsConfig = { ...this.config, mirror };
+      const next: CollectionsConfig = { ...this.config, mirror: update(this.config.mirror) };
       await saveConfig(next);
       this.config = next;
       this._broadcast();
@@ -346,21 +360,12 @@ export default class CollectionsBackend implements PluginBackend {
     // a sync reading it back can miss an edit that has already happened.
     this.editSeq += 1;
     if (after.mirror.pendingSync) return;
-    void this._setMirrorState({ ...after.mirror, pendingSync: true }).catch(() => {});
+    void this._setMirrorState((mirror) => ({ ...mirror, pendingSync: true })).catch(() => {});
   }
 
   // ── The grid ─────────────────────────────────────────────────────────
 
-  /**
-   * Every collection worth showing: the ones this plugin maintains, and the
-   * ones already in Steam.
-   *
-   * Linked collections are read live rather than stored, so a collection made
-   * in EmuDeck five minutes ago appears without the plugin knowing anything
-   * about it. When Steam is unreachable the managed half still renders — a
-   * smaller honest grid beats an error page.
-   */
-  /**
+    /**
    * Read Steam, but never wait on it indefinitely.
    *
    * Steam being *down* is already handled — `withSteamClient` throws and the
@@ -390,6 +395,15 @@ export default class CollectionsBackend implements PluginBackend {
     }
   }
 
+  /**
+   * Every collection worth showing: the ones this plugin maintains, and the
+   * ones already in Steam.
+   *
+   * Linked collections are read live rather than stored, so a collection made
+   * in EmuDeck five minutes ago appears without the plugin knowing anything
+   * about it. When Steam is unreachable the managed half still renders — a
+   * smaller honest grid beats an error page.
+   */
   async listAll(): Promise<{ collections: CollectionSummary[]; steamReachable: boolean }> {
     const snapshot = await this.getSnapshot();
     const evalGames = buildEvalGames(snapshot.games);
@@ -519,8 +533,19 @@ export default class CollectionsBackend implements PluginBackend {
    */
   async pruneLinked(id: string): Promise<{ removed: number; kept: number }> {
     this._assertWritable();
+    // **One** library read, used both to decide what is stale and to decide
+    // whether that decision can be trusted. Reading twice — once here, once
+    // inside `listGames` — meant the guard interrogated a healthy snapshot
+    // while the stale list came from a broken one, which is the exact
+    // combination the guard exists to refuse.
     const snapshot = await this.getSnapshot();
-    const { staleAppIds, games } = await this.listGames(id);
+    const steamCollections = await this._readSteam((c) => listCollections(c));
+    const found = steamCollections.find((c) => c.id === id);
+    if (!found) throw new Error("That collection no longer exists");
+
+    const known = new Set(snapshot.games.map((g) => g.appId));
+    const staleAppIds = found.appIds.filter((appId) => !known.has(appId));
+    const live = found.appIds.filter((appId) => known.has(appId));
     if (staleAppIds.length === 0) return { removed: 0, kept: 0 };
 
     // "Stale" means *the library doesn't know this id* — which is only a safe
@@ -529,27 +554,29 @@ export default class CollectionsBackend implements PluginBackend {
     // EmuDeck collection look dead: 700 entries, none of them in the manifest
     // scan (shortcuts have no appmanifest), all of them "prunable". Confirming
     // that dialog would empty a collection somebody else built.
-    if (snapshot.providers.appstore?.status !== "ok") {
+    // `appstore: "ok"` only means the call returned — Steam answers with an
+    // empty list while its stores are still hydrating, and that reads as a
+    // library where every owned-but-uninstalled game has vanished. Require
+    // evidence the read carried something, not merely that it completed.
+    if (snapshot.providers.appstore?.status !== "ok" || snapshot.games.length === 0) {
       throw new Error(
         "Steam's library isn't fully loaded, so this can't tell a dead entry from an unread one. Try again in a moment.",
       );
     }
     // Everything unknown and nothing known is what a broken read looks like,
     // not what a collection with some dead shortcuts looks like.
-    if (games.length === 0) {
+    if (live.length === 0) {
       throw new Error(
         "Every entry in this collection looks unreadable, which usually means the library is still loading rather than that they are all dead.",
       );
     }
 
-    const steamCollections = await this._readSteam((c) => listCollections(c));
-    const found = steamCollections.find((c) => c.id === id);
-    if (!found) throw new Error("That collection no longer exists");
-
-    const stale = new Set(staleAppIds);
-    const keep = found.appIds.filter((appId) => !stale.has(appId));
-    await withSteamClient((c) => setCollectionApps(c, { collectionId: id, appIds: keep }));
-    return { removed: found.appIds.length - keep.length, kept: keep.length };
+    // A targeted removal, not a rewrite: the ids being dropped are precisely
+    // the ones just judged dead, and nothing else in the collection is named.
+    await withSteamClient((c) =>
+      editCollectionApps(c, { collectionId: id, remove: staleAppIds }),
+    );
+    return { removed: staleAppIds.length, kept: live.length };
   }
 
   /**
@@ -564,7 +591,10 @@ export default class CollectionsBackend implements PluginBackend {
    * degraded, writing it back truncated the collection to whatever the UI
    * happened to be showing.
    *
-   * Re-reading here means the only thing that changes is what was asked for.
+   * The delta goes all the way down: `editCollectionApps` names the ids to add
+   * and remove rather than handing Steam a membership to converge on, so an
+   * entry EmuDeck adds between our read and Steam's evaluate survives — and so
+   * do the unresolvable ids the UI never saw.
    */
   async editLinked(
     id: string,
@@ -573,17 +603,10 @@ export default class CollectionsBackend implements PluginBackend {
     this._assertWritable();
     if (add.length === 0 && remove.length === 0) throw new Error("Nothing to change");
 
-    const steamCollections = await this._readSteam((c) => listCollections(c));
-    const found = steamCollections.find((c) => c.id === id);
-    if (!found) throw new Error("That collection no longer exists");
-
-    const dropped = new Set(remove);
-    const kept = found.appIds.filter((appId) => !dropped.has(appId));
-    const present = new Set(kept);
-    const appIds = [...kept, ...add.filter((appId) => !present.has(appId))];
-
-    await withSteamClient((c) => setCollectionApps(c, { collectionId: id, appIds }));
-    return { count: appIds.length };
+    const info = await withSteamClient((c) =>
+      editCollectionApps(c, { collectionId: id, add, remove }),
+    );
+    return { count: info.appIds.length };
   }
 
   async renameLinked(id: string, name: string): Promise<void> {
@@ -664,7 +687,7 @@ export default class CollectionsBackend implements PluginBackend {
     summary: string;
     labels: Record<string, string>;
   }> {
-    const plan = await this._buildMirrorPlan();
+    const { plan } = await this._buildMirrorPlan();
     return {
       plan,
       summary: summarizePlan(plan),
@@ -693,11 +716,12 @@ export default class CollectionsBackend implements PluginBackend {
     let plan: MirrorPlan;
     let result: MirrorSyncResult;
     try {
-      plan = await this._buildMirrorPlan();
+      const built = await this._buildMirrorPlan();
+      plan = built.plan;
       result = await withSteamClient(async (client) =>
         applyMirrorPlan({
           plan,
-          ledger: this.config.mirror.ledger,
+          ledger: built.ledger,
           ops: mirrorOps(client),
           now: Date.now(),
         }),
@@ -709,8 +733,8 @@ export default class CollectionsBackend implements PluginBackend {
       throw err;
     }
 
-    await this._setMirrorState({
-      ...this.config.mirror,
+    await this._setMirrorState((mirror) => ({
+      ...mirror,
       ledger: result.ledger,
       // Only clear the flag when everything landed. Steam dying *after* the
       // session connects makes each write fail individually, which the
@@ -721,7 +745,7 @@ export default class CollectionsBackend implements PluginBackend {
       // record it as synced and leave Steam quietly wrong until something
       // unrelated triggered another sync.
       pendingSync: result.failures.length > 0 || this.editSeq !== editsBefore,
-    });
+    }));
 
     const { created, updated, renamed, deleted, failures } = result;
     if (failures.length > 0) {
@@ -813,7 +837,7 @@ export default class CollectionsBackend implements PluginBackend {
   private async _rememberPendingSync(): Promise<void> {
     if (this.config.mirror.pendingSync) return;
     try {
-      await this._setMirrorState({ ...this.config.mirror, pendingSync: true });
+      await this._setMirrorState((mirror) => ({ ...mirror, pendingSync: true }));
     } catch {
       // The original failure is the one worth reporting.
     }
@@ -838,7 +862,7 @@ export default class CollectionsBackend implements PluginBackend {
    * Steam under it. That is exactly the accident the `unbuilt` guard exists to
    * prevent, arriving through the back door.
    */
-  private async _buildMirrorPlan(): Promise<MirrorPlan> {
+  private async _buildMirrorPlan(): Promise<{ plan: MirrorPlan; ledger: CollectionsConfig["mirror"]["ledger"] }> {
     const snapshot = await this.getSnapshot();
     const evalGames = buildEvalGames(snapshot.games);
     const now = Date.now();
@@ -861,7 +885,9 @@ export default class CollectionsBackend implements PluginBackend {
       listCollections(client),
     );
 
-    return planMirror({ collections, evaluated, ledger, steamCollections, namePrefix });
+    // The ledger travels with the plan. Applying against a second, later read
+    // meant `applyToLedger` patched a ledger the plan was never built from.
+    return { plan: planMirror({ collections, evaluated, ledger, steamCollections, namePrefix }), ledger };
   }
 
   // ── Internals ────────────────────────────────────────────────────────

--- a/plugins/collections/components/AddGamesPage.spec.tsx
+++ b/plugins/collections/components/AddGamesPage.spec.tsx
@@ -60,6 +60,17 @@ describe("browsing the library", () => {
     expect(screen.getAllByText("Installed").length).toBe(2);
   });
 
+  it("won't claim the library is exhausted before it has been read", () => {
+    // The empty list and the unread library look identical from here, and
+    // "every game in your library is already in this collection" is a
+    // confident statement of fact about somebody's library. `getSnapshot`
+    // never rejects — both its sources degrade to empty — so the unread case
+    // arrives as an ordinary empty candidate list and needs saying apart.
+    renderPage({ candidates: [], libraryLoaded: false });
+    expect(screen.queryByText(/already in this collection/)).toBeNull();
+    expect(screen.getByText(/Reading your library/)).toBeTruthy();
+  });
+
   it("says when there is nothing left to add", () => {
     renderPage({ candidates: [] });
     expect(screen.getByText(/already in this collection/)).toBeTruthy();

--- a/plugins/collections/components/AddGamesPage.tsx
+++ b/plugins/collections/components/AddGamesPage.tsx
@@ -29,6 +29,7 @@ import {
   IconButton,
   PluginHeader,
   SearchField,
+  Spinner,
   Text,
   pushBackInterceptor,
 } from "@loadout/ui";
@@ -47,6 +48,15 @@ export interface AddGamesPageProps {
   label: string;
   /** Everything in the library, already excluding current members. */
   candidates: readonly AddGamesCandidate[];
+  /**
+   * Whether the library snapshot has arrived.
+   *
+   * Without it, a snapshot that failed or hadn't landed produced an empty
+   * candidate list and the page said "every game in your library is already in
+   * this collection" — a confident, false statement about the user's library,
+   * dressed as an ordinary empty state.
+   */
+  libraryLoaded?: boolean;
   onBack: () => void;
   onAdd: (appIds: string[]) => void;
 }
@@ -54,7 +64,13 @@ export interface AddGamesPageProps {
 const artUrl = (appId: string, kind: "capsule" | "header") =>
   `http://localhost:33820/api/steam-grid/${appId}/${kind}`;
 
-export function AddGamesPage({ label, candidates, onBack, onAdd }: AddGamesPageProps) {
+export function AddGamesPage({
+  label,
+  candidates,
+  libraryLoaded = true,
+  onBack,
+  onAdd,
+}: AddGamesPageProps) {
   const [filter, setFilter] = useState("");
   const [chosen, setChosen] = useState<readonly string[]>([]);
 
@@ -141,7 +157,12 @@ export function AddGamesPage({ label, candidates, onBack, onAdd }: AddGamesPageP
         </div>
       </PluginHeader>
 
-      {candidates.length === 0 ? (
+      {!libraryLoaded ? (
+        <div className="flex items-center gap-2">
+          <Spinner size={16} />
+          <Text variant="secondary">Reading your library…</Text>
+        </div>
+      ) : candidates.length === 0 ? (
         <Text variant="secondary">
           Every game in your library is already in this collection.
         </Text>

--- a/plugins/collections/components/CollectionDetail.spec.tsx
+++ b/plugins/collections/components/CollectionDetail.spec.tsx
@@ -151,6 +151,23 @@ describe("removing games", () => {
     expect(header.getByRole("button", { name: "Keep it" })).toBeTruthy();
   });
 
+  it("keeps the confirm from growing without bound in the header", () => {
+    // That button is a whole sentence in a `shrink-0` row. A ROM-manager name
+    // plus a 180px filter beside it pushes the part that matters — what
+    // survives — off the edge of a handheld's header, so the name is bounded
+    // and the filter steps aside while the confirm is up.
+    const long = "Nintendo 64 (ROMs, no-intro, verified dumps)";
+    const { header } = renderDetail({ label: long });
+    expect(screen.queryByPlaceholderText(/Filter/)).toBeTruthy();
+
+    fireEvent.click(header.getByRole("button", { name: "Remove collection" }));
+    const confirm = header.getByText(/^Delete/);
+    expect(confirm.textContent!.length).toBeLessThan(long.length + 40);
+    // Still says what survives — that is the whole point of the sentence.
+    expect(confirm.textContent).toMatch(/3 games stay in your library/);
+    expect(screen.queryByPlaceholderText(/Filter/)).toBeNull();
+  });
+
   it("disarms the bin when you go into select mode", () => {
     // Otherwise you come back from picking games to a live delete button armed
     // by an intent expressed several interactions ago.

--- a/plugins/collections/components/CollectionDetail.spec.tsx
+++ b/plugins/collections/components/CollectionDetail.spec.tsx
@@ -128,6 +128,40 @@ describe("removing games", () => {
     expect(screen.queryByRole("button", { name: "Options" })).toBeNull();
   });
 
+  it("says how many picks the filter is hiding, before you confirm", () => {
+    // Picks survive a filter change on purpose. Without this count, narrowing
+    // the view after picking removes games that aren't on screen and nothing
+    // says so — the grid doesn't even change afterwards, because the filter is
+    // still applied.
+    renderDetail();
+    enterEditMode();
+    fireEvent.click(screen.getByText("Hades"));
+    filter("celeste");
+    expect(screen.getByText("1 picked · 1 not shown")).toBeTruthy();
+  });
+
+  it("names the collection and what survives before deleting it", () => {
+    // Trigger and confirm used to share an accessible name and a screen slot,
+    // so two quick presses on what reads as one control destroyed it.
+    const { header } = renderDetail();
+    fireEvent.click(header.getByRole("button", { name: "Remove collection" }));
+    expect(header.queryByRole("button", { name: "Remove collection" })).toBeNull();
+    expect(header.getByText(/Delete .*Emulation.*3 games stay in your library/)).toBeTruthy();
+    // The safe option comes first now.
+    expect(header.getByRole("button", { name: "Keep it" })).toBeTruthy();
+  });
+
+  it("disarms the bin when you go into select mode", () => {
+    // Otherwise you come back from picking games to a live delete button armed
+    // by an intent expressed several interactions ago.
+    const { header } = renderDetail();
+    fireEvent.click(header.getByRole("button", { name: "Remove collection" }));
+    enterEditMode();
+    fireEvent.click(header.getByRole("button", { name: "Done" }));
+    expect(header.getByRole("button", { name: "Remove collection" })).toBeTruthy();
+    expect(header.queryByText(/Delete .*Emulation/)).toBeNull();
+  });
+
   it("still filters while picking, so a long collection stays usable", () => {
     const h = renderDetail();
     enterEditMode();

--- a/plugins/collections/components/CollectionDetail.tsx
+++ b/plugins/collections/components/CollectionDetail.tsx
@@ -133,6 +133,16 @@ export function CollectionDetail({
     return selected.filter((id) => !visible.has(id)).length;
   }, [selected, shown]);
 
+  /**
+   * The name as it appears *inside* the delete confirm, bounded.
+   *
+   * That button already carries a whole sentence, and it sits in a `shrink-0`
+   * header row — so an EmuDeck-style "Nintendo 64 (ROMs, no-intro)" pushes the
+   * part that matters ("…stay in your library") off the edge. The full name is
+   * in the heading directly above it, which is where it belongs.
+   */
+  const shortLabel = label.length > 24 ? `${label.slice(0, 23)}…` : label;
+
   const rowWindow = useVisibleRows({
     total: shown?.length ?? 0,
     gridWrapperRef,
@@ -176,7 +186,12 @@ export function CollectionDetail({
           <div className="flex items-center gap-2 shrink-0">
             {/* A long ROM collection is unusable without this: 700+ tiles is
                 not something you scroll to the middle of with a thumbstick. */}
-            {games !== null && games.length > 0 ? (
+            {/* Hidden while the delete confirm is up: that confirm is a
+                sentence, not an icon, and this row is `shrink-0` — 180px of
+                filter beside it is what pushes a long collection name off the
+                edge of a handheld's header. Filtering is not the task at that
+                moment anyway. */}
+            {games !== null && games.length > 0 && !confirmingDelete ? (
               <SearchField
                 value={filter}
                 onChange={setFilter}
@@ -187,20 +202,25 @@ export function CollectionDetail({
             ) : null}
             {editing ? (
               <>
-                <Button
-                  variant="danger"
-                  disabled={selected.length === 0 || !onRemoveGames}
-                  onClick={() => {
-                    if (!onRemoveGames) return;
-                    onRemoveGames([...selected]);
-                    setSelected([]);
-                    setEditing(false);
-                  }}
-                >
-                  {selected.length === 0
-                    ? "Remove from collection"
-                    : `Remove ${selected.length} from collection`}
-                </Button>
+                {/* Gated on the handler rather than disabled by it: a disabled
+                    button that could never have been reached is a branch no
+                    test can cover, and the Done button below has to stay
+                    outside the gate so edit mode always has an exit. */}
+                {onRemoveGames ? (
+                  <Button
+                    variant="danger"
+                    disabled={selected.length === 0}
+                    onClick={() => {
+                      onRemoveGames([...selected]);
+                      setSelected([]);
+                      setEditing(false);
+                    }}
+                  >
+                    {selected.length === 0
+                      ? "Remove from collection"
+                      : `Remove ${selected.length} from collection`}
+                  </Button>
+                ) : null}
                 <IconButton
                   onClick={() => {
                     setEditing(false);
@@ -247,8 +267,8 @@ export function CollectionDetail({
                 </Button>
                 <Button variant="danger" onClick={onDelete}>
                   {games === null
-                    ? `Delete “${label}”`
-                    : `Delete “${label}” (${games.length} games stay in your library)`}
+                    ? `Delete “${shortLabel}”`
+                    : `Delete “${shortLabel}” (${games.length} games stay in your library)`}
                 </Button>
               </>
             ) : (

--- a/plugins/collections/components/CollectionDetail.tsx
+++ b/plugins/collections/components/CollectionDetail.tsx
@@ -125,10 +125,13 @@ export function CollectionDetail({
 
   const selectedSet = useMemo(() => new Set(selected), [selected]);
   /** Picked, but filtered out of view — the removals you cannot see. */
-  const hiddenPicked = useMemo(
-    () => (shown ? selected.filter((id) => !shown.some((g) => g.appId === id)).length : 0),
-    [selected, shown],
-  );
+  const hiddenPicked = useMemo(() => {
+    if (!shown) return 0;
+    // A set, not a scan per pick: this recomputes on every keystroke, and the
+    // collection this component exists for holds 700 entries.
+    const visible = new Set(shown.map((g) => g.appId));
+    return selected.filter((id) => !visible.has(id)).length;
+  }, [selected, shown]);
 
   const rowWindow = useVisibleRows({
     total: shown?.length ?? 0,
@@ -213,10 +216,12 @@ export function CollectionDetail({
             {onRemoveGames && !editing ? (
               <IconButton
                 onClick={() => {
-                  // Disarm: the confirm is hidden while editing, and coming
-                  // back to a live delete button from an intent expressed
-                  // several interactions ago is one press from disaster.
+                  // Disarm both: the confirms are hidden while editing, and
+                  // coming back to a live destructive button from an intent
+                  // expressed several interactions ago is one press from
+                  // disaster.
                   setConfirmingDelete(false);
+                  setConfirmingCleanUp(false);
                   setEditing(true);
                 }}
                 title="Edit collection"

--- a/plugins/collections/components/CollectionDetail.tsx
+++ b/plugins/collections/components/CollectionDetail.tsx
@@ -124,6 +124,11 @@ export function CollectionDetail({
   }, [games, filter]);
 
   const selectedSet = useMemo(() => new Set(selected), [selected]);
+  /** Picked, but filtered out of view — the removals you cannot see. */
+  const hiddenPicked = useMemo(
+    () => (shown ? selected.filter((id) => !shown.some((g) => g.appId === id)).length : 0),
+    [selected, shown],
+  );
 
   const rowWindow = useVisibleRows({
     total: shown?.length ?? 0,
@@ -153,7 +158,13 @@ export function CollectionDetail({
                 : editing
                   ? selected.length === 0
                     ? "Pick the ones to remove"
-                    : `${selected.length} picked`
+                    : hiddenPicked > 0
+                      ? // The count that matters when a filter is on: picks
+                        // survive it, so confirming can remove games that are
+                        // not on screen. Saying only "3 picked" while showing
+                        // one tile is how that goes unnoticed.
+                        `${selected.length} picked · ${hiddenPicked} not shown`
+                      : `${selected.length} picked`
                   : shown && shown.length !== games.length
                     ? `${shown.length} of ${games.length} games`
                     : `${games.length} games`}
@@ -175,9 +186,10 @@ export function CollectionDetail({
               <>
                 <Button
                   variant="danger"
-                  disabled={selected.length === 0}
+                  disabled={selected.length === 0 || !onRemoveGames}
                   onClick={() => {
-                    onRemoveGames?.([...selected]);
+                    if (!onRemoveGames) return;
+                    onRemoveGames([...selected]);
                     setSelected([]);
                     setEditing(false);
                   }}
@@ -200,7 +212,13 @@ export function CollectionDetail({
             ) : null}
             {onRemoveGames && !editing ? (
               <IconButton
-                onClick={() => setEditing(true)}
+                onClick={() => {
+                  // Disarm: the confirm is hidden while editing, and coming
+                  // back to a live delete button from an intent expressed
+                  // several interactions ago is one press from disaster.
+                  setConfirmingDelete(false);
+                  setEditing(true);
+                }}
                 title="Edit collection"
                 ariaLabel="Edit collection"
               >
@@ -214,16 +232,19 @@ export function CollectionDetail({
                 press is the one that acts. */}
             {editing ? null : confirmingDelete ? (
               <>
-                <Button variant="danger" onClick={onDelete}>
-                  Remove collection
+                {/* "Keep it" first, and the destructive button renamed and
+                    told to say what it destroys: the trigger and its
+                    confirmation used to share an accessible name *and* a
+                    screen position, so two quick presses on what reads as one
+                    control deleted a 700-entry collection. */}
+                <Button variant="neutral" onClick={() => setConfirmingDelete(false)}>
+                  Keep it
                 </Button>
-                <IconButton
-                  onClick={() => setConfirmingDelete(false)}
-                  title="Keep it"
-                  ariaLabel="Keep it"
-                >
-                  <FaXmark size={13} />
-                </IconButton>
+                <Button variant="danger" onClick={onDelete}>
+                  {games === null
+                    ? `Delete “${label}”`
+                    : `Delete “${label}” (${games.length} games stay in your library)`}
+                </Button>
               </>
             ) : (
               <IconButton

--- a/plugins/collections/components/NewCollectionPage.spec.tsx
+++ b/plugins/collections/components/NewCollectionPage.spec.tsx
@@ -96,6 +96,26 @@ describe("while a collection is being built", () => {
     expect(screen.getByText(/Building “Never played”/)).toBeTruthy();
   });
 
+  it("doesn't blame the library for a read that hasn't finished", () => {
+    // Until the snapshot lands nothing can be priced, and `metadataNeedsMet`
+    // sees an empty library — so every preset that reads anything came back
+    // "Needs play history", which blames the user's library for an outage of
+    // ours. It also left the D-pad with nothing to reach on the page.
+    renderPage({ libraryLoaded: false });
+    expect(screen.queryByText(/Needs play history/)).toBeNull();
+    expect(screen.getByText(/Reading your library/)).toBeTruthy();
+    // Blocked while it arrives, rather than pickable against nothing.
+    expect(screen.getByRole("button", { name: /Most played/ }).hasAttribute("disabled")).toBe(true);
+  });
+
+  it("prices and offers them once it has", () => {
+    renderPage();
+    expect(screen.queryByText(/Reading your library/)).toBeNull();
+    expect(screen.getByRole("button", { name: /Most played/ }).hasAttribute("disabled")).toBe(
+      false,
+    );
+  });
+
   it("locks every other preset too, not just the one pressed", () => {
     renderPage();
     fireEvent.click(screen.getByRole("button", { name: /Never played/ }));

--- a/plugins/collections/components/NewCollectionPage.tsx
+++ b/plugins/collections/components/NewCollectionPage.tsx
@@ -263,12 +263,12 @@ function PresetRow({
     : !libraryLoaded
       ? "…"
       : unavailable
-      ? `Needs ${missing.join(" and ")}`
-      : alreadyExists
-        ? "You have this one"
-        : count === 0
-          ? "Nothing matches — yet"
-          : `→ ${count} game${count === 1 ? "" : "s"}`;
+        ? `Needs ${missing.join(" and ")}`
+        : alreadyExists
+          ? "You have this one"
+          : count === 0
+            ? "Nothing matches — yet"
+            : `→ ${count} game${count === 1 ? "" : "s"}`;
 
   return (
     <button

--- a/plugins/collections/components/NewCollectionPage.tsx
+++ b/plugins/collections/components/NewCollectionPage.tsx
@@ -18,7 +18,7 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
-import { Button, Text, TextInput, useFocusable } from "@loadout/ui";
+import { Button, Spinner, Text, TextInput, useFocusable } from "@loadout/ui";
 import { BuilderPage } from "./BuilderPage";
 import { evaluateCollection } from "../lib/evaluate";
 import { NEED_LABELS, metadataNeedsMet, presets, unmetNeeds } from "../lib/presets";
@@ -30,6 +30,14 @@ export interface NewCollectionPageProps {
   existingNames: readonly string[];
   /** The library, for pricing each preset. Empty until the snapshot lands. */
   games: readonly EvalGame[];
+  /**
+   * Whether the library snapshot has arrived.
+   *
+   * Until it has, `metadataNeedsMet` sees nothing and every preset that reads
+   * anything is greyed out with "Needs play history" — blaming the user's
+   * library for an outage of ours, and leaving the D-pad nothing to reach.
+   */
+  libraryLoaded?: boolean;
   /** Facts a resolver can supply — decides whether HowLongToBeat is offered. */
   availableFacts?: ReadonlySet<FactKey>;
   onBack: () => void;
@@ -60,6 +68,7 @@ interface PricedPreset {
 export function NewCollectionPage({
   existingNames,
   games,
+  libraryLoaded = true,
   availableFacts,
   onBack,
   onPickPreset,
@@ -179,11 +188,20 @@ export function NewCollectionPage({
 
       <section className="flex flex-col gap-2 border-t border-base-300 pt-3">
         <Text variant="secondary">Or start from a preset</Text>
+        {!libraryLoaded ? (
+          <div className="flex items-center gap-2">
+            <Spinner size={16} />
+            <Text variant="secondary">
+              Reading your library — presets are priced against it, so they arrive in a moment.
+            </Text>
+          </div>
+        ) : null}
         <div className="flex flex-col gap-1.5">
           {priced.map((p) => (
             <PresetRow
               key={p.preset.id}
               priced={p}
+              libraryLoaded={libraryLoaded}
               alreadyExists={taken(p.preset.label)}
               busy={picked === p.preset.id}
               locked={busy}
@@ -206,12 +224,15 @@ export function NewCollectionPage({
  */
 function PresetRow({
   priced,
+  libraryLoaded,
   alreadyExists,
   busy,
   locked,
   onPick,
 }: {
   priced: PricedPreset;
+  /** False while the snapshot is still coming; nothing is priced yet. */
+  libraryLoaded: boolean;
   alreadyExists: boolean;
   /** This is the one being made. */
   busy: boolean;
@@ -220,11 +241,13 @@ function PresetRow({
   onPick: () => void;
 }) {
   const { preset, count, missing } = priced;
-  const unavailable = missing.length > 0;
+  // While the library is still arriving nothing can be priced, and "Needs play
+  // history" would be blaming the user for our own outage.
+  const unavailable = libraryLoaded && missing.length > 0;
   // A preset that cannot work here, or that duplicates a collection you
   // already have, is still shown — with the reason. Dropping it silently
   // invites the question of where it went.
-  const blocked = unavailable || alreadyExists || locked;
+  const blocked = !libraryLoaded || unavailable || alreadyExists || locked;
   // `focusable: !blocked` matters as much as the disabled attribute: a
   // disabled control left in the focus tree is one the D-pad stops on and A
   // does nothing to, which reads as the plugin having hung.
@@ -237,7 +260,9 @@ function PresetRow({
 
   const note = busy
     ? "Building it…"
-    : unavailable
+    : !libraryLoaded
+      ? "…"
+      : unavailable
       ? `Needs ${missing.join(" and ")}`
       : alreadyExists
         ? "You have this one"

--- a/plugins/collections/components/RuleBuilder.spec.tsx
+++ b/plugins/collections/components/RuleBuilder.spec.tsx
@@ -297,6 +297,21 @@ describe("RuleBuilder — the palette", () => {
     expect(onSave).not.toHaveBeenCalled();
   });
 
+  it("takes the card the D-pad can't use out of the way", () => {
+    // Refusing the press is only half of it: a control the stick stops on and
+    // A does nothing to reads as the plugin having hung. `PresetRow` gates its
+    // focus the same way and says so.
+    renderBuilder(tab([]));
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+
+    const blocked = screen.getAllByRole("button", { name: /How long to beat/ })[0]!;
+    expect(blocked.hasAttribute("disabled")).toBe(true);
+    // And a rule that simply matches nothing right now is still pickable —
+    // "0 games" is information, not a broken rule.
+    const installed = screen.getAllByRole("button", { name: /Installed/ })[0]!;
+    expect(installed.hasAttribute("disabled")).toBe(false);
+  });
+
   it("adds the picked rule to the tree", () => {
     const { onSave } = renderBuilder(tab([]));
     fireEvent.click(screen.getByRole("button", { name: "Add rule" }));

--- a/plugins/collections/components/RuleBuilder.spec.tsx
+++ b/plugins/collections/components/RuleBuilder.spec.tsx
@@ -37,11 +37,18 @@ function withHeader(ui: React.ReactElement) {
   return render(<PluginHeaderSlotProvider slot={slot}>{ui}</PluginHeaderSlotProvider>);
 }
 
-function renderBuilder(t: ManagedCollection) {
+function renderBuilder(t: ManagedCollection, props: { libraryLoaded?: boolean } = {}) {
   const onSave = mock((_: ManagedCollection) => {});
   const onCancel = mock(() => {});
   const view = withHeader(
-    <RuleBuilder collection={t} games={games} onSave={onSave} onCancel={onCancel} now={NOW} />,
+    <RuleBuilder
+      collection={t}
+      games={games}
+      onSave={onSave}
+      onCancel={onCancel}
+      now={NOW}
+      {...props}
+    />,
   );
   return { onSave, onCancel, view };
 }
@@ -333,6 +340,32 @@ describe("RuleBuilder — diagnostics", () => {
     expect(screen.getByText(/never both be true/i)).toBeTruthy();
   });
 
+  it("won't diagnose the rules against a library that is still arriving", () => {
+    // Every diagnosis on this screen reads "your rules are wrong". Said about
+    // a half-read library they are all wrong themselves, and wrong in the
+    // direction that sends somebody editing rules that were fine — the same
+    // "reported as facts about the user's library" mistake the pages beside
+    // it were fixed for.
+    renderBuilder(
+      tab([{ id: "a", kind: "installed" }, { id: "b", kind: "installed", invert: true }]),
+      { libraryLoaded: false },
+    );
+    expect(screen.queryByText(/never both be true/i)).toBeNull();
+    expect(screen.getByText(/Still reading your library/i)).toBeTruthy();
+  });
+
+  it("leaves the palette unpriced until then, rather than pricing it at zero", () => {
+    // "→ 0 games" is read as a fact about the rule, not about the read.
+    renderBuilder(tab([]), { libraryLoaded: false });
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    expect(screen.queryByText(/→ \d+ games?/)).toBeNull();
+  });
+
+  it("prices it once the library is there", () => {
+    renderBuilder(tab([]));
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    expect(screen.getAllByText(/→ \d+ games?/).length).toBeGreaterThan(0);
+  });
 });
 
 describe("RuleBuilder — generated rule ids", () => {

--- a/plugins/collections/components/RuleBuilder.spec.tsx
+++ b/plugins/collections/components/RuleBuilder.spec.tsx
@@ -211,6 +211,23 @@ describe("RuleBuilder — row actions", () => {
     openRowMenu(/Actions for Only these games/);
     expect(screen.queryByRole("button", { name: "Invert" })).toBeNull();
   });
+
+  it("offers no invert on a range rule, where it would match the unknowns", () => {
+    // `matchRange` resolves the -1 "unknown" sentinel to a definite false, and
+    // invert flips it to true — so "NOT played 2 hours or less" would collect
+    // every game whose playtime couldn't be read. The registry marks these
+    // non-invertible and the rule editor honoured it; the row menu used its
+    // own guess (`kind !== whitelist && kind !== blacklist`).
+    renderBuilder(tab([{ id: "p", kind: "playtime", minutes: { max: 120 } }]));
+    openRowMenu(/Actions for /);
+    expect(screen.queryByRole("button", { name: "Invert" })).toBeNull();
+  });
+
+  it("still offers invert where the registry allows it", () => {
+    renderBuilder(tab([{ id: "i", kind: "installed" }]));
+    openRowMenu(/Actions for /);
+    expect(screen.getByRole("button", { name: "Invert" })).toBeTruthy();
+  });
 });
 
 describe("RuleBuilder — the palette", () => {
@@ -262,6 +279,22 @@ describe("RuleBuilder — the palette", () => {
     const dialog = screen.getByRole("region", { name: "Test tab" });
     const card = within(dialog).getByText("Friends playing now").closest("button");
     expect(card?.textContent).not.toContain("Needs Steam friends data");
+  });
+
+  it("won't add a rule whose data nothing supplies", () => {
+    // The card is dimmed and says why, but pressing it used to insert the rule
+    // anyway — and a rule reading a fact no resolver answers evaluates to
+    // `indeterminate`, which the default policy counts as a match. The
+    // collection silently became the whole library.
+    const { onSave } = renderBuilder(tab([]));
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+
+    const blocked = screen.getAllByRole("button", { name: /How long to beat/ })[0]!;
+    fireEvent.click(blocked);
+
+    // Still on the palette, nothing inserted.
+    expect(screen.getByRole("button", { name: /How long to beat/ })).toBeTruthy();
+    expect(onSave).not.toHaveBeenCalled();
   });
 
   it("adds the picked rule to the tree", () => {

--- a/plugins/collections/components/RuleBuilder.tsx
+++ b/plugins/collections/components/RuleBuilder.tsx
@@ -29,7 +29,7 @@ import { countMatches, evaluateCollection } from "../lib/evaluate";
 import { diagnoseCollection } from "../lib/diagnose";
 import { ruleCandidate } from "../lib/rule-params";
 import type { ParamOption } from "../lib/rule-params";
-import { RULE_KINDS, factUnavailableReason, requiredFacts } from "../lib/rules";
+import { RULE_KINDS, factUnavailableReason, requiredFacts, ruleDef } from "../lib/rules";
 import {
   asRoot,
   duplicateRule,
@@ -254,7 +254,12 @@ export function RuleBuilder({
     (rule: Rule): RuleRowAction[] => {
       const parent = findParent(draft.root, rule.id);
       const at = parent?.children.findIndex((c) => c.id === rule.id) ?? -1;
-      const invertible = rule.kind !== "whitelist" && rule.kind !== "blacklist";
+      // The registry decides, not a local guess. Inverting a range rule turns
+      // "unknown" into a match — `matchRange` resolves the `-1` sentinel to a
+      // definite false, which invert flips to true — so "NOT played 2 hours or
+      // less" would collect every game whose playtime we couldn't read. The
+      // rule editor already gated on this flag; the row menu did not.
+      const invertible = rule.kind !== "group" && ruleDef(rule.kind)?.invertible === true;
 
       const close = () => setMenuOpenId(null);
       const apply = (next: Rule) => {
@@ -371,6 +376,11 @@ export function RuleBuilder({
           onPick={(candidate) => {
             const parentId = paletteParent;
             if (parentId === null) return;
+            // The card is dimmed and says why, but pressing it used to insert
+            // the rule anyway — and a rule whose fact nothing resolves passes
+            // every game, so the collection silently became the whole library
+            // and was mirrored into Steam that way.
+            if (candidate.unavailable) return;
             const rule = { ...candidate.rule, id: newId() } as Rule;
             setRoot(insertRule({ root: draft.root, parentId, rule }));
             setPaletteParent(null);

--- a/plugins/collections/components/RuleBuilder.tsx
+++ b/plugins/collections/components/RuleBuilder.tsx
@@ -59,6 +59,16 @@ function isInverted(rule: Rule): boolean {
 export interface RuleBuilderProps {
   collection: ManagedCollection;
   games: readonly EvalGame[];
+  /**
+   * Whether `games` is the whole library or whatever had arrived.
+   *
+   * Everything on this screen is a number priced against it — "→ 30 games",
+   * "Nothing in your library matches this rule", "try widening a range". Said
+   * about a half-read library they are all wrong, and wrong in the direction
+   * that sends somebody editing rules that were fine. The counts go quiet
+   * until the library is there.
+   */
+  libraryLoaded?: boolean;
   onSave: (collection: ManagedCollection) => void;
   onCancel: () => void;
   /**
@@ -100,6 +110,7 @@ function collectGroups(rule: Rule, into: GroupRule[] = []): GroupRule[] {
 export function RuleBuilder({
   collection,
   games,
+  libraryLoaded = true,
   onSave,
   onCancel,
   onDelete,
@@ -182,28 +193,36 @@ export function RuleBuilder({
     () =>
       diagnoseCollection(draft, result, {
         librarySize: games.length,
+        libraryLoaded,
         flippedCombinatorCount:
           groupCounts.get(draft.root.id)?.[
             draft.root.combinator === "all" ? "any" : "all"
           ] ?? 0,
       }),
-    [draft, result, games.length, groupCounts],
+    [draft, result, games.length, groupCounts, libraryLoaded],
   );
 
-  /** Count the collection would show with `rule` swapped in — used by the editor. */
+  /**
+   * Count the collection would show with `rule` swapped in — used by the
+   * editor. `null` while the library is still arriving: the editor turns a
+   * zero into "saving this will empty the collection", which is a claim about
+   * the user's library rather than about their rule.
+   */
   const countFor = useCallback(
     (rule: Rule) =>
-      countMatches(
-        {
-          root: asRoot({
-            candidate: replaceRule({ root: draft.root, id: rule.id, next: rule }),
-            fallback: draft.root,
-          }),
-          indeterminatePolicy: draft.indeterminatePolicy,
-        },
-        games,
-      ),
-    [draft.root, draft.indeterminatePolicy, games],
+      libraryLoaded
+        ? countMatches(
+            {
+              root: asRoot({
+                candidate: replaceRule({ root: draft.root, id: rule.id, next: rule }),
+                fallback: draft.root,
+              }),
+              indeterminatePolicy: draft.indeterminatePolicy,
+            },
+            games,
+          )
+        : null,
+    [draft.root, draft.indeterminatePolicy, games, libraryLoaded],
   );
 
   // The palette prices ~32 candidates. Deferring keeps the tree interactive
@@ -230,6 +249,10 @@ export function RuleBuilder({
       }
 
       if (candidate.needsInput) return candidate;
+      // Unpriced rather than priced against a partial library: "→ 0 games" is
+      // read as a fact about the rule, and `PricedCandidate` already renders
+      // an absent total as no claim at all.
+      if (!libraryLoaded) return candidate;
       const withCandidate = insertRule({
         root: deferredRoot,
         parentId: paletteParent,
@@ -246,7 +269,16 @@ export function RuleBuilder({
         ),
       };
     });
-  }, [paletteParent, deferredRoot, draft.root, draft.indeterminatePolicy, games, now, availableFacts]);
+  }, [
+    paletteParent,
+    deferredRoot,
+    draft.root,
+    draft.indeterminatePolicy,
+    games,
+    libraryLoaded,
+    now,
+    availableFacts,
+  ]);
 
   // ── Actions ────────────────────────────────────────────────────────
 

--- a/plugins/collections/components/RuleEditorPage.tsx
+++ b/plugins/collections/components/RuleEditorPage.tsx
@@ -24,9 +24,13 @@ export interface RuleEditorPageProps {
   onSave: (next: Rule) => void;
   /**
    * Live count for a candidate rule. The builder supplies this because only
-   * it knows the surrounding tab and library.
+   * it knows the surrounding collection and library.
+   *
+   * `null` means *not knowable yet* — the library is still arriving — which is
+   * a different thing from zero, and has to stay different: zero is what turns
+   * into "saving this will empty the collection".
    */
-  countFor: (rule: Rule) => number;
+  countFor: (rule: Rule) => number | null;
   /** Options for `picker` params, keyed by source. */
   pickerOptions?: {
     game?: readonly ParamOption[];
@@ -128,7 +132,11 @@ export function RuleEditorPage({
           </label>
         ) : null}
 
-        {count === 0 && complete ? (
+        {count === null && complete ? (
+          <p className="text-xs text-base-content/55">
+            Still reading your library — the match count arrives with it.
+          </p>
+        ) : count === 0 && complete ? (
           <p className="text-xs text-warning">
             Nothing in your library matches this rule on its own. Saving it
             will empty the collection unless the group uses ANY.

--- a/plugins/collections/components/RuleEditorPage.tsx
+++ b/plugins/collections/components/RuleEditorPage.tsx
@@ -131,7 +131,7 @@ export function RuleEditorPage({
         {count === 0 && complete ? (
           <p className="text-xs text-warning">
             Nothing in your library matches this rule on its own. Saving it
-            will empty the tab unless the group uses ANY.
+            will empty the collection unless the group uses ANY.
           </p>
         ) : null}
       </div>

--- a/plugins/collections/components/RulePalette.tsx
+++ b/plugins/collections/components/RulePalette.tsx
@@ -162,8 +162,17 @@ function CandidateCard({
   currentTotal: number;
   onPick: () => void;
 }) {
-  const { ref, focused } = useFocusable({ onEnterPress: onPick });
-  const zero = candidate.total === 0 || candidate.unavailable !== undefined;
+  // A rule whose data nothing supplies cannot be added at all — `RuleBuilder`
+  // refuses the pick, because such a rule matches every game and would mirror
+  // the whole library into Steam. Taking it out of the focus tree matters as
+  // much as the refusal: a control the D-pad stops on and A does nothing to
+  // reads as the plugin having hung. `PresetRow` gates the same way, for the
+  // same reason.
+  const unavailable = candidate.unavailable !== undefined;
+  const { ref, focused } = useFocusable({ onEnterPress: onPick, focusable: !unavailable });
+  // Dimmed for either reason; only the unavailable one is unpickable. A rule
+  // that currently matches nothing is still a rule you may want.
+  const zero = candidate.total === 0 || unavailable;
 
   const consequence = (() => {
     if (candidate.unavailable) return candidate.unavailable;
@@ -177,6 +186,7 @@ function CandidateCard({
     <button
       ref={ref as React.Ref<HTMLButtonElement>}
       type="button"
+      disabled={unavailable}
       onClick={onPick}
       className={[
         "flex w-full min-h-[44px] flex-col items-start gap-1 rounded-lg border p-3 text-left",

--- a/plugins/collections/lib/diagnose.test.ts
+++ b/plugins/collections/lib/diagnose.test.ts
@@ -94,6 +94,43 @@ describe("diagnoseCollection — over-capped", () => {
   });
 });
 
+describe("diagnoseCollection — the advice it gives", () => {
+  it("tells you to widen a range rule, not to delete it", () => {
+    // The check was `"range" in r`, and no rule variant has a `range`
+    // property — only the three date kinds were recognised, so every other
+    // range rule was told to remove itself when widening was the fix.
+    const collection = collectionWith([
+      { id: "a", kind: "playtime", minutes: { min: 999_999 } },
+    ]);
+    const diagnosis = diagnose(collection);
+    expect(diagnosis.message + JSON.stringify(diagnosis)).toMatch(/widen/i);
+  });
+
+  it("does not claim an unchecked rule matches everything under a fail policy", () => {
+    // Under "fail" an unchecked rule matches *nothing* — the collection is
+    // narrower, not wider, and the fix offered alongside says exactly that.
+    // Two rules under ANY: the unchecked one contributes nothing, the other
+    // matches — so the collection has games *and* a blocked fact, which is the
+    // only combination where the sentence gets appended at all.
+    const collection = {
+      // Combinator is the *third* argument; passing it second silently made
+      // this an ALL group, where the unchecked rule zeroes the collection and
+      // the sentence is never appended — so the test proved nothing.
+      ...collectionWith(
+        [
+          { id: "a", kind: "hltbMain", hours: { max: 10 } },
+          { id: "b", kind: "installed" },
+        ],
+        {},
+        "any",
+      ),
+      indeterminatePolicy: "fail" as const,
+    };
+    const diagnosis = diagnose(collection);
+    expect(diagnosis.message).not.toMatch(/wider than it looks/);
+  });
+});
+
 describe("diagnoseCollection — blocked-facts", () => {
   it("still reports them when the collection looks full", () => {
     // The dangerous case, and the one that used to return `ok`: an

--- a/plugins/collections/lib/diagnose.test.ts
+++ b/plugins/collections/lib/diagnose.test.ts
@@ -95,6 +95,21 @@ describe("diagnoseCollection — over-capped", () => {
 });
 
 describe("diagnoseCollection — blocked-facts", () => {
+  it("still reports them when the collection looks full", () => {
+    // The dangerous case, and the one that used to return `ok`: an
+    // unanswerable rule passes every game under the default policy, so the
+    // collection matches the whole library and reads as healthy — then gets
+    // mirrored into Steam that way.
+    const collection = collectionWith([{ id: "a", kind: "hltbMain", hours: { max: 10 } }]);
+    const result = evaluateCollection(collection, evalLibrary, { trace: true });
+    expect(result.matched.length).toBe(evalLibrary.length);
+
+    const diagnosis = diagnose(collection);
+    expect(diagnosis.kind).toBe("blocked-facts");
+    expect(diagnosis.message).toMatch(/wider than it looks/);
+  });
+
+
   const blocked = buildEvalGames(LIBRARY, {
     protonTier: new Map(
       LIBRARY.map((g) => [

--- a/plugins/collections/lib/diagnose.test.ts
+++ b/plugins/collections/lib/diagnose.test.ts
@@ -146,7 +146,6 @@ describe("diagnoseCollection — blocked-facts", () => {
     expect(diagnosis.message).toMatch(/wider than it looks/);
   });
 
-
   const blocked = buildEvalGames(LIBRARY, {
     protonTier: new Map(
       LIBRARY.map((g) => [

--- a/plugins/collections/lib/diagnose.ts
+++ b/plugins/collections/lib/diagnose.ts
@@ -172,6 +172,17 @@ export interface DiagnoseContext {
   /** Total games in the library, before any rule ran. */
   librarySize: number;
   /**
+   * Whether that library can be believed.
+   *
+   * `librarySize` alone cannot tell a small library from a half-read one:
+   * Steam's own read degrades to *some* games — the installed ones — long
+   * before it has the owned set, so a thin snapshot arrives non-empty and
+   * every diagnosis below becomes a confident claim about somebody's library
+   * built on a partial read of it. Defaults to `true` for callers that have no
+   * way of knowing; the ones that do should pass it.
+   */
+  libraryLoaded?: boolean;
+  /**
    * Match count the tab would have with the root combinator flipped.
    * Supplied by the caller because computing it needs another evaluation
    * pass, and only the editor needs it.
@@ -218,11 +229,17 @@ export function diagnoseCollection(
     return { kind: "ok" };
   }
 
-  // 1. Nothing to filter.
-  if (ctx.librarySize === 0) {
+  // 1. Nothing to filter, or nothing we can trust. Both outrank every rule
+  //    diagnosis below: those all read "your rules are wrong", and saying that
+  //    about a library we haven't finished reading sends people editing rules
+  //    that were fine.
+  if (ctx.librarySize === 0 || ctx.libraryLoaded === false) {
     return {
       kind: "empty-library",
-      message: "Your library hasn't been scanned yet",
+      message:
+        ctx.librarySize === 0
+          ? "Your library hasn't been scanned yet"
+          : "Still reading your library — counts and warnings arrive with it",
       fixes: [],
     };
   }

--- a/plugins/collections/lib/diagnose.ts
+++ b/plugins/collections/lib/diagnose.ts
@@ -25,6 +25,7 @@
 import type { EvalResult, RuleNodeTrace } from "./evaluate";
 import type { FactKey, GroupRule, Rule, ManagedCollection } from "./types";
 import { leafRules } from "./rules";
+import { paramSpecs } from "./rule-params";
 import { asRoot, removeRule } from "./rule-tree";
 import { summarizeRule } from "./summarize";
 
@@ -192,8 +193,15 @@ export function diagnoseCollection(
   ctx: DiagnoseContext,
 ): Diagnosis {
   // A tab that is showing games needs no explanation — except when the cap
-  // is hiding most of them, which surprises people.
-  if (result.matched.length > 0) {
+  // is hiding most of them, which surprises people, and except when a rule
+  // couldn't be checked at all.
+  //
+  // That second exception is the important one: `indeterminate` resolves to a
+  // match under the default policy, so a rule reading a fact no resolver
+  // supplies passes *every* game. The collection looks healthy, quietly
+  // contains the whole library, and gets mirrored into Steam that way. Exiting
+  // here on "it has matches" is what hid it.
+  if (result.matched.length > 0 && result.blockedFacts.length === 0) {
     if (
       tab.limit !== null &&
       result.cappedOut > 0 &&
@@ -241,7 +249,10 @@ export function diagnoseCollection(
       message:
         `${ruleCount} rule${ruleCount === 1 ? "" : "s"} couldn't be checked: ` +
         // The resolver's own sentence, verbatim — it knows why.
-        reasons.join(" "),
+        reasons.join(" ") +
+        (result.matched.length > 0
+          ? ` Until that data arrives ${ruleCount === 1 ? "it matches" : "they match"} everything, so this is wider than it looks.`
+          : ""),
       fixes:
         tab.indeterminatePolicy === "fail"
           ? [FIX_IGNORE_UNCHECKED]
@@ -300,7 +311,14 @@ export function diagnoseCollection(
   // Only suggest widening when there is something to widen. A tab whose one
   // rule is `familyShared` has no range anywhere in the tree, and telling its
   // owner to widen one sends them looking for a control that isn't there.
-  const hasRange = leafRules(tab.root).some((r) => "range" in r || "epochSec" in r);
+  // No rule variant has a `range` property — ranges are named `minutes`,
+  // `bytes`, `percent`, `score`, `hours`, `epochSec`. Testing for one meant
+  // only the three date kinds were recognised and every other range rule was
+  // told to remove itself when widening a bound was the actual fix. The
+  // registry already knows which params are ranges.
+  const hasRange = leafRules(tab.root).some((r) =>
+    paramSpecs(r.kind).some((spec) => spec.control === "range"),
+  );
   return {
     kind: "genuinely-empty",
     message: hasRange

--- a/plugins/collections/lib/diagnose.ts
+++ b/plugins/collections/lib/diagnose.ts
@@ -250,7 +250,7 @@ export function diagnoseCollection(
         `${ruleCount} rule${ruleCount === 1 ? "" : "s"} couldn't be checked: ` +
         // The resolver's own sentence, verbatim — it knows why.
         reasons.join(" ") +
-        (result.matched.length > 0
+        (result.matched.length > 0 && tab.indeterminatePolicy !== "fail"
           ? ` Until that data arrives ${ruleCount === 1 ? "it matches" : "they match"} everything, so this is wider than it looks.`
           : ""),
       fixes:

--- a/plugins/collections/lib/evaluate.ts
+++ b/plugins/collections/lib/evaluate.ts
@@ -372,6 +372,16 @@ export function evaluateCollection(
  * rule palette, which needs ~30 counts per keystroke and cares only about
  * the number.
  */
+/**
+ * How many games the rules match, **before** `limit`.
+ *
+ * Deliberately uncapped: the builder prices candidates with this, and a
+ * palette that said "→ 30 games" because a cap is set would be describing the
+ * cap rather than the rule. The consequence is that any surface claiming to
+ * show what the collection will *hold* must use {@link evaluateCollection},
+ * which does apply the cap — the two numbers are different questions and this
+ * one answers the rule's.
+ */
 export function countMatches(
   tab: Pick<ManagedCollection, "root" | "indeterminatePolicy">,
   games: readonly EvalGame[],

--- a/plugins/collections/lib/evaluate.ts
+++ b/plugins/collections/lib/evaluate.ts
@@ -368,12 +368,10 @@ export function evaluateCollection(
 }
 
 /**
- * Count matches for a tab without sorting, grouping or tracing. Used by the
- * rule palette, which needs ~30 counts per keystroke and cares only about
- * the number.
- */
-/**
  * How many games the rules match, **before** `limit`.
+ *
+ * No sorting, grouping or tracing: the rule palette needs ~30 of these per
+ * keystroke and cares only about the number.
  *
  * Deliberately uncapped: the builder prices candidates with this, and a
  * palette that said "→ 30 games" because a cap is set would be describing the

--- a/plugins/collections/lib/mirror.test.ts
+++ b/plugins/collections/lib/mirror.test.ts
@@ -637,7 +637,9 @@ describe("mirrorAffecting — when auto-sync should fire", () => {
 
   it("fires when a game override changes", () => {
     // Whitelists and blacklists live here and change membership directly.
-    expect(mirrorAffecting(config(), config({ gameOverrides: { "440": { pin: true } } }))).toBe(
+    expect(
+      mirrorAffecting(config(), config({ gameOverrides: { "440": { hidden: true } } })),
+    ).toBe(
       true,
     );
   });
@@ -653,10 +655,31 @@ describe("mirrorAffecting — when auto-sync should fire", () => {
     expect(mirrorAffecting(config(), config())).toBe(false);
   });
 
-  it("does not fire when a tab is merely hidden from the strip", () => {
-    // A concealed tab still evaluates and still mirrors — hiding it must not
-    // empty its Steam collection.
-    expect(mirrorAffecting(config(), config({ collections: [managed({ visible: false })] }))).toBe(false);
+  it("watches every field of a collection that could change its membership", () => {
+    // The projection is a whitelist, and its doc comment used to claim the
+    // opposite ("a new field is included by default"). A field added to
+    // `ManagedCollection` and forgotten here means editing it never marks a
+    // sync owed, and Steam goes quietly stale. Fail here rather than there.
+    const watched = new Set([
+      "id",
+      "label",
+      "root",
+      "sort",
+      "limit",
+      "manualOrder",
+      "indeterminatePolicy",
+    ]);
+    // Fields that genuinely cannot change what Steam holds.
+    const cosmetic = new Set(["display", "icon"]);
+
+    const sample = managed();
+    for (const key of Object.keys(sample)) {
+      expect(
+        watched.has(key) || cosmetic.has(key),
+        `\`${key}\` is neither watched by project() nor listed as cosmetic — ` +
+          "if it can change membership, add it to the projection",
+      ).toBe(true);
+    }
   });
 
   it("does not fire when only the tile size changed", () => {

--- a/plugins/collections/lib/mirror.test.ts
+++ b/plugins/collections/lib/mirror.test.ts
@@ -30,7 +30,7 @@ function managed(overrides: Partial<ManagedCollection> = {}): ManagedCollection 
     display: { tileWidth: 150, showLabels: true, badges: [] },
     indeterminatePolicy: "pass",
     ...overrides,
-  } as ManagedCollection;
+  };
 }
 
 function collection(overrides: Partial<SteamCollection> = {}): SteamCollection {
@@ -149,6 +149,22 @@ describe("planMirror — a collection with no rules", () => {
       steamCollections: [collection({ appIds: ["1"] })],
     });
     expect(plan.deletes).toHaveLength(1);
+  });
+
+  it("tells one already in Steam what its state actually is", () => {
+    // The refusal for an unmirrored collection describes an accident being
+    // prevented. For one Steam already holds — mirrored by a build that had no
+    // such guard, so its Steam collection *is* the whole library right now —
+    // "would put your whole library in Steam" describes a thing that has
+    // already happened, and offers nothing to do about it.
+    const plan = planMirror({
+      collections: [empty()],
+      evaluated: new Map([["t1", ["1", "2"]]]),
+      ledger: ledger(entry({ appIds: ["1"] })),
+      steamCollections: [collection({ appIds: ["1"] })],
+    });
+    expect(plan.skipped[0]?.reason).not.toMatch(/would match/);
+    expect(plan.skipped[0]?.reason).toMatch(/left exactly as it is|delete it/i);
   });
 
   it("does not hold the name against a real collection", () => {
@@ -658,27 +674,53 @@ describe("mirrorAffecting — when auto-sync should fire", () => {
   it("watches every field of a collection that could change its membership", () => {
     // The projection is a whitelist, and its doc comment used to claim the
     // opposite ("a new field is included by default"). A field added to
-    // `ManagedCollection` and forgotten here means editing it never marks a
+    // `ManagedCollection` and forgotten there means editing it never marks a
     // sync owed, and Steam goes quietly stale. Fail here rather than there.
-    const watched = new Set([
-      "id",
-      "label",
-      "root",
-      "sort",
-      "limit",
-      "manualOrder",
-      "indeterminatePolicy",
-    ]);
-    // Fields that genuinely cannot change what Steam holds.
-    const cosmetic = new Set(["display", "icon"]);
+    //
+    // The *existence* of a classification for every field is enforced by
+    // `COLLECTION_FIELDS` in `mirror.ts` — a `Record<keyof
+    // ManagedCollection, …>` in a compiled module, so a new field fails the
+    // build. It has to live there rather than here: `tsconfig.json` excludes
+    // `*.test.ts`, so the same map in this file would never be typechecked and
+    // would prove nothing at all.
+    //
+    // What's left for a test is whether the classification is *true* — that
+    // every field called membership-affecting really does move the projection,
+    // and every cosmetic one really doesn't.
+    const FIELDS: Record<string, "watched" | "cosmetic"> = {
+      id: "watched",
+      label: "watched",
+      root: "watched",
+      sort: "watched",
+      limit: "watched",
+      manualOrder: "watched",
+      indeterminatePolicy: "watched",
+      // Fields that genuinely cannot change what Steam holds.
+      display: "cosmetic",
+      icon: "cosmetic",
+    };
 
-    const sample = managed();
-    for (const key of Object.keys(sample)) {
+    const changed: Partial<Record<keyof ManagedCollection, ManagedCollection>> = {
+      id: managed({ id: "t2" }),
+      label: managed({ label: "Later" }),
+      root: managed({ root: { kind: "group", id: "g", combinator: "any", children: [] } }),
+      sort: managed({ sort: [{ field: "name", dir: "asc" }] }),
+      limit: managed({ limit: 10 }),
+      manualOrder: managed({ manualOrder: ["440"] }),
+      indeterminatePolicy: managed({ indeterminatePolicy: "fail" }),
+      display: managed({ display: { tileWidth: 200, showLabels: false, badges: [] } }),
+      icon: managed({ icon: "FaStar" }),
+    };
+
+    for (const [key, role] of Object.entries(FIELDS)) {
+      const after = changed[key as keyof ManagedCollection];
+      expect(after, `no sample edit for \`${key}\``).toBeDefined();
       expect(
-        watched.has(key) || cosmetic.has(key),
-        `\`${key}\` is neither watched by project() nor listed as cosmetic — ` +
-          "if it can change membership, add it to the projection",
-      ).toBe(true);
+        mirrorAffecting(config(), config({ collections: [after!] })),
+        role === "watched"
+          ? `changing \`${key}\` must mark a sync owed — add it to project()`
+          : `\`${key}\` is listed as cosmetic but changing it marks a sync owed`,
+      ).toBe(role === "watched");
     }
   });
 

--- a/plugins/collections/lib/mirror.ts
+++ b/plugins/collections/lib/mirror.ts
@@ -348,9 +348,16 @@ export function planMirror(args: PlanMirrorArgs): MirrorPlan {
  * ledger through the same config setter that triggers auto-sync, so without a
  * check on *what* changed the mirror would sync itself in a loop forever.
  *
- * Compared as a projection rather than field-by-field, so a new field on `Tab`
- * is included by default. Being too eager here costs a redundant sync; being
- * too lazy leaves Steam silently stale, which is the failure users can't see.
+ * Compared as a **projection**, which means the field list below is a
+ * whitelist, not a default. A new membership-affecting field on
+ * {@link ManagedCollection} — an exclude list, a per-collection cap — will not
+ * mark a sync owed until it is added to `project()`, and Steam then goes
+ * silently stale, which is the failure users can't see. `mirror.test.ts`
+ * enumerates the type's keys against the projection so adding one fails the
+ * build rather than the user's library.
+ *
+ * Being too eager costs a redundant sync; being too lazy costs correctness, so
+ * when in doubt, include the field.
  */
 export function mirrorAffecting(
   before: MirrorRelevantConfig,

--- a/plugins/collections/lib/mirror.ts
+++ b/plugins/collections/lib/mirror.ts
@@ -1,11 +1,12 @@
 /**
  * What syncing the mirror *would* do.
  *
- * This is the whole reason tabs can appear in Steam's own UI without patching
- * Steam. TabMaster injects itself into the library's React tree by hot-swapping
- * the `useMemo` dispatcher; when that breaks, the library becomes unreachable
- * and users report rebooting nineteen times. We write real Steam collections
- * instead, which Steam renders natively and which survive us being uninstalled.
+ * This is the whole reason a collection built here appears in Steam's own UI
+ * without patching Steam. TabMaster injects itself into the library's React
+ * tree by hot-swapping the `useMemo` dispatcher; when that breaks, the library
+ * becomes unreachable and users report rebooting nineteen times. We write real
+ * Steam collections instead, which Steam renders natively and which survive us
+ * being uninstalled.
  *
  * The planner is **pure and CDP-free** for two reasons. It is the part that can
  * destroy user data — a wrong id here deletes a collection someone spent an
@@ -14,8 +15,8 @@
  * possible if planning and executing are separate steps.
  *
  * Identity comes from the ledger, never from a collection's name. Names are the
- * user's; matching on them would let a tab called "Backlog" quietly take over a
- * collection the user made by hand years ago.
+ * user's; matching on them would let a collection called "Backlog" quietly take
+ * over one the user made by hand years ago.
  */
 
 import type { MirrorLedger, MirrorLedgerEntry, ManagedCollection } from "./types";

--- a/plugins/collections/lib/mirror.ts
+++ b/plugins/collections/lib/mirror.ts
@@ -90,6 +90,17 @@ export interface PlanMirrorArgs {
   steamCollections: readonly SteamCollection[];
   /** Optional prefix for the collection name. Empty by default. */
   namePrefix?: string;
+  /**
+   * Managed ids whose rules this build cannot actually evaluate — a rule
+   * reading a fact no resolver supplies.
+   *
+   * Such a rule returns `indeterminate`, which the default policy counts as a
+   * match, so the collection quietly matches the **whole library**. Writing
+   * that to Steam is the same accident `unbuilt` exists to prevent, reached by
+   * a different door: the rule looks built, and the membership looks huge
+   * because it is.
+   */
+  unevaluable?: ReadonlySet<string>;
 }
 
 function emptyPlan(): MirrorPlan {
@@ -132,7 +143,14 @@ export function collectionNameFor(
  * a collection and reusing the old name in the same sync doesn't collide.
  */
 export function planMirror(args: PlanMirrorArgs): MirrorPlan {
-  const { collections, evaluated, ledger, steamCollections, namePrefix = "" } = args;
+  const {
+    collections,
+    evaluated,
+    ledger,
+    steamCollections,
+    namePrefix = "",
+    unevaluable = new Set<string>(),
+  } = args;
   const plan = emptyPlan();
 
   const steamById = new Map(steamCollections.map((c) => [c.id, c]));
@@ -156,6 +174,20 @@ export function planMirror(args: PlanMirrorArgs): MirrorPlan {
    */
   const unbuilt = (collection: ManagedCollection) => collection.root.children.length === 0;
 
+  /** Why this collection must not be written, or null if it may be. */
+  const refuse = (collection: ManagedCollection): string | null => {
+    if (unbuilt(collection)) {
+      return `"${collection.label}" has no rules yet, so it would match your whole library.`;
+    }
+    if (unevaluable.has(collection.id)) {
+      return (
+        `"${collection.label}" has a rule this build can't check, and an unchecked rule ` +
+        `matches everything — so syncing it would put your whole library in Steam.`
+      );
+    }
+    return null;
+  };
+
   // Two passes, because a create has to know what the renames will free.
   // Swapping two collections' names is otherwise reported as a conflict
   // forever: the new one's name is held by a collection that is, in this very
@@ -165,11 +197,9 @@ export function planMirror(args: PlanMirrorArgs): MirrorPlan {
   for (const collection of collections) {
     const entry = ledgerByManaged.get(collection.id);
     if (!entry) continue;
-    if (unbuilt(collection)) {
-      plan.skipped.push({
-        managedId: collection.id,
-        reason: `"${collection.label}" has no rules yet, so it would match your whole library.`,
-      });
+    const refusal = refuse(collection);
+    if (refusal) {
+      plan.skipped.push({ managedId: collection.id, reason: refusal });
       continue;
     }
 
@@ -272,11 +302,9 @@ export function planMirror(args: PlanMirrorArgs): MirrorPlan {
   // Pass 2 — collections with no Steam collection yet.
   for (const collection of collections) {
     if (ledgerByManaged.has(collection.id)) continue;
-    if (unbuilt(collection)) {
-      plan.skipped.push({
-        managedId: collection.id,
-        reason: `"${collection.label}" has no rules yet, so it would match your whole library.`,
-      });
+    const refusal = refuse(collection);
+    if (refusal) {
+      plan.skipped.push({ managedId: collection.id, reason: refusal });
       continue;
     }
 

--- a/plugins/collections/lib/mirror.ts
+++ b/plugins/collections/lib/mirror.ts
@@ -174,16 +174,32 @@ export function planMirror(args: PlanMirrorArgs): MirrorPlan {
    */
   const unbuilt = (collection: ManagedCollection) => collection.root.children.length === 0;
 
-  /** Why this collection must not be written, or null if it may be. */
-  const refuse = (collection: ManagedCollection): string | null => {
+  /**
+   * Why this collection must not be written, or null if it may be.
+   *
+   * `mirrored` changes what the refusal is *about*. For a collection Steam has
+   * never seen, refusing prevents the accident. For one already in Steam —
+   * mirrored by an earlier build that had no such guard, so its Steam
+   * collection is the whole library right now — refusing only stops it getting
+   * worse, and saying "would put your whole library in Steam" describes a
+   * thing that has already happened. Say what is actually true, and what to do
+   * about it: this planner never deletes on the user's behalf.
+   */
+  const refuse = (collection: ManagedCollection, mirrored: boolean): string | null => {
     if (unbuilt(collection)) {
-      return `"${collection.label}" has no rules yet, so it would match your whole library.`;
+      return mirrored
+        ? `"${collection.label}" has no rules, so it is left exactly as it is in Steam. ` +
+            `Add a rule to sync it, or delete it to remove it from Steam.`
+        : `"${collection.label}" has no rules yet, so it would match your whole library.`;
     }
     if (unevaluable.has(collection.id)) {
-      return (
+      const why =
         `"${collection.label}" has a rule this build can't check, and an unchecked rule ` +
-        `matches everything — so syncing it would put your whole library in Steam.`
-      );
+        `matches every game.`;
+      return mirrored
+        ? `${why} Its Steam collection is left as it is — which may be your whole library, ` +
+            `if it was synced before. Delete it, or change the rule.`
+        : `${why} Syncing it would put your whole library in Steam.`;
     }
     return null;
   };
@@ -197,7 +213,7 @@ export function planMirror(args: PlanMirrorArgs): MirrorPlan {
   for (const collection of collections) {
     const entry = ledgerByManaged.get(collection.id);
     if (!entry) continue;
-    const refusal = refuse(collection);
+    const refusal = refuse(collection, true);
     if (refusal) {
       plan.skipped.push({ managedId: collection.id, reason: refusal });
       continue;
@@ -302,7 +318,7 @@ export function planMirror(args: PlanMirrorArgs): MirrorPlan {
   // Pass 2 — collections with no Steam collection yet.
   for (const collection of collections) {
     if (ledgerByManaged.has(collection.id)) continue;
-    const refusal = refuse(collection);
+    const refusal = refuse(collection, false);
     if (refusal) {
       plan.skipped.push({ managedId: collection.id, reason: refusal });
       continue;
@@ -348,16 +364,15 @@ export function planMirror(args: PlanMirrorArgs): MirrorPlan {
  * ledger through the same config setter that triggers auto-sync, so without a
  * check on *what* changed the mirror would sync itself in a loop forever.
  *
- * Compared as a **projection**, which means the field list below is a
- * whitelist, not a default. A new membership-affecting field on
- * {@link ManagedCollection} — an exclude list, a per-collection cap — will not
- * mark a sync owed until it is added to `project()`, and Steam then goes
- * silently stale, which is the failure users can't see. `mirror.test.ts`
- * enumerates the type's keys against the projection so adding one fails the
- * build rather than the user's library.
+ * Compared as a **projection**, which means the field list is a whitelist, not
+ * a default. A new membership-affecting field on {@link ManagedCollection} —
+ * an exclude list, a per-collection cap — would not mark a sync owed until
+ * somebody remembered to add it, and Steam then goes silently stale, which is
+ * the failure users can't see. {@link COLLECTION_FIELDS} is what stops that
+ * being a matter of remembering.
  *
  * Being too eager costs a redundant sync; being too lazy costs correctness, so
- * when in doubt, include the field.
+ * when in doubt, classify the field as `membership`.
  */
 export function mirrorAffecting(
   before: MirrorRelevantConfig,
@@ -374,18 +389,41 @@ export interface MirrorRelevantConfig {
   mirror: { autoSync: boolean };
 }
 
+/**
+ * Every field of a managed collection, classified by whether changing it can
+ * change what Steam ends up holding.
+ *
+ * Keyed on `keyof ManagedCollection` and **in a compiled module**, not a test:
+ * `tsconfig.json` excludes `*.test.ts`, so the same map in a spec file would
+ * never be typechecked and a new field would sail past it. Here, adding one to
+ * the type fails the build until somebody classifies it — which is the whole
+ * point, since the alternative failure is silent and lands on the user's Steam
+ * library.
+ */
+const COLLECTION_FIELDS: Record<keyof ManagedCollection, "membership" | "cosmetic"> = {
+  id: "membership",
+  // The name reaches Steam, so a rename is a sync-worthy change.
+  label: "membership",
+  root: "membership",
+  sort: "membership",
+  limit: "membership",
+  manualOrder: "membership",
+  indeterminatePolicy: "membership",
+  display: "cosmetic",
+  icon: "cosmetic",
+};
+
+const MEMBERSHIP_FIELDS = (Object.keys(COLLECTION_FIELDS) as Array<keyof ManagedCollection>).filter(
+  (key) => COLLECTION_FIELDS[key] === "membership",
+);
+
 function project(config: MirrorRelevantConfig) {
   return {
-    collections: config.collections.map((c) => ({
-      id: c.id,
-      // The name reaches Steam, so a rename is a sync-worthy change.
-      label: c.label,
-      root: c.root,
-      sort: c.sort,
-      limit: c.limit,
-      manualOrder: c.manualOrder,
-      policy: c.indeterminatePolicy,
-    })),
+    // Derived from the classification rather than restating it: two lists that
+    // have to agree eventually don't.
+    collections: config.collections.map((c) =>
+      Object.fromEntries(MEMBERSHIP_FIELDS.map((key) => [key, c[key]])),
+    ),
     // Whitelists and blacklists live here, so they change membership.
     overrides: config.gameOverrides,
     prefix: config.settings.namePrefix,

--- a/plugins/collections/lib/presets.test.ts
+++ b/plugins/collections/lib/presets.test.ts
@@ -122,6 +122,15 @@ describe("what the library can answer", () => {
     );
   });
 
+  it("doesn't count Deck compatibility as known when every game says 'unknown'", () => {
+    // `deckCompat` is non-nullable and the no-AppStore fallback hard-codes
+    // "unknown", so a presence test was true on a library that knows nothing —
+    // "Deck Verified" was offered, priced, and came back empty.
+    const blank = LIBRARY.map((g) => ({ ...g, deckCompat: "unknown" }));
+    expect(metadataNeedsMet(blank).has("deckCompat")).toBe(false);
+    expect(metadataNeedsMet(LIBRARY).has("deckCompat")).toBe(true);
+  });
+
   it("only offers HowLongToBeat when its plugin is supplying the fact", () => {
     expect(metadataNeedsMet(LIBRARY).has("hltb")).toBe(false);
     expect(metadataNeedsMet(LIBRARY, new Set(["hltbMain" as const])).has("hltb")).toBe(true);

--- a/plugins/collections/lib/presets.ts
+++ b/plugins/collections/lib/presets.ts
@@ -233,12 +233,12 @@ export function presets(now: number = Math.floor(Date.now() / 1000)): Collection
       label: "Recently added",
       description: "Everything that arrived in your library this month",
       needs: ["purchaseDate"],
+      // Sorted by release date rather than purchase date: `SortField` has no
+      // `purchasedAt`, and newest-released is the closest honest proxy for
+      // "what just arrived".
       build: (id) =>
         make(id, "Recently added", [
           { id: rid(id, 1), kind: "purchaseDate", epochSec: { min: now - 30 * DAY } },
-          // Sorted by release date rather than purchase date: `SortField` has
-          // no `purchasedAt`, and newest-released is the closest honest proxy
-          // for "what just arrived".
         ], { sort: [{ field: "releaseDate", dir: "desc" }] }),
     },
     {

--- a/plugins/collections/lib/presets.ts
+++ b/plugins/collections/lib/presets.ts
@@ -144,7 +144,7 @@ export function presets(now: number = Math.floor(Date.now() / 1000)): Collection
     {
       id: "barely-started",
       label: "Barely started",
-      description: "Opened once, played under 20 minutes — did they deserve longer?",
+      description: "Opened once, 20 minutes or less — did they deserve longer?",
       needs: ["playHistory"],
       build: (id) =>
         // `min: 1` matters: without it every never-played game qualifies, and
@@ -177,7 +177,7 @@ export function presets(now: number = Math.floor(Date.now() / 1000)): Collection
     {
       id: "most-played",
       label: "Most played",
-      description: "The ones you keep coming back to — over 10 hours in",
+      description: "The ones you keep coming back to — 10 hours or more",
       needs: ["playHistory"],
       build: (id) =>
         make(id, "Most played", [
@@ -236,12 +236,15 @@ export function presets(now: number = Math.floor(Date.now() / 1000)): Collection
       build: (id) =>
         make(id, "Recently added", [
           { id: rid(id, 1), kind: "purchaseDate", epochSec: { min: now - 30 * DAY } },
+          // Sorted by release date rather than purchase date: `SortField` has
+          // no `purchasedAt`, and newest-released is the closest honest proxy
+          // for "what just arrived".
         ], { sort: [{ field: "releaseDate", dir: "desc" }] }),
     },
     {
       id: "space-hogs",
       label: "Space hogs",
-      description: "Installed and over 20 GB — start here when you're short on space",
+      description: "Installed and 20 GB or more — start here when you're short on space",
       needs: ["sizeOnDisk"],
       build: (id) =>
         make(id, "Space hogs", [
@@ -313,7 +316,13 @@ export function metadataNeedsMet(
   if (some((g) => (g.sizeOnDisk ?? -1) > 0)) met.add("sizeOnDisk");
   if (some((g) => (g.reviewPercentage ?? -1) >= 0)) met.add("reviewScore");
   if (some((g) => (g.metacritic ?? -1) >= 0)) met.add("metacritic");
-  if (some((g) => typeof g.deckCompat === "string" && g.deckCompat.length > 0)) met.add("deckCompat");
+  // `deckCompat` is non-nullable and the no-AppStore fallback hard-codes
+  // "unknown", so a presence test was true even on a library that knows
+  // nothing — and "Deck Verified" was offered, priced, and came back empty.
+  // Every other need here tests a sentinel; this one has to test the value.
+  if (some((g) => typeof g.deckCompat === "string" && g.deckCompat !== "unknown")) {
+    met.add("deckCompat");
+  }
   if (some((g) => (g.purchasedAt ?? -1) > 0)) met.add("purchaseDate");
   if (some((g) => (g.storeTags ?? []).length > 0)) met.add("storeTags");
   if (availableFacts.has("hltbMain")) met.add("hltb");

--- a/plugins/collections/lib/rule-params.ts
+++ b/plugins/collections/lib/rule-params.ts
@@ -141,7 +141,7 @@ const SPECS: Partial<Record<RuleKind, ParamSpec[]>> = {
       options: [
         { value: "contains", label: "Contains", hint: "A plain substring — usually what you want" },
         { value: "startsWith", label: "Starts with" },
-        { value: "regex", label: "Regular expression", hint: "An invalid pattern can't be checked, so it won't narrow the tab" },
+        { value: "regex", label: "Regular expression", hint: "An invalid pattern can't be checked, so it won't narrow the collection" },
       ],
     },
     { key: "value", control: "text", label: "Text", placeholder: "e.g. Halo" },
@@ -258,7 +258,7 @@ export function paramSpecs(kind: RuleKind): readonly ParamSpec[] {
 /**
  * Per-kind starting parameters. `now` is passed in rather than read from the
  * clock so date defaults are deterministic under test — the same discipline
- * `evaluateTab` already uses.
+ * `evaluateCollection` already uses.
  */
 function defaultParams(kind: RuleKind, now: number): Record<string, unknown> {
   const anyOf: SetMode = "anyOf";

--- a/plugins/collections/lib/rule-tree.ts
+++ b/plugins/collections/lib/rule-tree.ts
@@ -8,7 +8,7 @@
  * 1. The builder's whole premise is that you can see the consequence of an
  *    edit *before* committing it. That requires producing the edited tree
  *    without touching the saved one, so the caller can evaluate a candidate
- *    (`evaluateTab({...tab, root: candidate})`) and throw it away.
+ *    (`evaluateCollection({...tab, root: candidate})`) and throw it away.
  * 2. `diagnose.ts` already expresses its one-tap repairs as pure
  *    `Tab -> Tab` fixes. Sharing the same primitives keeps a fix and the
  *    equivalent manual edit from drifting apart.

--- a/plugins/collections/lib/types.ts
+++ b/plugins/collections/lib/types.ts
@@ -1,9 +1,9 @@
 /**
- * The data model for collections: rules, sorting, grouping, tabs.
+ * The data model for collections: rules, sorting, and what a collection is.
  *
  * Type-only by design — every runtime concern lives in a sibling module
- * (`rules.ts` for predicates, `evaluate.ts` for the tree walk, `sort.ts`,
- * `group.ts`). Keeping this file declaration-only means both the overlay
+ * (`rules.ts` for predicates, `evaluate.ts` for the tree walk, `sort.ts`).
+ * Keeping this file declaration-only means both the overlay
  * bundle and the backend bundle can import it for free, and the spec gate
  * correctly treats it as having no runtime to test.
  *
@@ -17,7 +17,7 @@
  * TabMaster has no such state, so a cold achievement cache makes its
  * achievements filter return `false` and the games silently vanish — you
  * cannot tell a wrong rule from a missing data source. Here the tab's
- * {@link Tab.indeterminatePolicy} decides (defaulting to `"pass"`, so an
+ * {@link ManagedCollection.indeterminatePolicy} decides (defaulting to `"pass"`, so an
  * outage degrades a tab rather than emptying it), and the UI can always
  * name which rules it couldn't check and why.
  *
@@ -63,7 +63,7 @@ export interface NumericRange {
    * has hundreds of titles with no Metacritic score — so it resolves to a
    * definite `false` rather than to `"indeterminate"`. Reserve
    * `"indeterminate"` for a whole data source being unavailable; see
-   * {@link Tab.indeterminatePolicy}.
+   * {@link ManagedCollection.indeterminatePolicy}.
    */
   includeUnknown?: boolean;
 }
@@ -243,15 +243,6 @@ export interface MirrorLedger {
 }
 
 // ── Evaluation output ──────────────────────────────────────────────────
-
-/**
- * Decides whether a rule matches a game, with the tab's
- * {@link Tab.indeterminatePolicy} already folded in.
- *
- * Passed *into* `group.ts` rather than imported from `evaluate.ts`, so the
- * two modules don't form an import cycle. `evaluate.ts` owns rule
- * semantics; `group.ts` owns partitioning and only needs a yes/no.
- */
 
 // ── Facts ──────────────────────────────────────────────────────────────
 

--- a/plugins/collections/lib/types.ts
+++ b/plugins/collections/lib/types.ts
@@ -3,9 +3,9 @@
  *
  * Type-only by design — every runtime concern lives in a sibling module
  * (`rules.ts` for predicates, `evaluate.ts` for the tree walk, `sort.ts`).
- * Keeping this file declaration-only means both the overlay
- * bundle and the backend bundle can import it for free, and the spec gate
- * correctly treats it as having no runtime to test.
+ * Keeping this file declaration-only means both the overlay bundle and the
+ * backend bundle can import it for free, and the spec gate correctly treats
+ * it as having no runtime to test.
  *
  * ## Why three-valued logic
  *
@@ -16,10 +16,10 @@
  *
  * TabMaster has no such state, so a cold achievement cache makes its
  * achievements filter return `false` and the games silently vanish — you
- * cannot tell a wrong rule from a missing data source. Here the tab's
- * {@link ManagedCollection.indeterminatePolicy} decides (defaulting to `"pass"`, so an
- * outage degrades a tab rather than emptying it), and the UI can always
- * name which rules it couldn't check and why.
+ * cannot tell a wrong rule from a missing data source. Here the collection's
+ * {@link ManagedCollection.indeterminatePolicy} decides (defaulting to
+ * `"pass"`, so an outage degrades a collection rather than emptying it), and
+ * the UI can always name which rules it couldn't check and why.
  *
  * Note the deliberate boundary: *missing metadata for one game* — no known
  * release date, no Metacritic score — is **not** indeterminate. That is
@@ -94,7 +94,7 @@ export type FactKey =
   | "onSdCard";
 
 /**
- * One node in a tab's rule tree.
+ * One node in a collection's rule tree.
  *
  * Every variant carries a stable `id` (used as a React key, as the
  * addressing scheme for edits, and as the key into
@@ -241,8 +241,6 @@ export interface MirrorLedger {
   version: 1;
   entries: MirrorLedgerEntry[];
 }
-
-// ── Evaluation output ──────────────────────────────────────────────────
 
 // ── Facts ──────────────────────────────────────────────────────────────
 

--- a/plugins/theme-loader/app.tsx
+++ b/plugins/theme-loader/app.tsx
@@ -576,7 +576,7 @@ function ThemeLoader() {
               ariaLabel="Reapply themes"
             >
               <FaArrowsRotate
-                size={11}
+                size={13}
                 className={loading === "reconnect" ? "animate-spin" : ""}
               />
             </IconButton>

--- a/scripts/capture-screenshots.ts
+++ b/scripts/capture-screenshots.ts
@@ -96,11 +96,22 @@ const PAGE_RECIPES: Record<string, PageShot[]> = {
   collections: [
     { name: "games", steps: [{ kind: "card" }, { kind: "wait", ms: 400 }, { kind: "scrollTop" }] },
     { name: "new", steps: [{ kind: "aria", label: "New collection" }] },
-    { name: "rules", steps: [{ kind: "card" }, { kind: "aria", label: "Options" }] },
+    // Targeted by the card's own subtitle rather than by position: the first
+    // card is only a rule-built collection if the user has one, and on a fresh
+    // install `listAll` returns Steam's first — whose Options is the short
+    // page, so the shot would quietly capture the wrong screen instead of
+    // skipping.
+    {
+      name: "rules",
+      steps: [
+        { kind: "text", label: "Rules · updates itself" },
+        { kind: "aria", label: "Options" },
+      ],
+    },
     {
       name: "rule-palette",
       steps: [
-        { kind: "card" },
+        { kind: "text", label: "Rules · updates itself" },
         { kind: "aria", label: "Options" },
         { kind: "text", label: "Add rule" },
       ],
@@ -333,7 +344,15 @@ const GRID_TILE_THRESHOLD = 6;
 // Plugins whose grid we keep pinned to the top instead of random-
 // scrolling: their hero/top row is the intended look (RecompHub's hero
 // row, TDP's controls, PlayTime's headline + day filters).
-const NO_SCROLL = new Set(["recomp", "tdp-control", "playtime"]);
+const NO_SCROLL = new Set([
+  // Its recipes position the page deliberately (scroll to top after opening a
+  // sub-page whose windowed grid inherited the previous view's offset), and
+  // `varyGridView` would undo that a moment later.
+  "collections",
+  "recomp",
+  "tdp-control",
+  "playtime",
+]);
 
 /**
  * Before a shot, randomly scroll grid views so each capture shows a

--- a/scripts/scaffold-plugin-readmes.ts
+++ b/scripts/scaffold-plugin-readmes.ts
@@ -73,7 +73,7 @@ const DISPLAY_NAME_OVERRIDES: Record<string, string> = {
  * hand-tuned files (200+ lines on quick-links) can't be regenerated
  * from a template.
  */
-const HAND_TUNED: ReadonlySet<string> = new Set(["quick-links"]);
+const HAND_TUNED: ReadonlySet<string> = new Set(["quick-links", "collections"]);
 const FORCE_ALL = process.argv.includes("--force-all");
 
 /** Convert `quick-links` → "Quick Links". Override table wins for


### PR DESCRIPTION
Follow-up to #239. Four agents reviewed the merged collections plugin; this fixes what they found — including two fixes from the previous round that didn't hold, and the tests written beside them that certified the wrong thing.

## Fact-backed rules matched the entire library

`buildEvalGames` takes a facts bag and **no callsite passes one**, so `EvalGame.facts` is always `{}`, `readFact` returns `"indeterminate"`, and the default `"pass"` policy turns that into a match. Measured against the fixture library:

```
onSdCard        matched 10/10
protonTier      matched 10/10
hltbMain        matched 10/10
achievements    matched 10/10
onSdCard (indeterminatePolicy: "fail")   matched 0    ← the policy works; the data never arrives
```

Six rule kinds passed every game. `onSdCard` needs no parameter, and the palette had no guard on `candidate.unavailable` — it dimmed the card, said why, and inserted the rule anyway on press. So a collection holding the whole library was one press away, and `syncMirror` writes it to Steam.

Two changes: the palette refuses an unavailable candidate, and `diagnoseCollection` checks `blockedFacts` **before** its "it has matches, it's fine" exit. That exit is what hid this — the rule matched everything, so the collection looked healthy. It now says the collection is *"wider than it looks"*.

## Two fixes from #239 that didn't hold

**`pruneLinked` guarded the wrong snapshot.** It read the library once for the guard and `listGames` read it *again* for the stale list. A CDP timeout between them — documented as happening twice in one sync on the dev device — left the guard inspecting a healthy read while the deletion was computed from a broken one. One read now, used for both. And `appstore: "ok"` only means the call returned: Steam answers with an empty list while its stores hydrate, so it also requires evidence the read carried something.

**`editLinked` wasn't a delta.** `setCollectionApps` computes `have − want` in-page, so it is an absolute membership write however the caller phrases it — anything added between our read and Steam's evaluate was still removed, and the guarantee in #239's commit message and README was false. `editCollectionApps` in `steam-cdp` names the ids to add and remove and touches nothing else. It is also the only safe way to edit a collection holding ids we cannot resolve — dead non-Steam shortcut ids, invisible to a library read.

Verified against real Steam on a throwaway collection seeded with one real game and one dead shortcut id:

```
after add    : 3 ids, dead kept: true
after remove : 2 ids, dead kept: true, target gone: true
after prune  : {removed: 1, kept: 1} → 1 id, dead gone: true
```

## Also fixed

- **`_setMirrorState` took a mirror captured outside the lock.** `_markSyncOwed` captures before its own disk write and enqueues after it, so a sync landing in that gap had its freshly-written ledger overwritten by the pre-sync copy — orphaning a collection it had just created in Steam, and reporting it as `blocked` forever after. It takes an updater now. The plan and the executor also read the ledger separately; the plan carries its own.
- **`metadataNeedsMet`'s deckCompat test was a tautology** against a non-nullable field whose fallback is `"unknown"`, so *Deck Verified* was offered on a library that knows nothing and produced an empty collection — the exact failure the greying exists to prevent.
- **Invert was offered on the eleven kinds the registry marks non-invertible**, where `matchRange` resolves the `-1` unknown sentinel to a definite `false` and invert flips it to `true`: *"NOT played 2 hours or less"* collected every game whose playtime couldn't be read. The rule editor already gated on the registry flag; the row menu used its own guess.
- **`diagnose` tested `"range" in r`** — no rule variant has a `range` property, so six range kinds were told to remove a rule when widening a bound was the fix.
- **Select mode kept picks across a filter change without saying so.** Pick a game, filter it out of view, confirm: it was removed with nothing on screen indicating it existed. The header now reads *"1 picked · 1 not shown"*.
- **The bin's trigger and its confirmation shared an accessible name and a screen slot**, so two quick presses on what reads as one control deleted a 700-entry collection. "Keep it" comes first now, and the confirm names the collection and what survives.
- **An armed bin survived a trip through select mode** and came back live from an intent expressed several interactions ago.
- **A missing snapshot was reported as facts about the user's library** — *"every game in your library is already in this collection"*, and twelve presets greyed out blaming play history. Both now say the library is still being read.
- **Three edit paths wrote `games` after an await with no request token**, so one collection's rows could paint under another's header.
- Two user-visible strings still said "tab".

## Two more reviews, and two shipping-blockers

The branch was reviewed again — once as a whole plugin, once adversarially at this PR. Both found real problems, including in these fixes.

**A sync computed memberships from a library that degrades to empty.** Both sources swallow their failures, and a sync rewrites whole memberships across every mirrored collection at once — so a half-loaded library doesn't produce a smaller sync, it **empties every collection we own**, reported as *"Backlog — 3 removed"* with bare app ids, because the names came from the same broken read. `pruneLinked` already refused on this signal for a far more targeted write. The riskiest caller is the automatic one: the owed sync at plugin load, which fires exactly when Steam is least likely to have hydrated.

That guard immediately exposed something else — **every sync test in the file was already running in the degraded state**, because the fake's library read always returned empty.

**A rule this build cannot evaluate still mirrored the whole library.** The palette guard above only stops *new* ones; a `hltbMain` or `onSdCard` rule already on disk — trivially reachable, since the shipped build had no guard — still matched everything and still got written. `planMirror` refuses those now, the way it already refuses a rule-less collection.

**`pruneLinked`'s guard was weaker than advertised.** `games.length === 0` only catches a totally empty read; the dangerous one is partial — real Steam games present, non-Steam shortcuts absent, so every ROM in an EmuDeck collection reads dead and one resolvable game clears both guards. It now refuses to drop shortcut-shaped ids unless the library has listed a shortcut at all.

Smaller, all from the adversarial pass: `libraryLoaded` was added to `AddGamesPage`, documented with the bug it prevents, and never passed. `pruneLinked` reported `kept: 0` when it kept everything, and surfaced a raw in-page error for a dynamic collection. The blocked-facts message told a correctly-*narrow* collection it "matches everything" under a `fail` policy, contradicting the fix offered beside it. `editCollectionApps` saved an unmodified collection and returned ok when Steam lacked `RemoveApps`. `hiddenPicked` was O(picked × shown) per keystroke. The clean-up confirm wasn't disarmed on entering select mode, next to the bin that just was.

**`mirrorAffecting`'s comment asserted the opposite of what the code does** — "a new field is included by default", when `project()` is a whitelist. A field added to `ManagedCollection` and forgotten there means editing it never marks a sync owed. Both tests that should have caught it were vacuous, asserting on `visible` and `pin`, neither of which exists on its type any more.

## Tests

The suite was green throughout, which is the point: these are the cases it wasn't covering.

- The Steam fake **dropped `appIds` on create**, so a plan creating a collection holding the wrong games looked identical to one that got it right.
- *"Keeps what somebody else added between the read and the write"* pushed its entry in **before** the read — which the old whole-list write also survived. It interleaves properly now.
- The prune guard's assertion accepted either error message, so it never showed which guard fired. Both are asserted separately, and the fake can now produce a degraded-but-`"ok"` snapshot.
- The single-read plan fix had **no test at all** — reverting it left the suite green.

The adversarial review scored the first pass: of thirteen changes it checked, six were genuinely covered and seven were not — including the delta test, which passed with the fix fully reverted because only the delta fake honoured the write latch. Both write primitives are recorded now and the test names which one ran; the two prune tests were byte-identical and neither could distinguish a targeted removal from a rewrite landing on the same list.

The request-token test needed building properly rather than plausibly: a rejection that fires immediately resolves the race before it exists, so the fake holds the failure open — start a removal in one collection, leave for another, then let the first fail.

Every guard in this PR now fails when its fix is reverted, with one exception that says so in its comment: the `_setMirrorState` updater needs two config writes to land in one specific order, which a test can't force here — the updater makes the order moot.

`3148 backend + 521 UI pass, 0 fail`; typecheck, lint, `check:specs`, `check:dead-code` clean.

## Not changed

`countMatches` ignoring `limit` was reported as a divergence from `evaluateCollection`. It is deliberate — the palette prices the *rule*, not the cap — and a test pins it. Documented rather than changed.

## Docs and tooling

The README claimed *"editing never writes to Steam on its own"*, which is false for every linked-collection edit (add, remove, rename, delete, clean up all write immediately); that "everything on the grid syncs", which overstates by one kind; and that the tab-strip patching mechanism was proven, which the revert commit explicitly disclaims. The screenshot script's `varyGridView` random-scroll ran *after* recipe steps and undid the `scrollTop` those recipes end with, and the `rules` recipe clicked the first card — a Steam collection on a fresh install, so it captured the wrong screen instead of skipping. `collections` is now in `HAND_TUNED`, so a `--force` scaffold run can't delete the hand-written README sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvzCDtcwXDUGHg3tybwJtL

