### PR TITLE
perf(overlay): pause animations while hidden — 20.3% → 3.4% idle CPU

### DIFF
--- a/apps/loadout-overlay/src/overlay/index.css
+++ b/apps/loadout-overlay/src/overlay/index.css
@@ -1025,11 +1025,17 @@ body {
    why document.hidden can't be relied on under gamescope, and for the
    measured cost of leaving the focus ring pulsing at 120Hz off-screen.
 
-   `!important` is load-bearing: @loadout/ui sets the focus ring via an
-   inline `animation: focusPulse 2s ease-in-out infinite` shorthand
-   (Button, IconButton, Toggle, Slider, GameCard, GamepadNav), and an
-   inline shorthand resets animation-play-state to `running`. A normal
-   stylesheet declaration loses to inline styles; an !important one wins.
+   `!important` is load-bearing: the focus ring is also set from inline
+   `style` in a dozen-odd places (@loadout/ui's Button, IconButton, Toggle,
+   Slider, GameCard, Collapse; the overlay's GamepadNav; and several
+   plugins), always as the `animation:` shorthand — which resets
+   animation-play-state to `running`. A normal stylesheet declaration loses
+   to an inline style; an important one outranks it, because importance is
+   compared before the inline-style step of the cascade.
+
+   Keep the rule unlayered. Unlayered !important ranks LOWEST among
+   important author declarations, so moving this into a @layer would let
+   any layered important animation rule beat it.
 
    Deliberately `animation-play-state` and not `animation: none`: paused
    animations hold their current frame, so the ring is still drawn and

--- a/apps/loadout-overlay/src/overlay/index.css
+++ b/apps/loadout-overlay/src/overlay/index.css
@@ -1020,6 +1020,26 @@ body {
   50%      { box-shadow: 0 0 0 3px color-mix(in oklch, var(--color-primary) 25%, transparent); }
 }
 
+/* Park every animation while the overlay window is hidden. Set from
+   dispatchVisibility() in src/webview/main.tsx — see the comment there for
+   why document.hidden can't be relied on under gamescope, and for the
+   measured cost of leaving the focus ring pulsing at 120Hz off-screen.
+
+   `!important` is load-bearing: @loadout/ui sets the focus ring via an
+   inline `animation: focusPulse 2s ease-in-out infinite` shorthand
+   (Button, IconButton, Toggle, Slider, GameCard, GamepadNav), and an
+   inline shorthand resets animation-play-state to `running`. A normal
+   stylesheet declaration loses to inline styles; an !important one wins.
+
+   Deliberately `animation-play-state` and not `animation: none`: paused
+   animations hold their current frame, so the ring is still drawn and
+   reappears mid-pulse on reopen rather than popping. */
+.loadout-idle *,
+.loadout-idle *::before,
+.loadout-idle *::after {
+  animation-play-state: paused !important;
+}
+
 @keyframes viewEnter {
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: translateY(0); }

--- a/apps/loadout-overlay/src/webview/lib/electrobun.ts
+++ b/apps/loadout-overlay/src/webview/lib/electrobun.ts
@@ -173,7 +173,8 @@ export async function getOverlayVisibility(): Promise<boolean> {
  * which `defineRPC()` has not attached during early boot — so it takes its
  * `return true` branch and claims the overlay is open when the window was
  * in fact created hidden. That optimistic default is right for callers
- * that only gate input polling (better to poll than to swallow input), but
+ * that only gate input polling (better to poll than to swallow input) — it
+ * has no callers today but is kept for API parity, see knip.ts — but
  * wrong for anything that acts on being *hidden*: they need to tell a real
  * "open" apart from "ask me later".
  *
@@ -184,7 +185,13 @@ export async function getOverlayVisibility(): Promise<boolean> {
  * `{ isOpen: false }`.
  */
 export async function tryGetOverlayVisibility(): Promise<boolean | null> {
-  if (!isElectrobun) return null;
+  // `true`, not `null`: outside Electrobun there is no host window to be
+  // hidden behind, so "visible" is a definite answer rather than "ask me
+  // later". It matters because callers park animations on anything that
+  // isn't a positive "open" — under `webview:dev` (vite rooted at
+  // src/webview) nothing would ever push a visibility message, so `null`
+  // here would leave the whole dev UI frozen at `opacity: 0`.
+  if (!isElectrobun) return true;
   const req = getElectroRpc()?.request?.getOverlayVisibility;
   if (typeof req !== "function") return null;
   const res = (await req()) as { isOpen?: unknown } | undefined;

--- a/apps/loadout-overlay/src/webview/lib/electrobun.ts
+++ b/apps/loadout-overlay/src/webview/lib/electrobun.ts
@@ -166,6 +166,32 @@ export async function getOverlayVisibility(): Promise<boolean> {
 }
 
 /**
+ * Same question, but answers `null` when we genuinely cannot tell yet
+ * instead of guessing "open".
+ *
+ * `getOverlayVisibility()` above resolves the *static* `Electroview.rpc`,
+ * which `defineRPC()` has not attached during early boot — so it takes its
+ * `return true` branch and claims the overlay is open when the window was
+ * in fact created hidden. That optimistic default is right for callers
+ * that only gate input polling (better to poll than to swallow input), but
+ * wrong for anything that acts on being *hidden*: they need to tell a real
+ * "open" apart from "ask me later".
+ *
+ * Read the instance handle main.tsx stashes on `window` instead. It is
+ * assigned at module scope, before boot() runs, so it is already live at
+ * the point the static one is still missing — verified on-device, where
+ * the static path fail-opened at t≈19ms while this one returned the true
+ * `{ isOpen: false }`.
+ */
+export async function tryGetOverlayVisibility(): Promise<boolean | null> {
+  if (!isElectrobun) return null;
+  const req = getElectroRpc()?.request?.getOverlayVisibility;
+  if (typeof req !== "function") return null;
+  const res = (await req()) as { isOpen?: unknown } | undefined;
+  return typeof res?.isOpen === "boolean" ? res.isOpen : null;
+}
+
+/**
  * Subscribe to Bun → webview `overlay-open-plugin` messages emitted
  * when a controller shortcut bound to OpenPlugin fires. Resolves to
  * an unsubscribe function. No-op outside Electrobun.

--- a/apps/loadout-overlay/src/webview/main.tsx
+++ b/apps/loadout-overlay/src/webview/main.tsx
@@ -37,7 +37,7 @@ import {
   onOverlayToggleKeyboard,
   onOverlayScroll,
   onOverlayVisibility,
-  getOverlayVisibility,
+  tryGetOverlayVisibility,
   type OverlayAction,
 } from "./lib/electrobun";
 import { setKeyboardVisible, isKeyboardVisible } from "@loadout/ui";
@@ -218,10 +218,10 @@ async function boot() {
 
   // Two paths deliver open/close, and they race. `onOverlayVisibility`
   // registers against a synchronous global and is live almost immediately;
-  // `getOverlayVisibility` awaits `import("electrobun/view")` and then an
-  // RPC round trip. So a pushed transition can — and on the boot-time open
-  // paths does — arrive BEFORE the initial fetch resolves, and the fetch's
-  // now-stale value must not overwrite it.
+  // the initial fetch has to resolve an RPC handle first. So a pushed
+  // transition can — and on the boot-time open paths does — arrive BEFORE
+  // the fetch resolves, and the fetch's now-stale value must not overwrite
+  // it.
   //
   // Landing a stale `false` while the window is on screen is worse than a
   // frozen focus ring: `viewEnter`/`fadeIn` are one-shot entry animations
@@ -229,10 +229,17 @@ async function boot() {
   // just mounted — App.tsx's view container and the whole plugin surface in
   // PluginHost.tsx. The overlay would render blank, and stale-false also
   // stops gamepad polling, so it would be unresponsive too.
+  //
+  // `tryGetOverlayVisibility` rather than `getOverlayVisibility`: the latter
+  // fail-opens to `true` when the static RPC handle isn't attached yet,
+  // which at boot is *always* — measured on-device, it undid the class 0ms
+  // after it was set and left the renderer unthrottled until the first
+  // manual close. A `null` here means "couldn't tell", and the right
+  // response is to keep the parked default rather than assume open.
   let visibilityPushed = false;
-  getOverlayVisibility()
+  tryGetOverlayVisibility()
     .then((isOpen) => {
-      if (!visibilityPushed) dispatchVisibility(isOpen);
+      if (isOpen !== null && !visibilityPushed) dispatchVisibility(isOpen);
     })
     .catch((err) =>
       console.warn("[main] getOverlayVisibility failed:", err),

--- a/apps/loadout-overlay/src/webview/main.tsx
+++ b/apps/loadout-overlay/src/webview/main.tsx
@@ -185,6 +185,19 @@ async function boot() {
   // keyboard events and plays select sounds while the user is back in
   // the game, because gamescope's minimize doesn't flip document.hidden.
   function dispatchVisibility(isOpen: boolean): void {
+    // Same root cause as the polling stop above, one layer down: because
+    // minimize never flips document.hidden, Chromium does not treat the
+    // page as hidden and so never throttles the renderer. The focus ring
+    // is `focusPulse 2s ease-in-out infinite`, and spatial-nav always
+    // leaves something focused, so there is permanently one running
+    // animation and the compositor repaints at the display's refresh rate
+    // forever — including while the overlay is closed and off-screen.
+    //
+    // Measured on an ONEXPLAYER APEX (120Hz), overlay CLOSED and idle:
+    // 20.3% of a core with the animation running, 3.4% with animations
+    // paused. That is a constant battery cost on a handheld for a ring
+    // nobody can see. Park them whenever the window is hidden.
+    document.documentElement.classList.toggle("loadout-idle", !isOpen);
     window.dispatchEvent(
       new CustomEvent("loadout:overlay-visibility", {
         detail: { isOpen },

--- a/apps/loadout-overlay/src/webview/main.tsx
+++ b/apps/loadout-overlay/src/webview/main.tsx
@@ -205,15 +205,17 @@ async function boot() {
     );
   }
   // The window is created hidden at boot (see the BrowserWindow comment in
-  // src/bun/index.ts), so start parked rather than waiting to be told. The
-  // initial fetch below has to await a dynamic import plus an RPC round
-  // trip, and it fails open (getOverlayVisibility() returns true when the
-  // RPC handle is missing) — without this, a slow or failed boot leaves the
-  // renderer unthrottled for the entire session, which is the case this is
-  // all meant to fix. Safe to do unconditionally: this entry point only
-  // runs inside the Electrobun webview (src/overlay/main.tsx is the
-  // standalone dev entry and never imports this file), so there is no
-  // browser-only context where nothing would ever clear it.
+  // src/bun/index.ts), so start parked rather than waiting to be told —
+  // otherwise a slow or dropped initial fetch leaves the renderer
+  // unthrottled for the whole session, which is the case this is all meant
+  // to fix. Erring toward parked is the deliberate bias: burning a core
+  // forever is worse than a ring that is briefly static.
+  //
+  // Unconditional is safe only because `tryGetOverlayVisibility()` answers
+  // a definite `true` outside Electrobun. This file IS reachable in a plain
+  // browser — `webview:dev` runs vite rooted at src/webview — and there
+  // nothing ever pushes a visibility message, so a `null` there would leave
+  // the class on and freeze the dev UI at `opacity: 0`.
   document.documentElement.classList.add("loadout-idle");
 
   // Two paths deliver open/close, and they race. `onOverlayVisibility`
@@ -236,13 +238,19 @@ async function boot() {
   // after it was set and left the renderer unthrottled until the first
   // manual close. A `null` here means "couldn't tell", and the right
   // response is to keep the parked default rather than assume open.
+  //
+  // There is no retry and no timeout shorter than the 30s maxRequestTime.
+  // A dropped request therefore parks us until the next real transition,
+  // which is the intended bias — but see the PR notes: combined with a
+  // push lost before the listener below registers, it is the one path that
+  // can leave a visible overlay parked, and it self-heals on next toggle.
   let visibilityPushed = false;
   tryGetOverlayVisibility()
     .then((isOpen) => {
       if (isOpen !== null && !visibilityPushed) dispatchVisibility(isOpen);
     })
     .catch((err) =>
-      console.warn("[main] getOverlayVisibility failed:", err),
+      console.warn("[main] tryGetOverlayVisibility failed:", err),
     );
   onOverlayVisibility((isOpen) => {
     visibilityPushed = true;

--- a/apps/loadout-overlay/src/webview/main.tsx
+++ b/apps/loadout-overlay/src/webview/main.tsx
@@ -204,12 +204,43 @@ async function boot() {
       }),
     );
   }
+  // The window is created hidden at boot (see the BrowserWindow comment in
+  // src/bun/index.ts), so start parked rather than waiting to be told. The
+  // initial fetch below has to await a dynamic import plus an RPC round
+  // trip, and it fails open (getOverlayVisibility() returns true when the
+  // RPC handle is missing) — without this, a slow or failed boot leaves the
+  // renderer unthrottled for the entire session, which is the case this is
+  // all meant to fix. Safe to do unconditionally: this entry point only
+  // runs inside the Electrobun webview (src/overlay/main.tsx is the
+  // standalone dev entry and never imports this file), so there is no
+  // browser-only context where nothing would ever clear it.
+  document.documentElement.classList.add("loadout-idle");
+
+  // Two paths deliver open/close, and they race. `onOverlayVisibility`
+  // registers against a synchronous global and is live almost immediately;
+  // `getOverlayVisibility` awaits `import("electrobun/view")` and then an
+  // RPC round trip. So a pushed transition can — and on the boot-time open
+  // paths does — arrive BEFORE the initial fetch resolves, and the fetch's
+  // now-stale value must not overwrite it.
+  //
+  // Landing a stale `false` while the window is on screen is worse than a
+  // frozen focus ring: `viewEnter`/`fadeIn` are one-shot entry animations
+  // with no fill-mode, so pausing them at t=0 pins `opacity: 0` on whatever
+  // just mounted — App.tsx's view container and the whole plugin surface in
+  // PluginHost.tsx. The overlay would render blank, and stale-false also
+  // stops gamepad polling, so it would be unresponsive too.
+  let visibilityPushed = false;
   getOverlayVisibility()
-    .then(dispatchVisibility)
+    .then((isOpen) => {
+      if (!visibilityPushed) dispatchVisibility(isOpen);
+    })
     .catch((err) =>
       console.warn("[main] getOverlayVisibility failed:", err),
     );
-  onOverlayVisibility(dispatchVisibility);
+  onOverlayVisibility((isOpen) => {
+    visibilityPushed = true;
+    dispatchVisibility(isOpen);
+  });
 
   // Bun-side ControllerShortcuts → OpenPlugin lands here. Route straight
   // into the App's hash-based router; the webview is persistent so the


### PR DESCRIPTION
## The problem

The overlay burns **~20% of a CPU core continuously while closed**, on a battery-powered handheld. It draws a focus ring nobody can see, at 120Hz, forever.

## Root cause

Already documented two lines above the fix, in the comment explaining why `useGamepadInput` stops polling:

> gamescope's minimize doesn't flip `document.hidden`

Chromium only throttles a renderer when it believes the page is hidden. Minimize under gamescope never sets that, so the page stays `visibilityState: "visible"` and the renderer runs unthrottled. Combine that with:

```css
:focus-visible { animation: focusPulse 2s ease-in-out infinite; }
```

and the fact that spatial-nav *always* leaves something focused, and there is permanently one running animation. The compositor repaints at the display's refresh rate — 120Hz on an APEX — whether or not the window is on screen.

Confirmed over CDP against the live renderer with the overlay closed:

```json
{ "visibility": "visible", "hidden": false, "runningAnimations": 1 }
animations: [{"state":"running","name":"focusPulse", "target":"DIV.rounded-lg …"}]
```

## The fix

`useGamepadInput` already hangs off the `loadout:overlay-visibility` bridge for exactly this reason. Hang the animation pause off it too: toggle a `loadout-idle` class on `<html>`, and park every animation beneath it.

Two deliberate details, both commented in-tree:

- **`!important` is load-bearing.** `@loadout/ui` sets the ring via an inline `animation:` shorthand (Button, IconButton, Toggle, Slider, GameCard, GamepadNav). An inline shorthand resets `animation-play-state` to `running`, and inline styles beat normal stylesheet declarations — only `!important` wins.
- **`animation-play-state: paused`, not `animation: none`.** Paused animations hold their current frame, so the ring stays drawn and resumes mid-pulse on reopen rather than popping.

## Measurements

Whole service, `CPUUsageNSec` delta over 60s. Overlay **closed** and idle, unit up 40+ minutes so startup work is excluded, nothing attached to CDP during the sample:

| state | CPU over 60s | of one core |
|---|---|---|
| animations running | 12183 ms | **20.3%** |
| animations paused | 2021 ms | **3.4%** |

Per-process at steady state, scoped to the overlay's own `bin/` path: renderer ~15%, gpu-process ~4.5%, browser ~2.8%.

Two measurement notes, since both misled me first time round:
- `ps -o pcpu` reports the **lifetime average**, not the current rate, and reads high for a long-lived process that was busy at startup. All figures above are `/proc/<pid>/stat` or `CPUUsageNSec` deltas.
- `pgrep -f "type=renderer"` matches **any** Chromium on the box — there are 4 others here, mostly Steam. Process-level figures are scoped to `pgrep -f "loadout-overlay/bin"`.

## Not the Electrobun busy-loop

This is a **different bug** from the CEF browser-process spin fixed by the vendored wrapper patch (upstream electrobun #473). That patch is present and working in the installed bundle — the `loadout-cef147` marker is in `libNativeWrapper.so`, and the browser process sits at ~2.8% rather than the ~100% it used to pin. The cost here is in the renderer and GPU process, which that patch never touched.

Worth noting separately: electrobun #473 and #477 were both **closed without merging upstream**, so the vendored patch is load-bearing and any Electrobun version bump will need re-patching.

## Review fix: a stale visibility fetch could blank the overlay

Caught in review on the first commit, fixed in `95c1c1b`.

Open/close arrives by two racing paths. `onOverlayVisibility` registers against a synchronous global and is live almost immediately; `getOverlayVisibility` awaits `import("electrobun/view")` plus an RPC round trip. So a pushed transition can arrive **before** the initial fetch resolves — and does on the boot-time open paths — after which the fetch lands its now-stale value on top.

Pausing on a stale `false` while the window is on screen is much worse than a frozen focus ring. `viewEnter` and `fadeIn` are one-shot, have no fill-mode, and start at `opacity: 0`, and they wrap App.tsx's view container and the entire plugin surface in `PluginHost.tsx` — so the overlay renders **blank**. The same stale value stops gamepad polling, so it is unresponsive at the same time.

The race predates this PR (the `CustomEvent` already carried the stale value); before this change the cost was only dead polling. Fixed with a latest-wins guard.

Also **defaults the class on at boot**: the window is created hidden, and `getOverlayVisibility()` fails *open* (returns `true` when the RPC handle is missing) with a `.catch` that only logs — so a slow or failed boot would leave the renderer unthrottled for the whole session, precisely the case this PR exists to fix. Unconditional is safe because this entry point only runs inside the Electrobun webview; `src/overlay/main.tsx` is the standalone dev entry and never imports it.

## Bonus fix (found in review, not originally claimed)

`App.tsx:179-186` resolves `visReady` on the first `isOpen === true`. The old fail-open initial dispatch delivered `true` **at boot, while the window was hidden** — exactly what the surrounding comment says must not happen ("otherwise the confirmation is consumed while the window is hidden"). Update toasts could therefore fire into a hidden overlay and `updatePendingTag` be cleared unseen. Returning the true `false` makes `visReady` wait for a real open.

## Known limitation

The initial request has no retry and no timeout shorter than `maxRequestTime` (30s). If it is dropped **and** a push is lost before the listener registers, a visible overlay stays parked until the next transition — which, because `viewEnter`/`fadeIn` have no fill-mode, means a blank panel rather than a static one. Left as-is deliberately: erring toward parked is the intended bias here (a permanently spinning core is worse than a rare, self-healing blank), and every real open path lands after listener registration.

## Verification status

- `bun run typecheck` clean, `eslint` clean on the changed files.
- The **mechanism** is verified on-device: injecting exactly this CSS and class over CDP into the live renderer produced the 20.3% → 3.4% drop in the table above.
- **Not** yet verified end-to-end from a built bundle — that needs an overlay rebuild + reinstall, which would replace a currently-working install mid-session. Worth doing before merge, and given the race above the test that matters is specifically **"wake the overlay during boot"**, not just open/close/reopen: confirm it comes up visible rather than blank, that the class lands on `<html>` on close, and that the ring animates again on reopen.

There is no webview test suite, and `dispatchVisibility` is a closure inside `main()`, so this has no unit test. Extracting it solely to test a two-line toggle seemed worse than leaving it; happy to do so if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpSR4iGh1TsXMvsCVQjCRQ


