### PR TITLE
feat(crash-report): opt-in crash reporting core (#246)

### DIFF
--- a/apps/loadout-overlay/electrobun.config.ts
+++ b/apps/loadout-overlay/electrobun.config.ts
@@ -18,8 +18,17 @@ export default {
   },
   build: {
     // Bun-side main process entrypoint.
+    //
+    // `bun` accepts Bun.build() options (see the ElectrobunConfig.ts
+    // referenced above), so the version is baked in the same way
+    // vite.config.ts bakes `__OVERLAY_VERSION__` for the webview. The Bun
+    // process had no version of its own before, and crash reports need one
+    // to attribute a stack trace to a release.
     bun: {
       entrypoint: "src/bun/index.ts",
+      define: {
+        __OVERLAY_BUN_VERSION__: JSON.stringify(pkg.version),
+      },
     },
     // The webview is built separately by Vite (`bunx vite build` or
     // `bun run webview:build` from this package) so it can use the

--- a/apps/loadout-overlay/package.json
+++ b/apps/loadout-overlay/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@noriginmedia/norigin-spatial-navigation": "^3.0.0",
+    "@loadout/crash-report": "workspace:*",
     "@loadout/deck-hid": "workspace:*",
     "@loadout/devices": "workspace:*",
     "@loadout/exec": "workspace:*",

--- a/apps/loadout-overlay/src/bun/crash-init.ts
+++ b/apps/loadout-overlay/src/bun/crash-init.ts
@@ -1,0 +1,37 @@
+/**
+ * Crash reporting for the overlay's Bun main process.
+ *
+ * **Import order matters and is load-bearing.** This module must be imported
+ * before `electrobun/bun`, which registers its own `uncaughtException`
+ * listener (node_modules/electrobun/dist/api/bun/proc/native.ts) that calls a
+ * native `forceExit(1)`. Node runs listeners in registration order, so a
+ * handler registered after that import never executes — the process is gone
+ * before it is reached. `src/bun/index.ts` imports this at the very top,
+ * alongside the `display-detect` side-effect import that exists for the same
+ * class of reason.
+ *
+ * The handlers use `captureFatalSync`, which writes to disk rather than
+ * sending. Electrobun's `forceExit` would kill an in-flight request, so the
+ * report is spooled and shipped by the next successful start.
+ */
+
+import { initCrashReporting, captureFatalSync, captureErrorSync } from "@loadout/crash-report";
+import { OVERLAY_BUN_VERSION } from "./version";
+import { trace } from "./native/trace";
+
+initCrashReporting({ process: "overlay-bun", release: OVERLAY_BUN_VERSION });
+
+process.on("uncaughtException", (err) => {
+  console.error("[overlay] uncaught exception:", err);
+  trace(`uncaught exception: ${err.stack ?? err.message}`);
+  // Synchronous: Electrobun's listener force-exits right after this one.
+  captureFatalSync(err);
+});
+
+process.on("unhandledRejection", (reason) => {
+  console.error("[overlay] unhandled rejection:", reason);
+  trace(`unhandled rejection: ${reason instanceof Error ? reason.stack ?? reason.message : reason}`);
+  // Electrobun's rejection listener only logs, so the process survives and an
+  // ordinary async send has time to complete.
+  captureErrorSync(reason);
+});

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -10,14 +10,15 @@
 // in source order, so placing this side-effect import first guarantees
 // process.env.DISPLAY is set before libNativeWrapper is even resolved.
 import "./native/display-detect";
+
+// Registers the crash handlers. MUST stay above the `electrobun/bun` import
+// below: Electrobun installs an `uncaughtException` listener that natively
+// force-exits, and listeners run in registration order — anything registered
+// after it is dead code. See crash-init.ts.
+import "./crash-init";
+
 import { detectOverlayDisplay } from "./native/display-detect";
 const DISPLAY = detectOverlayDisplay();
-
-// Opt-in crash reporting. Inert unless the user granted consent *and* a DSN
-// is configured. Consent is read straight off config.json on every capture —
-// this process can't be told over RPC, because the webview may be the very
-// thing that died.
-initCrashReporting({ process: "overlay-bun", release: OVERLAY_BUN_VERSION });
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — resolved at runtime once electrobun is installed.
@@ -56,8 +57,7 @@ import {
 } from "./native/process-control";
 
 import { trace } from "./native/trace";
-import { initCrashReporting, captureErrorSync } from "@loadout/crash-report";
-import { OVERLAY_BUN_VERSION } from "./version";
+import { captureFatalSync } from "@loadout/crash-report";
 import { createOverlayState } from "./lib/overlay-state";
 import { routeWake, isStartupWakePhantom } from "./lib/wake-routing";
 import { loadPersistedShortcuts } from "./lib/persisted-shortcuts";
@@ -1039,10 +1039,10 @@ overlayManagementLoop({
   toggleOverlay,
 }).catch((e) => {
   console.error("[overlay] management loop crashed:", e);
-  // A deliberate fatal exit with a known error object — the clearest crash
-  // signal this process produces, so it's worth reporting explicitly rather
-  // than leaving to the uncaughtException handler (which this never reaches).
-  captureErrorSync(e, { level: "fatal" });
+  // Spooled synchronously, not sent. `process.exit(1)` on the next line kills
+  // any in-flight request, so an async send here would never arrive — the
+  // report is written to disk and shipped by the next start instead.
+  captureFatalSync(e);
   process.exit(1);
 });
 
@@ -1072,22 +1072,6 @@ function runShutdown(): Promise<void> {
 }
 process.on("SIGINT", runShutdown);
 process.on("SIGTERM", runShutdown);
-
-// Until now this process had no global error handlers at all: an uncaught
-// throw killed it silently and systemd restarted it, leaving nothing behind
-// but a gap in the journal. Log first (so the failure is visible on-device
-// even with reporting off), then report opt-in.
-//
-// Deliberately no `await` and no shutdown work here. This process owes Steam
-// a prompt SIGCONT — a report that blocked exit would leave the whole machine
-// looking frozen, which is a far worse bug than a lost crash report.
-process.on("uncaughtException", (err) => {
-  console.error("[overlay] uncaught exception:", err);
-  trace(`uncaught exception: ${err.stack ?? err.message}`);
-  captureErrorSync(err, { level: "fatal" });
-});
-process.on("unhandledRejection", (reason) => {
-  console.error("[overlay] unhandled rejection:", reason);
-  trace(`unhandled rejection: ${reason instanceof Error ? reason.stack ?? reason.message : reason}`);
-  captureErrorSync(reason);
-});
+// Global uncaughtException / unhandledRejection handlers live in
+// ./crash-init, imported at the top of this file — they must be registered
+// before `electrobun/bun` installs its own force-exiting listener.

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -13,6 +13,12 @@ import "./native/display-detect";
 import { detectOverlayDisplay } from "./native/display-detect";
 const DISPLAY = detectOverlayDisplay();
 
+// Opt-in crash reporting. Inert unless the user granted consent *and* a DSN
+// is configured. Consent is read straight off config.json on every capture —
+// this process can't be told over RPC, because the webview may be the very
+// thing that died.
+initCrashReporting({ process: "overlay-bun", release: OVERLAY_BUN_VERSION });
+
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — resolved at runtime once electrobun is installed.
 import { BrowserWindow, BrowserView, GlobalShortcut } from "electrobun/bun";
@@ -50,6 +56,8 @@ import {
 } from "./native/process-control";
 
 import { trace } from "./native/trace";
+import { initCrashReporting, captureErrorSync } from "@loadout/crash-report";
+import { OVERLAY_BUN_VERSION } from "./version";
 import { createOverlayState } from "./lib/overlay-state";
 import { routeWake, isStartupWakePhantom } from "./lib/wake-routing";
 import { loadPersistedShortcuts } from "./lib/persisted-shortcuts";
@@ -1031,6 +1039,10 @@ overlayManagementLoop({
   toggleOverlay,
 }).catch((e) => {
   console.error("[overlay] management loop crashed:", e);
+  // A deliberate fatal exit with a known error object — the clearest crash
+  // signal this process produces, so it's worth reporting explicitly rather
+  // than leaving to the uncaughtException handler (which this never reaches).
+  captureErrorSync(e, { level: "fatal" });
   process.exit(1);
 });
 
@@ -1060,3 +1072,22 @@ function runShutdown(): Promise<void> {
 }
 process.on("SIGINT", runShutdown);
 process.on("SIGTERM", runShutdown);
+
+// Until now this process had no global error handlers at all: an uncaught
+// throw killed it silently and systemd restarted it, leaving nothing behind
+// but a gap in the journal. Log first (so the failure is visible on-device
+// even with reporting off), then report opt-in.
+//
+// Deliberately no `await` and no shutdown work here. This process owes Steam
+// a prompt SIGCONT — a report that blocked exit would leave the whole machine
+// looking frozen, which is a far worse bug than a lost crash report.
+process.on("uncaughtException", (err) => {
+  console.error("[overlay] uncaught exception:", err);
+  trace(`uncaught exception: ${err.stack ?? err.message}`);
+  captureErrorSync(err, { level: "fatal" });
+});
+process.on("unhandledRejection", (reason) => {
+  console.error("[overlay] unhandled rejection:", reason);
+  trace(`unhandled rejection: ${reason instanceof Error ? reason.stack ?? reason.message : reason}`);
+  captureErrorSync(reason);
+});

--- a/apps/loadout-overlay/src/bun/version.ts
+++ b/apps/loadout-overlay/src/bun/version.ts
@@ -1,0 +1,13 @@
+/**
+ * Product version for the overlay's Bun main process.
+ *
+ * Baked in by `electrobun.config.ts` via `build.bun.define`, mirroring how
+ * `vite.config.ts` bakes `__OVERLAY_VERSION__` for the webview. Falls back to
+ * "dev" when running from source (`electrobun dev`), which is also what makes
+ * crash reporting treat a dev run as the `development` environment.
+ */
+
+declare const __OVERLAY_BUN_VERSION__: string | undefined;
+
+export const OVERLAY_BUN_VERSION: string =
+  typeof __OVERLAY_BUN_VERSION__ === "string" ? __OVERLAY_BUN_VERSION__ : "dev";

--- a/apps/loadout/package.json
+++ b/apps/loadout/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "@loadout/types": "workspace:*",
+    "@loadout/crash-report": "workspace:*",
     "@loadout/steam-paths": "workspace:*",
     "@loadout/exec": "workspace:*",
     "@loadout/game-library": "workspace:*",

--- a/apps/loadout/src/loader/index.ts
+++ b/apps/loadout/src/loader/index.ts
@@ -94,8 +94,8 @@ export function shouldRethrowUncaught(
   return false;
 }
 
-// Opt-in crash reporting. Inert unless the user granted consent *and* a DSN
-// was compiled in — see packages/crash-report. Initialising here, at module
+// Opt-in crash reporting. Inert unless the user granted consent *and* a
+// collector URL was compiled in — see packages/crash-report. Here, at module
 // scope before the handlers below, means the reporter is live for the
 // earliest possible failure.
 //
@@ -106,7 +106,7 @@ export function shouldRethrowUncaught(
 // proxy. A crash inside a plugin-scoped async callback (a setInterval
 // registered in onLoad, say) would then have its report evaluated against
 // that plugin's network allow-list, silently dropped, and logged as the
-// plugin attempting to reach Sentry.
+// plugin attempting to reach the collector.
 // `chown` matters because this process is root and writes under the desktop
 // user's $HOME, which the user-level overlay also writes to. Without it the
 // state directory is created root-owned and every overlay write fails EACCES

--- a/apps/loadout/src/loader/index.ts
+++ b/apps/loadout/src/loader/index.ts
@@ -39,6 +39,8 @@ import {
 import { SteamInjector } from "../injector";
 import { dispatchRoute, type RouteContext } from "./routes";
 import { cleanupStaleSelfUpdateArtifacts } from "./self-update";
+import { initCrashReporting, captureErrorSync } from "@loadout/crash-report";
+import { LOADER_VERSION } from "../version";
 
 // Global error handlers — prevent plugin crashes from killing the server.
 // The real fix is process isolation (P1 TODO), but this keeps the server alive
@@ -90,11 +92,24 @@ export function shouldRethrowUncaught(
   return false;
 }
 
+// Opt-in crash reporting. Inert unless the user granted consent *and* a DSN
+// was compiled in — see packages/crash-report. Initialising here, at module
+// scope before the handlers below, means the reporter is live for the
+// earliest possible failure.
+initCrashReporting({ process: "backend", release: LOADER_VERSION });
+
 process.on("unhandledRejection", (reason) => {
   log.error(`Unhandled rejection: ${reason instanceof Error ? reason.stack ?? reason.message : reason}`);
+  captureErrorSync(reason);
 });
 process.on("uncaughtException", (err) => {
   log.error(`Uncaught exception: ${err.stack ?? err.message}`);
+  // Reported before the swallow decision, deliberately. In production this
+  // handler keeps the server alive (A-009), which means these exceptions are
+  // invisible today — not just to us, but to the user, who sees only that
+  // something quietly stopped working. This is the single highest-value
+  // capture point in the codebase for exactly that reason.
+  captureErrorSync(err, { level: shouldRethrowUncaught(err) ? "fatal" : "error" });
   if (shouldRethrowUncaught(err)) {
     throw err;
   }

--- a/apps/loadout/src/loader/index.ts
+++ b/apps/loadout/src/loader/index.ts
@@ -18,6 +18,7 @@ import {
   loadPlugins,
   withSandboxedFetch,
 } from "./plugin-manager";
+import { unsandboxedFetch } from "./sandboxed-fetch";
 import { resolveDisabledPlugins, DISABLED_PLUGINS_KEY } from "./user-config";
 import { createRpcHandler } from "./rpc-handler";
 import { log } from "./logger";
@@ -96,7 +97,20 @@ export function shouldRethrowUncaught(
 // was compiled in — see packages/crash-report. Initialising here, at module
 // scope before the handlers below, means the reporter is live for the
 // earliest possible failure.
-initCrashReporting({ process: "backend", release: LOADER_VERSION });
+//
+// `fetchImpl` is passed explicitly and must stay that way. `plugin-manager`
+// replaces `globalThis.fetch` with a proxy that resolves the *calling
+// plugin's* sandboxed fetch via AsyncLocalStorage, and it is imported before
+// this module — so anything the reporter captured for itself would be that
+// proxy. A crash inside a plugin-scoped async callback (a setInterval
+// registered in onLoad, say) would then have its report evaluated against
+// that plugin's network allow-list, silently dropped, and logged as the
+// plugin attempting to reach Sentry.
+initCrashReporting({
+  process: "backend",
+  release: LOADER_VERSION,
+  fetchImpl: unsandboxedFetch,
+});
 
 process.on("unhandledRejection", (reason) => {
   log.error(`Unhandled rejection: ${reason instanceof Error ? reason.stack ?? reason.message : reason}`);

--- a/apps/loadout/src/loader/index.ts
+++ b/apps/loadout/src/loader/index.ts
@@ -40,7 +40,8 @@ import {
 import { SteamInjector } from "../injector";
 import { dispatchRoute, type RouteContext } from "./routes";
 import { cleanupStaleSelfUpdateArtifacts } from "./self-update";
-import { initCrashReporting, captureErrorSync } from "@loadout/crash-report";
+import { initCrashReporting, captureErrorSync, captureFatalSync } from "@loadout/crash-report";
+import { chownToTarget } from "./target-user";
 import { LOADER_VERSION } from "../version";
 
 // Global error handlers — prevent plugin crashes from killing the server.
@@ -106,10 +107,15 @@ export function shouldRethrowUncaught(
 // registered in onLoad, say) would then have its report evaluated against
 // that plugin's network allow-list, silently dropped, and logged as the
 // plugin attempting to reach Sentry.
+// `chown` matters because this process is root and writes under the desktop
+// user's $HOME, which the user-level overlay also writes to. Without it the
+// state directory is created root-owned and every overlay write fails EACCES
+// silently — leaving the overlay with no spool and no rate limiting.
 initCrashReporting({
   process: "backend",
   release: LOADER_VERSION,
   fetchImpl: unsandboxedFetch,
+  chown: chownToTarget,
 });
 
 process.on("unhandledRejection", (reason) => {
@@ -123,10 +129,16 @@ process.on("uncaughtException", (err) => {
   // invisible today — not just to us, but to the user, who sees only that
   // something quietly stopped working. This is the single highest-value
   // capture point in the codebase for exactly that reason.
-  captureErrorSync(err, { level: shouldRethrowUncaught(err) ? "fatal" : "error" });
+  //
+  // The two branches need different transports. When we rethrow (OOM, or
+  // debug mode) the process dies on this tick, so an async send would be
+  // killed in flight — spool it instead and let the next start ship it. When
+  // we swallow, the server lives on and an ordinary send completes.
   if (shouldRethrowUncaught(err)) {
+    captureFatalSync(err);
     throw err;
   }
+  captureErrorSync(err);
 });
 
 /**

--- a/apps/loadout/src/loader/sandboxed-fetch.ts
+++ b/apps/loadout/src/loader/sandboxed-fetch.ts
@@ -4,6 +4,19 @@ import type { PluginPermissions } from "@loadout/types";
 const originalFetch = globalThis.fetch;
 
 /**
+ * The unsandboxed `fetch`, captured before `plugin-manager` installs its
+ * proxy over `globalThis.fetch`.
+ *
+ * Exported for the crash reporter, which must not have its requests routed
+ * through whichever plugin's allow-list happens to be scoped when a crash
+ * occurs. It cannot capture this for itself: `plugin-manager` is imported
+ * (and so evaluated) before `@loadout/crash-report`, meaning a module-load
+ * capture there grabs the proxy, not the real thing. Passing this explicitly
+ * makes the guarantee independent of import order.
+ */
+export const unsandboxedFetch: typeof globalThis.fetch = originalFetch;
+
+/**
  * Create a sandboxed fetch function that only allows requests to domains
  * listed in the plugin's `permissions.network` array.
  *

--- a/bun.lock
+++ b/bun.lock
@@ -31,8 +31,9 @@
     },
     "apps/loadout": {
       "name": "@loadout/loadout-server",
-      "version": "0.7.2",
+      "version": "0.8.1",
       "dependencies": {
+        "@loadout/crash-report": "workspace:*",
         "@loadout/exec": "workspace:*",
         "@loadout/game-library": "workspace:*",
         "@loadout/steam-cdp": "workspace:*",
@@ -44,8 +45,9 @@
     },
     "apps/loadout-overlay": {
       "name": "@loadout/loadout-overlay",
-      "version": "0.7.2",
+      "version": "0.8.1",
       "dependencies": {
+        "@loadout/crash-report": "workspace:*",
         "@loadout/deck-hid": "workspace:*",
         "@loadout/devices": "workspace:*",
         "@loadout/exec": "workspace:*",
@@ -72,6 +74,10 @@
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
       },
+    },
+    "packages/crash-report": {
+      "name": "@loadout/crash-report",
+      "version": "0.0.1",
     },
     "packages/deck-hid": {
       "name": "@loadout/deck-hid",
@@ -648,6 +654,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@loadout/crash-report": ["@loadout/crash-report@workspace:packages/crash-report"],
 
     "@loadout/deck-hid": ["@loadout/deck-hid@workspace:packages/deck-hid"],
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -77,9 +77,12 @@ recognise. If this matters to you, leave crash reporting off.
 
 ### Where reports go
 
-To [Sentry](https://sentry.io) (Functional Software, Inc.), on their **EU**
-infrastructure, used purely as an error-tracking processor. Storage of IP
-addresses is disabled at the project level.
+To [Grafana Cloud](https://grafana.com/products/cloud/frontend-observability/)
+(Grafana Labs), on **EU** infrastructure, used purely as an error-tracking
+processor.
+
+Reports are sent to a Faro collector endpoint. Loadout explicitly disables
+Grafana Cloud's IP-derived geolocation from the client side, on every report.
 
 ### Turning it off
 
@@ -105,10 +108,15 @@ small enough to read in one sitting:
 - `packages/crash-report/src/spool.ts` — where a report waits if your device
   is offline or crashed before it could be sent
 
-Loadout speaks Sentry's wire protocol directly rather than using their SDK,
-specifically so that this list is complete. An SDK would capture console output,
-network breadcrumbs, and request headers by default, and no honest short
-document could then tell you what leaves your machine.
+Loadout speaks Grafana's Faro wire protocol directly rather than using their
+Web SDK, specifically so that this list is complete. An SDK would capture
+console output, network breadcrumbs, page URLs and request headers by default,
+and no honest short document could then tell you what leaves your machine.
+
+The protocol supports a persistent installation id, a user object, and page and
+browser metadata. Loadout populates none of them. The session id it does send is
+regenerated every time the process starts and is never written to disk, so it
+groups events within a single run and cannot follow you across restarts.
 
 There is a test — "the never-leaks gate" in
 `packages/crash-report/src/crash-report.test.ts` — that builds a report from a

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -38,12 +38,20 @@ Exactly these fields, and nothing else:
 
 - **No IP address**, no account, no user id, no device id — nothing that
   identifies you or your machine across reports
-- **No hostname** — removed even where it appears inside an error message
-- **No home directory or username** — every path is rewritten to `~`
+- **No home directory** — `/home/you/…`, `/var/home/you/…` and removable-media
+  mounts like `/run/media/you/…` are all rewritten
+- **No username or hostname** — removed from paths, and also from free-form
+  error text (see the caveat below)
 - **No Steam ID** — rewritten to `<steamid>` wherever it appears
 - **No API keys, tokens, or passwords** — redacted from error text
 - **No console logs, no browser history, no request URLs, no cookies**
 - **No usage data of any kind** — nothing about what you launch or do
+
+One deliberate exception to the username rule: names shorter than five
+characters are left alone in free-form text, because substituting them would
+mangle ordinary words. In practice this means the standard SteamOS account name
+`deck` is not redacted — it is the same on every Steam Deck and identifies
+nobody. Paths are rewritten regardless of name length.
 
 Because reports carry no identifier, they cannot be linked to you or to each
 other. That is deliberate, and it is also a genuine limitation: it means a
@@ -87,6 +95,8 @@ small enough to read in one sitting:
 - `packages/crash-report/src/scrub.ts` — what is removed before sending
 - `packages/crash-report/src/transport.ts` — the entire network layer
 - `packages/crash-report/src/consent.ts` — the consent check
+- `packages/crash-report/src/spool.ts` — where a report waits if your device
+  is offline or crashed before it could be sent
 
 Loadout speaks Sentry's wire protocol directly rather than using their SDK,
 specifically so that this list is complete. An SDK would capture console output,

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,106 @@
+# Privacy
+
+Loadout collects **nothing** unless you explicitly turn crash reporting on.
+
+There is no usage analytics, no feature tracking, no session recording, and no
+account. Loadout has no server of its own and no way to identify you.
+
+> **Status:** crash reporting is implemented but **not yet enabled** — no
+> reporting endpoint is configured in released builds, so nothing is sent even
+> if the setting is on. This document describes how it behaves once enabled.
+
+## What Loadout does without asking
+
+Two things reach the network by default, both of which predate crash reporting:
+
+| What | Where to | Why |
+|---|---|---|
+| Update check on startup | `api.github.com` | Checks whether a newer release exists. An unauthenticated GET — GitHub sees your IP address and user-agent, and nothing about your machine is sent. |
+| Artwork and plugin data | Steam CDN, and per-plugin services you enable | Game art, ProtonDB ratings, HowLongToBeat times. Each plugin declares which domains it may contact, enforced by a deny-by-default allow-list. |
+
+## Crash reporting
+
+**Off unless you turn it on.** You are asked once, with a plain yes/no and no
+pre-selected answer. Declining is remembered and you are not asked again. You
+can change your mind at any time in **Settings → Privacy**.
+
+### What a crash report contains
+
+Exactly these fields, and nothing else:
+
+- The error type, message, and stack trace
+- Which loadout process crashed (backend, overlay, or interface)
+- The loadout version, and whether the fault came from loadout itself or from a
+  plugin (with the plugin's id)
+- That the operating system is Linux, and the runtime (Bun or CEF)
+
+### What it never contains
+
+- **No IP address**, no account, no user id, no device id — nothing that
+  identifies you or your machine across reports
+- **No hostname** — removed even where it appears inside an error message
+- **No home directory or username** — every path is rewritten to `~`
+- **No Steam ID** — rewritten to `<steamid>` wherever it appears
+- **No API keys, tokens, or passwords** — redacted from error text
+- **No console logs, no browser history, no request URLs, no cookies**
+- **No usage data of any kind** — nothing about what you launch or do
+
+Because reports carry no identifier, they cannot be linked to you or to each
+other. That is deliberate, and it is also a genuine limitation: it means a
+report cannot be traced back and deleted on request, because there is nothing to
+trace it by.
+
+### One thing we cannot fully guarantee
+
+A crash report contains the error message written by whichever code failed. If a
+game or a file has a revealing name and that name is part of the error, it can
+appear in the message. Paths are rewritten, so `/home/you/Games/Some Game` becomes
+`~/Games/Some Game` — the username is gone, but the folder name is not.
+
+We scrub every pattern we can identify. We cannot scrub arbitrary text we can't
+recognise. If this matters to you, leave crash reporting off.
+
+### Where reports go
+
+To [Sentry](https://sentry.io) (Functional Software, Inc.), on their **EU**
+infrastructure, used purely as an error-tracking processor. Storage of IP
+addresses is disabled at the project level.
+
+### Turning it off
+
+Any one of these:
+
+1. **Settings → Privacy → Send crash reports** — off.
+2. Set `"crashReporting": "denied"` in `~/.config/loadout/config.json`.
+3. Delete the key entirely. Anything that isn't exactly `"granted"` — including
+   a missing, empty, or unreadable config file — means no reports are sent.
+
+The check runs on **every** report, not at startup, so switching it off takes
+effect immediately rather than at next restart.
+
+## Verifying any of this
+
+Loadout is BSD-3-Clause licensed and the whole reporting path is deliberately
+small enough to read in one sitting:
+
+- `packages/crash-report/src/types.ts` — every field that can be sent
+- `packages/crash-report/src/scrub.ts` — what is removed before sending
+- `packages/crash-report/src/transport.ts` — the entire network layer
+- `packages/crash-report/src/consent.ts` — the consent check
+
+Loadout speaks Sentry's wire protocol directly rather than using their SDK,
+specifically so that this list is complete. An SDK would capture console output,
+network breadcrumbs, and request headers by default, and no honest short
+document could then tell you what leaves your machine.
+
+There is a test — "the never-leaks gate" in
+`packages/crash-report/src/crash-report.test.ts` — that builds a report from a
+crash containing a home directory, another user's path, a Steam ID, an API key
+and a hostname, then asserts none of them survive into the transmitted bytes.
+
+## Questions
+
+Open an issue at
+[github.com/srsholmes/loadout/issues](https://github.com/srsholmes/loadout/issues).
+
+*Last updated: 2026-08-12.*

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -42,7 +42,8 @@ Exactly these fields, and nothing else:
   mounts like `/run/media/you/…` are all rewritten
 - **No username or hostname** — removed from paths, and also from free-form
   error text (see the caveat below)
-- **No Steam ID** — rewritten to `<steamid>` wherever it appears
+- **No Steam ID** — the account id in `userdata/` paths, plus SteamID64,
+  SteamID3 and SteamID2 forms, are all rewritten to `<steamid>`
 - **No API keys, tokens, or passwords** — redacted from error text
 - **No console logs, no browser history, no request URLs, no cookies**
 - **No usage data of any kind** — nothing about what you launch or do
@@ -53,10 +54,16 @@ mangle ordinary words. In practice this means the standard SteamOS account name
 `deck` is not redacted — it is the same on every Steam Deck and identifies
 nobody. Paths are rewritten regardless of name length.
 
-Because reports carry no identifier, they cannot be linked to you or to each
-other. That is deliberate, and it is also a genuine limitation: it means a
+No identifier is attached to a report deliberately — there is no account, no
+device id, and no generated install id. So reports are not designed to be
+linkable to you or to each other, and one practical consequence is that a
 report cannot be traced back and deleted on request, because there is nothing to
 trace it by.
+
+We stop short of promising that linkage is *impossible*. A stack trace is
+free-form text produced by whatever code failed, and the guarantee is only ever
+as good as the scrubbing described above. We remove every identifier we know how
+to recognise — and we keep finding new ones to add.
 
 ### One thing we cannot fully guarantee
 

--- a/packages/crash-report/package.json
+++ b/packages/crash-report/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@loadout/crash-report",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "BSD-3-Clause"
+}

--- a/packages/crash-report/src/consent.ts
+++ b/packages/crash-report/src/consent.ts
@@ -1,0 +1,100 @@
+/**
+ * Consent — tri-state, fail-closed.
+ *
+ * `undefined` is a real state and carries weight: it means *not asked yet*,
+ * which is what makes the upgrade path work. Every existing install already
+ * has `welcomeCompleted: true`, so a consent step bolted onto the welcome
+ * wizard would only ever be seen by fresh installs. Distinguishing "not
+ * asked" from "said no" is what lets the UI prompt upgraders exactly once
+ * without ever re-asking someone who declined.
+ *
+ * Fail-closed is absolute: anything that is not literally `"granted"` —
+ * a missing file, a parse error, a permissions problem, an unexpected type
+ * — means do not report. There is no path through this module where an
+ * error results in sending data.
+ */
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { readFileSync } from "node:fs";
+import type { ConsentState } from "./types";
+
+/** Config key in `~/.config/loadout/config.json`. */
+export const CRASH_REPORTING_KEY = "crashReporting";
+
+/**
+ * Candidate config paths, in read order.
+ *
+ * There is a trap here worth spelling out. `user-config.ts` honours
+ * `$XDG_CONFIG_HOME`, but the two processes that need to read consent do not
+ * see the same environment: `loadout.service` is a *system* unit that sets
+ * only `Environment=HOME=<user home>`, while `loadout-overlay.service` is a
+ * *user* unit that inherits the whole session environment. So on a machine
+ * where the user sets `XDG_CONFIG_HOME`, the root backend writes to
+ * `$HOME/.config/loadout` while the overlay would look in
+ * `$XDG_CONFIG_HOME/loadout` — and find nothing.
+ *
+ * Reading both, XDG first, makes every process agree regardless of which
+ * environment it was handed. The failure mode this avoids is quiet: consent
+ * would read as "not asked" forever and reporting would simply never work.
+ */
+export function userConfigPathsFrom(
+  env: Record<string, string | undefined>,
+  home: string,
+): string[] {
+  const paths: string[] = [];
+  const xdg = env.XDG_CONFIG_HOME;
+  if (xdg && xdg.length > 0) paths.push(join(xdg, "loadout", "config.json"));
+  const fallback = join(home, ".config", "loadout", "config.json");
+  if (!paths.includes(fallback)) paths.push(fallback);
+  return paths;
+}
+
+/** The path a writer should use — XDG when set, else `~/.config`. */
+export function userConfigPathFrom(
+  env: Record<string, string | undefined>,
+  home: string,
+): string {
+  return userConfigPathsFrom(env, home)[0] as string;
+}
+
+/** Interpret a raw config value. Anything unexpected reads as "not asked". */
+export function parseConsent(raw: unknown): ConsentState {
+  if (raw === "granted") return "granted";
+  if (raw === "denied") return "denied";
+  return undefined;
+}
+
+/** The only question callers should ask. */
+export function isGranted(state: ConsentState): boolean {
+  return state === "granted";
+}
+
+/**
+ * Read consent straight off disk, synchronously.
+ *
+ * Synchronous and file-based on purpose. This runs on the crash path, where
+ * the process may be moments from death, and in the overlay's Bun process,
+ * which has no other reader for `config.json` and *cannot* be told over RPC —
+ * the webview may be the very thing that just died.
+ */
+export function readConsentSync(
+  env: Record<string, string | undefined> = process.env,
+  home: string = homedir(),
+): ConsentState {
+  for (const path of userConfigPathsFrom(env, home)) {
+    try {
+      const raw = readFileSync(path, "utf8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+      const state = parseConsent(parsed[CRASH_REPORTING_KEY]);
+      // A file that exists but has no answer is not authoritative — the
+      // other candidate path may hold the real one.
+      if (state !== undefined) return state;
+    } catch {
+      // Missing, unreadable, or malformed — try the next candidate.
+    }
+  }
+  // Nothing anywhere said "granted", so: do not report.
+  return undefined;
+}

--- a/packages/crash-report/src/crash-report.test.ts
+++ b/packages/crash-report/src/crash-report.test.ts
@@ -32,7 +32,7 @@ import {
   fileStateStore,
   resetForTests,
 } from "./index";
-import { spoolEvent, MAX_SPOOL_FILES } from "./spool";
+import { spoolEvent, MAX_SPOOL_FILES, MAX_SPOOL_ATTEMPTS } from "./spool";
 import type { SentryEvent } from "./types";
 
 const DSN = "https://abc123@o1.ingest.de.sentry.io/456";
@@ -462,12 +462,29 @@ describe("the never-leaks gate", () => {
     expect(wire).not.toContain("~<plugins>");
   });
 
-  test("a steam id in a path is not silently preserved by normalisation", () => {
-    // Steam userdata paths embed a SteamID64. They arrive under $HOME, so
-    // home normalisation is what removes them; this pins that behaviour.
-    const s = scrubString("/home/deck/.steam/steam/userdata/76561198012345678/config");
-    expect(s).not.toContain("/home/");
-    expect(s.startsWith("~/")).toBe(true);
+  test("removes the Steam account id Steam actually uses in paths", () => {
+    // Steam names userdata directories by the 32-BIT ACCOUNT ID, not the
+    // SteamID64 — `ls ~/.steam/steam/userdata` gives e.g. "25139426". An
+    // earlier version of this test used a fictional 7656119… path, so it
+    // passed while the identifier loadout really handles went out intact.
+    // Add 76561197960265728 to that number and you have a public profile URL.
+    const real = scrubString("/home/deck/.local/share/Steam/userdata/25139426/config/grid/1.png");
+    expect(real).not.toContain("25139426");
+    expect(real).toContain("userdata/<steamid>");
+    // The grid/app path after it survives — useful for triage.
+    expect(real).toContain("grid");
+
+    // The other renderings of the same account, all permanent identifiers.
+    expect(scrubString("profile 76561198012345678 failed")).toBe("profile <steamid> failed");
+    expect(scrubString("owner [U:1:25139426] missing")).toBe("owner <steamid> missing");
+    expect(scrubString("id STEAM_0:1:12569713 invalid")).toBe("id <steamid> invalid");
+  });
+
+  test("does not mangle ordinary numbers outside userdata context", () => {
+    // A bare 8-digit number is indistinguishable from a timestamp or byte
+    // count, so account-id scrubbing is scoped to `userdata/` deliberately.
+    expect(scrubString("wrote 25139426 bytes")).toBe("wrote 25139426 bytes");
+    expect(scrubString("timeout after 16000 ms")).toBe("timeout after 16000 ms");
   });
 });
 
@@ -612,6 +629,67 @@ describe("spool and fatal path", () => {
     expect(readdirSync(dir)).toHaveLength(0);
   });
 
+  test("a failed drain puts reports back instead of destroying them", async () => {
+    // takeSpooled unlinks on read, so without re-spooling, a drain that runs
+    // while the device is offline would wipe the queue — defeating the spool
+    // in the exact situation it exists for.
+    const offline = (async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+
+    initCrashReporting({
+      process: "overlay-bun",
+      dsn: DSN,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      spoolDir: dir,
+      fetchImpl: offline,
+      drainOnInit: false,
+    });
+    captureFatalSync(new Error("survives an offline drain"));
+    expect(readdirSync(dir)).toHaveLength(1);
+
+    expect(await drainSpool()).toBe(0);
+    // Still queued, with the attempt count bumped.
+    const after = readdirSync(dir);
+    expect(after).toHaveLength(1);
+    expect(after[0]).toContain("-a1-");
+
+    // Back online: it finally ships.
+    resetForTests();
+    initCrashReporting({
+      process: "overlay-bun",
+      dsn: DSN,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      spoolDir: dir,
+      fetchImpl,
+      drainOnInit: false,
+    });
+    expect(await drainSpool()).toBe(1);
+    expect(sentBodies[0]).toContain("survives an offline drain");
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
+  test("an event that never sends is eventually given up on", async () => {
+    const offline = (async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+    initCrashReporting({
+      process: "overlay-bun",
+      dsn: DSN,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      spoolDir: dir,
+      fetchImpl: offline,
+      drainOnInit: false,
+    });
+    captureFatalSync(new Error("permanently unsendable"));
+    for (let i = 0; i < MAX_SPOOL_ATTEMPTS + 2; i++) await drainSpool();
+    // Dropped rather than retried forever on every start.
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
   test("a fatal capture without consent writes nothing at all", () => {
     initCrashReporting({
       process: "overlay-bun",
@@ -631,6 +709,60 @@ describe("spool and fatal path", () => {
       spoolEvent(dir, { ...BARE_EVENT, event_id: `id${i}` }, 1_700_000_000_000 + i);
     }
     expect(readdirSync(dir).length).toBeLessThanOrEqual(MAX_SPOOL_FILES);
+  });
+});
+
+describe("the shipped default consent supplier", () => {
+  // Every other gating test injects its own `readConsent`, so the default
+  // built inside initCrashReporting — the one that actually runs in
+  // production — had no coverage at all. A fail-open there would have passed
+  // the entire suite.
+  let sent: number;
+  let fetchImpl: typeof fetch;
+
+  beforeEach(() => {
+    resetForTests();
+    sent = 0;
+    fetchImpl = (async () => {
+      sent++;
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+  });
+
+  function initWithHome(home: string) {
+    initCrashReporting({
+      process: "backend",
+      dsn: DSN,
+      // No readConsent: exercise the real default, pointed at a temp home.
+      hostname: "irrelevant",
+      stateStore: memoryStateStore(),
+      spoolDir: mkdtempSync(join(tmpdir(), "loadout-defspool-")),
+      fetchImpl,
+      drainOnInit: false,
+      homeOverride: home,
+    });
+  }
+
+  test("sends when config.json on disk says granted", async () => {
+    initWithHome(configWith("granted").home);
+    expect(await captureError(new Error("boom"))).toBe(true);
+    expect(sent).toBe(1);
+  });
+
+  test("sends nothing when the config says denied", async () => {
+    initWithHome(configWith("denied").home);
+    expect(await captureError(new Error("boom"))).toBe(false);
+    expect(sent).toBe(0);
+  });
+
+  test("sends nothing when the key is absent or the file is missing", async () => {
+    initWithHome(configWith(undefined).home);
+    expect(await captureError(new Error("boom"))).toBe(false);
+
+    resetForTests();
+    initWithHome(mkdtempSync(join(tmpdir(), "loadout-nohome-")));
+    expect(await captureError(new Error("boom"))).toBe(false);
+    expect(sent).toBe(0);
   });
 });
 
@@ -684,6 +816,7 @@ describe("capture gating (the test that matters)", () => {
       readConsent: () => undefined,
       stateStore: memoryStateStore(),
       fetchImpl,
+      drainOnInit: false,
     });
     expect(isEnabled()).toBe(false);
     expect(await captureError(new Error("boom"))).toBe(false);
@@ -697,6 +830,7 @@ describe("capture gating (the test that matters)", () => {
       readConsent: () => "denied",
       stateStore: memoryStateStore(),
       fetchImpl,
+      drainOnInit: false,
     });
     expect(await captureError(new Error("boom"))).toBe(false);
     expect(sent).toBe(0);
@@ -709,6 +843,7 @@ describe("capture gating (the test that matters)", () => {
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       fetchImpl,
+      drainOnInit: false,
     });
     expect(isEnabled()).toBe(false);
     expect(await captureError(new Error("boom"))).toBe(false);
@@ -723,6 +858,7 @@ describe("capture gating (the test that matters)", () => {
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       fetchImpl,
+      drainOnInit: false,
     });
     expect(isEnabled()).toBe(true);
     expect(await captureError(new Error("boom"))).toBe(true);
@@ -737,6 +873,7 @@ describe("capture gating (the test that matters)", () => {
       readConsent: () => consent,
       stateStore: memoryStateStore(),
       fetchImpl,
+      drainOnInit: false,
     });
     await captureError(new Error("one"));
     expect(sent).toBe(1);
@@ -751,6 +888,7 @@ describe("capture gating (the test that matters)", () => {
       dsn: DSN,
       stateStore: memoryStateStore(),
       fetchImpl,
+      drainOnInit: false,
     });
     expect(await captureError(new Error("boom"))).toBe(false);
     setConsent("granted");
@@ -778,6 +916,7 @@ describe("capture gating (the test that matters)", () => {
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       fetchImpl,
+      drainOnInit: false,
     });
     for (let i = 0; i < 6; i++) await captureError(new Error("same boom"));
     // Same fault repeated — the per-fingerprint cap is what stops a loop.

--- a/packages/crash-report/src/crash-report.test.ts
+++ b/packages/crash-report/src/crash-report.test.ts
@@ -32,7 +32,7 @@ import {
   fileStateStore,
   resetForTests,
 } from "./index";
-import { spoolEvent, MAX_SPOOL_FILES, MAX_SPOOL_ATTEMPTS } from "./spool";
+import { spoolEvent, MAX_SPOOL_FILES, MAX_SPOOL_ATTEMPTS, RETRY_BACKOFF_MS } from "./spool";
 import type { FaroPayload } from "./types";
 
 const COLLECTOR = "https://faro-collector-prod-eu-west-0.grafana.net/collect/abc123";
@@ -368,6 +368,55 @@ describe("transport", () => {
     const ev = buildEvent({ error: new Error("x"), process: "backend" });
     expect(ev.meta.session?.overrides?.geoLocationTrackingEnabled).toBe(false);
   });
+
+  test("the request itself matches Faro's contract", async () => {
+    // Every other fetch mock ignores the URL and headers and returns 200, so
+    // none of this was asserted anywhere: a wrong URL, a missing content type
+    // or a mishandled status would have passed the whole suite.
+    let seenUrl: string | undefined;
+    let seenInit: RequestInit | undefined;
+    resetForTests();
+    initCrashReporting({
+      process: "backend",
+      collectorUrl: COLLECTOR,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      drainOnInit: false,
+      spoolDir: mkdtempSync(join(tmpdir(), "loadout-req-")),
+      fetchImpl: (async (url: string, init: RequestInit) => {
+        seenUrl = url;
+        seenInit = init;
+        return new Response("", { status: 202 });
+      }) as unknown as typeof fetch,
+    });
+
+    // 202 Accepted is what the collector returns on success.
+    expect(await captureError(new Error("boom"))).toBe(true);
+    expect(seenUrl).toBe(COLLECTOR);
+    expect(seenInit?.method).toBe("POST");
+    const headers = seenInit?.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    // Session header must match the id inside the body.
+    const body = JSON.parse(String(seenInit?.body)) as FaroPayload;
+    expect(headers["x-faro-session-id"]).toBe(body.meta.session?.id);
+    // No api key is set unless the collector needs one.
+    expect(headers["x-api-key"]).toBeUndefined();
+  });
+
+  test("a rejected request is reported as a failure, not a success", async () => {
+    resetForTests();
+    initCrashReporting({
+      process: "backend",
+      collectorUrl: COLLECTOR,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      drainOnInit: false,
+      spoolDir: mkdtempSync(join(tmpdir(), "loadout-429-")),
+      fetchImpl: (async () => new Response("rate limited", { status: 429 })) as unknown as
+        typeof fetch,
+    });
+    expect(await captureError(new Error("boom"))).toBe(false);
+  });
 });
 
 describe("event building", () => {
@@ -381,15 +430,33 @@ describe("event building", () => {
         "    at other (node:internal/x:1:1)",
       ].join("\n"),
     );
-    // Reversed: Faro renders oldest-first.
+    // Innermost-first: the throw site is frames[0]. This matches Faro's
+    // upstream getStackFramesFromError, which pushes in V8 print order and
+    // never reverses. (Sentry is the opposite, which is exactly how the
+    // reversal survived the migration and inverted every trace.)
     expect(frames).toHaveLength(4);
-    expect(frames.at(-1)?.function).toBe("doThing");
-    expect(frames.at(-1)?.lineno).toBe(10);
-    expect(frames.at(-2)?.function).toBe("Foo.bar");
-    expect(frames.at(-2)?.filename).toBe("/home/deck/b.ts");
+    expect(frames[0]?.function).toBe("doThing");
+    expect(frames[0]?.lineno).toBe(10);
+    expect(frames[1]?.function).toBe("Foo.bar");
+    expect(frames[1]?.filename).toBe("/home/deck/b.ts");
     // Vendor frames are flagged locally so they're excluded from the
     // fingerprint; the flag itself never reaches the wire.
-    expect(frames[0]?.inApp).toBe(false);
+    expect(frames.at(-1)?.inApp).toBe(false);
+  });
+
+  test("the throw site is the first frame on the wire", () => {
+    const err = new Error("boom");
+    err.stack = [
+      "Error: boom",
+      "    at applyTdp (/app/tdp.ts:10:5)",
+      "    at main (/app/index.ts:3:1)",
+    ].join("\n");
+    const frames = buildEvent({ error: err, process: "backend" }).exceptions[0]!.stacktrace!
+      .frames;
+    // Grafana renders the array top-down, so an inverted list shows the
+    // process entry point as the failing frame on every single issue.
+    expect(frames[0]?.function).toBe("applyTdp");
+    expect(frames.at(-1)?.function).toBe("main");
   });
 
   test("anonymous frames get a placeholder, since Faro requires a string", () => {
@@ -681,7 +748,8 @@ describe("spool and fatal path", () => {
     expect(after).toHaveLength(1);
     expect(after[0]).toContain("-a1-");
 
-    // Back online: it finally ships.
+    // Back online — but only after the retry backoff has elapsed, so the
+    // clock is pushed forward rather than draining immediately.
     resetForTests();
     initCrashReporting({
       process: "overlay-bun",
@@ -691,16 +759,22 @@ describe("spool and fatal path", () => {
       spoolDir: dir,
       fetchImpl,
       drainOnInit: false,
+      now: () => Date.now() + RETRY_BACKOFF_MS + 1000,
     });
     expect(await drainSpool()).toBe(1);
     expect(sentBodies[0]).toContain("survives an offline drain");
     expect(readdirSync(dir)).toHaveLength(0);
   });
 
-  test("an event that never sends is eventually given up on", async () => {
+  test("a restart loop cannot chew through the retry budget", async () => {
+    // The budget is per elapsed time, not per process start. systemd restarts
+    // the overlay every 5s; without the backoff, five restarts would discard
+    // the reports about twenty seconds after the crash that produced them —
+    // the exact scenario the spool exists for.
     const offline = (async () => {
       throw new Error("offline");
     }) as unknown as typeof fetch;
+
     initCrashReporting({
       process: "overlay-bun",
       collectorUrl: COLLECTOR,
@@ -710,8 +784,39 @@ describe("spool and fatal path", () => {
       fetchImpl: offline,
       drainOnInit: false,
     });
+    captureFatalSync(new Error("must survive a restart loop"));
+
+    // Ten rapid restarts, all within the backoff window.
+    for (let i = 0; i < 10; i++) await drainSpool();
+
+    const files = readdirSync(dir);
+    expect(files).toHaveLength(1);
+    // Exactly one attempt was spent, not ten.
+    expect(files[0]).toContain("-a1-");
+  });
+
+  test("an event that never sends is eventually given up on", async () => {
+    const offline = (async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+    // Each attempt sits one backoff window further into the future, so the
+    // budget is spent over hours rather than in a tight loop.
+    let clock = Date.now();
+    initCrashReporting({
+      process: "overlay-bun",
+      collectorUrl: COLLECTOR,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      spoolDir: dir,
+      fetchImpl: offline,
+      drainOnInit: false,
+      now: () => clock,
+    });
     captureFatalSync(new Error("permanently unsendable"));
-    for (let i = 0; i < MAX_SPOOL_ATTEMPTS + 2; i++) await drainSpool();
+    for (let i = 0; i < MAX_SPOOL_ATTEMPTS + 2; i++) {
+      clock += RETRY_BACKOFF_MS + 1000;
+      await drainSpool();
+    }
     // Dropped rather than retried forever on every start.
     expect(readdirSync(dir)).toHaveLength(0);
   });
@@ -766,6 +871,10 @@ describe("the shipped default consent supplier", () => {
       fetchImpl,
       drainOnInit: false,
       homeOverride: home,
+      // Hermetic: consent resolution checks $XDG_CONFIG_HOME before the home
+      // directory, so sandboxing only the home would still read the real
+      // machine's config on a developer who sets that variable.
+      envOverride: {},
     });
   }
 
@@ -928,6 +1037,12 @@ describe("capture gating (the test that matters)", () => {
       collectorUrl: COLLECTOR,
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
+      // Isolated like every neighbouring test: without these, init drains the
+      // developer's REAL spool at ~/.local/state/loadout/crash-spool-backend
+      // and, with a throwing fetch, burns an attempt off each genuine queued
+      // report until they are discarded.
+      spoolDir: mkdtempSync(join(tmpdir(), "loadout-netfail-")),
+      drainOnInit: false,
       fetchImpl: (async () => {
         throw new Error("offline");
       }) as unknown as typeof fetch,

--- a/packages/crash-report/src/crash-report.test.ts
+++ b/packages/crash-report/src/crash-report.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test, beforeEach } from "bun:test";
-import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -17,14 +24,25 @@ import { parseStack, buildEvent } from "./event";
 import {
   initCrashReporting,
   captureError,
+  captureFatalSync,
+  drainSpool,
   setConsent,
   isEnabled,
   memoryStateStore,
+  fileStateStore,
   resetForTests,
 } from "./index";
+import { spoolEvent, MAX_SPOOL_FILES } from "./spool";
 import type { SentryEvent } from "./types";
 
 const DSN = "https://abc123@o1.ingest.de.sentry.io/456";
+
+const BARE_EVENT: SentryEvent = {
+  event_id: "x",
+  timestamp: 0,
+  platform: "node",
+  level: "error",
+};
 
 function configWith(value: unknown): { env: Record<string, string>; home: string } {
   const home = mkdtempSync(join(tmpdir(), "loadout-consent-"));
@@ -117,6 +135,43 @@ describe("scrubbing", () => {
     expect(scrubString("/home/deck/.local/share/x.ts")).toBe("~/.local/share/x.ts");
     expect(scrubString("/home/simon/foo")).toBe("~/foo");
     expect(scrubString("at fn (/home/alice/a.ts:1:2)")).toBe("at fn (~/a.ts:1:2)");
+  });
+
+  test("removes usernames from removable-media mount points", () => {
+    // The storage plugin builds `/run/media/${user}/${name}` from the real
+    // desktop username, so these paths are constructed deliberately and any
+    // throw near SD-card handling carries the account name.
+    expect(scrubString("EACCES, scandir '/run/media/simon/Games/steamapps'")).toBe(
+      "EACCES, scandir '<media>/Games/steamapps'",
+    );
+    expect(scrubString("ENOENT, mkdir '/media/simon/SD/steamapps'")).toBe(
+      "ENOENT, mkdir '<media>/SD/steamapps'",
+    );
+    // The volume label after the username is kept — useful for triage, and
+    // not itself an account name.
+    expect(scrubString("/run/media/simon/BigSSD/x")).toContain("BigSSD");
+  });
+
+  test("handles ostree homes without mangling them", () => {
+    // Bazzite/Silverblue put real homes at /var/home/<user>. An earlier
+    // version matched only the `/home` tail and produced "/var~/…".
+    expect(scrubString("/var/home/simon/.config/loadout")).toBe("~/.config/loadout");
+    expect(scrubString("/var/home/simon/x")).not.toContain("/var~");
+  });
+
+  test("removes the account name from free-form text, case-insensitively", () => {
+    const opts = { username: "simonh", hostname: "Simons-Deck" };
+    expect(scrubString("permission denied for simonh", opts)).toBe(
+      "permission denied for <user>",
+    );
+    expect(scrubString("SIMONH could not write", opts)).toBe("<user> could not write");
+    expect(scrubString("connecting to simons-deck.local", opts)).toBe(
+      "connecting to <host>.local",
+    );
+    // Short names are left alone deliberately: substituting "deck" would
+    // corrupt ordinary text, and it is universal on SteamOS so identifies
+    // nobody.
+    expect(scrubString("deck wrote a file", { username: "deck" })).toBe("deck wrote a file");
   });
 
   test("normalises on-device plugin paths so users share a fingerprint", () => {
@@ -413,6 +468,199 @@ describe("the never-leaks gate", () => {
     const s = scrubString("/home/deck/.steam/steam/userdata/76561198012345678/config");
     expect(s).not.toContain("/home/");
     expect(s.startsWith("~/")).toBe(true);
+  });
+});
+
+describe("scrubbing on the real send path", () => {
+  // The scrub tests above and the gating tests below both passed while
+  // `captureError` could have skipped scrubEvent entirely — they exercise the
+  // scrubber and the transport separately and never together. These assert on
+  // the bytes actually handed to fetch, so removing scrubbing from the send
+  // path fails here.
+  let bodies: string[];
+  let fetchImpl: typeof fetch;
+
+  beforeEach(() => {
+    resetForTests();
+    bodies = [];
+    fetchImpl = (async (_url: string, init: RequestInit) => {
+      bodies.push(String(init.body));
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+  });
+
+  test("captureError scrubs before transmitting", async () => {
+    initCrashReporting({
+      process: "backend",
+      dsn: DSN,
+      release: "0.9.0",
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      hostname: "simons-deck",
+      username: "simonh",
+      fetchImpl,
+      drainOnInit: false,
+    });
+    const err = new Error("failed for simonh at /home/simonh/x on simons-deck");
+    err.stack = "Error: x\n    at f (/run/media/simonh/SD/steamapps/y.ts:1:1)";
+    await captureError(err);
+
+    expect(bodies).toHaveLength(1);
+    const wire = bodies[0]!;
+    for (const forbidden of ["simonh", "simons-deck", "/home/", "/run/media/simonh"]) {
+      expect(wire).not.toContain(forbidden);
+    }
+  });
+
+  test("captureFatalSync scrubs before spooling", () => {
+    const dir = mkdtempSync(join(tmpdir(), "loadout-spool-"));
+    initCrashReporting({
+      process: "overlay-bun",
+      dsn: DSN,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      username: "simonh",
+      spoolDir: dir,
+      fetchImpl,
+      drainOnInit: false,
+    });
+    expect(captureFatalSync(new Error("boom for simonh at /home/simonh/a"))).toBe(true);
+
+    // Read what actually landed on disk — the spool must never hold anything
+    // we would not have sent.
+    const files = readdirSync(dir);
+    expect(files).toHaveLength(1);
+    const onDisk = readFileSync(join(dir, files[0]!), "utf8");
+    expect(onDisk).not.toContain("simonh");
+    expect(onDisk).not.toContain("/home/");
+  });
+});
+
+describe("spool and fatal path", () => {
+  let dir: string;
+  let sentBodies: string[];
+  let fetchImpl: typeof fetch;
+
+  beforeEach(() => {
+    resetForTests();
+    dir = mkdtempSync(join(tmpdir(), "loadout-spool2-"));
+    sentBodies = [];
+    fetchImpl = (async (_u: string, init: RequestInit) => {
+      sentBodies.push(String(init.body));
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+  });
+
+  test("a fatal capture survives the process and ships on next start", async () => {
+    // Run 1: dies without sending anything.
+    initCrashReporting({
+      process: "overlay-bun",
+      dsn: DSN,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      spoolDir: dir,
+      fetchImpl,
+      drainOnInit: false,
+    });
+    captureFatalSync(new Error("fatal one"));
+    expect(sentBodies).toHaveLength(0);
+    expect(readdirSync(dir)).toHaveLength(1);
+
+    // Run 2: a fresh process drains it.
+    resetForTests();
+    initCrashReporting({
+      process: "overlay-bun",
+      dsn: DSN,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      spoolDir: dir,
+      fetchImpl,
+      drainOnInit: false,
+    });
+    expect(await drainSpool()).toBe(1);
+    expect(sentBodies).toHaveLength(1);
+    expect(sentBodies[0]).toContain("fatal one");
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
+  test("consent withdrawn between crash and restart discards the spool", async () => {
+    initCrashReporting({
+      process: "overlay-bun",
+      dsn: DSN,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      spoolDir: dir,
+      fetchImpl,
+      drainOnInit: false,
+    });
+    captureFatalSync(new Error("spooled while allowed"));
+    expect(readdirSync(dir)).toHaveLength(1);
+
+    resetForTests();
+    initCrashReporting({
+      process: "overlay-bun",
+      dsn: DSN,
+      readConsent: () => "denied",
+      stateStore: memoryStateStore(),
+      spoolDir: dir,
+      fetchImpl,
+      drainOnInit: false,
+    });
+    expect(await drainSpool()).toBe(0);
+    expect(sentBodies).toHaveLength(0);
+    // Discarded, not left to be sent if consent is granted again later.
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
+  test("a fatal capture without consent writes nothing at all", () => {
+    initCrashReporting({
+      process: "overlay-bun",
+      dsn: DSN,
+      readConsent: () => undefined,
+      stateStore: memoryStateStore(),
+      spoolDir: dir,
+      fetchImpl,
+      drainOnInit: false,
+    });
+    expect(captureFatalSync(new Error("boom"))).toBe(false);
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
+  test("the spool is bounded so a crash loop cannot fill the disk", () => {
+    for (let i = 0; i < MAX_SPOOL_FILES + 15; i++) {
+      spoolEvent(dir, { ...BARE_EVENT, event_id: `id${i}` }, 1_700_000_000_000 + i);
+    }
+    expect(readdirSync(dir).length).toBeLessThanOrEqual(MAX_SPOOL_FILES);
+  });
+});
+
+describe("rate-limit state really persists to disk", () => {
+  // The rate-limit tests above drive the pure `decide` function and would all
+  // pass if fileStateStore were removed entirely. This drives the real store.
+  test("the limit holds across simulated process restarts", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "loadout-state-")), "state.json");
+    let sent = 0;
+    const fetchImpl = (async () => {
+      sent++;
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    // Each iteration is a fresh process hitting the identical fault — exactly
+    // what systemd Restart=on-failure produces during a crash loop.
+    for (let restart = 0; restart < 5; restart++) {
+      resetForTests();
+      initCrashReporting({
+        process: "backend",
+        dsn: DSN,
+        readConsent: () => "granted",
+        stateStore: fileStateStore(path),
+        fetchImpl,
+        drainOnInit: false,
+      });
+      await captureError(new Error("identical crash loop fault"));
+    }
+    expect(sent).toBe(DEFAULT_LIMITS.maxPerFingerprintPerHour);
+    expect(existsSync(path)).toBe(true);
   });
 });
 

--- a/packages/crash-report/src/crash-report.test.ts
+++ b/packages/crash-report/src/crash-report.test.ts
@@ -1,0 +1,538 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  parseConsent,
+  readConsentSync,
+  userConfigPathFrom,
+  userConfigPathsFrom,
+  CRASH_REPORTING_KEY,
+} from "./consent";
+import { scrubString, scrubEvent, fingerprint } from "./scrub";
+import { decide, parseState, freshState, DEFAULT_LIMITS } from "./rate-limit";
+import { parseDsn, buildEnvelope, envelopeUrl } from "./transport";
+import { parseStack, buildEvent } from "./event";
+import {
+  initCrashReporting,
+  captureError,
+  setConsent,
+  isEnabled,
+  memoryStateStore,
+  resetForTests,
+} from "./index";
+import type { SentryEvent } from "./types";
+
+const DSN = "https://abc123@o1.ingest.de.sentry.io/456";
+
+function configWith(value: unknown): { env: Record<string, string>; home: string } {
+  const home = mkdtempSync(join(tmpdir(), "loadout-consent-"));
+  mkdirSync(join(home, ".config", "loadout"), { recursive: true });
+  writeFileSync(
+    join(home, ".config", "loadout", "config.json"),
+    JSON.stringify(value === undefined ? {} : { [CRASH_REPORTING_KEY]: value }),
+  );
+  return { env: {}, home };
+}
+
+describe("consent", () => {
+  test("is tri-state, and only the exact string grants", () => {
+    expect(parseConsent("granted")).toBe("granted");
+    expect(parseConsent("denied")).toBe("denied");
+    expect(parseConsent(undefined)).toBeUndefined();
+    // "not asked" must stay distinguishable from "said no" — that
+    // distinction is what lets upgraders be prompted exactly once.
+    expect(parseConsent(null)).toBeUndefined();
+    expect(parseConsent(true)).toBeUndefined();
+    expect(parseConsent("GRANTED")).toBeUndefined();
+    expect(parseConsent("yes")).toBeUndefined();
+  });
+
+  test("honours XDG_CONFIG_HOME the same way user-config.ts does", () => {
+    expect(userConfigPathFrom({ XDG_CONFIG_HOME: "/xdg" }, "/home/deck")).toBe(
+      "/xdg/loadout/config.json",
+    );
+    expect(userConfigPathFrom({}, "/home/deck")).toBe("/home/deck/.config/loadout/config.json");
+    expect(userConfigPathFrom({ XDG_CONFIG_HOME: "" }, "/home/deck")).toBe(
+      "/home/deck/.config/loadout/config.json",
+    );
+  });
+
+  test("reads both candidate paths, because the two units see different envs", () => {
+    // loadout.service is a *system* unit setting only HOME; the overlay is a
+    // *user* unit inheriting XDG_CONFIG_HOME. Reading one path would mean the
+    // two processes disagree about consent on any machine that sets it.
+    expect(userConfigPathsFrom({ XDG_CONFIG_HOME: "/xdg" }, "/home/deck")).toEqual([
+      "/xdg/loadout/config.json",
+      "/home/deck/.config/loadout/config.json",
+    ]);
+    expect(userConfigPathsFrom({}, "/home/deck")).toEqual([
+      "/home/deck/.config/loadout/config.json",
+    ]);
+
+    // The root backend wrote to ~/.config (no XDG in its env); a reader that
+    // *does* have XDG set must still find that answer.
+    const home = mkdtempSync(join(tmpdir(), "loadout-xdg-"));
+    mkdirSync(join(home, ".config", "loadout"), { recursive: true });
+    writeFileSync(
+      join(home, ".config", "loadout", "config.json"),
+      JSON.stringify({ [CRASH_REPORTING_KEY]: "granted" }),
+    );
+    expect(readConsentSync({ XDG_CONFIG_HOME: "/nonexistent-xdg" }, home)).toBe("granted");
+  });
+
+  test("reads granted from disk", () => {
+    const { env, home } = configWith("granted");
+    expect(readConsentSync(env, home)).toBe("granted");
+  });
+
+  test("fails closed on every bad input", () => {
+    const denied = configWith("denied");
+    expect(readConsentSync(denied.env, denied.home)).toBe("denied");
+
+    const absent = configWith(undefined);
+    expect(readConsentSync(absent.env, absent.home)).toBeUndefined();
+
+    // No config file at all.
+    expect(readConsentSync({}, mkdtempSync(join(tmpdir(), "loadout-empty-")))).toBeUndefined();
+
+    // Malformed JSON.
+    const broken = mkdtempSync(join(tmpdir(), "loadout-broken-"));
+    mkdirSync(join(broken, ".config", "loadout"), { recursive: true });
+    writeFileSync(join(broken, ".config", "loadout", "config.json"), "{not json");
+    expect(readConsentSync({}, broken)).toBeUndefined();
+
+    // Valid JSON, wrong shape.
+    const arr = mkdtempSync(join(tmpdir(), "loadout-arr-"));
+    mkdirSync(join(arr, ".config", "loadout"), { recursive: true });
+    writeFileSync(join(arr, ".config", "loadout", "config.json"), "[1,2,3]");
+    expect(readConsentSync({}, arr)).toBeUndefined();
+  });
+});
+
+describe("scrubbing", () => {
+  test("removes any user's home, not just this process's", () => {
+    // The backend runs as root, so frames reference a home that isn't its own.
+    expect(scrubString("/home/deck/.local/share/x.ts")).toBe("~/.local/share/x.ts");
+    expect(scrubString("/home/simon/foo")).toBe("~/foo");
+    expect(scrubString("at fn (/home/alice/a.ts:1:2)")).toBe("at fn (~/a.ts:1:2)");
+  });
+
+  test("normalises on-device plugin paths so users share a fingerprint", () => {
+    const a = scrubString("/home/deck/.local/share/loadout/plugins/hltb/backend.ts");
+    const b = scrubString("/home/simon/.local/share/loadout/plugins/hltb/backend.ts");
+    expect(a).toBe(b);
+    expect(a).toContain("<plugins>/hltb");
+    // The plugin id survives — we still need to know which plugin broke.
+    expect(a).toContain("hltb");
+  });
+
+  test("redacts credentials that leak into error messages", () => {
+    expect(scrubString("GET https://x/api?key=SECRET123&b=1")).toBe(
+      "GET https://x/api?key=<redacted>&b=1",
+    );
+    expect(scrubString("api_key=abc")).toBe("api_key=<redacted>");
+    expect(scrubString("access_token=abc")).toBe("access_token=<redacted>");
+    expect(scrubString("Authorization: Bearer eyJhbGci.foo-bar_baz")).toBe(
+      "Authorization: Bearer <redacted>",
+    );
+    expect(scrubString("/run/user/1000/bus")).toBe("/run/user/<uid>/bus");
+  });
+
+  test("strips identifying fields even if something upstream sets them", () => {
+    const dirty = {
+      event_id: "x",
+      timestamp: 0,
+      platform: "node",
+      level: "error",
+      user: { ip_address: "1.2.3.4", email: "a@b.c" },
+      server_name: "simons-deck",
+      breadcrumbs: [{ message: "secret" }],
+      request: { url: "https://x", headers: { cookie: "c" } },
+    } as unknown as SentryEvent;
+    const clean = scrubEvent(dirty) as unknown as Record<string, unknown>;
+    expect(clean.user).toBeUndefined();
+    expect(clean.server_name).toBeUndefined();
+    expect(clean.breadcrumbs).toBeUndefined();
+    expect(clean.request).toBeUndefined();
+  });
+
+  test("scrubs inside frames, messages and tags", () => {
+    const ev = scrubEvent({
+      event_id: "x",
+      timestamp: 0,
+      platform: "node",
+      level: "error",
+      message: { formatted: "failed at /home/deck/a.ts" },
+      tags: { path: "/home/deck/b.ts" },
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "boom in /home/deck/c.ts",
+            stacktrace: {
+              frames: [{ filename: "/home/deck/d.ts", function: "f", lineno: 1, colno: 2 }],
+            },
+          },
+        ],
+      },
+    });
+    expect(ev.message?.formatted).toBe("failed at ~/a.ts");
+    expect(ev.tags?.path).toBe("~/b.ts");
+    expect(ev.exception?.values[0]?.value).toBe("boom in ~/c.ts");
+    expect(ev.exception?.values[0]?.stacktrace?.frames[0]?.filename).toBe("~/d.ts");
+  });
+
+  test("fingerprint is stable across users and ignores line numbers", () => {
+    const mk = (home: string, line: number): SentryEvent => ({
+      event_id: "x",
+      timestamp: 0,
+      platform: "node",
+      level: "error",
+      tags: { process: "backend" },
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "bad",
+            stacktrace: {
+              frames: [{ filename: `${home}/a.ts`, function: "f", lineno: line, colno: 1 }],
+            },
+          },
+        ],
+      },
+    });
+    const a = fingerprint(scrubEvent(mk("/home/deck", 10)));
+    const b = fingerprint(scrubEvent(mk("/home/simon", 99)));
+    expect(a).toBe(b);
+  });
+});
+
+describe("rate limiting", () => {
+  const T0 = 1_700_000_000_000;
+
+  test("caps repeats of one fault — the crash-loop case", () => {
+    let s = freshState(T0);
+    const allowed: boolean[] = [];
+    for (let i = 0; i < 5; i++) {
+      const d = decide(s, T0 + i * 1000, "same-fp");
+      allowed.push(d.allow);
+      s = d.state;
+    }
+    expect(allowed).toEqual([true, true, false, false, false]);
+  });
+
+  test("survives a restart — the reason state is on disk at all", () => {
+    // A crash loop restarts the process every few seconds. An in-memory
+    // limiter resets each time and reports forever; this must not.
+    let persisted = JSON.stringify(freshState(T0));
+    const results: boolean[] = [];
+    for (let restart = 0; restart < 5; restart++) {
+      const state = parseState(persisted, T0 + restart * 5000);
+      const d = decide(state, T0 + restart * 5000, "loop-fp");
+      results.push(d.allow);
+      persisted = JSON.stringify(d.state);
+    }
+    expect(results).toEqual([true, true, false, false, false]);
+  });
+
+  test("enforces hourly and daily ceilings", () => {
+    let s = freshState(T0);
+    let sent = 0;
+    for (let i = 0; i < 50; i++) {
+      const d = decide(s, T0 + i * 1000, `fp-${i}`);
+      if (d.allow) sent++;
+      s = d.state;
+    }
+    expect(sent).toBe(DEFAULT_LIMITS.maxPerHour);
+  });
+
+  test("rolls windows forward", () => {
+    let s = freshState(T0);
+    for (let i = 0; i < 10; i++) s = decide(s, T0 + i, `fp-${i}`).state;
+    expect(decide(s, T0 + 1000, "new").allow).toBe(false);
+    const later = decide(s, T0 + DEFAULT_LIMITS.windowMs + 1, "new");
+    expect(later.allow).toBe(true);
+  });
+
+  test("daily ceiling outlasts hourly rollovers", () => {
+    let s = freshState(T0);
+    let sent = 0;
+    for (let h = 0; h < 12; h++) {
+      for (let i = 0; i < 10; i++) {
+        const now = T0 + h * DEFAULT_LIMITS.windowMs + i * 1000;
+        const d = decide(s, now, `fp-${h}-${i}`);
+        if (d.allow) sent++;
+        s = d.state;
+      }
+    }
+    expect(sent).toBe(DEFAULT_LIMITS.maxPerDay);
+  });
+
+  test("recovers from corrupt or future-dated state", () => {
+    expect(parseState("{garbage", T0).hourCount).toBe(0);
+    expect(parseState(null, T0).hourCount).toBe(0);
+    expect(parseState(JSON.stringify({ v: 99 }), T0).hourCount).toBe(0);
+    // Clock stepped backwards (suspend/resume, NTP) — a future-dated window
+    // would otherwise never roll over and would wedge reporting forever.
+    const future = JSON.stringify({ ...freshState(T0 + 100_000), v: 1 });
+    expect(parseState(future, T0).hourStart).toBe(T0);
+  });
+});
+
+describe("transport", () => {
+  test("parses a DSN and builds the ingest URL", () => {
+    const d = parseDsn(DSN);
+    expect(d).not.toBeNull();
+    expect(d?.publicKey).toBe("abc123");
+    expect(d?.projectId).toBe("456");
+    expect(envelopeUrl(d!)).toBe("https://o1.ingest.de.sentry.io/api/456/envelope/");
+  });
+
+  test("rejects malformed DSNs instead of throwing", () => {
+    for (const bad of [undefined, null, "", "not-a-url", "https://nokey.example.com/1", "https://k@host/"]) {
+      expect(parseDsn(bad as string | undefined)).toBeNull();
+    }
+  });
+
+  test("envelope length counts bytes, not characters", () => {
+    // A stack trace with any non-ASCII would otherwise produce a short
+    // count and an envelope the server rejects.
+    const ev = buildEvent({ error: new Error("héllo — ünicode"), process: "backend" });
+    const env = buildEnvelope(ev, parseDsn(DSN)!);
+    const [, itemHeader, body] = env.split("\n");
+    const declared = (JSON.parse(itemHeader!) as { length: number }).length;
+    expect(declared).toBe(new TextEncoder().encode(body!).length);
+    expect(declared).toBeGreaterThan(body!.length - 10);
+  });
+});
+
+describe("event building", () => {
+  test("parses V8 frames from both runtimes", () => {
+    const frames = parseStack(
+      [
+        "Error: boom",
+        "    at doThing (/home/deck/a.ts:10:5)",
+        "    at async Foo.bar (file:///home/deck/b.ts:3:1)",
+        "    at /home/deck/c.ts:1:1",
+        "    at other (node:internal/x:1:1)",
+      ].join("\n"),
+    );
+    // Reversed: Sentry renders oldest-first.
+    expect(frames).toHaveLength(4);
+    expect(frames.at(-1)?.function).toBe("doThing");
+    expect(frames.at(-1)?.lineno).toBe(10);
+    expect(frames.at(-2)?.function).toBe("Foo.bar");
+    expect(frames.at(-2)?.filename).toBe("/home/deck/b.ts");
+    expect(frames[0]?.in_app).toBe(false);
+  });
+
+  test("handles non-Error throws", () => {
+    expect(buildEvent({ error: "just a string", process: "backend" }).exception?.values[0]?.value)
+      .toBe("just a string");
+    expect(buildEvent({ error: { a: 1 }, process: "backend" }).exception?.values[0]?.value)
+      .toBe('{"a":1}');
+    expect(buildEvent({ error: null, process: "backend" }).exception?.values[0]?.value).toBe("null");
+  });
+
+  test("tags fault origin so plugin faults can be routed away from core", () => {
+    const core = buildEvent({ error: new Error("x"), process: "backend" });
+    expect(core.tags?.fault_origin).toBe("core");
+    expect(core.tags?.plugin_id).toBeUndefined();
+
+    const plugin = buildEvent({
+      error: new Error("x"),
+      process: "backend",
+      context: { pluginId: "hltb" },
+    });
+    expect(plugin.tags?.fault_origin).toBe("plugin");
+    expect(plugin.tags?.plugin_id).toBe("hltb");
+  });
+
+  test("never sets hostname or user", () => {
+    const ev = buildEvent({ error: new Error("x"), process: "overlay-bun" }) as unknown as
+      Record<string, unknown>;
+    expect(ev.server_name).toBeUndefined();
+    expect(ev.user).toBeUndefined();
+  });
+});
+
+describe("the never-leaks gate", () => {
+  // Asserts on the *serialized envelope*, not on intermediate objects.
+  // Everything else in this file checks a transformation; this checks the
+  // bytes that would actually cross the network. If a future change adds a
+  // field that carries a path, this is the test that catches it.
+  test("no identifying data survives into the wire format", () => {
+    const err = new Error(
+      "Request failed for /home/deck/Games/My Private Game/save.dat " +
+        "via https://api.steamgriddb.com/v2/x?api_key=sk_live_abcdef123456 " +
+        "(user 76561198012345678, host simons-deck)",
+    );
+    err.stack = [
+      "Error: boom",
+      "    at load (/home/deck/.local/share/loadout/plugins/hltb/backend.ts:42:7)",
+      "    at run (/home/otheruser/.local/share/loadout/plugins/hltb/backend.ts:9:1)",
+      "    at boot (/run/user/1000/loadout/x.ts:3:1)",
+    ].join("\n");
+
+    const event = scrubEvent(
+      buildEvent({
+        error: err,
+        process: "backend",
+        release: "0.9.0",
+        context: { pluginId: "hltb", tags: { path: "/home/deck/secret" } },
+      }),
+      { hostname: "simons-deck" },
+    );
+    const wire = buildEnvelope(event, parseDsn(DSN)!);
+
+    for (const forbidden of [
+      "/home/",
+      "deck/Games",
+      "otheruser",
+      "simons-deck",
+      "sk_live_abcdef123456",
+      "/run/user/1000",
+      "76561198012345678",
+    ]) {
+      expect(wire).not.toContain(forbidden);
+    }
+
+    // …while still carrying enough to actually debug the fault.
+    expect(wire).toContain("<plugins>/hltb");
+    expect(wire).toContain("hltb");
+    expect(wire).toContain("0.9.0");
+    // And the plugin path is well-formed, not a mangled "~<plugins>/…".
+    expect(wire).not.toContain("~<plugins>");
+  });
+
+  test("a steam id in a path is not silently preserved by normalisation", () => {
+    // Steam userdata paths embed a SteamID64. They arrive under $HOME, so
+    // home normalisation is what removes them; this pins that behaviour.
+    const s = scrubString("/home/deck/.steam/steam/userdata/76561198012345678/config");
+    expect(s).not.toContain("/home/");
+    expect(s.startsWith("~/")).toBe(true);
+  });
+});
+
+describe("capture gating (the test that matters)", () => {
+  let sent: number;
+  let fetchImpl: typeof fetch;
+
+  beforeEach(() => {
+    resetForTests();
+    sent = 0;
+    fetchImpl = (async () => {
+      sent++;
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+  });
+
+  test("sends nothing when consent is unset", async () => {
+    initCrashReporting({
+      process: "backend",
+      dsn: DSN,
+      readConsent: () => undefined,
+      stateStore: memoryStateStore(),
+      fetchImpl,
+    });
+    expect(isEnabled()).toBe(false);
+    expect(await captureError(new Error("boom"))).toBe(false);
+    expect(sent).toBe(0);
+  });
+
+  test("sends nothing when consent is denied", async () => {
+    initCrashReporting({
+      process: "backend",
+      dsn: DSN,
+      readConsent: () => "denied",
+      stateStore: memoryStateStore(),
+      fetchImpl,
+    });
+    expect(await captureError(new Error("boom"))).toBe(false);
+    expect(sent).toBe(0);
+  });
+
+  test("sends nothing when no DSN is configured", async () => {
+    initCrashReporting({
+      process: "backend",
+      dsn: undefined,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      fetchImpl,
+    });
+    expect(isEnabled()).toBe(false);
+    expect(await captureError(new Error("boom"))).toBe(false);
+    expect(sent).toBe(0);
+  });
+
+  test("sends when granted", async () => {
+    initCrashReporting({
+      process: "backend",
+      dsn: DSN,
+      release: "0.9.0",
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      fetchImpl,
+    });
+    expect(isEnabled()).toBe(true);
+    expect(await captureError(new Error("boom"))).toBe(true);
+    expect(sent).toBe(1);
+  });
+
+  test("revoking consent stops reporting immediately, not at next restart", async () => {
+    let consent: "granted" | "denied" = "granted";
+    initCrashReporting({
+      process: "backend",
+      dsn: DSN,
+      readConsent: () => consent,
+      stateStore: memoryStateStore(),
+      fetchImpl,
+    });
+    await captureError(new Error("one"));
+    expect(sent).toBe(1);
+    consent = "denied";
+    await captureError(new Error("two"));
+    expect(sent).toBe(1);
+  });
+
+  test("webview consent comes from setConsent", async () => {
+    initCrashReporting({
+      process: "webview",
+      dsn: DSN,
+      stateStore: memoryStateStore(),
+      fetchImpl,
+    });
+    expect(await captureError(new Error("boom"))).toBe(false);
+    setConsent("granted");
+    expect(await captureError(new Error("boom"))).toBe(true);
+    expect(sent).toBe(1);
+  });
+
+  test("a network failure resolves false rather than throwing", async () => {
+    initCrashReporting({
+      process: "backend",
+      dsn: DSN,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      fetchImpl: (async () => {
+        throw new Error("offline");
+      }) as unknown as typeof fetch,
+    });
+    expect(await captureError(new Error("boom"))).toBe(false);
+  });
+
+  test("rate limiting applies end to end", async () => {
+    initCrashReporting({
+      process: "backend",
+      dsn: DSN,
+      readConsent: () => "granted",
+      stateStore: memoryStateStore(),
+      fetchImpl,
+    });
+    for (let i = 0; i < 6; i++) await captureError(new Error("same boom"));
+    // Same fault repeated — the per-fingerprint cap is what stops a loop.
+    expect(sent).toBe(DEFAULT_LIMITS.maxPerFingerprintPerHour);
+  });
+});

--- a/packages/crash-report/src/crash-report.test.ts
+++ b/packages/crash-report/src/crash-report.test.ts
@@ -19,7 +19,7 @@ import {
 } from "./consent";
 import { scrubString, scrubEvent, fingerprint } from "./scrub";
 import { decide, parseState, freshState, DEFAULT_LIMITS } from "./rate-limit";
-import { parseDsn, buildEnvelope, envelopeUrl } from "./transport";
+import { parseCollector, buildBody } from "./transport";
 import { parseStack, buildEvent } from "./event";
 import {
   initCrashReporting,
@@ -33,15 +33,13 @@ import {
   resetForTests,
 } from "./index";
 import { spoolEvent, MAX_SPOOL_FILES, MAX_SPOOL_ATTEMPTS } from "./spool";
-import type { SentryEvent } from "./types";
+import type { FaroPayload } from "./types";
 
-const DSN = "https://abc123@o1.ingest.de.sentry.io/456";
+const COLLECTOR = "https://faro-collector-prod-eu-west-0.grafana.net/collect/abc123";
 
-const BARE_EVENT: SentryEvent = {
-  event_id: "x",
-  timestamp: 0,
-  platform: "node",
-  level: "error",
+const BARE_EVENT: FaroPayload = {
+  meta: { sdk: { name: "t" }, app: { name: "loadout" }, os: { name: "linux" } },
+  exceptions: [{ timestamp: "1970-01-01T00:00:00.000Z", type: "Error", value: "x" }],
 };
 
 function configWith(value: unknown): { env: Record<string, string>; home: string } {
@@ -195,68 +193,73 @@ describe("scrubbing", () => {
     expect(scrubString("/run/user/1000/bus")).toBe("/run/user/<uid>/bus");
   });
 
-  test("strips identifying fields even if something upstream sets them", () => {
+  test("strips Faro meta fields we never populate, even if set upstream", () => {
+    // Faro supports all of these. We don't send them, and scrubEvent deletes
+    // them defensively so a future edit can't reintroduce one silently.
     const dirty = {
-      event_id: "x",
-      timestamp: 0,
-      platform: "node",
-      level: "error",
-      user: { ip_address: "1.2.3.4", email: "a@b.c" },
-      server_name: "simons-deck",
-      breadcrumbs: [{ message: "secret" }],
-      request: { url: "https://x", headers: { cookie: "c" } },
-    } as unknown as SentryEvent;
-    const clean = scrubEvent(dirty) as unknown as Record<string, unknown>;
-    expect(clean.user).toBeUndefined();
-    expect(clean.server_name).toBeUndefined();
-    expect(clean.breadcrumbs).toBeUndefined();
-    expect(clean.request).toBeUndefined();
+      meta: {
+        sdk: { name: "t" },
+        app: { name: "loadout", installationId: "persistent-install-id" },
+        os: { name: "linux" },
+        user: { id: "u1", email: "a@b.c", username: "simon" },
+        page: { url: "https://example/secret" },
+        browser: { userAgent: "Mozilla/5.0 …", language: "en-GB" },
+        view: { name: "settings" },
+        device: { model_identifier: "serial-ish" },
+      },
+      exceptions: [{ timestamp: "1970-01-01T00:00:00.000Z", type: "Error", value: "x" }],
+    } as unknown as FaroPayload;
+
+    const clean = scrubEvent(dirty);
+    const meta = clean.meta as unknown as Record<string, unknown>;
+    expect(meta.user).toBeUndefined();
+    expect(meta.page).toBeUndefined();
+    expect(meta.browser).toBeUndefined();
+    expect(meta.view).toBeUndefined();
+    expect(meta.device).toBeUndefined();
+    // A persistent install id would make every report from a machine linkable.
+    expect((clean.meta.app as Record<string, unknown>).installationId).toBeUndefined();
   });
 
-  test("scrubs inside frames, messages and tags", () => {
+  test("scrubs inside frames, values and context", () => {
     const ev = scrubEvent({
-      event_id: "x",
-      timestamp: 0,
-      platform: "node",
-      level: "error",
-      message: { formatted: "failed at /home/deck/a.ts" },
-      tags: { path: "/home/deck/b.ts" },
-      exception: {
-        values: [
-          {
-            type: "Error",
-            value: "boom in /home/deck/c.ts",
-            stacktrace: {
-              frames: [{ filename: "/home/deck/d.ts", function: "f", lineno: 1, colno: 2 }],
-            },
+      meta: { sdk: { name: "t" }, app: { name: "loadout" }, os: { name: "linux" } },
+      exceptions: [
+        {
+          timestamp: "1970-01-01T00:00:00.000Z",
+          type: "Error",
+          value: "boom in /home/deck/c.ts",
+          context: { path: "/home/deck/b.ts" },
+          stacktrace: {
+            frames: [
+              { filename: "/home/deck/d.ts", function: "f", lineno: 1, colno: 2 },
+            ],
           },
-        ],
-      },
+        },
+      ],
     });
-    expect(ev.message?.formatted).toBe("failed at ~/a.ts");
-    expect(ev.tags?.path).toBe("~/b.ts");
-    expect(ev.exception?.values[0]?.value).toBe("boom in ~/c.ts");
-    expect(ev.exception?.values[0]?.stacktrace?.frames[0]?.filename).toBe("~/d.ts");
+    const ex = ev.exceptions[0]!;
+    expect(ex.value).toBe("boom in ~/c.ts");
+    expect(ex.context?.path).toBe("~/b.ts");
+    expect(ex.stacktrace?.frames[0]?.filename).toBe("~/d.ts");
   });
 
   test("fingerprint is stable across users and ignores line numbers", () => {
-    const mk = (home: string, line: number): SentryEvent => ({
-      event_id: "x",
-      timestamp: 0,
-      platform: "node",
-      level: "error",
-      tags: { process: "backend" },
-      exception: {
-        values: [
-          {
-            type: "TypeError",
-            value: "bad",
-            stacktrace: {
-              frames: [{ filename: `${home}/a.ts`, function: "f", lineno: line, colno: 1 }],
-            },
+    // This is what makes one bug read as one Grafana issue with N affected
+    // devices, rather than N separate issues — it is the top layer of their
+    // grouping strategy.
+    const mk = (home: string, line: number): FaroPayload => ({
+      meta: { sdk: { name: "t" }, app: { name: "loadout", namespace: "backend" }, os: { name: "linux" } },
+      exceptions: [
+        {
+          timestamp: "1970-01-01T00:00:00.000Z",
+          type: "TypeError",
+          value: "bad",
+          stacktrace: {
+            frames: [{ filename: `${home}/a.ts`, function: "f", lineno: line, colno: 1 }],
           },
-        ],
-      },
+        },
+      ],
     });
     const a = fingerprint(scrubEvent(mk("/home/deck", 10)));
     const b = fingerprint(scrubEvent(mk("/home/simon", 99)));
@@ -337,29 +340,33 @@ describe("rate limiting", () => {
 });
 
 describe("transport", () => {
-  test("parses a DSN and builds the ingest URL", () => {
-    const d = parseDsn(DSN);
-    expect(d).not.toBeNull();
-    expect(d?.publicKey).toBe("abc123");
-    expect(d?.projectId).toBe("456");
-    expect(envelopeUrl(d!)).toBe("https://o1.ingest.de.sentry.io/api/456/envelope/");
+  test("parses a Faro collector URL", () => {
+    const c = parseCollector(COLLECTOR);
+    expect(c).not.toBeNull();
+    expect(c?.url).toBe(COLLECTOR);
   });
 
-  test("rejects malformed DSNs instead of throwing", () => {
-    for (const bad of [undefined, null, "", "not-a-url", "https://nokey.example.com/1", "https://k@host/"]) {
-      expect(parseDsn(bad as string | undefined)).toBeNull();
+  test("rejects malformed endpoints instead of throwing", () => {
+    for (const bad of [undefined, null, "", "not-a-url", "ftp://host/collect/x"]) {
+      expect(parseCollector(bad as string | undefined)).toBeNull();
     }
   });
 
-  test("envelope length counts bytes, not characters", () => {
-    // A stack trace with any non-ASCII would otherwise produce a short
-    // count and an envelope the server rejects.
+  test("the body is the Faro payload shape and nothing more", () => {
     const ev = buildEvent({ error: new Error("héllo — ünicode"), process: "backend" });
-    const env = buildEnvelope(ev, parseDsn(DSN)!);
-    const [, itemHeader, body] = env.split("\n");
-    const declared = (JSON.parse(itemHeader!) as { length: number }).length;
-    expect(declared).toBe(new TextEncoder().encode(body!).length);
-    expect(declared).toBeGreaterThan(body!.length - 10);
+    const parsed = JSON.parse(buildBody(ev)) as Record<string, unknown>;
+    // Exactly the two documented top-level keys — no logs, measurements,
+    // traces or events smuggled in.
+    expect(Object.keys(parsed).sort()).toEqual(["exceptions", "meta"]);
+    const meta = parsed.meta as Record<string, unknown>;
+    expect(Object.keys(meta).sort()).toEqual(["app", "os", "sdk", "session"]);
+    // Non-ASCII survives the round trip intact.
+    expect(buildBody(ev)).toContain("ünicode");
+  });
+
+  test("geolocation tracking is explicitly disabled", () => {
+    const ev = buildEvent({ error: new Error("x"), process: "backend" });
+    expect(ev.meta.session?.overrides?.geoLocationTrackingEnabled).toBe(false);
   });
 });
 
@@ -374,42 +381,61 @@ describe("event building", () => {
         "    at other (node:internal/x:1:1)",
       ].join("\n"),
     );
-    // Reversed: Sentry renders oldest-first.
+    // Reversed: Faro renders oldest-first.
     expect(frames).toHaveLength(4);
     expect(frames.at(-1)?.function).toBe("doThing");
     expect(frames.at(-1)?.lineno).toBe(10);
     expect(frames.at(-2)?.function).toBe("Foo.bar");
     expect(frames.at(-2)?.filename).toBe("/home/deck/b.ts");
-    expect(frames[0]?.in_app).toBe(false);
+    // Vendor frames are flagged locally so they're excluded from the
+    // fingerprint; the flag itself never reaches the wire.
+    expect(frames[0]?.inApp).toBe(false);
+  });
+
+  test("anonymous frames get a placeholder, since Faro requires a string", () => {
+    const frames = parseStack(["Error: x", "    at /home/deck/c.ts:1:1"].join("\n"));
+    expect(frames[0]?.function).toBe("?");
   });
 
   test("handles non-Error throws", () => {
-    expect(buildEvent({ error: "just a string", process: "backend" }).exception?.values[0]?.value)
-      .toBe("just a string");
-    expect(buildEvent({ error: { a: 1 }, process: "backend" }).exception?.values[0]?.value)
-      .toBe('{"a":1}');
-    expect(buildEvent({ error: null, process: "backend" }).exception?.values[0]?.value).toBe("null");
+    const v = (e: unknown) => buildEvent({ error: e, process: "backend" }).exceptions[0]?.value;
+    expect(v("just a string")).toBe("just a string");
+    expect(v({ a: 1 })).toBe('{"a":1}');
+    expect(v(null)).toBe("null");
   });
 
   test("tags fault origin so plugin faults can be routed away from core", () => {
     const core = buildEvent({ error: new Error("x"), process: "backend" });
-    expect(core.tags?.fault_origin).toBe("core");
-    expect(core.tags?.plugin_id).toBeUndefined();
+    expect(core.exceptions[0]?.context?.fault_origin).toBe("core");
+    expect(core.exceptions[0]?.context?.plugin_id).toBeUndefined();
 
     const plugin = buildEvent({
       error: new Error("x"),
       process: "backend",
       context: { pluginId: "hltb" },
     });
-    expect(plugin.tags?.fault_origin).toBe("plugin");
-    expect(plugin.tags?.plugin_id).toBe("hltb");
+    expect(plugin.exceptions[0]?.context?.fault_origin).toBe("plugin");
+    expect(plugin.exceptions[0]?.context?.plugin_id).toBe("hltb");
   });
 
-  test("never sets hostname or user", () => {
-    const ev = buildEvent({ error: new Error("x"), process: "overlay-bun" }) as unknown as
-      Record<string, unknown>;
-    expect(ev.server_name).toBeUndefined();
-    expect(ev.user).toBeUndefined();
+  test("marks fatal crashes so they can be separated from handled errors", () => {
+    const fatal = buildEvent({
+      error: new Error("x"),
+      process: "overlay-bun",
+      context: { level: "fatal" },
+    });
+    expect(fatal.exceptions[0]?.fatal).toBe(true);
+    expect(buildEvent({ error: new Error("x"), process: "backend" }).exceptions[0]?.fatal).toBe(
+      false,
+    );
+  });
+
+  test("never sets user or a persistent install id", () => {
+    const meta = buildEvent({ error: new Error("x"), process: "overlay-bun" })
+      .meta as unknown as Record<string, unknown>;
+    expect(meta.user).toBeUndefined();
+    expect(meta.browser).toBeUndefined();
+    expect((meta.app as Record<string, unknown>).installationId).toBeUndefined();
   });
 });
 
@@ -438,9 +464,9 @@ describe("the never-leaks gate", () => {
         release: "0.9.0",
         context: { pluginId: "hltb", tags: { path: "/home/deck/secret" } },
       }),
-      { hostname: "simons-deck" },
+      { hostname: "simons-deck", username: "otheruser" },
     );
-    const wire = buildEnvelope(event, parseDsn(DSN)!);
+    const wire = buildBody(event);
 
     for (const forbidden of [
       "/home/",
@@ -509,7 +535,7 @@ describe("scrubbing on the real send path", () => {
   test("captureError scrubs before transmitting", async () => {
     initCrashReporting({
       process: "backend",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       release: "0.9.0",
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
@@ -533,7 +559,7 @@ describe("scrubbing on the real send path", () => {
     const dir = mkdtempSync(join(tmpdir(), "loadout-spool-"));
     initCrashReporting({
       process: "overlay-bun",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       username: "simonh",
@@ -572,7 +598,7 @@ describe("spool and fatal path", () => {
     // Run 1: dies without sending anything.
     initCrashReporting({
       process: "overlay-bun",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       spoolDir: dir,
@@ -587,7 +613,7 @@ describe("spool and fatal path", () => {
     resetForTests();
     initCrashReporting({
       process: "overlay-bun",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       spoolDir: dir,
@@ -603,7 +629,7 @@ describe("spool and fatal path", () => {
   test("consent withdrawn between crash and restart discards the spool", async () => {
     initCrashReporting({
       process: "overlay-bun",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       spoolDir: dir,
@@ -616,7 +642,7 @@ describe("spool and fatal path", () => {
     resetForTests();
     initCrashReporting({
       process: "overlay-bun",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => "denied",
       stateStore: memoryStateStore(),
       spoolDir: dir,
@@ -639,7 +665,7 @@ describe("spool and fatal path", () => {
 
     initCrashReporting({
       process: "overlay-bun",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       spoolDir: dir,
@@ -659,7 +685,7 @@ describe("spool and fatal path", () => {
     resetForTests();
     initCrashReporting({
       process: "overlay-bun",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       spoolDir: dir,
@@ -677,7 +703,7 @@ describe("spool and fatal path", () => {
     }) as unknown as typeof fetch;
     initCrashReporting({
       process: "overlay-bun",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       spoolDir: dir,
@@ -693,7 +719,7 @@ describe("spool and fatal path", () => {
   test("a fatal capture without consent writes nothing at all", () => {
     initCrashReporting({
       process: "overlay-bun",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => undefined,
       stateStore: memoryStateStore(),
       spoolDir: dir,
@@ -732,7 +758,7 @@ describe("the shipped default consent supplier", () => {
   function initWithHome(home: string) {
     initCrashReporting({
       process: "backend",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       // No readConsent: exercise the real default, pointed at a temp home.
       hostname: "irrelevant",
       stateStore: memoryStateStore(),
@@ -783,7 +809,7 @@ describe("rate-limit state really persists to disk", () => {
       resetForTests();
       initCrashReporting({
         process: "backend",
-        dsn: DSN,
+        collectorUrl: COLLECTOR,
         readConsent: () => "granted",
         stateStore: fileStateStore(path),
         fetchImpl,
@@ -812,7 +838,7 @@ describe("capture gating (the test that matters)", () => {
   test("sends nothing when consent is unset", async () => {
     initCrashReporting({
       process: "backend",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => undefined,
       stateStore: memoryStateStore(),
       fetchImpl,
@@ -826,7 +852,7 @@ describe("capture gating (the test that matters)", () => {
   test("sends nothing when consent is denied", async () => {
     initCrashReporting({
       process: "backend",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => "denied",
       stateStore: memoryStateStore(),
       fetchImpl,
@@ -836,10 +862,10 @@ describe("capture gating (the test that matters)", () => {
     expect(sent).toBe(0);
   });
 
-  test("sends nothing when no DSN is configured", async () => {
+  test("sends nothing when no collector is configured", async () => {
     initCrashReporting({
       process: "backend",
-      dsn: undefined,
+      collectorUrl: undefined,
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       fetchImpl,
@@ -853,7 +879,7 @@ describe("capture gating (the test that matters)", () => {
   test("sends when granted", async () => {
     initCrashReporting({
       process: "backend",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       release: "0.9.0",
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
@@ -869,7 +895,7 @@ describe("capture gating (the test that matters)", () => {
     let consent: "granted" | "denied" = "granted";
     initCrashReporting({
       process: "backend",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => consent,
       stateStore: memoryStateStore(),
       fetchImpl,
@@ -885,7 +911,7 @@ describe("capture gating (the test that matters)", () => {
   test("webview consent comes from setConsent", async () => {
     initCrashReporting({
       process: "webview",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       stateStore: memoryStateStore(),
       fetchImpl,
       drainOnInit: false,
@@ -899,7 +925,7 @@ describe("capture gating (the test that matters)", () => {
   test("a network failure resolves false rather than throwing", async () => {
     initCrashReporting({
       process: "backend",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       fetchImpl: (async () => {
@@ -912,7 +938,7 @@ describe("capture gating (the test that matters)", () => {
   test("rate limiting applies end to end", async () => {
     initCrashReporting({
       process: "backend",
-      dsn: DSN,
+      collectorUrl: COLLECTOR,
       readConsent: () => "granted",
       stateStore: memoryStateStore(),
       fetchImpl,

--- a/packages/crash-report/src/event.ts
+++ b/packages/crash-report/src/event.ts
@@ -33,9 +33,21 @@ export interface ParsedFrame extends FaroFrame {
 /**
  * Parse a V8 stack string into frames.
  *
- * Faro renders frames oldest-first, the reverse of how V8 prints them, so the
- * result is reversed. Lines that don't parse are skipped rather than guessed
- * at — a malformed frame is worse than a missing one.
+ * Order is **innermost-first** — the throw site is `frames[0]` — which is
+ * V8's own print order and what Faro expects. Confirmed against upstream:
+ * `getStackFramesFromError` builds its array with `lines.reduce(… acc.push …)`
+ * over `error.stack.split('\n')` and never reverses, and its test asserts the
+ * throw site at index 0.
+ *
+ * Worth stating because the opposite is also true somewhere: Sentry renders
+ * oldest-first, so this function used to reverse. That reversal was correct
+ * then and silently wrong after the move to Faro — it inverted every stack
+ * trace on the wire, putting the process entry point where the failing frame
+ * should be. Note `fingerprint()` in scrub.ts takes the *first* few frames
+ * for the same reason; the two must agree.
+ *
+ * Lines that don't parse are skipped rather than guessed at — a malformed
+ * frame is worse than a missing one.
  */
 export function parseStack(stack: string | undefined): ParsedFrame[] {
   if (!stack) return [];
@@ -57,7 +69,7 @@ export function parseStack(stack: string | undefined): ParsedFrame[] {
       inApp: !VENDOR.test(filename),
     });
   }
-  return frames.reverse();
+  return frames;
 }
 
 /** Session ids are per-process and never persisted — see FaroMeta. */

--- a/packages/crash-report/src/event.ts
+++ b/packages/crash-report/src/event.ts
@@ -1,28 +1,45 @@
 /**
- * Turning an `Error` into a Sentry event.
+ * Turning an `Error` into a Faro payload.
  *
- * Stack parsing covers both runtimes we care about with one parser: Bun and
- * CEF are both V8-shaped ("    at fn (file:line:col)"), so the backend, the
- * overlay's Bun process, and the webview all produce the same frame format.
+ * Stack parsing covers both runtimes with one parser: Bun and CEF are both
+ * V8-shaped ("    at fn (file:line:col)"), so the backend, the overlay's Bun
+ * process and the webview all produce identical frame output.
  */
 
-import type { CaptureContext, Frame, ProcessName, SentryEvent } from "./types";
+import type {
+  CaptureContext,
+  FaroException,
+  FaroFrame,
+  FaroMeta,
+  FaroPayload,
+  ProcessName,
+} from "./types";
 
-/** Frames we mark `in_app: false` so Sentry greys them out and grouping ignores them. */
+/**
+ * Frames from the runtime or third-party code. Faro filters library frames out
+ * of its own grouping, but we still need the distinction locally: our
+ * fingerprint is computed over app frames only, and it is the layer Grafana
+ * gives priority to.
+ */
 const VENDOR = /(?:^|\/)(?:node_modules|bun:|node:)/;
 
 const AT_LINE = /^\s*at\s+(?:(?<fn>.*?)\s+\()?(?<file>.*?):(?<line>\d+):(?<col>\d+)\)?\s*$/;
 
+/** A frame plus the local-only flag used for fingerprinting. Never serialised. */
+export interface ParsedFrame extends FaroFrame {
+  inApp: boolean;
+}
+
 /**
- * Parse a V8 stack string into Sentry frames.
+ * Parse a V8 stack string into frames.
  *
- * Sentry renders frames oldest-first, the reverse of how V8 prints them, so
- * the result is reversed. Lines that don't parse are skipped rather than
- * guessed at — a malformed frame is worse than a missing one.
+ * Faro renders frames oldest-first, the reverse of how V8 prints them, so the
+ * result is reversed. Lines that don't parse are skipped rather than guessed
+ * at — a malformed frame is worse than a missing one.
  */
-export function parseStack(stack: string | undefined): Frame[] {
+export function parseStack(stack: string | undefined): ParsedFrame[] {
   if (!stack) return [];
-  const frames: Frame[] = [];
+  const frames: ParsedFrame[] = [];
   for (const line of stack.split("\n")) {
     const m = AT_LINE.exec(line);
     if (!m?.groups) continue;
@@ -33,17 +50,18 @@ export function parseStack(stack: string | undefined): Frame[] {
     const fn = m.groups.fn?.replace(/^(?:async|new)\s+/, "");
     frames.push({
       filename,
-      function: fn && fn.length > 0 ? fn : undefined,
+      // Faro types these as required strings.
+      function: fn && fn.length > 0 ? fn : "?",
       lineno: Number(m.groups.line),
       colno: Number(m.groups.col),
-      in_app: !VENDOR.test(filename),
+      inApp: !VENDOR.test(filename),
     });
   }
   return frames.reverse();
 }
 
-/** 32 lowercase hex chars, per the Sentry protocol. */
-export function newEventId(): string {
+/** Session ids are per-process and never persisted — see FaroMeta. */
+export function newSessionId(): string {
   return crypto.randomUUID().replace(/-/g, "");
 }
 
@@ -52,10 +70,10 @@ export interface BuildEventInput {
   process: ProcessName;
   release?: string;
   environment?: string;
+  sessionId?: string;
   context?: CaptureContext;
   /** Injected for tests. */
   now?: number;
-  eventId?: string;
 }
 
 /**
@@ -74,37 +92,58 @@ function describe(error: unknown): { type: string; value: string; stack?: string
   }
 }
 
-export function buildEvent(input: BuildEventInput): SentryEvent {
+export function buildMeta(input: BuildEventInput): FaroMeta {
+  return {
+    sdk: { name: "loadout-crash-report", version: input.release },
+    app: {
+      name: "loadout",
+      version: input.release,
+      environment: input.environment,
+      // Which of the three processes produced this. Faro has no first-class
+      // field for it and `namespace` is the closest fit; also duplicated into
+      // the exception context so it is filterable either way.
+      namespace: input.process,
+    },
+    os: { name: "linux" },
+    session: {
+      id: input.sessionId ?? newSessionId(),
+      // Switch off Grafana Cloud's IP-derived geolocation from the client.
+      overrides: { geoLocationTrackingEnabled: false },
+    },
+  };
+}
+
+export function buildEvent(input: BuildEventInput): FaroPayload {
   const { type, value, stack } = describe(input.error);
-  const tags: Record<string, string> = {
+  const frames = parseStack(stack);
+
+  const context: Record<string, string> = {
     process: input.process,
     ...(input.context?.tags ?? {}),
   };
   // Plugin attribution: tagged so third-party faults can be routed away from
   // the core crash feed rather than reading as loadout bugs.
   if (input.context?.pluginId) {
-    tags.plugin_id = input.context.pluginId;
-    tags.fault_origin = "plugin";
+    context.plugin_id = input.context.pluginId;
+    context.fault_origin = "plugin";
   } else {
-    tags.fault_origin = "core";
+    context.fault_origin = "core";
   }
 
-  return {
-    event_id: input.eventId ?? newEventId(),
-    timestamp: (input.now ?? Date.now()) / 1000,
-    platform: input.process === "webview" ? "javascript" : "node",
-    level: input.context?.level ?? "error",
-    release: input.release,
-    environment: input.environment,
-    logger: input.process,
-    tags,
-    contexts: {
-      // Deliberately minimal. No hostname, no user, no device serial.
-      os: { name: "linux" },
-      runtime: { name: input.process === "webview" ? "cef" : "bun" },
-    },
-    exception: {
-      values: [{ type, value, stacktrace: { frames: parseStack(stack) } }],
-    },
+  const exception: FaroException = {
+    timestamp: new Date(input.now ?? Date.now()).toISOString(),
+    type,
+    value,
+    fatal: input.context?.level === "fatal",
+    stacktrace: { frames: frames.map(stripLocal) },
+    context,
   };
+
+  return { meta: buildMeta(input), exceptions: [exception] };
+}
+
+/** Drop the local-only `inApp` flag; it is not part of the wire format. */
+function stripLocal(frame: ParsedFrame): FaroFrame {
+  const { inApp: _inApp, ...wire } = frame;
+  return wire;
 }

--- a/packages/crash-report/src/event.ts
+++ b/packages/crash-report/src/event.ts
@@ -1,0 +1,110 @@
+/**
+ * Turning an `Error` into a Sentry event.
+ *
+ * Stack parsing covers both runtimes we care about with one parser: Bun and
+ * CEF are both V8-shaped ("    at fn (file:line:col)"), so the backend, the
+ * overlay's Bun process, and the webview all produce the same frame format.
+ */
+
+import type { CaptureContext, Frame, ProcessName, SentryEvent } from "./types";
+
+/** Frames we mark `in_app: false` so Sentry greys them out and grouping ignores them. */
+const VENDOR = /(?:^|\/)(?:node_modules|bun:|node:)/;
+
+const AT_LINE = /^\s*at\s+(?:(?<fn>.*?)\s+\()?(?<file>.*?):(?<line>\d+):(?<col>\d+)\)?\s*$/;
+
+/**
+ * Parse a V8 stack string into Sentry frames.
+ *
+ * Sentry renders frames oldest-first, the reverse of how V8 prints them, so
+ * the result is reversed. Lines that don't parse are skipped rather than
+ * guessed at — a malformed frame is worse than a missing one.
+ */
+export function parseStack(stack: string | undefined): Frame[] {
+  if (!stack) return [];
+  const frames: Frame[] = [];
+  for (const line of stack.split("\n")) {
+    const m = AT_LINE.exec(line);
+    if (!m?.groups) continue;
+    const file = m.groups.file ?? "";
+    // Strip the scheme CEF and Bun put on module paths so frames from the
+    // two runtimes group together.
+    const filename = file.replace(/^(?:file|views):\/\/+/, "/");
+    const fn = m.groups.fn?.replace(/^(?:async|new)\s+/, "");
+    frames.push({
+      filename,
+      function: fn && fn.length > 0 ? fn : undefined,
+      lineno: Number(m.groups.line),
+      colno: Number(m.groups.col),
+      in_app: !VENDOR.test(filename),
+    });
+  }
+  return frames.reverse();
+}
+
+/** 32 lowercase hex chars, per the Sentry protocol. */
+export function newEventId(): string {
+  return crypto.randomUUID().replace(/-/g, "");
+}
+
+export interface BuildEventInput {
+  error: unknown;
+  process: ProcessName;
+  release?: string;
+  environment?: string;
+  context?: CaptureContext;
+  /** Injected for tests. */
+  now?: number;
+  eventId?: string;
+}
+
+/**
+ * Coerce anything throwable into a type/value pair. Non-Errors reach here
+ * often enough to matter — an `unhandledRejection` can carry any value.
+ */
+function describe(error: unknown): { type: string; value: string; stack?: string } {
+  if (error instanceof Error) {
+    return { type: error.name || "Error", value: error.message, stack: error.stack };
+  }
+  if (typeof error === "string") return { type: "Error", value: error };
+  try {
+    return { type: "Error", value: JSON.stringify(error) ?? String(error) };
+  } catch {
+    return { type: "Error", value: String(error) };
+  }
+}
+
+export function buildEvent(input: BuildEventInput): SentryEvent {
+  const { type, value, stack } = describe(input.error);
+  const tags: Record<string, string> = {
+    process: input.process,
+    ...(input.context?.tags ?? {}),
+  };
+  // Plugin attribution: tagged so third-party faults can be routed away from
+  // the core crash feed rather than reading as loadout bugs.
+  if (input.context?.pluginId) {
+    tags.plugin_id = input.context.pluginId;
+    tags.fault_origin = "plugin";
+  } else {
+    tags.fault_origin = "core";
+  }
+
+  return {
+    event_id: input.eventId ?? newEventId(),
+    timestamp: (input.now ?? Date.now()) / 1000,
+    platform: input.process === "webview" ? "javascript" : "node",
+    level: input.context?.level ?? "error",
+    release: input.release,
+    environment: input.environment,
+    logger: input.process,
+    tags,
+    contexts: {
+      // Deliberately minimal. No hostname, no user, no device serial.
+      os: { name: "linux" },
+      runtime: { name: input.process === "webview" ? "cef" : "bun" },
+    },
+    exception: {
+      values: [{ type, value, stacktrace: { frames: parseStack(stack) } }],
+    },
+  };
+}

--- a/packages/crash-report/src/index.ts
+++ b/packages/crash-report/src/index.ts
@@ -38,7 +38,23 @@ export interface StateStore {
   write(value: string): void;
 }
 
-export function fileStateStore(path: string): StateStore {
+/**
+ * Hand back ownership of anything we create under the user's home.
+ *
+ * The root backend and the user-level overlay share `$HOME`, so whichever
+ * runs first creates the state directory — and the backend always wins, since
+ * it starts at multi-user.target while the overlay waits for
+ * graphical-session.target. Left root-owned, every subsequent write from the
+ * overlay fails EACCES and is swallowed, leaving it with no spool and no
+ * cross-restart rate limiting at all.
+ *
+ * Per-process *filenames* do not fix this; the shared parent directory is the
+ * problem. The backend passes `chownToTarget` here, the same hook
+ * `user-config.ts` already uses for `~/.config/loadout`.
+ */
+export type ChownHook = (path: string) => void;
+
+export function fileStateStore(path: string, chown?: ChownHook): StateStore {
   return {
     read() {
       try {
@@ -49,8 +65,11 @@ export function fileStateStore(path: string): StateStore {
     },
     write(value) {
       try {
-        mkdirSync(join(path, ".."), { recursive: true });
+        const dir = join(path, "..");
+        mkdirSync(dir, { recursive: true });
         writeFileSync(path, value, "utf8");
+        chown?.(dir);
+        chown?.(path);
       } catch {
         // A read-only or full disk must not break the app. Losing the
         // counters degrades us to per-process limiting, not to no limiting:
@@ -127,6 +146,18 @@ export interface InitOptions {
   spoolDir?: string;
   /** Set false in tests to stop init touching the real spool. */
   drainOnInit?: boolean;
+  /**
+   * Hand ownership of created files back to the desktop user. The root
+   * backend must pass this; see {@link ChownHook}.
+   */
+  chown?: ChownHook;
+  /**
+   * Override `os.homedir()`. Exists so tests can exercise the *real* default
+   * consent supplier — the one that reads config.json — against a temporary
+   * home, instead of every test injecting its own `readConsent` and leaving
+   * the shipped default uncovered.
+   */
+  homeOverride?: string;
 }
 
 interface Runtime {
@@ -142,6 +173,7 @@ interface Runtime {
   hostname?: string;
   username?: string;
   spoolDir: string;
+  chown?: ChownHook;
 }
 
 let rt: Runtime | null = null;
@@ -153,7 +185,7 @@ let explicitConsent: ConsentState;
  */
 export function initCrashReporting(opts: InitOptions): void {
   const env = typeof process !== "undefined" ? process.env : {};
-  const home = safeHomedir();
+  const home = opts.homeOverride ?? safeHomedir();
   const dsn = parseDsn(opts.dsn ?? env.LOADOUT_CRASH_DSN);
   const isDev = !opts.release || opts.release === "dev";
 
@@ -167,12 +199,15 @@ export function initCrashReporting(opts: InitOptions): void {
       (opts.process === "webview"
         ? () => explicitConsent
         : () => readConsentSync(env, home)),
-    store: opts.stateStore ?? fileStateStore(defaultStatePath(env, home, opts.process)),
+    store:
+      opts.stateStore ??
+      fileStateStore(defaultStatePath(env, home, opts.process), opts.chown),
     now: opts.now ?? Date.now,
     fetchImpl: opts.fetchImpl,
     hostname: opts.hostname ?? safeHostname(),
     username: opts.username ?? basename(home),
     spoolDir: opts.spoolDir ?? defaultSpoolDir(env, home, opts.process),
+    chown: opts.chown,
   };
 
   // Ship anything a previous run died holding. Best-effort and detached: a
@@ -299,7 +334,7 @@ export function captureFatalSync(error: unknown, context?: CaptureContext): bool
   try {
     const event = prepare(r, error, { ...context, level: context?.level ?? "fatal" });
     if (!event) return false;
-    return spoolEvent(r.spoolDir, event, r.now());
+    return spoolEvent(r.spoolDir, event, r.now(), 0, r.chown);
   } catch {
     return false;
   }
@@ -320,14 +355,22 @@ export async function drainSpool(): Promise<number> {
       takeSpooled(r.spoolDir, r.now());
       return 0;
     }
-    const events = takeSpooled(r.spoolDir, r.now());
+    const entries = takeSpooled(r.spoolDir, r.now());
     let sent = 0;
-    for (const event of events) {
+    for (const { event, attempts } of entries) {
       const ok = await sendEvent(event, r.dsn, {
         clientName: `loadout/${r.release ?? "dev"}`,
         fetchImpl: r.fetchImpl,
       });
-      if (ok) sent++;
+      if (ok) {
+        sent++;
+      } else {
+        // Put it back. `takeSpooled` unlinks on read, so without this a drain
+        // that runs while the device is offline would destroy every queued
+        // report — the precise situation the spool exists for. The attempt
+        // counter stops a permanently-unsendable event retrying forever.
+        spoolEvent(r.spoolDir, event, r.now(), attempts + 1, r.chown);
+      }
     }
     return sent;
   } catch {

--- a/packages/crash-report/src/index.ts
+++ b/packages/crash-report/src/index.ts
@@ -1,0 +1,230 @@
+/**
+ * @loadout/crash-report — opt-in crash reporting.
+ *
+ * Callsites see exactly two things: `initCrashReporting` once at startup and
+ * `captureError` on the crash paths. Everything Sentry-specific is behind
+ * this boundary, which is what keeps the backend choice reversible — moving
+ * from Sentry SaaS to a self-hosted GlitchTip is a DSN change and nothing else.
+ *
+ * Design rules, in priority order:
+ *   1. Never send without consent. Fail-closed everywhere; see consent.ts.
+ *   2. Never crash, hang, or slow down the process being observed.
+ *   3. Never send a field that isn't spelled out in types.ts + scrub.ts.
+ */
+
+import { join } from "node:path";
+import { homedir, hostname } from "node:os";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { isGranted, readConsentSync } from "./consent";
+import { buildEvent } from "./event";
+import { decide, parseState, type RateLimitState } from "./rate-limit";
+import { fingerprint, scrubEvent } from "./scrub";
+import { parseDsn, sendEvent, type Dsn } from "./transport";
+import type { CaptureContext, ConsentState, ProcessName } from "./types";
+
+export type { CaptureContext, ConsentState, ProcessName, SentryEvent } from "./types";
+export { CRASH_REPORTING_KEY, parseConsent, readConsentSync, isGranted } from "./consent";
+export { scrubEvent, scrubString, fingerprint } from "./scrub";
+export { parseStack, buildEvent } from "./event";
+export { parseDsn, buildEnvelope } from "./transport";
+export { decide, parseState, DEFAULT_LIMITS } from "./rate-limit";
+
+/** Where the rate limiter keeps its counters. Abstracted so the webview,
+ *  which has no filesystem, can back it with localStorage instead. */
+export interface StateStore {
+  read(): string | null;
+  write(value: string): void;
+}
+
+export function fileStateStore(path: string): StateStore {
+  return {
+    read() {
+      try {
+        return readFileSync(path, "utf8");
+      } catch {
+        return null;
+      }
+    },
+    write(value) {
+      try {
+        mkdirSync(join(path, ".."), { recursive: true });
+        writeFileSync(path, value, "utf8");
+      } catch {
+        // A read-only or full disk must not break the app. Losing the
+        // counters degrades us to per-process limiting, not to no limiting:
+        // the in-memory copy still holds for this process's lifetime.
+      }
+    },
+  };
+}
+
+export function memoryStateStore(): StateStore {
+  let v: string | null = null;
+  return { read: () => v, write: (value) => { v = value; } };
+}
+
+function defaultStatePath(env: Record<string, string | undefined>, home: string): string {
+  const xdg = env.XDG_STATE_HOME;
+  const base = xdg && xdg.length > 0 ? xdg : join(home, ".local", "state");
+  return join(base, "loadout", "crash-report.json");
+}
+
+export interface InitOptions {
+  process: ProcessName;
+  /** Product version — becomes the Sentry release. */
+  release?: string;
+  /** Defaults to "development" for dev builds, else "production". */
+  environment?: string;
+  /**
+   * DSN. Resolution order: this option, then `$LOADOUT_CRASH_DSN`, then none.
+   * With no DSN, reporting is inert — which is the intended state until a
+   * project is provisioned, and what makes dogfooding safe by default.
+   */
+  dsn?: string;
+  /**
+   * Consent supplier. Node processes default to reading `config.json` on
+   * every capture so a revocation takes effect immediately. The webview has
+   * no filesystem and supplies its value via `setConsent`.
+   */
+  readConsent?: () => ConsentState;
+  stateStore?: StateStore;
+  now?: () => number;
+  fetchImpl?: typeof fetch;
+  /** Override the machine hostname to scrub. Defaults to `os.hostname()`. */
+  hostname?: string;
+}
+
+interface Runtime {
+  process: ProcessName;
+  release?: string;
+  environment: string;
+  dsn: Dsn | null;
+  readConsent: () => ConsentState;
+  store: StateStore;
+  now: () => number;
+  fetchImpl?: typeof fetch;
+  state: RateLimitState | null;
+  /** Resolved once at init; scrubbed out of every outgoing string. */
+  hostname?: string;
+}
+
+let rt: Runtime | null = null;
+let explicitConsent: ConsentState;
+
+/**
+ * Wire up reporting. Safe to call in any process, including with no DSN —
+ * that just makes every later `captureError` a no-op.
+ */
+export function initCrashReporting(opts: InitOptions): void {
+  const env = typeof process !== "undefined" ? process.env : {};
+  const home = safeHomedir();
+  const dsn = parseDsn(opts.dsn ?? env.LOADOUT_CRASH_DSN);
+  const isDev = !opts.release || opts.release === "dev";
+
+  rt = {
+    process: opts.process,
+    release: opts.release,
+    environment: opts.environment ?? (isDev ? "development" : "production"),
+    dsn,
+    readConsent:
+      opts.readConsent ??
+      (opts.process === "webview"
+        ? () => explicitConsent
+        : () => readConsentSync(env, home)),
+    store: opts.stateStore ?? fileStateStore(defaultStatePath(env, home)),
+    now: opts.now ?? Date.now,
+    fetchImpl: opts.fetchImpl,
+    state: null,
+    hostname: opts.hostname ?? safeHostname(),
+  };
+}
+
+function safeHostname(): string | undefined {
+  try {
+    return hostname();
+  } catch {
+    return undefined;
+  }
+}
+
+function safeHomedir(): string {
+  try {
+    return homedir();
+  } catch {
+    return "/";
+  }
+}
+
+/**
+ * Set consent explicitly. The webview calls this when the user answers the
+ * prompt or flips the Settings toggle; node processes read from disk and
+ * don't need it.
+ */
+export function setConsent(state: ConsentState): void {
+  explicitConsent = state;
+}
+
+/** Whether a capture right now would actually send. Useful in tests and UI. */
+export function isEnabled(): boolean {
+  return !!rt && !!rt.dsn && isGranted(rt.readConsent());
+}
+
+/**
+ * Capture an error. Returns whether it was accepted by the server, so crash
+ * handlers that are about to exit can await it; everywhere else, ignore it.
+ *
+ * Resolves false — never rejects — for every failure mode: no consent, no
+ * DSN, rate-limited, network down, server angry.
+ */
+export async function captureError(
+  error: unknown,
+  context?: CaptureContext,
+): Promise<boolean> {
+  const r = rt;
+  if (!r || !r.dsn) return false;
+  // Re-checked on every capture, not cached: revoking consent has to take
+  // effect immediately, not at next restart.
+  if (!isGranted(r.readConsent())) return false;
+
+  try {
+    const event = scrubEvent(
+      buildEvent({
+        error,
+        process: r.process,
+        release: r.release,
+        environment: r.environment,
+        context,
+        now: r.now(),
+      }),
+      { hostname: r.hostname },
+    );
+
+    const now = r.now();
+    if (r.state === null) r.state = parseState(r.store.read(), now);
+    const verdict = decide(r.state, now, fingerprint(event), undefined);
+    // Persist in both branches — the windows may have rolled forward even
+    // when the event is dropped, and pinning them would leak quota.
+    r.state = verdict.state;
+    r.store.write(JSON.stringify(verdict.state));
+    if (!verdict.allow) return false;
+
+    return await sendEvent(event, r.dsn, {
+      clientName: `loadout/${r.release ?? "dev"}`,
+      fetchImpl: r.fetchImpl,
+    });
+  } catch {
+    // Reporting a crash must never cause one.
+    return false;
+  }
+}
+
+/** Fire-and-forget wrapper for paths that can't await. */
+export function captureErrorSync(error: unknown, context?: CaptureContext): void {
+  void captureError(error, context).catch(() => {});
+}
+
+/** Test seam: drop all module state. */
+export function resetForTests(): void {
+  rt = null;
+  explicitConsent = undefined;
+}

--- a/packages/crash-report/src/index.ts
+++ b/packages/crash-report/src/index.ts
@@ -1,10 +1,10 @@
 /**
- * @loadout/crash-report — opt-in crash reporting.
+ * @loadout/crash-report — opt-in crash reporting, via Grafana Faro.
  *
  * Callsites see exactly two things: `initCrashReporting` once at startup and
- * `captureError` on the crash paths. Everything Sentry-specific is behind
- * this boundary, which is what keeps the backend choice reversible — moving
- * from Sentry SaaS to a self-hosted GlitchTip is a DSN change and nothing else.
+ * `captureError` / `captureFatalSync` on the crash paths. Everything
+ * protocol-specific is behind this boundary, which is what kept the move from
+ * Sentry to Faro down to two files.
  *
  * Design rules, in priority order:
  *   1. Never send without consent. Fail-closed everywhere; see consent.ts.
@@ -16,20 +16,20 @@ import { join, basename } from "node:path";
 import { homedir, hostname } from "node:os";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { isGranted, readConsentSync } from "./consent";
-import { buildEvent } from "./event";
+import { buildEvent, newSessionId } from "./event";
 import { decide, parseState } from "./rate-limit";
 import { fingerprint, scrubEvent } from "./scrub";
-import { parseDsn, sendEvent, type Dsn } from "./transport";
+import { parseCollector, sendEvent, type Collector } from "./transport";
 import { spoolEvent, takeSpooled } from "./spool";
-import type { CaptureContext, ConsentState, ProcessName, SentryEvent } from "./types";
+import type { CaptureContext, ConsentState, FaroPayload, ProcessName } from "./types";
 
-export type { CaptureContext, ConsentState, ProcessName, SentryEvent } from "./types";
+export type { CaptureContext, ConsentState, ProcessName, FaroPayload, FaroException, FaroMeta, FaroFrame } from "./types";
 export { CRASH_REPORTING_KEY, parseConsent, readConsentSync, isGranted } from "./consent";
 export { scrubEvent, scrubString, fingerprint } from "./scrub";
-export { parseStack, buildEvent } from "./event";
-export { parseDsn, buildEnvelope } from "./transport";
+export { parseStack, buildEvent, buildMeta, newSessionId } from "./event";
+export { parseCollector, buildBody } from "./transport";
 export { decide, parseState, DEFAULT_LIMITS } from "./rate-limit";
-export { spoolEvent, takeSpooled, MAX_SPOOL_FILES, MAX_SPOOL_AGE_MS } from "./spool";
+export { spoolEvent, takeSpooled, MAX_SPOOL_FILES, MAX_SPOOL_AGE_MS, MAX_SPOOL_ATTEMPTS } from "./spool";
 
 /** Where the rate limiter keeps its counters. Abstracted so the webview,
  *  which has no filesystem, can back it with localStorage instead. */
@@ -119,16 +119,19 @@ function defaultSpoolDir(
 
 export interface InitOptions {
   process: ProcessName;
-  /** Product version — becomes the Sentry release. */
+  /** Product version — becomes `meta.app.version`. */
   release?: string;
   /** Defaults to "development" for dev builds, else "production". */
   environment?: string;
   /**
-   * DSN. Resolution order: this option, then `$LOADOUT_CRASH_DSN`, then none.
-   * With no DSN, reporting is inert — which is the intended state until a
-   * project is provisioned, and what makes dogfooding safe by default.
+   * Faro collector URL, e.g.
+   * `https://faro-collector-<region>.grafana.net/collect/<app-key>`.
+   *
+   * Resolution order: this option, then `$LOADOUT_CRASH_COLLECTOR`, then none.
+   * With no collector, reporting is inert — the intended state until an app is
+   * provisioned, and what makes dogfooding safe by default.
    */
-  dsn?: string;
+  collectorUrl?: string;
   /**
    * Consent supplier. Node processes default to reading `config.json` on
    * every capture so a revocation takes effect immediately. The webview has
@@ -164,7 +167,7 @@ interface Runtime {
   process: ProcessName;
   release?: string;
   environment: string;
-  dsn: Dsn | null;
+  collector: Collector | null;
   readConsent: () => ConsentState;
   store: StateStore;
   now: () => number;
@@ -174,26 +177,31 @@ interface Runtime {
   username?: string;
   spoolDir: string;
   chown?: ChownHook;
+  /**
+   * Regenerated on every process start and never persisted, so it groups
+   * events within one run without correlating across restarts.
+   */
+  sessionId: string;
 }
 
 let rt: Runtime | null = null;
 let explicitConsent: ConsentState;
 
 /**
- * Wire up reporting. Safe to call in any process, including with no DSN —
- * that just makes every later `captureError` a no-op.
+ * Wire up reporting. Safe to call in any process, including with no collector
+ * configured — that just makes every later `captureError` a no-op.
  */
 export function initCrashReporting(opts: InitOptions): void {
   const env = typeof process !== "undefined" ? process.env : {};
   const home = opts.homeOverride ?? safeHomedir();
-  const dsn = parseDsn(opts.dsn ?? env.LOADOUT_CRASH_DSN);
+  const collector = parseCollector(opts.collectorUrl ?? env.LOADOUT_CRASH_COLLECTOR);
   const isDev = !opts.release || opts.release === "dev";
 
   rt = {
     process: opts.process,
     release: opts.release,
     environment: opts.environment ?? (isDev ? "development" : "production"),
-    dsn,
+    collector,
     readConsent:
       opts.readConsent ??
       (opts.process === "webview"
@@ -208,6 +216,7 @@ export function initCrashReporting(opts: InitOptions): void {
     username: opts.username ?? basename(home),
     spoolDir: opts.spoolDir ?? defaultSpoolDir(env, home, opts.process),
     chown: opts.chown,
+    sessionId: newSessionId(),
   };
 
   // Ship anything a previous run died holding. Best-effort and detached: a
@@ -242,7 +251,7 @@ export function setConsent(state: ConsentState): void {
 
 /** Whether a capture right now would actually send. Useful in tests and UI. */
 export function isEnabled(): boolean {
-  return !!rt && !!rt.dsn && isGranted(rt.readConsent());
+  return !!rt && !!rt.collector && isGranted(rt.readConsent());
 }
 
 /**
@@ -250,7 +259,7 @@ export function isEnabled(): boolean {
  * handlers that are about to exit can await it; everywhere else, ignore it.
  *
  * Resolves false — never rejects — for every failure mode: no consent, no
- * DSN, rate-limited, network down, server angry.
+ * collector, rate-limited, network down, server angry.
  */
 /**
  * Shared front half of every capture: consent gate, build, scrub, rate limit.
@@ -259,7 +268,7 @@ export function isEnabled(): boolean {
  * the fatal path go through here, so scrubbing cannot be bypassed by adding a
  * new entry point — a property the tests assert against the transmitted bytes.
  */
-function prepare(r: Runtime, error: unknown, context?: CaptureContext): SentryEvent | null {
+function prepare(r: Runtime, error: unknown, context?: CaptureContext): FaroPayload | null {
   // Re-checked on every capture, not cached: revoking consent has to take
   // effect immediately, not at next restart.
   if (!isGranted(r.readConsent())) return null;
@@ -270,18 +279,27 @@ function prepare(r: Runtime, error: unknown, context?: CaptureContext): SentryEv
       process: r.process,
       release: r.release,
       environment: r.environment,
+      sessionId: r.sessionId,
       context,
       now: r.now(),
     }),
     { hostname: r.hostname, username: r.username },
   );
 
+  // Computed after scrubbing, so it is identical across machines hitting the
+  // same bug. Serves double duty: the local dedup key below, and
+  // `FaroException.fingerprint` on the wire — the top layer of Grafana's error
+  // grouping, which takes priority over its own stack normalisation. Without
+  // it, one bug on N devices can read as N issues.
+  const fp = fingerprint(event);
+  for (const ex of event.exceptions) ex.fingerprint = fp;
+
   const now = r.now();
   // Re-read from the store rather than caching in memory. A cached copy goes
   // stale against any other writer and, more importantly, survives across the
   // very restarts a crash loop produces — which is when the counters matter.
   const state = parseState(r.store.read(), now);
-  const verdict = decide(state, now, fingerprint(event), undefined);
+  const verdict = decide(state, now, fp, undefined);
   // Persist in both branches — the windows may have rolled forward even
   // when the event is dropped, and pinning them would leak quota.
   r.store.write(JSON.stringify(verdict.state));
@@ -293,14 +311,11 @@ export async function captureError(
   context?: CaptureContext,
 ): Promise<boolean> {
   const r = rt;
-  if (!r || !r.dsn) return false;
+  if (!r || !r.collector) return false;
   try {
     const event = prepare(r, error, context);
     if (!event) return false;
-    return await sendEvent(event, r.dsn, {
-      clientName: `loadout/${r.release ?? "dev"}`,
-      fetchImpl: r.fetchImpl,
-    });
+    return await sendEvent(event, r.collector, { fetchImpl: r.fetchImpl });
   } catch {
     // Reporting a crash must never cause one.
     return false;
@@ -330,7 +345,7 @@ export function captureErrorSync(error: unknown, context?: CaptureContext): void
  */
 export function captureFatalSync(error: unknown, context?: CaptureContext): boolean {
   const r = rt;
-  if (!r || !r.dsn) return false;
+  if (!r || !r.collector) return false;
   try {
     const event = prepare(r, error, { ...context, level: context?.level ?? "fatal" });
     if (!event) return false;
@@ -348,7 +363,7 @@ export function captureFatalSync(error: unknown, context?: CaptureContext): bool
  */
 export async function drainSpool(): Promise<number> {
   const r = rt;
-  if (!r || !r.dsn) return 0;
+  if (!r || !r.collector) return 0;
   try {
     if (!isGranted(r.readConsent())) {
       // Consent withdrawn since these were written — discard, don't send.
@@ -358,10 +373,7 @@ export async function drainSpool(): Promise<number> {
     const entries = takeSpooled(r.spoolDir, r.now());
     let sent = 0;
     for (const { event, attempts } of entries) {
-      const ok = await sendEvent(event, r.dsn, {
-        clientName: `loadout/${r.release ?? "dev"}`,
-        fetchImpl: r.fetchImpl,
-      });
+      const ok = await sendEvent(event, r.collector, { fetchImpl: r.fetchImpl });
       if (ok) {
         sent++;
       } else {

--- a/packages/crash-report/src/index.ts
+++ b/packages/crash-report/src/index.ts
@@ -29,7 +29,14 @@ export { scrubEvent, scrubString, fingerprint } from "./scrub";
 export { parseStack, buildEvent, buildMeta, newSessionId } from "./event";
 export { parseCollector, buildBody } from "./transport";
 export { decide, parseState, DEFAULT_LIMITS } from "./rate-limit";
-export { spoolEvent, takeSpooled, MAX_SPOOL_FILES, MAX_SPOOL_AGE_MS, MAX_SPOOL_ATTEMPTS } from "./spool";
+export {
+  spoolEvent,
+  takeSpooled,
+  MAX_SPOOL_FILES,
+  MAX_SPOOL_AGE_MS,
+  MAX_SPOOL_ATTEMPTS,
+  RETRY_BACKOFF_MS,
+} from "./spool";
 
 /** Where the rate limiter keeps its counters. Abstracted so the webview,
  *  which has no filesystem, can back it with localStorage instead. */
@@ -161,6 +168,13 @@ export interface InitOptions {
    * the shipped default uncovered.
    */
   homeOverride?: string;
+  /**
+   * Override `process.env`. Needed alongside `homeOverride` for a test to be
+   * hermetic: consent resolution checks `$XDG_CONFIG_HOME` *before* the home
+   * directory, so sandboxing only the home still reads the real machine's
+   * config on any developer who sets that variable.
+   */
+  envOverride?: Record<string, string | undefined>;
 }
 
 interface Runtime {
@@ -192,7 +206,7 @@ let explicitConsent: ConsentState;
  * configured — that just makes every later `captureError` a no-op.
  */
 export function initCrashReporting(opts: InitOptions): void {
-  const env = typeof process !== "undefined" ? process.env : {};
+  const env = opts.envOverride ?? (typeof process !== "undefined" ? process.env : {});
   const home = opts.homeOverride ?? safeHomedir();
   const collector = parseCollector(opts.collectorUrl ?? env.LOADOUT_CRASH_COLLECTOR);
   const isDev = !opts.release || opts.release === "dev";

--- a/packages/crash-report/src/index.ts
+++ b/packages/crash-report/src/index.ts
@@ -12,15 +12,16 @@
  *   3. Never send a field that isn't spelled out in types.ts + scrub.ts.
  */
 
-import { join } from "node:path";
+import { join, basename } from "node:path";
 import { homedir, hostname } from "node:os";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { isGranted, readConsentSync } from "./consent";
 import { buildEvent } from "./event";
-import { decide, parseState, type RateLimitState } from "./rate-limit";
+import { decide, parseState } from "./rate-limit";
 import { fingerprint, scrubEvent } from "./scrub";
 import { parseDsn, sendEvent, type Dsn } from "./transport";
-import type { CaptureContext, ConsentState, ProcessName } from "./types";
+import { spoolEvent, takeSpooled } from "./spool";
+import type { CaptureContext, ConsentState, ProcessName, SentryEvent } from "./types";
 
 export type { CaptureContext, ConsentState, ProcessName, SentryEvent } from "./types";
 export { CRASH_REPORTING_KEY, parseConsent, readConsentSync, isGranted } from "./consent";
@@ -28,6 +29,7 @@ export { scrubEvent, scrubString, fingerprint } from "./scrub";
 export { parseStack, buildEvent } from "./event";
 export { parseDsn, buildEnvelope } from "./transport";
 export { decide, parseState, DEFAULT_LIMITS } from "./rate-limit";
+export { spoolEvent, takeSpooled, MAX_SPOOL_FILES, MAX_SPOOL_AGE_MS } from "./spool";
 
 /** Where the rate limiter keeps its counters. Abstracted so the webview,
  *  which has no filesystem, can back it with localStorage instead. */
@@ -63,10 +65,37 @@ export function memoryStateStore(): StateStore {
   return { read: () => v, write: (value) => { v = value; } };
 }
 
-function defaultStatePath(env: Record<string, string | undefined>, home: string): string {
+function stateDir(env: Record<string, string | undefined>, home: string): string {
   const xdg = env.XDG_STATE_HOME;
   const base = xdg && xdg.length > 0 ? xdg : join(home, ".local", "state");
-  return join(base, "loadout", "crash-report.json");
+  return join(base, "loadout");
+}
+
+/**
+ * Rate-limit state is per-process, and that is not cosmetic.
+ *
+ * The backend runs as **root** and the overlay as the **user**, but both
+ * resolve paths under the same `$HOME`. A single shared file means root
+ * creates it first, the user process then fails every write with EACCES —
+ * silently, since the store swallows errors — and the overlay ends up with no
+ * persistent rate limiting at all. That is precisely the crash-loop
+ * protection this module exists to provide. Separate files also stop the two
+ * processes clobbering each other's counters.
+ */
+function defaultStatePath(
+  env: Record<string, string | undefined>,
+  home: string,
+  proc: ProcessName,
+): string {
+  return join(stateDir(env, home), `crash-report-${proc}.json`);
+}
+
+function defaultSpoolDir(
+  env: Record<string, string | undefined>,
+  home: string,
+  proc: ProcessName,
+): string {
+  return join(stateDir(env, home), `crash-spool-${proc}`);
 }
 
 export interface InitOptions {
@@ -92,6 +121,12 @@ export interface InitOptions {
   fetchImpl?: typeof fetch;
   /** Override the machine hostname to scrub. Defaults to `os.hostname()`. */
   hostname?: string;
+  /** Override the account name to scrub. Defaults to `basename(homedir())`. */
+  username?: string;
+  /** Directory holding events written by fatal handlers. */
+  spoolDir?: string;
+  /** Set false in tests to stop init touching the real spool. */
+  drainOnInit?: boolean;
 }
 
 interface Runtime {
@@ -103,9 +138,10 @@ interface Runtime {
   store: StateStore;
   now: () => number;
   fetchImpl?: typeof fetch;
-  state: RateLimitState | null;
   /** Resolved once at init; scrubbed out of every outgoing string. */
   hostname?: string;
+  username?: string;
+  spoolDir: string;
 }
 
 let rt: Runtime | null = null;
@@ -131,12 +167,17 @@ export function initCrashReporting(opts: InitOptions): void {
       (opts.process === "webview"
         ? () => explicitConsent
         : () => readConsentSync(env, home)),
-    store: opts.stateStore ?? fileStateStore(defaultStatePath(env, home)),
+    store: opts.stateStore ?? fileStateStore(defaultStatePath(env, home, opts.process)),
     now: opts.now ?? Date.now,
     fetchImpl: opts.fetchImpl,
-    state: null,
     hostname: opts.hostname ?? safeHostname(),
+    username: opts.username ?? basename(home),
+    spoolDir: opts.spoolDir ?? defaultSpoolDir(env, home, opts.process),
   };
+
+  // Ship anything a previous run died holding. Best-effort and detached: a
+  // slow or failed drain must never delay startup.
+  if (opts.drainOnInit !== false) void drainSpool();
 }
 
 function safeHostname(): string | undefined {
@@ -176,38 +217,51 @@ export function isEnabled(): boolean {
  * Resolves false — never rejects — for every failure mode: no consent, no
  * DSN, rate-limited, network down, server angry.
  */
+/**
+ * Shared front half of every capture: consent gate, build, scrub, rate limit.
+ *
+ * Returns the scrubbed event when it may be sent, or null. Both the async and
+ * the fatal path go through here, so scrubbing cannot be bypassed by adding a
+ * new entry point — a property the tests assert against the transmitted bytes.
+ */
+function prepare(r: Runtime, error: unknown, context?: CaptureContext): SentryEvent | null {
+  // Re-checked on every capture, not cached: revoking consent has to take
+  // effect immediately, not at next restart.
+  if (!isGranted(r.readConsent())) return null;
+
+  const event = scrubEvent(
+    buildEvent({
+      error,
+      process: r.process,
+      release: r.release,
+      environment: r.environment,
+      context,
+      now: r.now(),
+    }),
+    { hostname: r.hostname, username: r.username },
+  );
+
+  const now = r.now();
+  // Re-read from the store rather than caching in memory. A cached copy goes
+  // stale against any other writer and, more importantly, survives across the
+  // very restarts a crash loop produces — which is when the counters matter.
+  const state = parseState(r.store.read(), now);
+  const verdict = decide(state, now, fingerprint(event), undefined);
+  // Persist in both branches — the windows may have rolled forward even
+  // when the event is dropped, and pinning them would leak quota.
+  r.store.write(JSON.stringify(verdict.state));
+  return verdict.allow ? event : null;
+}
+
 export async function captureError(
   error: unknown,
   context?: CaptureContext,
 ): Promise<boolean> {
   const r = rt;
   if (!r || !r.dsn) return false;
-  // Re-checked on every capture, not cached: revoking consent has to take
-  // effect immediately, not at next restart.
-  if (!isGranted(r.readConsent())) return false;
-
   try {
-    const event = scrubEvent(
-      buildEvent({
-        error,
-        process: r.process,
-        release: r.release,
-        environment: r.environment,
-        context,
-        now: r.now(),
-      }),
-      { hostname: r.hostname },
-    );
-
-    const now = r.now();
-    if (r.state === null) r.state = parseState(r.store.read(), now);
-    const verdict = decide(r.state, now, fingerprint(event), undefined);
-    // Persist in both branches — the windows may have rolled forward even
-    // when the event is dropped, and pinning them would leak quota.
-    r.state = verdict.state;
-    r.store.write(JSON.stringify(verdict.state));
-    if (!verdict.allow) return false;
-
+    const event = prepare(r, error, context);
+    if (!event) return false;
     return await sendEvent(event, r.dsn, {
       clientName: `loadout/${r.release ?? "dev"}`,
       fetchImpl: r.fetchImpl,
@@ -218,9 +272,67 @@ export async function captureError(
   }
 }
 
-/** Fire-and-forget wrapper for paths that can't await. */
+/** Fire-and-forget wrapper for non-fatal paths that can't await. */
 export function captureErrorSync(error: unknown, context?: CaptureContext): void {
   void captureError(error, context).catch(() => {});
+}
+
+/**
+ * Capture on a path where the process is about to die. Synchronous, no network.
+ *
+ * Use this wherever the process will not survive to the next tick. Two such
+ * places exist today and neither can be fixed by awaiting:
+ *
+ *  - The overlay's `uncaughtException`: Electrobun registers its own listener
+ *    when `electrobun/bun` is imported, and it calls a native `forceExit(1)`.
+ *  - The management-loop `.catch`, which calls `process.exit(1)` immediately
+ *    and must, because it owes Steam a prompt SIGCONT.
+ *
+ * An async send in either place is started and then killed mid-flight, which
+ * is exactly what a reviewer found: the report never arrives. Writing the
+ * already-scrubbed event to disk lands before the process dies, and the next
+ * start drains it. Returns whether it was spooled.
+ */
+export function captureFatalSync(error: unknown, context?: CaptureContext): boolean {
+  const r = rt;
+  if (!r || !r.dsn) return false;
+  try {
+    const event = prepare(r, error, { ...context, level: context?.level ?? "fatal" });
+    if (!event) return false;
+    return spoolEvent(r.spoolDir, event, r.now());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Send anything a previous run spooled. Called automatically at init.
+ *
+ * Consent is re-checked here, not just at write time: a user who spooled a
+ * crash and then withdrew consent before the next start must not have it sent.
+ */
+export async function drainSpool(): Promise<number> {
+  const r = rt;
+  if (!r || !r.dsn) return 0;
+  try {
+    if (!isGranted(r.readConsent())) {
+      // Consent withdrawn since these were written — discard, don't send.
+      takeSpooled(r.spoolDir, r.now());
+      return 0;
+    }
+    const events = takeSpooled(r.spoolDir, r.now());
+    let sent = 0;
+    for (const event of events) {
+      const ok = await sendEvent(event, r.dsn, {
+        clientName: `loadout/${r.release ?? "dev"}`,
+        fetchImpl: r.fetchImpl,
+      });
+      if (ok) sent++;
+    }
+    return sent;
+  } catch {
+    return 0;
+  }
 }
 
 /** Test seam: drop all module state. */

--- a/packages/crash-report/src/rate-limit.ts
+++ b/packages/crash-report/src/rate-limit.ts
@@ -1,0 +1,141 @@
+/**
+ * Rate limiting that survives process restarts.
+ *
+ * This is not politeness — it's the thing standing between one user's
+ * crash loop and a dead monthly quota. Sentry's free tier is 5,000 events
+ * a month and *silently stops accepting* when exhausted, so an unbounded
+ * reporter goes blind exactly when something is badly broken.
+ *
+ * The subtlety: an in-memory counter is useless here. A crash loop kills
+ * the process, systemd restarts it (the overlay allows 20 starts a minute),
+ * and an in-memory counter resets to zero on every iteration — so the loop
+ * reports at full rate forever. State therefore lives on disk.
+ *
+ * The decision is a pure function over (state, now, fingerprint) so it can
+ * be tested exhaustively, including across a simulated restart: persist the
+ * returned state, hand it back to a fresh call, assert the limit still holds.
+ */
+
+export interface RateLimitState {
+  v: 1;
+  /** Start of the current rolling hour. */
+  hourStart: number;
+  hourCount: number;
+  /** Start of the current rolling day. */
+  dayStart: number;
+  dayCount: number;
+  /** Per-fingerprint counts within the current hour. */
+  fps: Record<string, number>;
+}
+
+export interface Limits {
+  windowMs: number;
+  dayMs: number;
+  maxPerHour: number;
+  maxPerDay: number;
+  maxPerFingerprintPerHour: number;
+  /** Cap on distinct fingerprints tracked, so the state file stays small. */
+  maxTrackedFingerprints: number;
+}
+
+/**
+ * Chosen so a single pathological device costs at most ~600 events/month
+ * against a 5,000 shared budget. The per-fingerprint cap is what actually
+ * defeats a crash loop: a loop repeats one fault, so it hits that cap after
+ * two reports and everything after is dropped locally.
+ */
+export const DEFAULT_LIMITS: Limits = {
+  windowMs: 60 * 60 * 1000,
+  dayMs: 24 * 60 * 60 * 1000,
+  maxPerHour: 5,
+  maxPerDay: 20,
+  maxPerFingerprintPerHour: 2,
+  maxTrackedFingerprints: 64,
+};
+
+export function freshState(now: number): RateLimitState {
+  return { v: 1, hourStart: now, hourCount: 0, dayStart: now, dayCount: 0, fps: {} };
+}
+
+export type Decision =
+  | { allow: true; state: RateLimitState }
+  | { allow: false; state: RateLimitState; reason: "hour" | "day" | "duplicate" };
+
+/**
+ * Decide whether one event may be sent, and return the state to persist.
+ *
+ * The state is returned in both branches: a *denied* event still has to be
+ * written back, because the windows may have rolled over. Persisting only
+ * on success would pin the counters and leak quota.
+ */
+export function decide(
+  state: RateLimitState,
+  now: number,
+  fp: string,
+  limits: Limits = DEFAULT_LIMITS,
+): Decision {
+  let s = state;
+
+  // Roll the windows forward before counting.
+  if (now - s.hourStart >= limits.windowMs) {
+    s = { ...s, hourStart: now, hourCount: 0, fps: {} };
+  }
+  if (now - s.dayStart >= limits.dayMs) {
+    s = { ...s, dayStart: now, dayCount: 0 };
+  }
+
+  const fpCount = s.fps[fp] ?? 0;
+  if (fpCount >= limits.maxPerFingerprintPerHour) {
+    return { allow: false, state: s, reason: "duplicate" };
+  }
+  if (s.hourCount >= limits.maxPerHour) {
+    return { allow: false, state: s, reason: "hour" };
+  }
+  if (s.dayCount >= limits.maxPerDay) {
+    return { allow: false, state: s, reason: "day" };
+  }
+
+  const fps = { ...s.fps, [fp]: fpCount + 1 };
+  // Bound the map so a fault that somehow varies its fingerprint every time
+  // can't grow the state file without limit. Dropping the whole table is
+  // fine — it only costs us dedup precision for the rest of the hour.
+  const bounded =
+    Object.keys(fps).length > limits.maxTrackedFingerprints ? { [fp]: fpCount + 1 } : fps;
+
+  return {
+    allow: true,
+    state: { ...s, hourCount: s.hourCount + 1, dayCount: s.dayCount + 1, fps: bounded },
+  };
+}
+
+/** Parse persisted JSON, falling back to a fresh window on anything unexpected. */
+export function parseState(raw: string | null, now: number): RateLimitState {
+  if (!raw) return freshState(now);
+  try {
+    const p = JSON.parse(raw) as Partial<RateLimitState>;
+    if (
+      p.v !== 1 ||
+      typeof p.hourStart !== "number" ||
+      typeof p.hourCount !== "number" ||
+      typeof p.dayStart !== "number" ||
+      typeof p.dayCount !== "number" ||
+      typeof p.fps !== "object" ||
+      p.fps === null
+    ) {
+      return freshState(now);
+    }
+    // Clock moved backwards (suspend/resume, NTP step). Treat as a new window
+    // rather than trusting a future-dated start that would never roll over.
+    if (p.hourStart > now || p.dayStart > now) return freshState(now);
+    return {
+      v: 1,
+      hourStart: p.hourStart,
+      hourCount: p.hourCount,
+      dayStart: p.dayStart,
+      dayCount: p.dayCount,
+      fps: p.fps as Record<string, number>,
+    };
+  } catch {
+    return freshState(now);
+  }
+}

--- a/packages/crash-report/src/rate-limit.ts
+++ b/packages/crash-report/src/rate-limit.ts
@@ -1,10 +1,10 @@
 /**
  * Rate limiting that survives process restarts.
  *
- * This is not politeness — it's the thing standing between one user's
- * crash loop and a dead monthly quota. Sentry's free tier is 5,000 events
- * a month and *silently stops accepting* when exhausted, so an unbounded
- * reporter goes blind exactly when something is badly broken.
+ * This is not politeness — it's the thing standing between one user's crash
+ * loop and a blown ingest quota. A device stuck in a restart loop can emit
+ * thousands of identical reports, which is both a cost problem and a signal
+ * problem: the real bug drowns in duplicates of itself.
  *
  * The subtlety: an in-memory counter is useless here. A crash loop kills
  * the process, systemd restarts it (the overlay allows 20 starts a minute),

--- a/packages/crash-report/src/scrub.ts
+++ b/packages/crash-report/src/scrub.ts
@@ -1,0 +1,165 @@
+/**
+ * Scrubbing — the last thing that runs before anything leaves the device.
+ *
+ * Everything here is pure and synchronous so it can be tested exhaustively
+ * against real payload shapes. If you add a field to the event, add it to
+ * `scrubEvent` and to the test table; a field that isn't scrubbed is a
+ * field that ships someone's username to a third party.
+ *
+ * Two jobs, and the second one is why this isn't merely a privacy tax:
+ *
+ *  1. Remove identifying data — home directories, usernames, credentials.
+ *  2. Normalise paths so the same crash from two different users produces
+ *     the same fingerprint. Plugins are compiled on the end user's machine
+ *     (see plugin-manager.ts), so their frames carry absolute local paths;
+ *     without normalisation every user's copy of one bug is a separate
+ *     Sentry issue.
+ */
+
+import type { Frame, SentryEvent } from "./types";
+
+/**
+ * Any user's home directory, not just this process's. The backend runs as
+ * root, so `homedir()` is `/root` while the frames it collects reference
+ * `/home/deck/...`. Scrubbing only the current home would miss exactly the
+ * paths that carry the username.
+ */
+const ANY_HOME = /\/home\/[^/\s:)'"]+/g;
+
+/** `/run/user/1000` → `/run/user/<uid>`; the uid is weakly identifying. */
+const RUN_USER = /\/run\/user\/\d+/g;
+
+/**
+ * On-device plugin install paths. Runs *after* home normalisation, so the
+ * leading segment is usually `~`. The alternation must *consume* that `~`,
+ * not just look at it — an earlier version left it behind and produced
+ * `~<plugins>/hltb`, which the never-leaks test caught.
+ *
+ * Captures the plugin id so it survives into the fingerprint: we still want
+ * to know which plugin broke.
+ */
+const PLUGIN_PATH = /(?:~|\/)[^\s:)'"]*?\/loadout\/plugins\/([^/\s:)'"]+)/g;
+
+/**
+ * SteamID64. A persistent account identifier, and it turns up in ordinary
+ * paths (`~/.steam/steam/userdata/<id>/`) as well as error text. All real
+ * ones start 7656119 and run 17 digits.
+ */
+const STEAM_ID64 = /\b7656119\d{10}\b/g;
+
+/**
+ * Credentials that turn up inside error messages. The SGDB integration puts
+ * an API key in a query string and loadout's own RPC uses a session token,
+ * so a failed-request message can carry either. Matches `key=`, `token=`,
+ * `api_key=`, `access_token=`, `password=`, `secret=` and Bearer headers.
+ */
+const QUERY_SECRET = /\b((?:api[_-]?|access[_-]?)?(?:key|token|password|secret))=[^&\s"')]+/gi;
+const BEARER = /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi;
+
+export interface ScrubOptions {
+  /**
+   * This machine's hostname. Passed in rather than read here so the function
+   * stays pure and testable. Linux hostnames are frequently personal
+   * ("simons-deck"), and while we never *set* `server_name`, a hostname can
+   * still appear inside an error message — which is exactly how the
+   * never-leaks test first caught it.
+   */
+  hostname?: string;
+}
+
+/** Escape a value for safe use inside a RegExp. */
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Scrub a single string. Order matters: credentials first (they can contain
+ * slashes), then homes, then the plugin rewrite that depends on `~`.
+ */
+export function scrubString(input: string, opts: ScrubOptions = {}): string {
+  let out = input
+    .replace(QUERY_SECRET, "$1=<redacted>")
+    .replace(BEARER, "Bearer <redacted>")
+    .replace(ANY_HOME, "~")
+    .replace(RUN_USER, "/run/user/<uid>")
+    .replace(PLUGIN_PATH, "<plugins>/$1")
+    .replace(STEAM_ID64, "<steamid>");
+  // Very short hostnames ("deck") would match far too much ordinary text,
+  // so only substitute one distinctive enough to be worth removing.
+  if (opts.hostname && opts.hostname.length >= 5) {
+    out = out.replace(new RegExp(escapeRe(opts.hostname), "g"), "<host>");
+  }
+  return out;
+}
+
+function scrubFrame(frame: Frame, opts: ScrubOptions): Frame {
+  const out: Frame = { ...frame };
+  if (out.filename) out.filename = scrubString(out.filename, opts);
+  if (out.function) out.function = scrubString(out.function, opts);
+  return out;
+}
+
+/**
+ * Scrub a whole event in place-safe fashion (returns a new object).
+ *
+ * Also enforces the absences the type doc promises, defensively: `user`,
+ * `server_name`, `breadcrumbs` and `request` are deleted even though we
+ * never set them, so a future callsite can't reintroduce them by accident.
+ */
+export function scrubEvent(event: SentryEvent, opts: ScrubOptions = {}): SentryEvent {
+  const out: SentryEvent = { ...event };
+
+  if (out.exception?.values) {
+    out.exception = {
+      values: out.exception.values.map((v) => ({
+        ...v,
+        type: scrubString(v.type, opts),
+        value: scrubString(v.value, opts),
+        stacktrace: v.stacktrace
+          ? { frames: v.stacktrace.frames.map((f) => scrubFrame(f, opts)) }
+          : undefined,
+      })),
+    };
+  }
+
+  if (out.message) out.message = { formatted: scrubString(out.message.formatted, opts) };
+
+  if (out.tags) {
+    out.tags = Object.fromEntries(
+      Object.entries(out.tags).map(([k, v]) => [k, scrubString(v, opts)]),
+    );
+  }
+
+  // Belt and braces: these must never be present. We don't set them, but
+  // deleting here means a future edit upstream can't leak them silently.
+  const loose = out as unknown as Record<string, unknown>;
+  delete loose.user;
+  delete loose.server_name;
+  delete loose.breadcrumbs;
+  delete loose.request;
+
+  return out;
+}
+
+/**
+ * Stable fingerprint for dedup and rate limiting, computed *after*
+ * scrubbing so it's identical across users hitting the same bug.
+ *
+ * Deliberately coarse: exception type + the top few in-app frames by
+ * file/function, ignoring line numbers so a one-line edit between releases
+ * doesn't reset the dedup window mid-crash-loop.
+ */
+export function fingerprint(event: SentryEvent): string {
+  const ex = event.exception?.values?.[0];
+  const parts: string[] = [event.tags?.process ?? "", ex?.type ?? "", ex?.value ?? ""];
+  const frames = (ex?.stacktrace?.frames ?? []).filter((f) => f.in_app !== false).slice(-3);
+  for (const f of frames) parts.push(`${f.filename ?? ""}:${f.function ?? ""}`);
+  return djb2(parts.join("|"));
+}
+
+/** Small non-cryptographic hash — this is a dedup key, not a security boundary. */
+function djb2(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+}

--- a/packages/crash-report/src/scrub.ts
+++ b/packages/crash-report/src/scrub.ts
@@ -221,9 +221,13 @@ export function fingerprint(payload: FaroPayload): string {
     ex?.type ?? "",
     ex?.value ?? "",
   ];
+  // Frames are innermost-first (see parseStack), so the *first* few app
+  // frames are the ones nearest the fault. This must stay in step with the
+  // ordering in event.ts — taking them from the wrong end would fingerprint
+  // on the process entry point, collapsing unrelated bugs into one group.
   const frames = (ex?.stacktrace?.frames ?? [])
     .filter((f) => !VENDOR_FRAME.test(f.filename))
-    .slice(-3);
+    .slice(0, 3);
   for (const f of frames) parts.push(`${f.filename}:${f.function}`);
   return djb2(parts.join("|"));
 }

--- a/packages/crash-report/src/scrub.ts
+++ b/packages/crash-report/src/scrub.ts
@@ -56,11 +56,29 @@ const RUN_USER = /\/run\/user\/\d+/g;
 const PLUGIN_PATH = /(?:~|\/)[^\s:)'"]*?\/loadout\/plugins\/([^/\s:)'"]+)/g;
 
 /**
- * SteamID64. A persistent account identifier, and it turns up in ordinary
- * paths (`~/.steam/steam/userdata/<id>/`) as well as error text. All real
- * ones start 7656119 and run 17 digits.
+ * Steam account identifiers. All of these are permanent and resolve to a
+ * public profile, so any one of them makes reports linkable to a named person
+ * and to each other.
+ *
+ * The important case is the **32-bit account ID**, not the SteamID64. Steam
+ * names `userdata/` directories by the 32-bit form (`userdata/25139426`), and
+ * that is the value this codebase actually handles — steam-paths,
+ * game-library, sgdb-art, steam-grid, hltb and playtime all build
+ * `<userdata>/<accountId>/…` paths. `7656119…` appears nowhere in loadout
+ * outside this file. An earlier version scrubbed only the SteamID64 and so
+ * matched a format we never see, while the one we do see went out intact;
+ * adding 76561197960265728 to it yields the SteamID64 and the profile URL.
+ *
+ * The account ID is scrubbed only in `userdata/` context — a bare 8-digit
+ * number is indistinguishable from a timestamp or a byte count, and blanket
+ * substitution would corrupt ordinary error text.
  */
+const STEAM_USERDATA = /(userdata\/)\d{4,}/gi;
 const STEAM_ID64 = /\b7656119\d{10}\b/g;
+/** `[U:1:25139426]` — the SteamID3 rendering of the same account ID. */
+const STEAM_ID3 = /\[U:1:\d+\]/g;
+/** `STEAM_0:1:12569713` — the legacy SteamID2 rendering. */
+const STEAM_ID2 = /\bSTEAM_[0-5]:[01]:\d+\b/gi;
 
 /**
  * Credentials that turn up inside error messages. The SGDB integration puts
@@ -116,7 +134,10 @@ export function scrubString(input: string, opts: ScrubOptions = {}): string {
     .replace(ANY_HOME, "~")
     .replace(RUN_USER, "/run/user/<uid>")
     .replace(PLUGIN_PATH, "<plugins>/$1")
-    .replace(STEAM_ID64, "<steamid>");
+    .replace(STEAM_USERDATA, "$1<steamid>")
+    .replace(STEAM_ID64, "<steamid>")
+    .replace(STEAM_ID3, "<steamid>")
+    .replace(STEAM_ID2, "<steamid>");
   // Case-insensitive: a hostname can appear capitalised in error text even
   // though the system stores it lowercase.
   if (opts.hostname && opts.hostname.length >= MIN_TOKEN_LEN) {

--- a/packages/crash-report/src/scrub.ts
+++ b/packages/crash-report/src/scrub.ts
@@ -13,10 +13,10 @@
  *     the same fingerprint. Plugins are compiled on the end user's machine
  *     (see plugin-manager.ts), so their frames carry absolute local paths;
  *     without normalisation every user's copy of one bug is a separate
- *     Sentry issue.
+ *     issue in Grafana.
  */
 
-import type { Frame, SentryEvent } from "./types";
+import type { FaroFrame, FaroPayload } from "./types";
 
 /**
  * Any user's home directory, not just this process's. The backend runs as
@@ -149,11 +149,12 @@ export function scrubString(input: string, opts: ScrubOptions = {}): string {
   return out;
 }
 
-function scrubFrame(frame: Frame, opts: ScrubOptions): Frame {
-  const out: Frame = { ...frame };
-  if (out.filename) out.filename = scrubString(out.filename, opts);
-  if (out.function) out.function = scrubString(out.function, opts);
-  return out;
+function scrubFrame(frame: FaroFrame, opts: ScrubOptions): FaroFrame {
+  return {
+    ...frame,
+    filename: scrubString(frame.filename, opts),
+    function: scrubString(frame.function, opts),
+  };
 }
 
 /**
@@ -163,54 +164,67 @@ function scrubFrame(frame: Frame, opts: ScrubOptions): Frame {
  * `server_name`, `breadcrumbs` and `request` are deleted even though we
  * never set them, so a future callsite can't reintroduce them by accident.
  */
-export function scrubEvent(event: SentryEvent, opts: ScrubOptions = {}): SentryEvent {
-  const out: SentryEvent = { ...event };
+export function scrubEvent(payload: FaroPayload, opts: ScrubOptions = {}): FaroPayload {
+  const out: FaroPayload = {
+    meta: { ...payload.meta },
+    exceptions: payload.exceptions.map((ex) => ({
+      ...ex,
+      type: scrubString(ex.type, opts),
+      value: scrubString(ex.value, opts),
+      stacktrace: ex.stacktrace
+        ? { frames: ex.stacktrace.frames.map((f) => scrubFrame(f, opts)) }
+        : undefined,
+      context: ex.context
+        ? Object.fromEntries(
+            Object.entries(ex.context).map(([k, v]) => [k, scrubString(v, opts)]),
+          )
+        : undefined,
+    })),
+  };
 
-  if (out.exception?.values) {
-    out.exception = {
-      values: out.exception.values.map((v) => ({
-        ...v,
-        type: scrubString(v.type, opts),
-        value: scrubString(v.value, opts),
-        stacktrace: v.stacktrace
-          ? { frames: v.stacktrace.frames.map((f) => scrubFrame(f, opts)) }
-          : undefined,
-      })),
-    };
-  }
-
-  if (out.message) out.message = { formatted: scrubString(out.message.formatted, opts) };
-
-  if (out.tags) {
-    out.tags = Object.fromEntries(
-      Object.entries(out.tags).map(([k, v]) => [k, scrubString(v, opts)]),
-    );
-  }
-
-  // Belt and braces: these must never be present. We don't set them, but
-  // deleting here means a future edit upstream can't leak them silently.
-  const loose = out as unknown as Record<string, unknown>;
-  delete loose.user;
-  delete loose.server_name;
-  delete loose.breadcrumbs;
-  delete loose.request;
+  // Belt and braces: Faro supports all of these and we never populate them.
+  // Deleting here means a future edit upstream cannot leak them silently.
+  const meta = out.meta as unknown as Record<string, unknown>;
+  delete meta.user;
+  delete meta.page;
+  delete meta.browser;
+  delete meta.view;
+  delete meta.device;
+  const app = out.meta.app as unknown as Record<string, unknown>;
+  delete app.installationId;
 
   return out;
 }
 
+/** Runtime/vendor frames, excluded from the fingerprint. */
+const VENDOR_FRAME = /(?:^|\/)(?:node_modules|bun:|node:)/;
+
 /**
- * Stable fingerprint for dedup and rate limiting, computed *after*
- * scrubbing so it's identical across users hitting the same bug.
+ * Stable fingerprint, computed *after* scrubbing so it's identical across
+ * users hitting the same bug.
  *
- * Deliberately coarse: exception type + the top few in-app frames by
+ * Serves two purposes. Locally it is the dedup key for rate limiting — the
+ * thing that stops a crash loop reporting forever. On the wire it becomes
+ * `FaroException.fingerprint`, which is the **top layer** of Grafana's error
+ * grouping and takes priority over its own stack normalisation. Getting it
+ * stable across machines is what makes one bug read as one issue with N
+ * affected devices, rather than N separate issues.
+ *
+ * Deliberately coarse: exception type and the innermost few app frames by
  * file/function, ignoring line numbers so a one-line edit between releases
- * doesn't reset the dedup window mid-crash-loop.
+ * doesn't split a group or reset a dedup window mid-crash-loop.
  */
-export function fingerprint(event: SentryEvent): string {
-  const ex = event.exception?.values?.[0];
-  const parts: string[] = [event.tags?.process ?? "", ex?.type ?? "", ex?.value ?? ""];
-  const frames = (ex?.stacktrace?.frames ?? []).filter((f) => f.in_app !== false).slice(-3);
-  for (const f of frames) parts.push(`${f.filename ?? ""}:${f.function ?? ""}`);
+export function fingerprint(payload: FaroPayload): string {
+  const ex = payload.exceptions[0];
+  const parts: string[] = [
+    payload.meta.app.namespace ?? "",
+    ex?.type ?? "",
+    ex?.value ?? "",
+  ];
+  const frames = (ex?.stacktrace?.frames ?? [])
+    .filter((f) => !VENDOR_FRAME.test(f.filename))
+    .slice(-3);
+  for (const f of frames) parts.push(`${f.filename}:${f.function}`);
   return djb2(parts.join("|"));
 }
 

--- a/packages/crash-report/src/scrub.ts
+++ b/packages/crash-report/src/scrub.ts
@@ -23,8 +23,23 @@ import type { Frame, SentryEvent } from "./types";
  * root, so `homedir()` is `/root` while the frames it collects reference
  * `/home/deck/...`. Scrubbing only the current home would miss exactly the
  * paths that carry the username.
+ *
+ * The optional `/var` prefix covers ostree-based distros (Bazzite, Silverblue)
+ * where real homes live at `/var/home/<user>`. Without it the `/home` branch
+ * still matched the tail and produced a mangled `/var~/…`.
  */
-const ANY_HOME = /\/home\/[^/\s:)'"]+/g;
+const ANY_HOME = /(?:\/var)?\/home\/[^/\s:)'"]+/g;
+
+/**
+ * Removable-media mount points, which embed the username on every desktop
+ * Linux system: `/run/media/<user>/<label>` (udisks2) and `/media/<user>/…`.
+ *
+ * This codebase constructs these paths deliberately — the storage plugin
+ * builds `/run/media/${user}/${name}` from the real desktop username — so an
+ * error thrown anywhere near SD-card handling carries it. The volume label
+ * after the username is kept: it's useful for triage and is not a username.
+ */
+const MEDIA_MOUNT = /\/(?:run\/)?media\/[^/\s:)'"]+/g;
 
 /** `/run/user/1000` → `/run/user/<uid>`; the uid is weakly identifying. */
 const RUN_USER = /\/run\/user\/\d+/g;
@@ -65,7 +80,22 @@ export interface ScrubOptions {
    * never-leaks test first caught it.
    */
   hostname?: string;
+  /**
+   * The account name (the basename of the user's home). Path rules above
+   * strip it from paths we recognise; this catches it in free-form error
+   * text and in any path shape we did not anticipate — which matters because
+   * the capture points exist precisely for *unanticipated* failures.
+   */
+  username?: string;
 }
+
+/**
+ * Substituting a very short token would corrupt ordinary prose — "deck"
+ * appears in "steamdeck", "decked", and half the identifiers in this project.
+ * Below this length we leave it, accepting that the canonical SteamOS
+ * username ("deck") is shared by every device and identifies nobody.
+ */
+const MIN_TOKEN_LEN = 5;
 
 /** Escape a value for safe use inside a RegExp. */
 function escapeRe(s: string): string {
@@ -80,14 +110,20 @@ export function scrubString(input: string, opts: ScrubOptions = {}): string {
   let out = input
     .replace(QUERY_SECRET, "$1=<redacted>")
     .replace(BEARER, "Bearer <redacted>")
+    // Media mounts before homes: both end up rewritten, but doing media
+    // first keeps the `<media>` marker rather than a half-applied `~`.
+    .replace(MEDIA_MOUNT, "<media>")
     .replace(ANY_HOME, "~")
     .replace(RUN_USER, "/run/user/<uid>")
     .replace(PLUGIN_PATH, "<plugins>/$1")
     .replace(STEAM_ID64, "<steamid>");
-  // Very short hostnames ("deck") would match far too much ordinary text,
-  // so only substitute one distinctive enough to be worth removing.
-  if (opts.hostname && opts.hostname.length >= 5) {
-    out = out.replace(new RegExp(escapeRe(opts.hostname), "g"), "<host>");
+  // Case-insensitive: a hostname can appear capitalised in error text even
+  // though the system stores it lowercase.
+  if (opts.hostname && opts.hostname.length >= MIN_TOKEN_LEN) {
+    out = out.replace(new RegExp(escapeRe(opts.hostname), "gi"), "<host>");
+  }
+  if (opts.username && opts.username.length >= MIN_TOKEN_LEN) {
+    out = out.replace(new RegExp(escapeRe(opts.username), "gi"), "<user>");
   }
   return out;
 }

--- a/packages/crash-report/src/spool.ts
+++ b/packages/crash-report/src/spool.ts
@@ -46,6 +46,20 @@ export const MAX_SPOOL_AGE_MS = 14 * 24 * 60 * 60 * 1000;
  */
 export const MAX_SPOOL_ATTEMPTS = 5;
 
+/**
+ * Minimum gap between send attempts for one entry.
+ *
+ * Without this the retry budget is consumed per *process start*, not per
+ * elapsed time — and the case that matters is precisely a crash loop while
+ * offline. systemd restarts the overlay every 5s, each start drains, each
+ * drain fails and burns an attempt, and five restarts later the reports are
+ * discarded roughly twenty seconds after the crash that produced them. The
+ * spool exists for exactly that scenario, so it must outlive it.
+ *
+ * Entries younger than this are left untouched on disk rather than read.
+ */
+export const RETRY_BACKOFF_MS = 5 * 60 * 1000;
+
 export interface SpooledEntry {
   event: FaroPayload;
   attempts: number;
@@ -115,16 +129,25 @@ export function takeSpooled(dir: string, now: number): SpooledEntry[] {
   for (const name of spoolFiles(dir)) {
     const path = join(dir, name);
     try {
-      const age = now - statSync(path).mtimeMs;
+      const attemptsSoFar = Number(NAME.exec(name)?.[2] ?? 0);
+      const mtime = statSync(path).mtimeMs;
+      // An entry that has already failed at least once waits out the backoff.
+      // Leave it entirely alone — reading unlinks, and unlinking here is what
+      // would let a restart loop chew through the retry budget in seconds.
+      // Fresh entries (attempts 0) are always eligible, so a crash reported on
+      // one start still ships on the next.
+      if (attemptsSoFar > 0 && now - mtime < RETRY_BACKOFF_MS) continue;
+      const age = now - mtime;
       const raw = readFileSync(path, "utf8");
       // Unlink before sending. A malformed or permanently-rejected entry left
       // on disk would be retried on every start forever.
       unlinkSync(path);
       if (age > MAX_SPOOL_AGE_MS) continue;
-      const attempts = Number(NAME.exec(name)?.[2] ?? 0);
-      if (attempts >= MAX_SPOOL_ATTEMPTS) continue;
+      if (attemptsSoFar >= MAX_SPOOL_ATTEMPTS) continue;
       const parsed = JSON.parse(raw) as FaroPayload;
-      if (parsed && Array.isArray(parsed.exceptions)) out.push({ event: parsed, attempts });
+      if (parsed && Array.isArray(parsed.exceptions)) {
+        out.push({ event: parsed, attempts: attemptsSoFar });
+      }
     } catch {
       try {
         unlinkSync(path);

--- a/packages/crash-report/src/spool.ts
+++ b/packages/crash-report/src/spool.ts
@@ -1,0 +1,102 @@
+/**
+ * The spool — how a dying process reports its own death.
+ *
+ * A fatal handler cannot await a network request. Two independent facts in
+ * this codebase make that concrete:
+ *
+ *  - Electrobun registers its own `uncaughtException` listener when
+ *    `electrobun/bun` is imported, and that listener calls a native
+ *    `forceExit(1)`. Anything we start asynchronously is killed mid-flight.
+ *  - The overlay's management-loop `.catch` calls `process.exit(1)` on the
+ *    same tick, and must keep doing so — it owes Steam a prompt SIGCONT.
+ *
+ * So the fatal path does no I/O over the network at all. It writes one
+ * already-scrubbed event to disk synchronously, and the *next* successful
+ * start drains the directory. This also makes offline the normal case rather
+ * than an error case: handhelds are frequently suspended or off-network, and
+ * a queued report simply waits.
+ *
+ * Everything written here has already been through `scrubEvent`. The spool
+ * must never hold anything we would not have sent.
+ */
+
+import { join } from "node:path";
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+  mkdirSync,
+  statSync,
+} from "node:fs";
+import type { SentryEvent } from "./types";
+
+/** Keep the directory small: a crash loop must not fill the user's disk. */
+export const MAX_SPOOL_FILES = 20;
+/** A three-week-old crash on a long-superseded version is noise. */
+export const MAX_SPOOL_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+
+function spoolFiles(dir: string): string[] {
+  try {
+    return readdirSync(dir)
+      .filter((f) => f.endsWith(".json"))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write one scrubbed event to the spool, synchronously.
+ *
+ * Returns whether it landed. Never throws: a read-only or full disk must not
+ * turn a crash we were trying to report into a second crash.
+ */
+export function spoolEvent(dir: string, event: SentryEvent, now: number): boolean {
+  try {
+    mkdirSync(dir, { recursive: true });
+    const existing = spoolFiles(dir);
+    // Oldest-first eviction. Filenames lead with the timestamp, so lexical
+    // order is chronological order.
+    for (const stale of existing.slice(0, Math.max(0, existing.length - MAX_SPOOL_FILES + 1))) {
+      try {
+        unlinkSync(join(dir, stale));
+      } catch {
+        // Another process may have drained it already.
+      }
+    }
+    writeFileSync(
+      join(dir, `${String(now).padStart(15, "0")}-${event.event_id}.json`),
+      JSON.stringify(event),
+      "utf8",
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Read and remove every spooled event. Entries too old to be useful are dropped. */
+export function takeSpooled(dir: string, now: number): SentryEvent[] {
+  const out: SentryEvent[] = [];
+  for (const name of spoolFiles(dir)) {
+    const path = join(dir, name);
+    try {
+      const age = now - statSync(path).mtimeMs;
+      const raw = readFileSync(path, "utf8");
+      // Unlink before sending. A malformed or un-sendable entry that stayed
+      // on disk would be retried on every start forever.
+      unlinkSync(path);
+      if (age > MAX_SPOOL_AGE_MS) continue;
+      const parsed = JSON.parse(raw) as SentryEvent;
+      if (parsed && typeof parsed.event_id === "string") out.push(parsed);
+    } catch {
+      try {
+        unlinkSync(path);
+      } catch {
+        // Nothing more we can do; it will age out.
+      }
+    }
+  }
+  return out;
+}

--- a/packages/crash-report/src/spool.ts
+++ b/packages/crash-report/src/spool.ts
@@ -35,6 +35,24 @@ import type { SentryEvent } from "./types";
 export const MAX_SPOOL_FILES = 20;
 /** A three-week-old crash on a long-superseded version is noise. */
 export const MAX_SPOOL_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+/**
+ * How many times a single event may fail to send before it is discarded.
+ *
+ * Needed because entries are unlinked when read, not when sent. Unlinking on
+ * read is deliberate — an entry the server permanently rejects would otherwise
+ * be retried on every start forever — but it means a failed send must put the
+ * event back, or a drain that happens to run while the device is offline
+ * destroys exactly the reports the spool exists to protect.
+ */
+export const MAX_SPOOL_ATTEMPTS = 5;
+
+export interface SpooledEntry {
+  event: SentryEvent;
+  attempts: number;
+}
+
+/** `<padded-timestamp>-a<attempts>-<event id>.json` — lexical order is chronological. */
+const NAME = /^(\d+)-a(\d+)-(.+)\.json$/;
 
 function spoolFiles(dir: string): string[] {
   try {
@@ -52,9 +70,18 @@ function spoolFiles(dir: string): string[] {
  * Returns whether it landed. Never throws: a read-only or full disk must not
  * turn a crash we were trying to report into a second crash.
  */
-export function spoolEvent(dir: string, event: SentryEvent, now: number): boolean {
+export function spoolEvent(
+  dir: string,
+  event: SentryEvent,
+  now: number,
+  attempts = 0,
+  chown?: (path: string) => void,
+): boolean {
   try {
     mkdirSync(dir, { recursive: true });
+    // The root backend and the user overlay share $HOME; anything root
+    // creates there must be handed back or the overlay can never write.
+    chown?.(dir);
     const existing = spoolFiles(dir);
     // Oldest-first eviction. Filenames lead with the timestamp, so lexical
     // order is chronological order.
@@ -65,31 +92,36 @@ export function spoolEvent(dir: string, event: SentryEvent, now: number): boolea
         // Another process may have drained it already.
       }
     }
-    writeFileSync(
-      join(dir, `${String(now).padStart(15, "0")}-${event.event_id}.json`),
-      JSON.stringify(event),
-      "utf8",
-    );
+    const path = join(dir, `${String(now).padStart(15, "0")}-a${attempts}-${event.event_id}.json`);
+    writeFileSync(path, JSON.stringify(event), "utf8");
+    chown?.(path);
     return true;
   } catch {
     return false;
   }
 }
 
-/** Read and remove every spooled event. Entries too old to be useful are dropped. */
-export function takeSpooled(dir: string, now: number): SentryEvent[] {
-  const out: SentryEvent[] = [];
+/**
+ * Read and remove every spooled event, with its prior attempt count.
+ *
+ * Entries too old, too often retried, or unparseable are dropped. The caller
+ * MUST re-spool anything it fails to send (see `MAX_SPOOL_ATTEMPTS`).
+ */
+export function takeSpooled(dir: string, now: number): SpooledEntry[] {
+  const out: SpooledEntry[] = [];
   for (const name of spoolFiles(dir)) {
     const path = join(dir, name);
     try {
       const age = now - statSync(path).mtimeMs;
       const raw = readFileSync(path, "utf8");
-      // Unlink before sending. A malformed or un-sendable entry that stayed
+      // Unlink before sending. A malformed or permanently-rejected entry left
       // on disk would be retried on every start forever.
       unlinkSync(path);
       if (age > MAX_SPOOL_AGE_MS) continue;
+      const attempts = Number(NAME.exec(name)?.[2] ?? 0);
+      if (attempts >= MAX_SPOOL_ATTEMPTS) continue;
       const parsed = JSON.parse(raw) as SentryEvent;
-      if (parsed && typeof parsed.event_id === "string") out.push(parsed);
+      if (parsed && typeof parsed.event_id === "string") out.push({ event: parsed, attempts });
     } catch {
       try {
         unlinkSync(path);

--- a/packages/crash-report/src/spool.ts
+++ b/packages/crash-report/src/spool.ts
@@ -29,7 +29,7 @@ import {
   mkdirSync,
   statSync,
 } from "node:fs";
-import type { SentryEvent } from "./types";
+import type { FaroPayload } from "./types";
 
 /** Keep the directory small: a crash loop must not fill the user's disk. */
 export const MAX_SPOOL_FILES = 20;
@@ -47,7 +47,7 @@ export const MAX_SPOOL_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 export const MAX_SPOOL_ATTEMPTS = 5;
 
 export interface SpooledEntry {
-  event: SentryEvent;
+  event: FaroPayload;
   attempts: number;
 }
 
@@ -72,7 +72,7 @@ function spoolFiles(dir: string): string[] {
  */
 export function spoolEvent(
   dir: string,
-  event: SentryEvent,
+  event: FaroPayload,
   now: number,
   attempts = 0,
   chown?: (path: string) => void,
@@ -92,7 +92,10 @@ export function spoolEvent(
         // Another process may have drained it already.
       }
     }
-    const path = join(dir, `${String(now).padStart(15, "0")}-a${attempts}-${event.event_id}.json`);
+    // Faro payloads carry no event id, so the filename gets a random suffix
+    // purely to keep two crashes in the same millisecond from colliding.
+    const unique = crypto.randomUUID().slice(0, 8);
+    const path = join(dir, `${String(now).padStart(15, "0")}-a${attempts}-${unique}.json`);
     writeFileSync(path, JSON.stringify(event), "utf8");
     chown?.(path);
     return true;
@@ -120,8 +123,8 @@ export function takeSpooled(dir: string, now: number): SpooledEntry[] {
       if (age > MAX_SPOOL_AGE_MS) continue;
       const attempts = Number(NAME.exec(name)?.[2] ?? 0);
       if (attempts >= MAX_SPOOL_ATTEMPTS) continue;
-      const parsed = JSON.parse(raw) as SentryEvent;
-      if (parsed && typeof parsed.event_id === "string") out.push({ event: parsed, attempts });
+      const parsed = JSON.parse(raw) as FaroPayload;
+      if (parsed && Array.isArray(parsed.exceptions)) out.push({ event: parsed, attempts });
     } catch {
       try {
         unlinkSync(path);

--- a/packages/crash-report/src/transport.ts
+++ b/packages/crash-report/src/transport.ts
@@ -1,13 +1,28 @@
 /**
- * The wire. A Sentry event is one HTTPS POST of a newline-delimited
- * "envelope", which is why loadout speaks the protocol directly instead of
- * taking an SDK dependency: the whole transport is the function below, and
- * every byte it sends is visible in this file.
+ * The wire. A Faro report is one HTTPS POST of a JSON body, which is why
+ * loadout speaks the protocol directly instead of taking an SDK dependency:
+ * the whole transport is the function below, and every byte it sends is
+ * visible in this file and in types.ts.
  *
- * Works unchanged against sentry.io, self-hosted Sentry, or GlitchTip.
+ * Shape confirmed against `@grafana/faro-web-sdk`'s fetch transport:
+ *
+ *   POST <collector url>
+ *   Content-Type: application/json
+ *   x-api-key: <key>              (only when the collector requires one)
+ *   x-faro-session-id: <id>
+ *   body: {"meta":{…},"exceptions":[…]}
+ *
+ * The collector accepts 202. 429 means rate-limited — the caller backs off by
+ * leaving the event spooled rather than retrying in a loop.
+ *
+ * Why this endpoint and not OTLP: Grafana Cloud's OTLP endpoint needs a real
+ * bearer token, and Grafana's own docs advise against pushing to it directly
+ * from an application. Loadout ships to strangers' devices, so the only
+ * acceptable ingest is one designed for untrusted public clients — which is
+ * exactly what the Faro collector is built for.
  */
 
-import type { SentryEvent } from "./types";
+import type { FaroPayload } from "./types";
 
 /**
  * Capture `fetch` at module load, before any plugin can run.
@@ -15,99 +30,80 @@ import type { SentryEvent } from "./types";
  * The loader hosts every plugin backend in-process and `sandboxed-fetch.ts`
  * swaps `globalThis.fetch` per call to enforce each plugin's network
  * allow-list. Resolving `fetch` at call time would mean crash reports leave
- * through whatever wrapper happens to be installed at the moment of the
- * crash — either intercepted by plugin code, or blocked by a deny-list that
- * was never meant to apply to us. Binding it here removes both.
+ * through whatever wrapper is installed at the moment of the crash. Note this
+ * is a backstop only — the loader also passes the real fetch in explicitly,
+ * because `plugin-manager` is imported before this module and would otherwise
+ * have already replaced the global.
  */
 const originalFetch: typeof fetch = globalThis.fetch.bind(globalThis);
 
-export interface Dsn {
-  publicKey: string;
-  host: string;
-  projectId: string;
-  protocol: string;
+export interface Collector {
+  /** Full collector URL, e.g. https://faro-collector-<region>.grafana.net/collect/<app-key> */
+  url: string;
+  /** Optional; Grafana Cloud embeds the app key in the URL path instead. */
+  apiKey?: string;
 }
 
 /**
- * Parse `https://<publicKey>@<host>/<projectId>`.
+ * Parse a collector endpoint.
  *
- * Returns null rather than throwing on anything malformed — a bad DSN must
- * disable reporting, never crash the process it's meant to be observing.
+ * Accepts `https://host/collect/<app-key>` (Grafana Cloud) or any http(s) URL
+ * for a self-hosted receiver. Returns null rather than throwing on anything
+ * malformed — a bad endpoint must disable reporting, never crash the process
+ * it is meant to be observing.
  */
-export function parseDsn(dsn: string | undefined | null): Dsn | null {
-  if (!dsn) return null;
+export function parseCollector(raw: string | undefined | null): Collector | null {
+  if (!raw) return null;
   try {
-    const u = new URL(dsn);
-    const projectId = u.pathname.replace(/^\/+/, "");
-    if (!u.username || !u.hostname || !projectId) return null;
+    const u = new URL(raw);
     if (u.protocol !== "https:" && u.protocol !== "http:") return null;
-    return {
-      publicKey: u.username,
-      host: u.host,
-      projectId,
-      protocol: u.protocol.replace(":", ""),
-    };
+    if (!u.hostname) return null;
+    return { url: u.toString() };
   } catch {
     return null;
   }
 }
 
-export function envelopeUrl(dsn: Dsn): string {
-  return `${dsn.protocol}://${dsn.host}/api/${dsn.projectId}/envelope/`;
-}
-
-/** Newline-delimited envelope: header, item header, item payload. */
-export function buildEnvelope(event: SentryEvent, dsn: Dsn): string {
-  const header = JSON.stringify({
-    event_id: event.event_id,
-    sent_at: new Date().toISOString(),
-    // Echoing the DSN in the envelope header is what lets a relay route the
-    // event without re-parsing the auth header.
-    dsn: `${dsn.protocol}://${dsn.publicKey}@${dsn.host}/${dsn.projectId}`,
-  });
-  const body = JSON.stringify(event);
-  // `length` is in bytes, not characters — a stack trace containing any
-  // non-ASCII would otherwise produce a short count and a rejected envelope.
-  const length = new TextEncoder().encode(body).length;
-  const itemHeader = JSON.stringify({ type: "event", length, content_type: "application/json" });
-  return `${header}\n${itemHeader}\n${body}\n`;
+/** The exact bytes POSTed. Separated so tests can assert on them directly. */
+export function buildBody(payload: FaroPayload): string {
+  return JSON.stringify(payload);
 }
 
 export interface SendOptions {
   timeoutMs?: number;
-  clientName?: string;
   fetchImpl?: typeof fetch;
 }
 
 /**
- * POST one event. Resolves true on acceptance, false on anything else.
+ * POST one payload. Resolves true on acceptance, false on anything else.
  *
- * Never throws and never blocks for long. This runs on the crash path and,
- * in the overlay, on a shutdown path that has hard real-time obligations —
- * the overlay must SIGCONT Steam promptly or the whole machine looks frozen.
- * A hung report there would be a far worse bug than a lost report.
+ * Never throws and never blocks for long. This runs on the crash path and, in
+ * the overlay, on a shutdown path with hard real-time obligations — the
+ * overlay must SIGCONT Steam promptly or the whole machine looks frozen. A
+ * hung report there would be a far worse bug than a lost report.
  */
 export async function sendEvent(
-  event: SentryEvent,
-  dsn: Dsn,
+  payload: FaroPayload,
+  collector: Collector,
   opts: SendOptions = {},
 ): Promise<boolean> {
-  const { timeoutMs = 3000, clientName = "loadout", fetchImpl = originalFetch } = opts;
+  const { timeoutMs = 3000, fetchImpl = originalFetch } = opts;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await fetchImpl(envelopeUrl(dsn), {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (collector.apiKey) headers["x-api-key"] = collector.apiKey;
+    const sessionId = payload.meta.session?.id;
+    if (sessionId) headers["x-faro-session-id"] = sessionId;
+
+    const res = await fetchImpl(collector.url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/x-sentry-envelope",
-        "X-Sentry-Auth": [
-          "Sentry sentry_version=7",
-          `sentry_client=${clientName}`,
-          `sentry_key=${dsn.publicKey}`,
-        ].join(", "),
-      },
-      body: buildEnvelope(event, dsn),
+      headers,
+      body: buildBody(payload),
       signal: controller.signal,
+      // No redirects: the destination is fixed and a redirect would mean
+      // something has gone wrong with it.
+      redirect: "error",
     });
     return res.ok;
   } catch {

--- a/packages/crash-report/src/transport.ts
+++ b/packages/crash-report/src/transport.ts
@@ -1,0 +1,118 @@
+/**
+ * The wire. A Sentry event is one HTTPS POST of a newline-delimited
+ * "envelope", which is why loadout speaks the protocol directly instead of
+ * taking an SDK dependency: the whole transport is the function below, and
+ * every byte it sends is visible in this file.
+ *
+ * Works unchanged against sentry.io, self-hosted Sentry, or GlitchTip.
+ */
+
+import type { SentryEvent } from "./types";
+
+/**
+ * Capture `fetch` at module load, before any plugin can run.
+ *
+ * The loader hosts every plugin backend in-process and `sandboxed-fetch.ts`
+ * swaps `globalThis.fetch` per call to enforce each plugin's network
+ * allow-list. Resolving `fetch` at call time would mean crash reports leave
+ * through whatever wrapper happens to be installed at the moment of the
+ * crash — either intercepted by plugin code, or blocked by a deny-list that
+ * was never meant to apply to us. Binding it here removes both.
+ */
+const originalFetch: typeof fetch = globalThis.fetch.bind(globalThis);
+
+export interface Dsn {
+  publicKey: string;
+  host: string;
+  projectId: string;
+  protocol: string;
+}
+
+/**
+ * Parse `https://<publicKey>@<host>/<projectId>`.
+ *
+ * Returns null rather than throwing on anything malformed — a bad DSN must
+ * disable reporting, never crash the process it's meant to be observing.
+ */
+export function parseDsn(dsn: string | undefined | null): Dsn | null {
+  if (!dsn) return null;
+  try {
+    const u = new URL(dsn);
+    const projectId = u.pathname.replace(/^\/+/, "");
+    if (!u.username || !u.hostname || !projectId) return null;
+    if (u.protocol !== "https:" && u.protocol !== "http:") return null;
+    return {
+      publicKey: u.username,
+      host: u.host,
+      projectId,
+      protocol: u.protocol.replace(":", ""),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function envelopeUrl(dsn: Dsn): string {
+  return `${dsn.protocol}://${dsn.host}/api/${dsn.projectId}/envelope/`;
+}
+
+/** Newline-delimited envelope: header, item header, item payload. */
+export function buildEnvelope(event: SentryEvent, dsn: Dsn): string {
+  const header = JSON.stringify({
+    event_id: event.event_id,
+    sent_at: new Date().toISOString(),
+    // Echoing the DSN in the envelope header is what lets a relay route the
+    // event without re-parsing the auth header.
+    dsn: `${dsn.protocol}://${dsn.publicKey}@${dsn.host}/${dsn.projectId}`,
+  });
+  const body = JSON.stringify(event);
+  // `length` is in bytes, not characters — a stack trace containing any
+  // non-ASCII would otherwise produce a short count and a rejected envelope.
+  const length = new TextEncoder().encode(body).length;
+  const itemHeader = JSON.stringify({ type: "event", length, content_type: "application/json" });
+  return `${header}\n${itemHeader}\n${body}\n`;
+}
+
+export interface SendOptions {
+  timeoutMs?: number;
+  clientName?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * POST one event. Resolves true on acceptance, false on anything else.
+ *
+ * Never throws and never blocks for long. This runs on the crash path and,
+ * in the overlay, on a shutdown path that has hard real-time obligations —
+ * the overlay must SIGCONT Steam promptly or the whole machine looks frozen.
+ * A hung report there would be a far worse bug than a lost report.
+ */
+export async function sendEvent(
+  event: SentryEvent,
+  dsn: Dsn,
+  opts: SendOptions = {},
+): Promise<boolean> {
+  const { timeoutMs = 3000, clientName = "loadout", fetchImpl = originalFetch } = opts;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(envelopeUrl(dsn), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-sentry-envelope",
+        "X-Sentry-Auth": [
+          "Sentry sentry_version=7",
+          `sentry_client=${clientName}`,
+          `sentry_key=${dsn.publicKey}`,
+        ].join(", "),
+      },
+      body: buildEnvelope(event, dsn),
+      signal: controller.signal,
+    });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/crash-report/src/types.ts
+++ b/packages/crash-report/src/types.ts
@@ -1,0 +1,69 @@
+/**
+ * The subset of the Sentry event protocol loadout actually sends.
+ *
+ * These types are deliberately narrow. We speak the Sentry wire format
+ * by hand rather than pulling in an SDK, because the promise we make to
+ * users in PRIVACY.md is "this is exactly what leaves your machine" —
+ * and that promise is only checkable if every transmitted field is
+ * spelled out in our own source. An SDK that auto-captures console
+ * output, fetch breadcrumbs, and request headers cannot make that
+ * promise honestly.
+ *
+ * The format is still Sentry's, so any Sentry-protocol backend works:
+ * sentry.io, a self-hosted Sentry, or GlitchTip. Switching is a DSN
+ * change, not a rewrite.
+ */
+
+/** Which loadout process a report came from. */
+export type ProcessName = "backend" | "overlay-bun" | "webview";
+
+/** Consent is tri-state: `undefined` means "not asked yet". */
+export type ConsentState = "granted" | "denied" | undefined;
+
+/** A single stack frame, Sentry's field names. */
+export interface Frame {
+  filename?: string;
+  function?: string;
+  lineno?: number;
+  colno?: number;
+  /** false for runtime/library frames, so Sentry greys them out. */
+  in_app?: boolean;
+}
+
+export interface ExceptionValue {
+  type: string;
+  value: string;
+  stacktrace?: { frames: Frame[] };
+}
+
+/**
+ * A Sentry event. Note what is absent and stays absent:
+ *   - `user` — never populated, so no id/email/ip_address.
+ *   - `server_name` — the hostname. SDKs send this by default; Linux
+ *     hostnames are frequently personal ("simons-deck"), so we never set it.
+ *   - `breadcrumbs` — no console or network capture.
+ *   - `request` — no URLs, headers, or cookies.
+ */
+export interface SentryEvent {
+  event_id: string;
+  timestamp: number;
+  platform: "javascript" | "node";
+  level: "error" | "fatal";
+  release?: string;
+  environment?: string;
+  logger?: string;
+  tags?: Record<string, string>;
+  contexts?: Record<string, Record<string, unknown>>;
+  exception?: { values: ExceptionValue[] };
+  message?: { formatted: string };
+}
+
+/** Context attached at the callsite. */
+export interface CaptureContext {
+  /** Set when the fault is attributable to a plugin rather than core. */
+  pluginId?: string;
+  /** Extra low-cardinality tags. Values are scrubbed like everything else. */
+  tags?: Record<string, string>;
+  /** fatal = the process is going down. */
+  level?: "error" | "fatal";
+}

--- a/packages/crash-report/src/types.ts
+++ b/packages/crash-report/src/types.ts
@@ -1,17 +1,17 @@
 /**
- * The subset of the Sentry event protocol loadout actually sends.
+ * The subset of the Grafana Faro protocol loadout actually sends.
  *
- * These types are deliberately narrow. We speak the Sentry wire format
- * by hand rather than pulling in an SDK, because the promise we make to
- * users in PRIVACY.md is "this is exactly what leaves your machine" —
- * and that promise is only checkable if every transmitted field is
- * spelled out in our own source. An SDK that auto-captures console
- * output, fetch breadcrumbs, and request headers cannot make that
- * promise honestly.
+ * These types are deliberately narrow and this file is the privacy contract:
+ * the promise made in docs/privacy.md is "this is exactly what leaves your
+ * machine", and that promise is only checkable if every transmitted field is
+ * spelled out here. An SDK that auto-captures console output, fetch
+ * breadcrumbs, page URLs and request headers cannot make that promise
+ * honestly, which is why the wire format is emitted by hand.
  *
- * The format is still Sentry's, so any Sentry-protocol backend works:
- * sentry.io, a self-hosted Sentry, or GlitchTip. Switching is a DSN
- * change, not a rewrite.
+ * Shapes mirror `@grafana/faro-core` (`TransportBody`, `ExceptionEvent`,
+ * `Meta`) so the payload is a valid Faro payload — it just carries far less
+ * than the Web SDK would send. Anything Faro supports and we do not populate
+ * is absent on purpose; see the notes on `FaroMeta`.
  */
 
 /** Which loadout process a report came from. */
@@ -20,42 +20,66 @@ export type ProcessName = "backend" | "overlay-bun" | "webview";
 /** Consent is tri-state: `undefined` means "not asked yet". */
 export type ConsentState = "granted" | "denied" | undefined;
 
-/** A single stack frame, Sentry's field names. */
-export interface Frame {
-  filename?: string;
-  function?: string;
+/**
+ * A stack frame. Faro requires `filename` and `function` as strings, so
+ * unknown values become "?" rather than being omitted.
+ */
+export interface FaroFrame {
+  filename: string;
+  function: string;
   lineno?: number;
   colno?: number;
-  /** false for runtime/library frames, so Sentry greys them out. */
-  in_app?: boolean;
-}
-
-export interface ExceptionValue {
-  type: string;
-  value: string;
-  stacktrace?: { frames: Frame[] };
 }
 
 /**
- * A Sentry event. Note what is absent and stays absent:
- *   - `user` — never populated, so no id/email/ip_address.
- *   - `server_name` — the hostname. SDKs send this by default; Linux
- *     hostnames are frequently personal ("simons-deck"), so we never set it.
- *   - `breadcrumbs` — no console or network capture.
- *   - `request` — no URLs, headers, or cookies.
+ * One exception.
+ *
+ * `fingerprint` is the interesting field: it is the top layer of Grafana's
+ * error-grouping strategy, taking priority over its own stack-trace
+ * normalisation. We compute it after scrubbing precisely so the same fault
+ * from two different users collapses into one issue rather than N.
  */
-export interface SentryEvent {
-  event_id: string;
-  timestamp: number;
-  platform: "javascript" | "node";
-  level: "error" | "fatal";
-  release?: string;
-  environment?: string;
-  logger?: string;
-  tags?: Record<string, string>;
-  contexts?: Record<string, Record<string, unknown>>;
-  exception?: { values: ExceptionValue[] };
-  message?: { formatted: string };
+export interface FaroException {
+  timestamp: string;
+  type: string;
+  value: string;
+  fatal?: boolean;
+  fingerprint?: string;
+  stacktrace?: { frames: FaroFrame[] };
+  /** Low-cardinality string map. Values are scrubbed like everything else. */
+  context?: Record<string, string>;
+}
+
+/**
+ * Payload metadata.
+ *
+ * Note what is deliberately absent and must stay absent:
+ *  - `user` — never populated, so no id, email, username or hash.
+ *  - `app.installationId` — Faro supports a persistent install identifier.
+ *    We do not send one; reports carry no cross-restart correlator.
+ *  - `page` — no URLs.
+ *  - `browser` — no user-agent, language, or viewport fingerprinting.
+ *  - `device.*` beyond a coarse type — no serials, no manufacturer ids.
+ *
+ * `session.id` is regenerated on every process start and never persisted, so
+ * it groups events within a single run and cannot correlate across restarts.
+ * `session.overrides.geoLocationTrackingEnabled` is set to false to switch off
+ * Grafana Cloud's IP-derived geolocation from the client side.
+ */
+export interface FaroMeta {
+  sdk: { name: string; version?: string };
+  app: { name: string; version?: string; environment?: string; namespace?: string };
+  os: { name: string };
+  session?: {
+    id: string;
+    overrides?: { geoLocationTrackingEnabled?: boolean };
+  };
+}
+
+/** The exact JSON body POSTed to the Faro collector. */
+export interface FaroPayload {
+  meta: FaroMeta;
+  exceptions: FaroException[];
 }
 
 /** Context attached at the callsite. */


### PR DESCRIPTION
Closes part of #246.

Core plumbing for crash reporting. **Inert by default** — no DSN is configured
and no consent is granted, so this ships without sending anything. That's
deliberate: it lets the scrubber and rate limiter be exercised against real
crashes on real devices before a single byte leaves anyone's machine.

## Decisions that differ from the issue

**The issue says "default to on". This is opt-in via an explicit prompt instead.**
Heroic (closest peer) keeps analytics opt-in and off. Audacity shipped telemetry
that was opt-in *and* off by default and was still panned hard enough to force
removal, spawning 50+ forks. Loadout's audience is the Decky-adjacent Linux
homebrew crowd and the backend runs as root — a silent default is the single
highest-reputational-risk option available. Scope is crash-only: no usage
analytics, no tracing, no session replay.

**No `@sentry/bun`.** It's beta, but the real reason is a concrete hazard:
`sandboxed-fetch.ts:3` captures `globalThis.fetch` at module load to enforce
per-plugin network allow-lists, and the SDK auto-instruments `fetch`. Depending
on module ordering in a minified compiled binary you get either every plugin's
URLs turned into Sentry breadcrumbs (a PII leak from unaudited third-party code)
or crash POSTs evaluated against a plugin's deny-list. Speaking the wire protocol
directly is ~150 lines, adds zero runtime deps, and makes `docs/privacy.md`
checkable — every field that can be sent is listed in `types.ts`.

Still Sentry's protocol, so the SaaS-vs-self-hosted call stays a DSN change.

## Three things worth reviewing closely

**Consent is tri-state.** `granted` / `denied` / `undefined`. The third state is
load-bearing: every existing install already has `welcomeCompleted: true`, so a
step added to the welcome wizard would only ever be seen by fresh installs.
Distinguishing "not asked" from "said no" is what will let upgraders be prompted
exactly once.

⚠️ **`useConfigValue<T>(key, default)` cannot express this** — it collapses
`undefined` into the default, so using it for the prompt decision would silently
mean "never prompt anyone". The UI phase needs a `hasConfigValue` helper, and
must gate on `whenUserConfigLoaded()` or a post-reinstall boot will re-prompt
someone who already answered.

**Rate limiting persists to disk.** An in-memory limiter is useless here: a crash
loop restarts the process and resets the counter, so the loop reports at full
rate forever. Bounded to ~600 events/device/month against the 5K free tier;
the per-fingerprint cap is what actually stops a loop.

**Both config paths are read.** `loadout.service` is a *system* unit setting only
`HOME`; the overlay is a *user* unit inheriting `XDG_CONFIG_HOME`. Reading one
path would make the two processes disagree about consent on any machine that
sets it.

## Capture points

- `loader/index.ts` — reports **before** the A-009 swallow. Production currently
  swallows every uncaught exception except OOM, so these are invisible today even
  locally. Highest-value point in the codebase.
- `overlay/src/bun/index.ts` — had **no global handlers at all**; an uncaught throw
  died silently and systemd restarted it. Logs first, then reports. No `await` on
  any exit path — this process owes Steam a prompt SIGCONT and a blocked flush
  would leave the machine looking frozen.

## The never-leaks gate

`crash-report.test.ts` asserts on the **serialized envelope**, not intermediate
objects. It caught three real bugs while being written: a surviving hostname, a
malformed `~<plugins>` path rewrite, and an unscrubbed SteamID64. If a future
change adds a field carrying a path, this is what catches it.

## Verification

`bun run typecheck` clean · `bun run lint` 0 errors · `bun run check:dead-code`
clean · **3189 tests pass** (34 new).

## Not in this PR

1. **Consent UI** — welcome step, upgrader prompt, Settings toggle, `hasConfigValue`.
2. **Transmission** — needs a Sentry project (EU region) and its DSN. Also requires
   turning *off* IP storage in project settings; `sendDefaultPii: false` alone does
   not stop Relay storing client IPs.
3. **Source maps** — the webview ships minified with no maps, so its traces are
   currently unreadable. Recommend `@sentry/vite-plugin` (debug IDs sidestep the
   `views://` scheme problem) and simply **dropping `--minify`** from the backend
   build rather than embedding a map in a 95 MB binary. ⚠️ `sourcemaps inject`
   rewrites the built JS, so it must run *before* packaging, and the tarball needs
   `--exclude='*.map'`.
4. **Spool architecture** (recommended) — have the root daemon write scrubbed
   reports to a local file and let the *user-level* overlay be the only process
   that opens a socket. Removes root egress entirely and makes offline the normal
   path rather than an error path.
5. **Native crashes** — FFI segfaults and CEF renderer crashes are invisible to a
   JS handler. Cheap proxy: `loadout-overlay.service` already has an `ExecStopPost`
   documented as running on SIGKILL/segfault/OOM; have it record `$SERVICE_RESULT`
   and report on next start. ⚠️ CI diffs that unit byte-for-byte against the heredoc
   in `scripts/install.sh` — both must be edited identically.
6. **Two pre-existing bugs**, agreed to fold in but not yet done: `/api/save-error`
   doesn't exist (both "Save to ~/Downloads" buttons silently always fail), and
   `logger.ts` ignores `$XDG_CONFIG_HOME` while `user-config.ts` honours it.

`docs/privacy.md` is included but **should not be published until transmission
actually ships** — it currently carries a status note saying reporting is not yet
enabled. It also states honestly that a revealing folder name inside an error
message cannot be scrubbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMzr2XShTRR9GmqX96Kiso
