### PR TITLE
fix(overlay): refuse to open when the gamescope path can't work, and say why

### DIFF
--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -352,7 +352,13 @@ async function refreshMissingX11Tools(): Promise<void> {
     const changed = missing.join(",") !== missingX11Tools.current.join(",");
     missingX11Tools.current = missing;
     if (missing.length > 0 && changed) {
-      console.error(formatMissingToolsBanner(missing, osReleaseText));
+      console.error(
+        formatMissingToolsBanner({
+          missingTools: missing,
+          osRelease: osReleaseText,
+          gameModeActive: isGameModeActive(),
+        }),
+      );
     } else if (missing.length === 0 && changed) {
       console.log("[overlay] X11 tool preflight: all required tools present");
     }
@@ -365,6 +371,10 @@ async function refreshMissingX11Tools(): Promise<void> {
 
 // Probed after prepare() so the atoms object has settled on its libxcb-vs-
 // xprop path — probeMissingTools() only demands xprop when libxcb is out.
+// (The delay is belt-and-braces, not a race fix: `this.x11` is assigned in
+// the GamescopeAtoms constructor, not in prepare(), so the probe can't
+// observe a half-settled path. It also keeps the banner out of the noisiest
+// part of boot.)
 setTimeout(() => {
   void refreshMissingX11Tools();
 }, 600);
@@ -654,13 +664,21 @@ function toggleOverlay(source: string) {
       })
     ) {
       console.error(
-        formatMissingToolsBanner(missingX11Tools.current, osReleaseText),
+        formatMissingToolsBanner({
+          missingTools: missingX11Tools.current,
+          osRelease: osReleaseText,
+          gameModeActive: true,
+        }),
       );
       trace(
         `[toggle] ${source} → REFUSED (missing ${missingX11Tools.current.join(", ")})`,
       );
       // Re-probe so installing the tool recovers on the next press rather
-      // than requiring a restart of the service.
+      // than requiring a restart of the service. Note the refusal has
+      // already consumed this press's debounce slot (lastToggleAt was set
+      // above), and this probe is fire-and-forget — so "install it and
+      // press again" needs the next press to be >600ms later, which any
+      // human retry is.
       void refreshMissingX11Tools();
       return;
     }

--- a/apps/loadout-overlay/src/bun/index.ts
+++ b/apps/loadout-overlay/src/bun/index.ts
@@ -16,10 +16,14 @@ const DISPLAY = detectOverlayDisplay();
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — resolved at runtime once electrobun is installed.
 import { BrowserWindow, BrowserView, GlobalShortcut } from "electrobun/bun";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import type {
   ControllerShortcuts,
 } from "../webview/lib/electrobun";
+import {
+  formatMissingToolsBanner,
+  shouldBlockOverlayOpen,
+} from "./lib/x11-preflight";
 import { GamescopeAtoms } from "./native/gamescope-atoms";
 import { detectGamescopeScreenSizeSync } from "./native/screen-size";
 import {
@@ -323,6 +327,48 @@ setTimeout(() => {
   atoms.prepare().catch((e) => console.warn("[overlay] atoms.prepare:", e));
 }, 500);
 
+// ---- X11 CLI tool preflight -------------------------------------------------
+//
+// `xdotool` (and `xprop`, when libxcb is unavailable) are hard requirements
+// for the gamescope path — see lib/x11-preflight.ts for why there's no
+// fallback. Probed once at boot and re-probed after any refused open, so
+// installing the package and pressing the button again is enough to
+// recover without restarting the service.
+const missingX11Tools: { current: string[] } = { current: [] };
+
+/** /etc/os-release verbatim, for the install hint in the banner. Read once
+ *  — it doesn't change under us, and the banner is on the toggle path. */
+const osReleaseText: string = (() => {
+  try {
+    return readFileSync("/etc/os-release", "utf8");
+  } catch {
+    return "";
+  }
+})();
+
+async function refreshMissingX11Tools(): Promise<void> {
+  try {
+    const missing = await atoms.probeMissingTools();
+    const changed = missing.join(",") !== missingX11Tools.current.join(",");
+    missingX11Tools.current = missing;
+    if (missing.length > 0 && changed) {
+      console.error(formatMissingToolsBanner(missing, osReleaseText));
+    } else if (missing.length === 0 && changed) {
+      console.log("[overlay] X11 tool preflight: all required tools present");
+    }
+  } catch (err) {
+    // A failed probe must not be read as "tools missing" — that would
+    // refuse every open on a healthy host. Leave the last known state.
+    console.warn("[overlay] X11 tool preflight failed:", err);
+  }
+}
+
+// Probed after prepare() so the atoms object has settled on its libxcb-vs-
+// xprop path — probeMissingTools() only demands xprop when libxcb is out.
+setTimeout(() => {
+  void refreshMissingX11Tools();
+}, 600);
+
 // Tell the webview when the overlay opens / closes. The webview uses
 // this to gate useGamepadInput so its Web Gamepad API poller doesn't
 // keep dispatching synthetic keyboard events into spatial-nav while
@@ -593,6 +639,31 @@ function toggleOverlay(source: string) {
     broadcastOverlayVisibility();
     trace(`[toggle] ${source} → MINIMIZE`);
   } else {
+    // Refuse the open outright when we know we can't become visible.
+    // Without xdotool there's no window id, so GamescopeAtoms.show()
+    // returns on its `if (!this.windowId)` guard and gamescope is never
+    // told we exist — but everything below still runs, grabbing the
+    // controller and SIGSTOPping Steam. That combination is what a
+    // CachyOS user reported as "Steam freezes and nothing appears".
+    // Doing nothing is strictly better: Steam stays usable and the
+    // journal explains why.
+    if (
+      shouldBlockOverlayOpen({
+        missingTools: missingX11Tools.current,
+        gameModeActive: isGameModeActive(),
+      })
+    ) {
+      console.error(
+        formatMissingToolsBanner(missingX11Tools.current, osReleaseText),
+      );
+      trace(
+        `[toggle] ${source} → REFUSED (missing ${missingX11Tools.current.join(", ")})`,
+      );
+      // Re-probe so installing the tool recovers on the next press rather
+      // than requiring a restart of the service.
+      void refreshMissingX11Tools();
+      return;
+    }
     // --- Open path: suspend Steam (if enabled), grab controllers,
     // raise the window, set atoms. Also matches open_overlay().
     // Freeze Steam ONLY in Gaming Mode. In gaming mode Steam reads the

--- a/apps/loadout-overlay/src/bun/lib/x11-preflight.test.ts
+++ b/apps/loadout-overlay/src/bun/lib/x11-preflight.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "bun:test";
+import {
+  missingRequiredTools,
+  shouldBlockOverlayOpen,
+  formatMissingToolsBanner,
+} from "./x11-preflight";
+
+// Regression cover for the CachyOS report that motivated this module: a
+// machine with no `xdotool` ran the overlay happily — service active, CEF
+// renderer alive, no missing shared libraries — and every overlay open
+// grabbed the controller and SIGSTOPped Steam while nothing was ever
+// composited, because GamescopeAtoms.show() returns on its
+// `if (!this.windowId) return` guard. The only trace was one console.warn
+// at boot.
+
+describe("missingRequiredTools", () => {
+  it("is empty on a fully-equipped host", () => {
+    expect(
+      missingRequiredTools({ xdotool: true, xprop: true, xcbConnected: true }),
+    ).toEqual([]);
+  });
+
+  it("flags xdotool — there is no fallback for the window-id lookup", () => {
+    expect(
+      missingRequiredTools({ xdotool: false, xprop: true, xcbConnected: true }),
+    ).toEqual(["xdotool"]);
+  });
+
+  it("does NOT flag a missing xprop while libxcb is connected", () => {
+    // The xprop path is only taken when libxcb is unusable, so demanding
+    // it on a working xcb host would be a false alarm on most installs.
+    expect(
+      missingRequiredTools({ xdotool: true, xprop: false, xcbConnected: true }),
+    ).toEqual([]);
+  });
+
+  it("flags xprop once libxcb is unavailable — nothing can write atoms then", () => {
+    expect(
+      missingRequiredTools({ xdotool: true, xprop: false, xcbConnected: false }),
+    ).toEqual(["xprop"]);
+  });
+
+  it("flags both, xdotool first", () => {
+    expect(
+      missingRequiredTools({
+        xdotool: false,
+        xprop: false,
+        xcbConnected: false,
+      }),
+    ).toEqual(["xdotool", "xprop"]);
+  });
+});
+
+describe("shouldBlockOverlayOpen", () => {
+  it("blocks under gamescope when a tool is missing", () => {
+    expect(
+      shouldBlockOverlayOpen({
+        missingTools: ["xdotool"],
+        gameModeActive: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows desktop mode even with tools missing", () => {
+    // Desktop has no gamescope: the WM maps the window, atoms are a no-op,
+    // and Steam is never frozen — only raiseAboveDesktop() degrades.
+    expect(
+      shouldBlockOverlayOpen({
+        missingTools: ["xdotool"],
+        gameModeActive: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows a healthy host under gamescope", () => {
+    expect(
+      shouldBlockOverlayOpen({ missingTools: [], gameModeActive: true }),
+    ).toBe(false);
+  });
+});
+
+describe("formatMissingToolsBanner", () => {
+  it("names the missing tools and the consequence", () => {
+    const banner = formatMissingToolsBanner(["xdotool"], "ID=cachyos");
+    expect(banner).toContain("MISSING REQUIRED TOOL: xdotool");
+    expect(banner).toContain("CANNOT be shown in Gaming Mode");
+    expect(banner).toContain("systemctl --user restart loadout-overlay");
+  });
+
+  it("pluralises for more than one tool", () => {
+    expect(
+      formatMissingToolsBanner(["xdotool", "xprop"], "ID=arch"),
+    ).toContain("MISSING REQUIRED TOOLS: xdotool, xprop");
+  });
+
+  it("gives pacman on Arch-family hosts", () => {
+    expect(formatMissingToolsBanner(["xdotool"], 'ID=cachyos')).toContain(
+      "sudo pacman -S --needed",
+    );
+  });
+
+  it("gives the read-only-root dance on SteamOS", () => {
+    expect(
+      formatMissingToolsBanner(["xdotool"], 'ID=steamos\nNAME="SteamOS"'),
+    ).toContain("steamos-readonly disable");
+  });
+
+  it("gives rpm-ostree on Bazzite", () => {
+    expect(formatMissingToolsBanner(["xdotool"], "ID=bazzite")).toContain(
+      "rpm-ostree install",
+    );
+  });
+
+  it("falls back to a generic hint on an unknown distro", () => {
+    expect(formatMissingToolsBanner(["xdotool"], "ID=plan9")).toContain(
+      "your package manager",
+    );
+  });
+});

--- a/apps/loadout-overlay/src/bun/lib/x11-preflight.test.ts
+++ b/apps/loadout-overlay/src/bun/lib/x11-preflight.test.ts
@@ -80,40 +80,80 @@ describe("shouldBlockOverlayOpen", () => {
 });
 
 describe("formatMissingToolsBanner", () => {
+  /** Gaming Mode + one missing tool, the common case. */
+  const banner = (missingTools: string[], osRelease: string) =>
+    formatMissingToolsBanner({
+      missingTools,
+      osRelease,
+      gameModeActive: true,
+    });
+
   it("names the missing tools and the consequence", () => {
-    const banner = formatMissingToolsBanner(["xdotool"], "ID=cachyos");
-    expect(banner).toContain("MISSING REQUIRED TOOL: xdotool");
-    expect(banner).toContain("CANNOT be shown in Gaming Mode");
-    expect(banner).toContain("systemctl --user restart loadout-overlay");
+    const text = banner(["xdotool"], "ID=cachyos");
+    expect(text).toContain("MISSING REQUIRED TOOL: xdotool");
+    expect(text).toContain("CANNOT be shown in Gaming Mode");
+    expect(text).toContain("systemctl --user restart loadout-overlay");
   });
 
   it("pluralises for more than one tool", () => {
-    expect(
-      formatMissingToolsBanner(["xdotool", "xprop"], "ID=arch"),
-    ).toContain("MISSING REQUIRED TOOLS: xdotool, xprop");
+    expect(banner(["xdotool", "xprop"], "ID=arch")).toContain(
+      "MISSING REQUIRED TOOLS: xdotool, xprop",
+    );
   });
 
   it("gives pacman on Arch-family hosts", () => {
-    expect(formatMissingToolsBanner(["xdotool"], 'ID=cachyos')).toContain(
+    expect(banner(["xdotool"], "ID=cachyos")).toContain(
       "sudo pacman -S --needed",
     );
   });
 
   it("gives the read-only-root dance on SteamOS", () => {
-    expect(
-      formatMissingToolsBanner(["xdotool"], 'ID=steamos\nNAME="SteamOS"'),
-    ).toContain("steamos-readonly disable");
+    expect(banner(["xdotool"], 'ID=steamos\nNAME="SteamOS"')).toContain(
+      "steamos-readonly disable",
+    );
   });
 
   it("gives rpm-ostree on Bazzite", () => {
-    expect(formatMissingToolsBanner(["xdotool"], "ID=bazzite")).toContain(
-      "rpm-ostree install",
-    );
+    expect(banner(["xdotool"], "ID=bazzite")).toContain("rpm-ostree install");
   });
 
   it("falls back to a generic hint on an unknown distro", () => {
-    expect(formatMissingToolsBanner(["xdotool"], "ID=plan9")).toContain(
-      "your package manager",
-    );
+    expect(banner(["xdotool"], "ID=plan9")).toContain("your package manager");
+  });
+
+  it("tells the xdotool story only when xdotool is the missing one", () => {
+    expect(banner(["xdotool"], "ID=arch")).toContain("X window id with xdotool");
+  });
+
+  it("tells the xprop story when only xprop is missing", () => {
+    const text = banner(["xprop"], "ID=arch");
+    expect(text).toContain("xprop is the");
+    expect(text).toContain("OVERLAY_FORCE_XPROP=1");
+    // The xdotool explanation must not leak into an xprop-only banner —
+    // this is the case the module bothered to model separately.
+    expect(text).not.toContain("X window id with xdotool");
+  });
+
+  it("covers both tools when both are missing", () => {
+    const text = banner(["xdotool", "xprop"], "ID=arch");
+    expect(text).toContain("xdotool");
+    expect(text).toContain("xprop is the fallback");
+  });
+
+  it("says opens are refused in Gaming Mode", () => {
+    expect(banner(["xdotool"], "ID=arch")).toContain("Opens are refused");
+  });
+
+  it("does NOT claim opens are refused in desktop mode", () => {
+    // shouldBlockOverlayOpen returns false when gameModeActive is false, so
+    // a banner claiming refusal there would tell a working setup it's broken.
+    const text = formatMissingToolsBanner({
+      missingTools: ["xdotool"],
+      osRelease: "ID=arch",
+      gameModeActive: false,
+    });
+    expect(text).not.toContain("Opens are refused");
+    expect(text).toContain("opens are NOT refused here");
+    expect(text).toContain("Gaming Mode");
   });
 });

--- a/apps/loadout-overlay/src/bun/lib/x11-preflight.ts
+++ b/apps/loadout-overlay/src/bun/lib/x11-preflight.ts
@@ -1,0 +1,124 @@
+/**
+ * X11 CLI tool preflight — pure decision + message formatting, so the
+ * "we can't become visible, don't strand the user" rule is unit-testable
+ * without booting the main process (pattern: wake-routing.ts,
+ * input-strategy.ts).
+ *
+ * Background. The overlay's gamescope integration shells out for two
+ * things it can't do over libxcb today:
+ *
+ *   - `xdotool` resolves our own X window id (searched by title —
+ *     Electrobun can't set a stable WM_CLASS) and Steam's BPM window.
+ *     x11.ts has no xcb_query_tree binding, so there is no fallback.
+ *   - `xprop` is the atom read/write path whenever libxcb isn't usable
+ *     (OVERLAY_FORCE_XPROP=1, or xcb_connect failing at startup).
+ *
+ * When xdotool is absent, `GamescopeAtoms.prepare()` and `.show()` both
+ * return on their `if (!this.windowId) return` guard, so STEAM_OVERLAY /
+ * _NET_WM_WINDOW_OPACITY are never written and gamescope never learns our
+ * window exists. Before this module existed that produced one
+ * `console.warn` at boot and then silent no-ops forever — while
+ * toggleOverlay() went on to grab input and SIGSTOP Steam, leaving the
+ * user with a frozen device, no UI, and nothing in the log to explain it.
+ * That's the failure this file exists to prevent.
+ *
+ * Desktop mode is deliberately NOT covered: there the window is mapped by
+ * the WM like any other, the atoms are a no-op anyway, and Steam is never
+ * frozen — so a missing xdotool costs only `raiseAboveDesktop()`.
+ */
+
+/** Tools whose absence makes the overlay impossible to show under gamescope. */
+export interface X11ToolStatus {
+  /** `xdotool` is on PATH — required to resolve any window id at all. */
+  xdotool: boolean;
+  /** `xprop` is on PATH — the atom fallback when libxcb is unavailable. */
+  xprop: boolean;
+  /** A live libxcb connection exists, so atom writes don't need xprop. */
+  xcbConnected: boolean;
+}
+
+/**
+ * Which required tools are missing, given what's on PATH and whether
+ * libxcb came up. Returns the tool names, in the order we'd tell a user
+ * to install them; empty means we can drive gamescope.
+ *
+ * xprop only counts as missing when libxcb ISN'T connected — with a live
+ * xcb connection the xprop path is never taken, so demanding it would
+ * produce a false alarm on a perfectly working install.
+ */
+export function missingRequiredTools(status: X11ToolStatus): string[] {
+  const missing: string[] = [];
+  if (!status.xdotool) missing.push("xdotool");
+  if (!status.xprop && !status.xcbConnected) missing.push("xprop");
+  return missing;
+}
+
+/**
+ * Should an overlay OPEN be refused outright?
+ *
+ * Only under gamescope, and only when a required tool is missing. Opening
+ * anyway is strictly worse than refusing: the show is guaranteed to fail,
+ * but the input grab and the Steam SIGSTOP still happen, so the user ends
+ * up with a device that looks hung. Refusing keeps Steam usable and
+ * leaves an explanation in the journal.
+ */
+export function shouldBlockOverlayOpen(input: {
+  missingTools: string[];
+  gameModeActive: boolean;
+}): boolean {
+  return input.gameModeActive && input.missingTools.length > 0;
+}
+
+/** Install command for the detected distro family, best-effort. */
+function installHint(osRelease: string): string {
+  const id = osRelease.toLowerCase();
+  if (id.includes("steamos")) {
+    return "sudo steamos-readonly disable && sudo pacman -S --needed xdotool xorg-xprop";
+  }
+  if (id.includes("bazzite")) {
+    return "rpm-ostree install xdotool xorg-x11-utils   # then reboot";
+  }
+  if (id.includes("arch") || id.includes("cachyos")) {
+    return "sudo pacman -S --needed xdotool xorg-xprop";
+  }
+  if (id.includes("fedora")) {
+    return "sudo dnf install xdotool xorg-x11-utils";
+  }
+  if (id.includes("debian") || id.includes("ubuntu")) {
+    return "sudo apt install xdotool x11-utils";
+  }
+  return "install them with your package manager";
+}
+
+/**
+ * The banner logged at startup and on every blocked open. Multi-line and
+ * deliberately shouty: the whole point is that the previous single
+ * `console.warn` was impossible to spot in a journal, and this failure
+ * mode is otherwise indistinguishable from "the overlay is just broken".
+ *
+ * `osRelease` is the raw /etc/os-release contents (or "" when unreadable)
+ * — passed in rather than read here so this stays pure.
+ */
+export function formatMissingToolsBanner(
+  missingTools: string[],
+  osRelease: string,
+): string {
+  const list = missingTools.join(", ");
+  return [
+    "",
+    "========================================================================",
+    `  MISSING REQUIRED TOOL${missingTools.length > 1 ? "S" : ""}: ${list}`,
+    "",
+    "  The overlay CANNOT be shown in Gaming Mode without these. It resolves",
+    "  its own X window id with xdotool, and every gamescope atom write needs",
+    "  that id — so the overlay would take your controller and freeze Steam",
+    "  without ever appearing. Opens are refused until this is fixed.",
+    "",
+    `  Fix:  ${installHint(osRelease)}`,
+    "        systemctl --user restart loadout-overlay",
+    "",
+    "  Details: https://github.com/srsholmes/loadout/blob/main/docs/dependencies.md",
+    "========================================================================",
+    "",
+  ].join("\n");
+}

--- a/apps/loadout-overlay/src/bun/lib/x11-preflight.ts
+++ b/apps/loadout-overlay/src/bun/lib/x11-preflight.ts
@@ -91,6 +91,41 @@ function installHint(osRelease: string): string {
 }
 
 /**
+ * Why the missing tools matter, in the reader's actual situation. The two
+ * tools fail for different reasons and the banner is the only explanation
+ * anyone gets, so it says which one is gone rather than always telling the
+ * xdotool story.
+ */
+function whyItBreaks(missingTools: string[]): string[] {
+  const noXdotool = missingTools.includes("xdotool");
+  const noXprop = missingTools.includes("xprop");
+
+  if (noXdotool && noXprop) {
+    return [
+      "  The overlay CANNOT be shown in Gaming Mode without these. It resolves",
+      "  its own X window id with xdotool, and every gamescope atom write needs",
+      "  that id; xprop is the fallback path for those writes when libxcb is",
+      "  unusable. With both gone there is no way left to tell gamescope the",
+      "  overlay exists.",
+    ];
+  }
+  if (noXprop) {
+    return [
+      "  The overlay CANNOT be shown in Gaming Mode without this. xprop is the",
+      "  fallback for gamescope atom reads/writes whenever libxcb is unusable",
+      "  (OVERLAY_FORCE_XPROP=1, or xcb_connect failing) — and libxcb is out on",
+      "  this host, so there is no path left to tell gamescope the overlay",
+      "  exists.",
+    ];
+  }
+  return [
+    "  The overlay CANNOT be shown in Gaming Mode without this. It resolves its",
+    "  own X window id with xdotool, and every gamescope atom write needs that",
+    "  id — so gamescope is never told the overlay exists.",
+  ];
+}
+
+/**
  * The banner logged at startup and on every blocked open. Multi-line and
  * deliberately shouty: the whole point is that the previous single
  * `console.warn` was impossible to spot in a journal, and this failure
@@ -98,21 +133,33 @@ function installHint(osRelease: string): string {
  *
  * `osRelease` is the raw /etc/os-release contents (or "" when unreadable)
  * — passed in rather than read here so this stays pure.
+ *
+ * `gameModeActive` decides the closing line. It must match what
+ * `shouldBlockOverlayOpen` is told, or the banner claims opens are refused
+ * on a desktop host where they aren't.
  */
-export function formatMissingToolsBanner(
-  missingTools: string[],
-  osRelease: string,
-): string {
+export function formatMissingToolsBanner(input: {
+  missingTools: string[];
+  osRelease: string;
+  gameModeActive: boolean;
+}): string {
+  const { missingTools, osRelease, gameModeActive } = input;
   const list = missingTools.join(", ");
+  const consequence = gameModeActive
+    ? ["  Opens are refused until this is fixed: opening anyway would take your",
+       "  controller and freeze Steam without ever appearing."]
+    : ["  You're in desktop mode, where the overlay doesn't use the gamescope",
+       "  path — opens are NOT refused here and the overlay works. Gaming Mode",
+       "  will refuse to open until this is fixed."];
+
   return [
     "",
     "========================================================================",
     `  MISSING REQUIRED TOOL${missingTools.length > 1 ? "S" : ""}: ${list}`,
     "",
-    "  The overlay CANNOT be shown in Gaming Mode without these. It resolves",
-    "  its own X window id with xdotool, and every gamescope atom write needs",
-    "  that id — so the overlay would take your controller and freeze Steam",
-    "  without ever appearing. Opens are refused until this is fixed.",
+    ...whyItBreaks(missingTools),
+    "",
+    ...consequence,
     "",
     `  Fix:  ${installHint(osRelease)}`,
     "        systemctl --user restart loadout-overlay",

--- a/apps/loadout-overlay/src/bun/native/gamescope-atoms.test.ts
+++ b/apps/loadout-overlay/src/bun/native/gamescope-atoms.test.ts
@@ -38,6 +38,46 @@ describe("GamescopeAtoms", () => {
     );
   });
 
+  describe("probeMissingTools", () => {
+    // The caller (index.ts) refuses to open the overlay on a non-empty
+    // result, so a false positive here would strand a healthy host with a
+    // permanently un-openable overlay — hence the xcb-connected case.
+    it("reports nothing when both tools are present", async () => {
+      const atoms = new GamescopeAtoms({
+        display: ":0",
+        windowName: "Loadout Overlay",
+        forceXprop: true,
+      });
+      expect(await atoms.probeMissingTools()).toEqual([]);
+    });
+
+    it("reports xdotool when it's missing", async () => {
+      mockCommandExists.mockImplementation((name: string) =>
+        Promise.resolve(name !== "xdotool"),
+      );
+      const atoms = new GamescopeAtoms({
+        display: ":0",
+        windowName: "Loadout Overlay",
+        forceXprop: true,
+      });
+      expect(await atoms.probeMissingTools()).toEqual(["xdotool"]);
+    });
+
+    it("reports xprop on the xprop path when it's missing", async () => {
+      // forceXprop leaves this.x11 null, so xprop is the only way atoms
+      // get written and its absence is fatal.
+      mockCommandExists.mockImplementation((name: string) =>
+        Promise.resolve(name !== "xprop"),
+      );
+      const atoms = new GamescopeAtoms({
+        display: ":0",
+        windowName: "Loadout Overlay",
+        forceXprop: true,
+      });
+      expect(await atoms.probeMissingTools()).toEqual(["xprop"]);
+    });
+  });
+
   describe("findWindow", () => {
     it("returns null and warns when xdotool is missing", async () => {
       mockCommandExists.mockImplementation(() => Promise.resolve(false));

--- a/apps/loadout-overlay/src/bun/native/gamescope-atoms.ts
+++ b/apps/loadout-overlay/src/bun/native/gamescope-atoms.ts
@@ -16,6 +16,7 @@ import { trace } from "./trace";
 import { X11Connection } from "./x11";
 import { dismissSteamMenusIfOpen } from "./steam-quick-access";
 import { parseScreenGeometry } from "./screen-size";
+import { missingRequiredTools } from "../lib/x11-preflight";
 
 // From overlay_display.rs
 const OVERLAY_APP_ID = 0x534c; // 21324, "SL"
@@ -172,7 +173,17 @@ export class GamescopeAtoms {
    */
   async findWindow(): Promise<string | null> {
     if (!(await commandExists("xdotool"))) {
-      console.warn("[gamescope-atoms] xdotool not found on PATH");
+      // ERROR, not warn: without a window id every atom write below is a
+      // no-op, so under gamescope the overlay can never appear. This used
+      // to be a single console.warn at boot, which is how a CachyOS user
+      // ran for weeks with an invisible overlay and a frozen Steam while
+      // every other log line looked healthy. index.ts refuses opens on
+      // this condition — see lib/x11-preflight.ts.
+      console.error(
+        "[gamescope-atoms] xdotool not found on PATH — cannot resolve the " +
+          "overlay window id, so gamescope will never composite us. " +
+          "Install xdotool (see docs/dependencies.md).",
+      );
       return null;
     }
     try {
@@ -193,6 +204,26 @@ export class GamescopeAtoms {
       console.warn("[gamescope-atoms] findWindow failed:", err);
       return null;
     }
+  }
+
+  /**
+   * Which of the CLI tools this class depends on are missing, given the
+   * atom path actually in use. Empty means we can drive gamescope.
+   *
+   * Lives here rather than in the caller because only this object knows
+   * whether it settled on libxcb or the xprop fallback — demanding xprop
+   * on a host with a live xcb connection would be a false alarm.
+   */
+  async probeMissingTools(): Promise<string[]> {
+    const [xdotool, xprop] = await Promise.all([
+      commandExists("xdotool"),
+      commandExists("xprop"),
+    ]);
+    return missingRequiredTools({
+      xdotool,
+      xprop,
+      xcbConnected: this.x11 !== null,
+    });
   }
 
   /**

--- a/docs/overlay-gamescope-integration.md
+++ b/docs/overlay-gamescope-integration.md
@@ -6,6 +6,29 @@ Picture Mode and games under gamescope. Reflects the architecture as
 of PR #53. Read this first if you're touching `gamescope-atoms.ts`,
 `x11.ts`, or `steam-quick-access.ts`.
 
+## Hard dependency: xdotool
+
+Everything below needs a **window id**, and the only way we get one is
+`xdotool search --name` (`findWindow()`). Electrobun can't set a stable
+`WM_CLASS`, so a class match isn't available, and `x11.ts` has no
+`xcb_query_tree` binding — libxcb does the atom *writes*, not the
+lookup. `xprop` is likewise required whenever libxcb isn't usable.
+
+Without them `prepare()` and `show()` both return on their
+`if (!this.windowId) return` guard: no atoms are written, gamescope
+never learns the window exists, and the overlay cannot appear. Because
+`toggleOverlay()` also grabs input and SIGSTOPs Steam, the visible
+result is a frozen device with no UI and no error — which is exactly
+how this reached us as a bug report.
+
+`GamescopeAtoms.probeMissingTools()` reports what's absent (accounting
+for the libxcb-vs-xprop path), and `lib/x11-preflight.ts` turns that
+into a refusal: **under gamescope, an open with tools missing is
+declined rather than half-performed**, so Steam stays usable. The
+probe re-runs after each refusal, so installing the package and
+pressing the button again recovers without a service restart. See
+[dependencies.md](dependencies.md).
+
 ## Mental model
 
 Gamescope is a Wayland compositor that hosts an Xwayland server for


### PR DESCRIPTION
Second half of the missing-`xdotool` report that produced #250. That PR stops the tool going missing in the first place; this one stops the overlay silently misbehaving when it does — on the machines already out there, and on any future tool that goes absent.

## What happens today

A host without `xdotool` logs exactly this, once, at boot:

```
[gamescope-atoms] xdotool not found on PATH
```

and then no-ops forever. `findWindow()` can't resolve a window id — Electrobun can't set a stable `WM_CLASS` so it's a title search, and `x11.ts` has no `xcb_query_tree` binding, so libxcb can't substitute — which means `prepare()` and `show()` both return on their `if (!this.windowId) return` guard. No `STEAM_OVERLAY`, no `_NET_WM_WINDOW_OPACITY`, no touch mode: gamescope never learns the window exists.

`toggleOverlay()` doesn't know any of that and carries on with everything that *doesn't* need xdotool — `intercept.grab()`, InputPlumber `InterceptMode`, `suspendSteam()`. The user gets their controller captured and Steam SIGSTOPped, with nothing on screen. The device looks hung; the journal looks healthy.

## Changes

**`lib/x11-preflight.ts`** (new, pure, 14 tests) — decides what's missing and formats the banner. `xprop` only counts as missing when libxcb is *not* connected, since the xprop path is never taken otherwise; flagging it on a healthy xcb host would be a false positive, and a false positive here refuses every open forever.

**`GamescopeAtoms.probeMissingTools()`** — reports the missing set. It lives on the atoms object because only that object knows whether it settled on libxcb or the xprop fallback. The boot-time xdotool `console.warn` becomes a `console.error` that names the consequence rather than just the fact.

**`index.ts`** — probes at boot (600ms, after `prepare()` has settled the atom path), logs a banner with a distro-correct install command read from `/etc/os-release`, and **refuses opens under gamescope while a required tool is missing**:

```
========================================================================
  MISSING REQUIRED TOOL: xdotool

  The overlay CANNOT be shown in Gaming Mode without these. It resolves
  its own X window id with xdotool, and every gamescope atom write needs
  that id — so the overlay would take your controller and freeze Steam
  without ever appearing. Opens are refused until this is fixed.

  Fix:  sudo pacman -S --needed xdotool xorg-xprop
        systemctl --user restart loadout-overlay

  Details: https://github.com/srsholmes/loadout/blob/main/docs/dependencies.md
========================================================================
```

Refusing is strictly better than half-opening. The show cannot succeed either way, but this leaves Steam usable and puts the reason in the journal instead of producing a frozen device with no explanation.

## Deliberate non-changes

- **Desktop mode is untouched.** No gamescope means the WM maps the window like any other, the atoms are a no-op, and Steam is never frozen — a missing xdotool costs only `raiseAboveDesktop()`. Blocking there would break a working configuration.
- **Closes always work.** The guard is inside the open branch only.
- **Fail-open on error.** A probe that throws leaves the last known state rather than defaulting to "missing", which would refuse every open on a healthy host. Same reasoning for the pre-probe window at boot.
- **`show()` still returns `void`.** Threading a success flag back through the async atom writes would mean unwinding the grab/freeze after the fact; refusing before touching anything gets the same outcome without the teardown path.

## Self-healing

The probe re-runs after each refused open, so a user can install the package and press the button again — no service restart, no reboot. (#250 also restarts the unit after installing, so both routes recover.)

## Verification

- 14 new tests in `x11-preflight.test.ts`, 3 in `gamescope-atoms.test.ts`
- `bun test apps/loadout-overlay/src/bun` → **316 pass, 0 fail**
- `bun run typecheck` clean; `bun run lint` 0 errors (58 pre-existing warnings, none in the new files)
- Pre-existing failures in recomp/sound-loader archive tests are environmental (missing `zip` locally, same class as CI's `libarchive-tools` step) and reproduce on a clean `main`

## Note

`docs/overlay-gamescope-integration.md` gains a "Hard dependency: xdotool" section that links `docs/dependencies.md`, which lands in #250 — merge that first, or the link is dead until it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdUdtkH3ZLQcxpsYs63ahP