### PR TITLE
fix(overlay): bundle libs by SONAME, and recover from a Gaming→Desktop mode switch

### DIFF
--- a/loadout-overlay.service
+++ b/loadout-overlay.service
@@ -142,9 +142,10 @@ WantedBy=graphical-session.target
 # restarts us whenever we aren't running, whether or not it ever cycled.
 #
 # This is an [Install] directive, so it only takes effect on enable — it
-# writes the graphical-session.target.upholds/ symlink. Existing installs
-# need `systemctl --user reenable loadout-overlay` to pick it up; putting
-# it in [Unit] parses as an unknown key and is silently ignored.
+# writes the graphical-session.target.upholds/ symlink. install.sh runs
+# `reenable` rather than `enable` for that reason: plain `enable` is a
+# no-op for an already-enabled unit, so upgraders would silently never
+# get the symlink. In [Unit] it parses as an unknown key and is ignored.
 #
 # Trade-off worth knowing when debugging: this also reverts a manual
 # `systemctl --user stop` within seconds. To hold it down, mask it

--- a/loadout-overlay.service
+++ b/loadout-overlay.service
@@ -6,11 +6,20 @@ Description=Loadout Overlay
 After=graphical-session.target
 PartOf=graphical-session.target
 
-# Never let the restart limiter wedge us permanently. A mode switch has a
-# window with no X server at all, so several starts can fail back to back;
-# the default (5 starts / 10s) would then give up for good and leave the
-# overlay dead — the precise state this whole block exists to prevent.
-StartLimitIntervalSec=0
+# Widen, but do NOT remove, the start limiter. A mode switch has a window
+# with no X server at all, so several starts can fail back to back, and the
+# default 5-in-10s is tight enough to trip and leave the overlay dead — the
+# state this block exists to prevent.
+#
+# The limiter still has to exist, because `UpheldBy=` above re-queues a start
+# the instant the unit goes inactive and those starts are NOT paced by
+# RestartSec= (that only paces the Restart= path). So if the launcher ever
+# exits cleanly, upholds alone would respawn it as fast as it can exit, with
+# nothing else to throttle it: `Restart=on-failure` does not fire on exit 0,
+# and the ExecStartPre `/up` wait only blocks while the backend is down.
+# 20-in-60s absorbs any plausible mode switch while still capping a runaway.
+StartLimitIntervalSec=60
+StartLimitBurst=20
 
 [Service]
 Type=simple

--- a/loadout-overlay.service
+++ b/loadout-overlay.service
@@ -6,6 +6,12 @@ Description=Loadout Overlay
 After=graphical-session.target
 PartOf=graphical-session.target
 
+# Never let the restart limiter wedge us permanently. A mode switch has a
+# window with no X server at all, so several starts can fail back to back;
+# the default (5 starts / 10s) would then give up for good and leave the
+# overlay dead — the precise state this whole block exists to prevent.
+StartLimitIntervalSec=0
+
 [Service]
 Type=simple
 
@@ -119,3 +125,28 @@ ExecStopPost=-/bin/sh -c 'pkill -CONT -x steam || true'
 
 [Install]
 WantedBy=graphical-session.target
+
+# Recovery net for a session switch that doesn't cycle the target.
+# `PartOf=` stops us when graphical-session.target goes down and
+# `WantedBy=` starts us again when it comes back UP — but on a SteamOS
+# Gaming -> Desktop switch those two never pair up. The target's own stop
+# job gets refused as destructive:
+#
+#   Transaction for graphical-session.target/stop is destructive
+#   (xdg-desktop-portal.service has 'start' job queued)
+#
+# so the target stays active while `PartOf=` has already stopped us, it
+# never "starts" again, and nothing brings us back — the overlay stays
+# dead until the next reboot or a manual `systemctl --user start`.
+# `UpheldBy=` closes exactly that gap: while the target is active, systemd
+# restarts us whenever we aren't running, whether or not it ever cycled.
+#
+# This is an [Install] directive, so it only takes effect on enable — it
+# writes the graphical-session.target.upholds/ symlink. Existing installs
+# need `systemctl --user reenable loadout-overlay` to pick it up; putting
+# it in [Unit] parses as an unknown key and is silently ignored.
+#
+# Trade-off worth knowing when debugging: this also reverts a manual
+# `systemctl --user stop` within seconds. To hold it down, mask it
+# (`systemctl --user mask --now loadout-overlay`) and unmask after.
+UpheldBy=graphical-session.target

--- a/loadout-overlay.service
+++ b/loadout-overlay.service
@@ -8,8 +8,11 @@ PartOf=graphical-session.target
 
 # Widen, but do NOT remove, the start limiter. A mode switch has a window
 # with no X server at all, so several starts can fail back to back, and the
-# default 5-in-10s is tight enough to trip and leave the overlay dead — the
-# state this block exists to prevent.
+# default 5-in-10s is tight enough to trip during one. Tripping is not fatal
+# — with UpheldBy= above systemd logs "not starting since we tried this too
+# often recently" and does keep retrying — but it stalls recovery for no
+# reason. Measured on the no-X-yet shape: ~12 starts/min, RestartSec-paced,
+# comfortably inside this 20/min budget.
 #
 # The limiter still has to exist, because `UpheldBy=` above re-queues a start
 # the instant the unit goes inactive and those starts are NOT paced by

--- a/scripts/fetch-deck-overlay-libs.sh
+++ b/scripts/fetch-deck-overlay-libs.sh
@@ -264,14 +264,35 @@ for link in "$EXTRACT_TMP/lib/"*; do
         "$(basename "$(readlink "$link")")" "$(basename "$link")" >> "$SONAME_MAP"
 done
 
-# True when the deck already provides this entry, under its own name or
-# under its SONAME. The SONAME arm is what catches version-suffix drift.
-deck_owns() {
-    if grep -qxF "$1" "$DECK_LIBS_TMP"; then
-        return 0
-    fi
+# The SONAME an entry is reached by. A soname symlink IS its own soname, so
+# it never appears in field 1 and correctly falls through to itself. A real
+# file's soname is whatever `ldconfig -n` pointed at it. An entry with no
+# link at all also falls back to its own basename, which is right for the
+# privately-loaded libs the deck-list walk exists to protect (e.g.
+# `libpulsecommon-17.0.so`, where the file name IS the soname).
+soname_of() {
     _sn="$(awk -F'\t' -v f="$1" '$1 == f { print $2; exit }' "$SONAME_MAP")"
-    [ -n "$_sn" ] && grep -qxF "$_sn" "$DECK_LIBS_TMP"
+    [ -n "$_sn" ] || _sn="$1"
+    printf '%s\n' "$_sn"
+}
+
+# True when the deck provides the SONAME this entry is reached by.
+#
+# Testing the SONAME and *only* the SONAME is the whole point. Consumers
+# link against the SONAME, so the deck owning some other alias — or even
+# owning the real versioned file — does not mean the deck can satisfy the
+# link. Matching the entry's own basename as well (an earlier version of
+# this fix did) reintroduces the librav1e bug: SteamOS ships
+# `librav1e.so`, `librav1e.so.0.8` and `librav1e.so.0.8.1` but NOT
+# `librav1e.so.0`, which is what the bundled libavif actually needs. The
+# basename arm matched `librav1e.so.0.8.1` and skipped the real file,
+# while its `librav1e.so.0` link — absent from the deck list — was
+# bundled, leaving exactly the dangling link this was meant to eliminate.
+#
+# Because a link and its target now resolve to the same SONAME, they always
+# get the same answer, so a bundled link can never lose its target.
+deck_owns() {
+    grep -qxF "$(soname_of "$1")" "$DECK_LIBS_TMP"
 }
 
 # Electrobun's launcher sets LD_LIBRARY_PATH=./ (its bin/ cwd) — it does
@@ -307,9 +328,16 @@ if [ "$skipped_deck" -gt 0 ]; then
     echo "[fetch-deck-libs] skipped $skipped_deck libs the deck owns (deck's loader will resolve them)"
 fi
 
-# Sweep any dangling links still in the bundle, including ones planted by
-# an earlier version of this script. They resolve to nothing, and leaving
-# them in place only hides which copy the loader actually ends up using.
+# Belt to the SONAME rule's braces: with link and target now always decided
+# together, this should find nothing. It stays as a cheap invariant check
+# against a closure whose links don't come from `ldconfig -n`, since a
+# dangling link resolves to nothing and only hides which copy the loader
+# actually ends up using.
+#
+# Note this cannot repair an existing broken install: both entry points
+# `rm -rf` the overlay tree before calling us (install.sh, install-local.sh),
+# so $TARGET_DIR is always a freshly extracted tree and the only links here
+# are ones this run just copied.
 pruned=0
 for link in "$TARGET_DIR"/*; do
     if [ -L "$link" ] && [ ! -e "$link" ]; then
@@ -332,18 +360,31 @@ done
 
 # Being present is not the same as being loadable. Resolve each root the way
 # the launcher will (LD_LIBRARY_PATH=./ from bin/) and fail loudly on anything
-# missing. Every SONAME we deferred to the deck is a bet that the deck keeps
-# shipping that major; this is the check that turns losing the bet into one
-# actionable line at install time rather than a crash-loop weeks later, after
-# an OS update, with only a dlopen failure to go on.
-unresolved="$(cd "$TARGET_DIR" && LD_LIBRARY_PATH=. ldd $TEST_LIBS 2>/dev/null \
-    | awk '/not found/ { print $1 }' | sort -u)"
-if [ -n "$unresolved" ]; then
-    echo "[fetch-deck-libs] ERROR: sonames resolve nowhere — not in the bundle," >&2
-    echo "  and not on this system:" >&2
-    echo "$unresolved" | sed 's/^/    /' >&2
-    echo "  Delete $CACHE_TAR and re-run to rebuild the closure against the" >&2
-    echo "  current system, or install the matching library." >&2
+# broken. Every SONAME we defer to the deck is a bet that the deck keeps
+# shipping a compatible one; this turns losing that bet into one actionable
+# line at install time rather than a crash-loop weeks later, after an OS
+# update, with only a dlopen failure to go on.
+#
+# `-r` (resolve ALL relocations), not a plain `ldd`. Plain `ldd` reports only
+# missing DT_NEEDED *files* and is blind to the second failure mode this
+# script can produce: a lib that IS present but whose symbols don't resolve.
+# That is the fontconfig bug — the deck's own libpangoft2 failing with
+# `undefined symbol: FcConfigSetDefaultSubstitute` against a stale bundled
+# fontconfig. It matters more the more we defer, since every deferred lib is
+# one more chance for the bundled Fedora webkit to meet an incompatible
+# SteamOS library.
+broken="$(cd "$TARGET_DIR" && LD_LIBRARY_PATH=. ldd -r $TEST_LIBS 2>/dev/null \
+    | awk '/not found/ { print "  missing:   " $1 }
+           /undefined symbol/ { print "  unresolved:" $0 }' | sort -u)"
+if [ -n "$broken" ]; then
+    echo "[fetch-deck-libs] ERROR: the installed closure does not fully resolve:" >&2
+    echo "$broken" >&2
+    echo "  'missing' means no bundled or system library provides that SONAME." >&2
+    echo "  'unresolved' means one was found but is the wrong version." >&2
+    echo "  Both are decided against THIS system's libraries, so a plain re-run" >&2
+    echo "  reproduces them. Either install the missing/newer library, or force" >&2
+    echo "  the lib to be bundled instead of deferred (it is skipped only when" >&2
+    echo "  /usr/lib* already offers its SONAME)." >&2
     exit 1
 fi
 

--- a/scripts/fetch-deck-overlay-libs.sh
+++ b/scripts/fetch-deck-overlay-libs.sh
@@ -374,8 +374,9 @@ done
 # one more chance for the bundled Fedora webkit to meet an incompatible
 # SteamOS library.
 broken="$(cd "$TARGET_DIR" && LD_LIBRARY_PATH=. ldd -r $TEST_LIBS 2>/dev/null \
-    | awk '/not found/ { print "  missing:   " $1 }
-           /undefined symbol/ { print "  unresolved:" $0 }' | sort -u)"
+    | awk '/not found/ { print "  missing:    " $1 }
+           /undefined symbol/ { sub(/^[[:space:]]*undefined symbol: /, "")
+                                print "  unresolved: " $0 }' | sort -u)"
 if [ -n "$broken" ]; then
     echo "[fetch-deck-libs] ERROR: the installed closure does not fully resolve:" >&2
     echo "$broken" >&2

--- a/scripts/fetch-deck-overlay-libs.sh
+++ b/scripts/fetch-deck-overlay-libs.sh
@@ -224,12 +224,55 @@ fi
 # and the overlay crashes at dlopen time with `undefined symbol:
 # pa_in_valgrind` and the like. Walk the whole `/usr/lib*` tree so we
 # catch those too.
+#
+# Match symlinks as well as regular files (`! -type d`, not `-type f`).
+# The deck exposes most libraries under two names — the real
+# `libfontconfig.so.1.17.0` and the SONAME link `libfontconfig.so.1` —
+# and the skip test below needs to see both. Counting only real files
+# let two distinct bugs through, both of which shipped:
+#   - Fedora's `libfontconfig.so.1.15.0` didn't match the deck's
+#     `libfontconfig.so.1.17.0` (different version suffix), so we bundled
+#     it. With LD_LIBRARY_PATH=./ our stale copy won, and the deck's own
+#     libpangoft2 then failed to relocate against it:
+#     `undefined symbol: FcConfigSetDefaultSubstitute`.
+#   - The container's `ldconfig -n` SONAME links didn't match either, so
+#     they were copied while their real targets were (correctly) skipped
+#     as deck-owned — planting dangling links like
+#     `libicui18n.so.76 -> libicui18n.so.76.1`. A dangling link is skipped
+#     by the loader, which silently falls through to the deck's copy, so
+#     the bundle ends up pinned to whatever major the deck ships today.
+#     Invisible until the deck moves: ICU 76 -> 78 in the Aug 2026 SteamOS
+#     update left the overlay unable to dlopen libNativeWrapper.so at all.
 DECK_LIBS_TMP="$EXTRACT_TMP/deck-libs.txt"
 # `-printf '%f'` emits the basename in-process. The old `xargs -n1 basename`
 # spawned one process PER .so (~4500 on SteamOS), which on the Deck's session
 # took minutes (and looked like a hang) — find's own printf does it in <1s.
-find /usr/lib /usr/lib64 -name '*.so*' -type f -printf '%f\n' 2>/dev/null \
+find /usr/lib /usr/lib64 -name '*.so*' ! -type d -printf '%f\n' 2>/dev/null \
     | sort -u > "$DECK_LIBS_TMP"
+
+# Map each real closure file to the SONAME it is reachable by, so the skip
+# test can compare SONAME-to-SONAME instead of comparing version-suffixed
+# basenames that drift between distros. `ldconfig -n` already built exactly
+# this relation in the container (`libfoo.so.1 -> libfoo.so.1.2.3`), so read
+# it back off the symlinks rather than shelling out to objdump/readelf —
+# binutils is not guaranteed to be installed on a stock deck.
+SONAME_MAP="$EXTRACT_TMP/soname-map.txt"
+: > "$SONAME_MAP"
+for link in "$EXTRACT_TMP/lib/"*; do
+    [ -L "$link" ] || continue
+    printf '%s\t%s\n' \
+        "$(basename "$(readlink "$link")")" "$(basename "$link")" >> "$SONAME_MAP"
+done
+
+# True when the deck already provides this entry, under its own name or
+# under its SONAME. The SONAME arm is what catches version-suffix drift.
+deck_owns() {
+    if grep -qxF "$1" "$DECK_LIBS_TMP"; then
+        return 0
+    fi
+    _sn="$(awk -F'\t' -v f="$1" '$1 == f { print $2; exit }' "$SONAME_MAP")"
+    [ -n "$_sn" ] && grep -qxF "$_sn" "$DECK_LIBS_TMP"
+}
 
 # Electrobun's launcher sets LD_LIBRARY_PATH=./ (its bin/ cwd) — it does
 # NOT add `./lib`. So the closure must sit alongside the launcher itself,
@@ -249,7 +292,7 @@ for entry in "$EXTRACT_TMP/lib/"*; do
         skipped_existing=$((skipped_existing + 1))
         continue
     fi
-    if grep -qxF "$base" "$DECK_LIBS_TMP"; then
+    if deck_owns "$base"; then
         skipped_deck=$((skipped_deck + 1))
         continue
     fi
@@ -264,6 +307,20 @@ if [ "$skipped_deck" -gt 0 ]; then
     echo "[fetch-deck-libs] skipped $skipped_deck libs the deck owns (deck's loader will resolve them)"
 fi
 
+# Sweep any dangling links still in the bundle, including ones planted by
+# an earlier version of this script. They resolve to nothing, and leaving
+# them in place only hides which copy the loader actually ends up using.
+pruned=0
+for link in "$TARGET_DIR"/*; do
+    if [ -L "$link" ] && [ ! -e "$link" ]; then
+        rm -f "$link"
+        pruned=$((pruned + 1))
+    fi
+done
+if [ "$pruned" -gt 0 ]; then
+    echo "[fetch-deck-libs] pruned $pruned dangling soname symlink(s)"
+fi
+
 # Final smoke: the three top-level sonames must resolve in the target dir.
 TEST_LIBS="libwebkit2gtk-4.1.so.0 libjavascriptcoregtk-4.1.so.0 libayatana-appindicator3.so.1"
 for lib in $TEST_LIBS; do
@@ -272,5 +329,22 @@ for lib in $TEST_LIBS; do
         exit 1
     fi
 done
+
+# Being present is not the same as being loadable. Resolve each root the way
+# the launcher will (LD_LIBRARY_PATH=./ from bin/) and fail loudly on anything
+# missing. Every SONAME we deferred to the deck is a bet that the deck keeps
+# shipping that major; this is the check that turns losing the bet into one
+# actionable line at install time rather than a crash-loop weeks later, after
+# an OS update, with only a dlopen failure to go on.
+unresolved="$(cd "$TARGET_DIR" && LD_LIBRARY_PATH=. ldd $TEST_LIBS 2>/dev/null \
+    | awk '/not found/ { print $1 }' | sort -u)"
+if [ -n "$unresolved" ]; then
+    echo "[fetch-deck-libs] ERROR: sonames resolve nowhere — not in the bundle," >&2
+    echo "  and not on this system:" >&2
+    echo "$unresolved" | sed 's/^/    /' >&2
+    echo "  Delete $CACHE_TAR and re-run to rebuild the closure against the" >&2
+    echo "  current system, or install the matching library." >&2
+    exit 1
+fi
 
 echo "[fetch-deck-libs] Closure installed into $TARGET_DIR ($(find "$TARGET_DIR" -maxdepth 1 -name '*.so*' | wc -l) so files)"

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -144,7 +144,18 @@ fi
 # native wrapper dlopens at startup). Fetch the closure from a Fedora container
 # the first time and cache the tarball; subsequent installs reuse it. No-op on
 # Bazzite/CachyOS/Fedora — those ship the libs in the base image.
-sh "$SCRIPT_DIR/fetch-deck-overlay-libs.sh" "$OVERLAY_INSTALL_DIR/bin"
+#
+# Non-fatal, matching install.sh's handling. This script runs under `set -e`,
+# so a bare call would abort the whole install the moment the closure build or
+# its resolvability check fails — after the overlay tree is already in place
+# but before Steam CEF remote debugging and everything below, leaving a
+# half-configured dev install. The overlay alone is broken in that case, and
+# the operator is better served finishing the install and reading the error.
+if ! sh "$SCRIPT_DIR/fetch-deck-overlay-libs.sh" "$OVERLAY_INSTALL_DIR/bin"; then
+    echo "[install-local] WARNING: overlay runtime libraries are not ready" >&2
+    echo "  (see the error above). The rest of the install continues; the" >&2
+    echo "  overlay will not launch until that is resolved." >&2
+fi
 
 # --- Steam CEF remote debugging ---
 # Drop the empty `.cef-enable-remote-debugging` marker in Steam's root so

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -965,11 +965,20 @@ Description=Loadout Overlay
 After=graphical-session.target
 PartOf=graphical-session.target
 
-# Never let the restart limiter wedge us permanently. A mode switch has a
-# window with no X server at all, so several starts can fail back to back;
-# the default (5 starts / 10s) would then give up for good and leave the
-# overlay dead — the precise state this whole block exists to prevent.
-StartLimitIntervalSec=0
+# Widen, but do NOT remove, the start limiter. A mode switch has a window
+# with no X server at all, so several starts can fail back to back, and the
+# default 5-in-10s is tight enough to trip and leave the overlay dead — the
+# state this block exists to prevent.
+#
+# The limiter still has to exist, because `UpheldBy=` above re-queues a start
+# the instant the unit goes inactive and those starts are NOT paced by
+# RestartSec= (that only paces the Restart= path). So if the launcher ever
+# exits cleanly, upholds alone would respawn it as fast as it can exit, with
+# nothing else to throttle it: `Restart=on-failure` does not fire on exit 0,
+# and the ExecStartPre `/up` wait only blocks while the backend is down.
+# 20-in-60s absorbs any plausible mode switch while still capping a runaway.
+StartLimitIntervalSec=60
+StartLimitBurst=20
 
 [Service]
 Type=simple

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -967,8 +967,11 @@ PartOf=graphical-session.target
 
 # Widen, but do NOT remove, the start limiter. A mode switch has a window
 # with no X server at all, so several starts can fail back to back, and the
-# default 5-in-10s is tight enough to trip and leave the overlay dead — the
-# state this block exists to prevent.
+# default 5-in-10s is tight enough to trip during one. Tripping is not fatal
+# — with UpheldBy= above systemd logs "not starting since we tried this too
+# often recently" and does keep retrying — but it stalls recovery for no
+# reason. Measured on the no-X-yet shape: ~12 starts/min, RestartSec-paced,
+# comfortably inside this 20/min budget.
 #
 # The limiter still has to exist, because `UpheldBy=` above re-queues a start
 # the instant the unit goes inactive and those starts are NOT paced by

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1101,10 +1101,10 @@ WantedBy=graphical-session.target
 # restarts us whenever we aren't running, whether or not it ever cycled.
 #
 # This is an [Install] directive, so it only takes effect on enable — it
-# writes the graphical-session.target.upholds/ symlink. That's why the
-# enable below is a `reenable`: plain `enable` is a no-op for a unit that
-# is already enabled, so upgraders would silently never get the symlink.
-# Putting it in [Unit] parses as an unknown key and is silently ignored.
+# writes the graphical-session.target.upholds/ symlink. install.sh runs
+# `reenable` rather than `enable` for that reason: plain `enable` is a
+# no-op for an already-enabled unit, so upgraders would silently never
+# get the symlink. In [Unit] it parses as an unknown key and is ignored.
 #
 # Trade-off worth knowing when debugging: this also reverts a manual
 # `systemctl --user stop` within seconds. To hold it down, mask it

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -965,6 +965,12 @@ Description=Loadout Overlay
 After=graphical-session.target
 PartOf=graphical-session.target
 
+# Never let the restart limiter wedge us permanently. A mode switch has a
+# window with no X server at all, so several starts can fail back to back;
+# the default (5 starts / 10s) would then give up for good and leave the
+# overlay dead — the precise state this whole block exists to prevent.
+StartLimitIntervalSec=0
+
 [Service]
 Type=simple
 
@@ -1078,6 +1084,32 @@ ExecStopPost=-/bin/sh -c 'pkill -CONT -x steam || true'
 
 [Install]
 WantedBy=graphical-session.target
+
+# Recovery net for a session switch that doesn't cycle the target.
+# `PartOf=` stops us when graphical-session.target goes down and
+# `WantedBy=` starts us again when it comes back UP — but on a SteamOS
+# Gaming -> Desktop switch those two never pair up. The target's own stop
+# job gets refused as destructive:
+#
+#   Transaction for graphical-session.target/stop is destructive
+#   (xdg-desktop-portal.service has 'start' job queued)
+#
+# so the target stays active while `PartOf=` has already stopped us, it
+# never "starts" again, and nothing brings us back — the overlay stays
+# dead until the next reboot or a manual `systemctl --user start`.
+# `UpheldBy=` closes exactly that gap: while the target is active, systemd
+# restarts us whenever we aren't running, whether or not it ever cycled.
+#
+# This is an [Install] directive, so it only takes effect on enable — it
+# writes the graphical-session.target.upholds/ symlink. That's why the
+# enable below is a `reenable`: plain `enable` is a no-op for a unit that
+# is already enabled, so upgraders would silently never get the symlink.
+# Putting it in [Unit] parses as an unknown key and is silently ignored.
+#
+# Trade-off worth knowing when debugging: this also reverts a manual
+# `systemctl --user stop` within seconds. To hold it down, mask it
+# (`systemctl --user mask --now loadout-overlay`) and unmask after.
+UpheldBy=graphical-session.target
 OVERLAYEOF
         success "Overlay service file written to $OVERLAY_SERVICE_FILE"
 
@@ -1088,7 +1120,7 @@ OVERLAYEOF
         # before the user-facing summary — leaving a confusing half-install.
         # The unit file is on disk regardless, so it'll be picked up on the
         # next graphical login even if we couldn't reload/enable now.
-        if systemctl --user daemon-reload 2>/dev/null && systemctl --user enable loadout-overlay 2>/dev/null; then
+        if systemctl --user daemon-reload 2>/dev/null && systemctl --user reenable loadout-overlay 2>/dev/null; then
             success "Overlay service enabled (starts with graphical session)"
         else
             warn "Couldn't enable the overlay user service now (no active user session?)."


### PR DESCRIPTION
Two independent overlay bugs found while debugging "loadout won't open" after a SteamOS update. Both leave the backend perfectly healthy and only kill the overlay, and both are invisible unless you check the **user** unit rather than the system one:

```
journalctl --user -u loadout-overlay.service -b
```

1. **Library resolution** — the bundled closure was pinned to the deck's library majors, so an OS update broke it. Also breaks *fresh installs* outright (see symptom 3).
2. **Session lifecycle** — switching Gaming → Desktop Mode left the overlay dead until a reboot.

---

# Fix 1 — bundle libs by SONAME, not versioned basename

## What broke

A SteamOS update on 2026-08-11 (ICU 76 → 78, libjxl 0.11 → 0.12, fontconfig 1.15 → 1.17) had the overlay crash-looping every ~5s:

```
[LAUNCHER] Failed to load library: .../libNativeWrapper.so:
           libicui18n.so.76: cannot open shared object file
```

## Root cause

One bug, three symptoms. The "deck already owns this" filter built its skip-list with `-type f`, so it only ever matched **real files**, by **version-suffixed basename**:

```sh
find /usr/lib /usr/lib64 -name '*.so*' -type f -printf '%f\n'
```

**1. Dangling soname links → a silent pin.** The container's `ldconfig -n` creates `libicui18n.so.76 -> libicui18n.so.76.1`. The real target matched the skip-list (deck-owned, correctly skipped); the *symlink* didn't match (not a regular file), so it was copied. That planted 78 dangling links in `bin/`.

A dangling link is skipped by the loader, which falls through to `/usr/lib` — so everything worked, while the bundle was quietly pinned to whatever majors the deck shipped that day. No build-time signal. ICU 76 → 78 broke the pin two months later.

**2. Stale bundled lib shadowing a newer system one.** Fedora's `libfontconfig.so.1.15.0` didn't match the deck's `libfontconfig.so.1.17.0` — different suffix, no basename match — so it got bundled. With `LD_LIBRARY_PATH=./` the stale copy won, and the deck's own libpangoft2 could no longer relocate against it:

```
/usr/lib/libpangoft2-1.0.so.0: undefined symbol: FcConfigSetDefaultSubstitute
```

This only surfaced *after* fixing #1 — it was queued up behind it.

**3. Fresh installs break on arrival.** The widest-reaching case, reported in Discord by a user who "had to manually download librav1e and add them to the loadout-overlay folder", and who found reinstalling and older releases didn't help (correctly — the bug is in the closure filter, not any release).

`librav1e.so.0.8.1` has **SONAME `librav1e.so.0`**, which the bundled `libavif.so.16` links against. SteamOS ships the real file plus `librav1e.so` and `librav1e.so.0.8` — but **never** the `librav1e.so.0` alias:

```
/usr/lib/librav1e.so     -> librav1e.so.0.8.1
/usr/lib/librav1e.so.0.8 -> librav1e.so.0.8.1
/usr/lib/librav1e.so.0.8.1
```

So the old filter skipped the real file, copied the dangling `librav1e.so.0` link, and the loader found nothing — no OS update required. The deciding factor is *when you installed*: SteamOS picked up librav1e on 2026-06-26, so bundles built before that date vendored it correctly, and every SteamOS install since has shipped broken.

## The fix

- **Compare SONAME to SONAME**, and nothing else, read off the closure's own `ldconfig -n` symlinks rather than via `objdump`/`readelf` (binutils isn't guaranteed on a stock deck). A link and its target resolve to the same SONAME and so always get the same answer — which is what makes "a bundled link can never lose its target" actually true.
- **Match symlinks too** (`! -type d`), catching version-suffix drift and missing soname aliases.
- **Sweep dangling links** left by earlier runs.
- **`ldd -r` resolvability check** at install time — deferring a lib to the deck is a bet that the deck keeps shipping a compatible one, and this turns losing the bet into one actionable line instead of a crash-loop weeks later. `-r` rather than plain `ldd` because plain `ldd` reports missing *files* only and is blind to the fontconfig failure mode above, where the lib is present but its symbols don't resolve.

## Scope: SteamOS Holo only

No-op on Bazzite/CachyOS/Fedora-ostree, and not needed there — the capability gate short-circuits first:

```sh
if ldconfig -p 2>/dev/null | grep -q "libwebkit2gtk-4.1.so.0"; then
    echo "[fetch-deck-libs] libwebkit2gtk-4.1.so.0 already on system — nothing to do."
    exit 0
fi
```

The bug is also structurally impossible there. `libNativeWrapper.so` has **no direct ICU dependency** — ICU only arrives transitively:

```
libwebkit2gtk-4.1.so.0        → libicui18n.so.76, libicuuc.so.76
libjavascriptcoregtk-4.1.so.0 → libicui18n.so.76, libicuuc.so.76
```

On SteamOS those webkit libs are **Fedora 42's**, vendored onto a Holo runtime and linked against *Fedora's* ICU 76 — a foreign pin the deck's ICU had to keep satisfying by coincidence. Everywhere else webkit comes from the system and is linked against that same system's ICU, so they cannot drift apart. Same for fontconfig.

Where the script no-ops, `bin/` holds only Electrobun's own tar — `libEGL.so`, `libGLESv2.so`, `libNativeWrapper.so`, `libasar.so`, `libcef.so`, `libvk_swiftshader.so`, `libvulkan.so.1`. Nothing vendored that could shadow or dangle.

Verified by reading the gate and the `DT_NEEDED` graph on an ONEXPLAYER APEX running SteamOS Holo — not by running it on Bazzite or CachyOS.

## Verification

Replayed both deck states against a synthetic closure:

| shape | real file | soname link | correct? |
|---|---|---|---|
| librav1e — deck has the file but no `.so.0` alias | BUNDLE | BUNDLE | the reported bug |
| fontconfig — deck has a newer lib, same soname | SKIP | SKIP | no shadowing |
| ICU, post-update deck (has 78 only) | BUNDLE | BUNDLE | survives the bump |
| ICU, pre-update deck (has 76) | SKIP | SKIP | consistent, no dangle |
| `libpulsecommon-17.0.so`, no soname link | SKIP | — | private-lib guard kept |

Link and target always agree.

Against the **real cached closure** on this device: 57 bundled / 267 skipped, **zero** dangling links (the pre-review revision produced one, `librav1e.so.0`), and `librav1e.so.0` + `librav1e.so.0.8.1` bundled together. `ldd -r` on the live bundle reports no missing files and no undefined symbols, so the new hard-fail doesn't false-positive. `sh -n` clean (POSIX `sh` — no `local`, no process substitution). The 25 `updater.test.ts` tests pass.

---

# Fix 2 — overlay stays dead after a Gaming → Desktop switch

Switching SteamOS from Gaming to Desktop Mode left the overlay dead until a reboot or a manual start. It is meant to run in **both** modes — the `ExecStart` detects gamescope's inner X or falls back to the desktop's `$DISPLAY`, and the comment says so explicitly.

`PartOf=graphical-session.target` stops the unit when the target goes down; `WantedBy=` starts it again when the target comes back **up**. On this transition the two never pair up, because the target's own stop job is refused:

```
Transaction for graphical-session.target/stop is destructive
(xdg-desktop-portal.service has 'start' job queued, but 'stop' is
included in transaction)
graphical-session.target: Failed to enqueue stop job, ignoring
```

The target therefore stays `active` while `PartOf=` has already stopped us. It never "starts", so `WantedBy=` never fires and nothing brings the overlay back.

**`UpheldBy=graphical-session.target`** closes the gap: while the target is active, systemd restarts the unit whenever it isn't running, whether or not the target ever cycled. `PartOf=` is kept, so teardown ordering still lets the shutdown handler clear `STEAM_OVERLAY` and release the evdev grabs while gamescope is alive — the hazard called out in `lifecycle.ts`.

**`StartLimitIntervalSec=0`** is added too: a mode switch has a window with no X server at all, so several starts can fail back to back, and the default 5-starts-in-10s limiter would give up permanently — landing in the exact dead state this fixes.

Two gotchas worth knowing, both handled:

- `UpheldBy=` is an **[Install]** directive. In `[Unit]` it parses as an unknown key and is silently ignored (`systemd-analyze verify` catches this; `systemctl show` reports it empty).
- It only writes the `.upholds` symlink on **enable**, and plain `enable` is a no-op for an already-enabled unit — so the installer now calls `reenable`. Without that, upgraders would silently never get the symlink.

Verified on an ONEXPLAYER APEX (systemd 261): stopping the unit while the target is active now recovers automatically in ~2s, reproducing the state the mode switch left it in. Both copies of the unit — the repo-root `loadout-overlay.service` and the `install.sh` heredoc — were diffed to confirm no functional drift.

**Trade-off:** `UpheldBy=` also reverts a manual `systemctl --user stop` within seconds. To hold the overlay down for debugging, use `systemctl --user mask --now loadout-overlay` and unmask after. This is documented in the unit itself.

---

## Rollout note

The in-app updater cannot deliver Fix 1: it lives inside the overlay window, which affected users can't open, and `updater.ts` carries the existing `bin/*.so*` forward rather than re-running the closure script. Recovery is re-running the installer, which `rm -rf`s the overlay tree (`install.sh:583`) and re-runs the deps script against a clean `bin/`. Since `install.sh:633` fetches that script from `main`, **merging this PR is what unblocks users — no release is required.** Fix 2 ships the same way, via the installer rewriting the unit.

## Known limitations

- The closure filter still evaluates against the deck as it exists at install time, so a lib deferred today can still be dropped by a future OS update. This PR removes the dangling-link artifact and the shadowing, not the deferral itself. Worth a follow-up: have `ExecStartPre` detect unresolved sonames and re-run the closure build, so the bundle self-heals after an OS update.
- `StartLimitIntervalSec=0` was replaced with `60`/`StartLimitBurst=20` after review: `UpheldBy=` re-queues a start as soon as the unit goes inactive, and those starts are not paced by `RestartSec=`, so removing the limiter entirely left a clean exit able to respawn unthrottled.
- `libvulkan.so.1` is bundled by Electrobun *and* present system-wide (`1.4.350` on this deck), so the bundled copy wins via `LD_LIBRARY_PATH=./` on **every** distro. Same shape as the fontconfig bug, and untouched here: the copy loop skips pre-existing files and never modifies Electrobun's own libs. Low risk — the Vulkan loader ABI is stable at `.so.1` and nothing else in the closure links against it — but it is the one shadowing candidate this fix leaves in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpSR4iGh1TsXMvsCVQjCRQ

