### PR TITLE
fix(steam-cef-badges): keep ProtonDB/HLTB badges out of the Steam menu

### DIFF
--- a/packages/steam-cef-badges/src/injector.test.ts
+++ b/packages/steam-cef-badges/src/injector.test.ts
@@ -265,17 +265,87 @@ describe("SteamCefBadgeInjector — render-target selection", () => {
   it("route polling is a no-op without SharedJSContext, not a badge eviction", async () => {
     // tempNavStore only exists on SharedJSContext, and BPM's location is
     // pinned to the entry URL — so reading the route from the render tab
-    // would push a null update and wipe a badge that was on screen.
-    tabsResponse = [tab("Steam Big Picture Mode", BPM_WINDOW)];
-    evalResponder = () => "https://steamloopback.host/index.html";
+    // would yield a non-matching pathname, push a null update, and wipe a
+    // badge that was on screen.
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamloopback.host/routes/"),
+      tab("Steam Big Picture Mode", BPM_WINDOW),
+    ];
+    evalResponder = (expr) =>
+      expr.includes("tempNavStore")
+        ? "/library/app/620"
+        : "https://steamloopback.host/index.html";
     const inj = makeInjector(() => true);
     await inj.start();
+
+    // Establish a badge on screen — without this the test is vacuous, since
+    // a null-yielding fallback is indistinguishable from no poll at all.
+    await (inj as unknown as { _pollCurrentAppId(): Promise<void> })._pollCurrentAppId();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(inj.getCurrentAppId()).toBe("620");
+
+    // Now lose the shared context, leaving the render tab alive.
+    const conns = (
+      inj as unknown as { connections: Map<string, { client: FakeCDPClient }> }
+    ).connections;
+    conns.delete("SharedJSContext");
+    evalResponder = () => "https://steamloopback.host/index.html";
     evalCalls = [];
 
     await (inj as unknown as { _pollCurrentAppId(): Promise<void> })._pollCurrentAppId();
     await new Promise((r) => setTimeout(r, 0));
 
+    expect(inj.getCurrentAppId()).toBe("620");
     expect(evalCalls.some((c) => c.expr.includes("update(null)"))).toBe(false);
+    await inj.stop();
+  });
+
+  it("ignores a same-titled tab that isn't served from steamloopback", async () => {
+    // SHARED_JS_NAMES contains generic titles, so an ordinary community tab
+    // titled "Steam" can claim the key on title alone.
+    tabsResponse = [
+      tab("Steam", "https://steamcommunity.com/app/440", "decoy"),
+      tab("SharedJSContext", "https://steamloopback.host/routes/", "shared"),
+      tab("Steam Big Picture Mode", BPM_WINDOW, "bpm"),
+    ];
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    expect(clientsConstructed).not.toContain("ws://decoy");
+    await inj.stop();
+  });
+
+  it("resolves a duplicate SharedJSContext claim on merit, not list order", async () => {
+    // Both are candidates here (both titled SharedJSContext), so only the
+    // ranking decides — and Steam lists the weaker one first.
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamcommunity.com/", "weak"),
+      tab("SharedJSContext", "https://steamloopback.host/routes/", "canonical"),
+      tab("Steam Big Picture Mode", BPM_WINDOW, "bpm"),
+    ];
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    const conns = (
+      inj as unknown as { connections: Map<string, { client: { wsUrl: string } }> }
+    ).connections;
+    expect(conns.get("SharedJSContext")?.client.wsUrl).toBe("ws://canonical");
+    await inj.stop();
+  });
+
+  it("elects a single BPM window when two are present", async () => {
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamloopback.host/routes/", "shared"),
+      tab("Steam", "about:blank?browserType=4", "desktop-bpm"),
+      tab("Steam Big Picture Mode", BPM_WINDOW, "gaming-bpm"),
+    ];
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    const script = (ws: string) =>
+      evalCalls.some((c) => c.wsUrl === ws && c.expr.includes("/*bpm-script*/"));
+    expect(script("ws://gaming-bpm")).toBe(true);
+    expect(script("ws://desktop-bpm")).toBe(false);
     await inj.stop();
   });
 });
@@ -409,6 +479,198 @@ describe("SteamCefBadgeInjector — status detail", () => {
     const inj = makeInjector(() => true);
     await inj.start();
     expect(inj.getStatus().detail).toBeUndefined();
+    await inj.stop();
+  });
+});
+
+describe("SteamCefBadgeInjector — rediscovery back-off", () => {
+  const BPM_WINDOW = "about:blank?createflags=6292738&browserType=4";
+  const tick = (inj: unknown) =>
+    (inj as { _checkHealth(): Promise<void> })._checkHealth();
+
+  it("stops re-running discovery when Steam simply has no shared context", async () => {
+    // Without a back-off this re-connects every socket and re-runs the BPM
+    // script every 5s forever — and the badge script's own cleanup() drops
+    // the badge before the async re-push restores it, so it blinks each tick.
+    tabsResponse = [
+      tab("Steam Big Picture Mode", BPM_WINDOW, "bpm"),
+      tab("MainMenu_uid2", "about:blank?browserviewpopup=1", "menu"),
+    ];
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    fetchCalls = [];
+    evalCalls = [];
+    for (let i = 0; i < 8; i++) await tick(inj);
+
+    // 8 ticks, but the back-off ratchets 1→3→7, so only a couple land.
+    expect(fetchCalls.length).toBeLessThanOrEqual(3);
+    const reinjects = evalCalls.filter((c) => c.expr.includes("/*bpm-script*/"));
+    expect(reinjects.length).toBeLessThanOrEqual(3);
+    await inj.stop();
+  });
+
+  it("backs off the same way when only SharedJSContext exists", async () => {
+    tabsResponse = [tab("SharedJSContext", "https://steamloopback.host/routes/")];
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    fetchCalls = [];
+    for (let i = 0; i < 8; i++) await tick(inj);
+    expect(fetchCalls.length).toBeLessThanOrEqual(3);
+    await inj.stop();
+  });
+
+  it("keeps retrying every tick while Steam is unreachable", async () => {
+    // A failed connect is Steam-not-up-yet, not a missing target — that must
+    // not inherit the back-off or startup reconnection gets slow.
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    const inj = makeInjector(() => true);
+    await inj.start();
+    for (let i = 0; i < 4; i++) await tick(inj);
+    expect(inj.connected).toBe(false);
+    await inj.stop();
+  });
+
+  it("resets the back-off as soon as a connection drops", async () => {
+    tabsResponse = [tab("Steam Big Picture Mode", BPM_WINDOW, "bpm")];
+    const inj = makeInjector(() => true);
+    await inj.start();
+    // 5 ticks leaves the countdown mid-flight (ratchet 1 → 3, one skip left),
+    // which is the only state where the reset is observable.
+    for (let i = 0; i < 5; i++) await tick(inj);
+
+    const conns = (
+      inj as unknown as { connections: Map<string, { client: FakeCDPClient }> }
+    ).connections;
+    for (const c of conns.values()) c.client.connected = false;
+
+    fetchCalls = [];
+    await tick(inj);
+    expect(fetchCalls.some((u) => u.includes("/json"))).toBe(true);
+    await inj.stop();
+  });
+
+  it("reports the missing shared context instead of looking healthy", async () => {
+    tabsResponse = [tab("Steam Big Picture Mode", BPM_WINDOW, "bpm")];
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    const { connected, detail } = inj.getStatus();
+    expect(connected).toBe(true);
+    expect(detail).toMatch(/shared context/i);
+    await inj.stop();
+  });
+});
+
+describe("SteamCefBadgeInjector — state emission", () => {
+  it("emits the connect failure reason to an already-open panel", async () => {
+    const emitted: { connected: boolean; detail?: string }[] = [];
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    const inj = makeInjector(() => true, {
+      onStateChange: (s) => void emitted.push(s),
+    });
+    await inj.start();
+
+    expect(emitted.some((e) => e.detail?.includes(".cef-enable-remote-debugging"))).toBe(
+      true,
+    );
+    await inj.stop();
+  });
+
+  it("emits the Gaming-Mode reason on a mode flip", async () => {
+    const emitted: { connected: boolean; detail?: string }[] = [];
+    let mode = true;
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamloopback.host/routes/"),
+      tab("Steam Big Picture Mode", "about:blank?browserType=4", "bpm"),
+    ];
+    const inj = makeInjector(() => mode, {
+      onStateChange: (s) => void emitted.push(s),
+    });
+    await inj.start();
+    emitted.length = 0;
+
+    mode = false;
+    const r = await inj.reconnect();
+    expect(r.success).toBe(false);
+    expect(inj.connected).toBe(false);
+    expect(emitted.some((e) => e.detail?.includes("Gaming Mode"))).toBe(true);
+    await inj.stop();
+  });
+
+  it("emits the Gaming-Mode reason when rediscovery lands in desktop mode", async () => {
+    // Steam restarted into Desktop Mode: the old sockets die, health prunes
+    // them, rediscovery runs and hits _tryConnect's Gaming-Mode gate.
+    const emitted: { connected: boolean; detail?: string }[] = [];
+    let mode = true;
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamloopback.host/routes/"),
+      tab("Steam Big Picture Mode", "about:blank?browserType=4", "bpm"),
+    ];
+    const inj = makeInjector(() => mode, {
+      onStateChange: (s2) => void emitted.push(s2),
+    });
+    await inj.start();
+    emitted.length = 0;
+
+    const conns = (
+      inj as unknown as { connections: Map<string, { client: FakeCDPClient }> }
+    ).connections;
+    for (const c of conns.values()) c.client.connected = false;
+    mode = false;
+
+    await (inj as unknown as { _checkHealth(): Promise<void> })._checkHealth();
+    expect(emitted.some((e) => e.detail?.includes("Gaming Mode"))).toBe(true);
+    await inj.stop();
+  });
+
+  it("emits the Gaming-Mode reason at startup in desktop mode", async () => {
+    const emitted: { connected: boolean; detail?: string }[] = [];
+    const inj = makeInjector(() => false, {
+      onStateChange: (s2) => void emitted.push(s2),
+    });
+    await inj.start();
+    expect(emitted.some((e) => e.detail?.includes("Gaming Mode"))).toBe(true);
+    await inj.stop();
+  });
+
+  it("does not re-emit an unchanged reason", async () => {
+    const emitted: unknown[] = [];
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    const inj = makeInjector(() => true, {
+      onStateChange: (s) => void emitted.push(s),
+    });
+    await inj.start();
+    const after = emitted.length;
+    await (inj as unknown as { _checkHealth(): Promise<void> })._checkHealth();
+    expect(emitted.length).toBe(after);
+    await inj.stop();
+  });
+});
+
+describe("SteamCefBadgeInjector — inject re-entrancy", () => {
+  it("does not run two injects concurrently", async () => {
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamloopback.host/routes/"),
+      tab("Steam Big Picture Mode", "about:blank?browserType=4", "bpm"),
+    ];
+    const inj = makeInjector(() => true);
+    await inj.start();
+    evalCalls = [];
+
+    const inject = () =>
+      (inj as unknown as { _injectBadgeSystem(): Promise<void> })._injectBadgeSystem();
+    await Promise.all([inject(), inject()]);
+
+    const scripts = evalCalls.filter((c) => c.expr.includes("/*bpm-script*/"));
+    expect(scripts.length).toBe(1);
     await inj.stop();
   });
 });

--- a/packages/steam-cef-badges/src/injector.test.ts
+++ b/packages/steam-cef-badges/src/injector.test.ts
@@ -228,26 +228,54 @@ describe("SteamCefBadgeInjector — render-target selection", () => {
     await inj.stop();
   });
 
-  it("falls back to SharedJSContext when it is the only candidate", async () => {
+  it("never renders into SharedJSContext, and says so", async () => {
+    // SharedJSContext is the invisible page (docs/steam-ui-injection.md).
+    // Electing it would draw nothing while reporting everything is fine.
     tabsResponse = [tab("SharedJSContext", "https://steamloopback.host/")];
     const inj = makeInjector(() => true);
     await inj.start();
 
     const sharedEvals = evalCalls.filter((c) => c.wsUrl === "ws://SharedJSContext");
-    expect(sharedEvals.some((c) => c.expr.includes("/*bpm-script*/"))).toBe(true);
+    expect(sharedEvals.some((c) => c.expr.includes("/*bpm-script*/"))).toBe(false);
+    expect(inj.getStatus().detail).toMatch(/no Big Picture window/i);
     await inj.stop();
   });
 
-  it("reads the route from the render tab when SharedJSContext is absent", async () => {
-    tabsResponse = [tab("Steam Big Picture Mode", BPM_WINDOW)];
-    evalResponder = (expr) =>
-      expr.includes("tempNavStore") ? "/library/app/620" : "";
+  it("classifies a BPM window titled \"Steam\" as the window, not the context", async () => {
+    // "Steam" is in SHARED_JS_NAMES, so a desktop-BPM window carrying
+    // browserType=4 would otherwise collapse onto the SharedJSContext key,
+    // evict the real shared context and be excluded from the render tier.
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamloopback.host/", "shared"),
+      tab("Steam", "about:blank?browserType=4", "bpm"),
+      tab("MainMenu_uid2", POPUP),
+    ];
     const inj = makeInjector(() => true);
     await inj.start();
+
+    const bpmEvals = evalCalls.filter((c) => c.wsUrl === "ws://bpm");
+    const menuEvals = evalCalls.filter((c) => c.wsUrl === "ws://MainMenu_uid2");
+    expect(bpmEvals.some((c) => c.expr.includes("/*bpm-script*/"))).toBe(true);
+    expect(menuEvals.some((c) => c.expr.includes("/*bpm-script*/"))).toBe(false);
+    // The real shared context survived under its own key.
+    expect(clientsConstructed).toContain("ws://shared");
+    await inj.stop();
+  });
+
+  it("route polling is a no-op without SharedJSContext, not a badge eviction", async () => {
+    // tempNavStore only exists on SharedJSContext, and BPM's location is
+    // pinned to the entry URL — so reading the route from the render tab
+    // would push a null update and wipe a badge that was on screen.
+    tabsResponse = [tab("Steam Big Picture Mode", BPM_WINDOW)];
+    evalResponder = () => "https://steamloopback.host/index.html";
+    const inj = makeInjector(() => true);
+    await inj.start();
+    evalCalls = [];
+
     await (inj as unknown as { _pollCurrentAppId(): Promise<void> })._pollCurrentAppId();
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(inj.getCurrentAppId()).toBe("620");
+    expect(evalCalls.some((c) => c.expr.includes("update(null)"))).toBe(false);
     await inj.stop();
   });
 });
@@ -319,7 +347,7 @@ describe("SteamCefBadgeInjector — obscured gate", () => {
     expect(
       bpm.some((c) =>
         c.expr.includes(
-          "html.loadout-badges-obscured #test-badge { display: none !important; }",
+          "html.loadout-badges-obscured-test_badges #test-badge { display: none !important; }",
         ),
       ),
     ).toBe(true);

--- a/packages/steam-cef-badges/src/injector.test.ts
+++ b/packages/steam-cef-badges/src/injector.test.ts
@@ -89,7 +89,11 @@ describe("SteamCefBadgeInjector — desktop mode gate (#111)", () => {
     expect(fetchCalls).toEqual([]);
     expect(clientsConstructed).toEqual([]);
     expect(inj.connected).toBe(false);
-    expect(inj.getStatus()).toEqual({ connected: false, tabs: 0 });
+    expect(inj.getStatus()).toEqual({
+      connected: false,
+      tabs: 0,
+      detail: "Steam CEF badges are only available in Gaming Mode.",
+    });
     expect(inj.getCurrentAppId()).toBeNull();
     await inj.stop();
   });
@@ -166,6 +170,88 @@ describe("SteamCefBadgeInjector — Gaming Mode connect + inject", () => {
   });
 });
 
+describe("SteamCefBadgeInjector — render-target selection", () => {
+  // Real SteamOS shape: the Steam menu / QAM / toasts are browser-view
+  // popups; the BPM window is not.
+  const POPUP = "about:blank?browserviewpopup=1&requestid=1&parentpopup=2";
+  const BPM_WINDOW = "about:blank?createflags=6292738&browserType=4";
+
+  it("renders into the BPM window only, never the Steam menu popup", async () => {
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamloopback.host/"),
+      tab("MainMenu_uid2", POPUP),
+      tab("Steam Big Picture Mode", BPM_WINDOW),
+    ];
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    const menuEvals = evalCalls.filter((c) => c.wsUrl === "ws://MainMenu_uid2");
+    const bpmEvals = evalCalls.filter(
+      (c) => c.wsUrl === "ws://Steam Big Picture Mode",
+    );
+    expect(bpmEvals.some((c) => c.expr.includes("/*bpm-script*/"))).toBe(true);
+    expect(menuEvals.some((c) => c.expr.includes("/*bpm-script*/"))).toBe(false);
+    expect(menuEvals.some((c) => c.expr.includes("/*css*/"))).toBe(false);
+    await inj.stop();
+  });
+
+  it("scrubs a badge an earlier build left in the Steam menu popup", async () => {
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamloopback.host/"),
+      tab("MainMenu_uid2", POPUP),
+      tab("Steam Big Picture Mode", BPM_WINDOW),
+    ];
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    const menuEvals = evalCalls.filter((c) => c.wsUrl === "ws://MainMenu_uid2");
+    expect(
+      menuEvals.some(
+        (c) =>
+          c.expr.includes("__test_badges.cleanup()") &&
+          c.expr.includes('getElementById("test-styles")'),
+      ),
+    ).toBe(true);
+    await inj.stop();
+  });
+
+  it("falls back to MainMenu popups when there is no BPM window", async () => {
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamloopback.host/"),
+      tab("MainMenu_uid2", POPUP),
+    ];
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    const menuEvals = evalCalls.filter((c) => c.wsUrl === "ws://MainMenu_uid2");
+    expect(menuEvals.some((c) => c.expr.includes("/*bpm-script*/"))).toBe(true);
+    await inj.stop();
+  });
+
+  it("falls back to SharedJSContext when it is the only candidate", async () => {
+    tabsResponse = [tab("SharedJSContext", "https://steamloopback.host/")];
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    const sharedEvals = evalCalls.filter((c) => c.wsUrl === "ws://SharedJSContext");
+    expect(sharedEvals.some((c) => c.expr.includes("/*bpm-script*/"))).toBe(true);
+    await inj.stop();
+  });
+
+  it("reads the route from the render tab when SharedJSContext is absent", async () => {
+    tabsResponse = [tab("Steam Big Picture Mode", BPM_WINDOW)];
+    evalResponder = (expr) =>
+      expr.includes("tempNavStore") ? "/library/app/620" : "";
+    const inj = makeInjector(() => true);
+    await inj.start();
+    await (inj as unknown as { _pollCurrentAppId(): Promise<void> })._pollCurrentAppId();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(inj.getCurrentAppId()).toBe("620");
+    await inj.stop();
+  });
+});
+
 describe("SteamCefBadgeInjector — route poll + push coalescing", () => {
   beforeEach(() => {
     tabsResponse = [
@@ -212,6 +298,93 @@ describe("SteamCefBadgeInjector — route poll + push coalescing", () => {
   });
 });
 
+describe("SteamCefBadgeInjector — obscured gate", () => {
+  const BPM_WINDOW = "about:blank?createflags=6292738";
+
+  beforeEach(() => {
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamloopback.host/"),
+      tab("Steam Big Picture Mode", BPM_WINDOW),
+    ];
+  });
+
+  it("injects the gate and the hide rule when a selector is configured", async () => {
+    const inj = makeInjector(() => true, {
+      obscuredHideSelector: "#test-badge",
+    });
+    await inj.start();
+
+    const bpm = evalCalls.filter((c) => c.wsUrl === "ws://Steam Big Picture Mode");
+    // Hide rule rides along with the plugin CSS.
+    expect(
+      bpm.some((c) =>
+        c.expr.includes(
+          "html.loadout-badges-obscured #test-badge { display: none !important; }",
+        ),
+      ),
+    ).toBe(true);
+    // Gate listens on standard DOM events only — no Steam globals.
+    const gate = bpm.find((c) => c.expr.includes("__loadout_badge_gate_"));
+    expect(gate).toBeDefined();
+    expect(gate?.expr).toContain('addEventListener("blur"');
+    expect(gate?.expr).toContain('addEventListener("visibilitychange"');
+    expect(gate?.expr).toContain("document.hasFocus()");
+    await inj.stop();
+  });
+
+  it("stays out entirely when no selector is configured", async () => {
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    const bpm = evalCalls.filter((c) => c.wsUrl === "ws://Steam Big Picture Mode");
+    expect(bpm.some((c) => c.expr.includes("__loadout_badge_gate_"))).toBe(false);
+    expect(bpm.some((c) => c.expr.includes("loadout-badges-obscured"))).toBe(false);
+    await inj.stop();
+  });
+
+  it("cleans the gate up on stop()", async () => {
+    const inj = makeInjector(() => true, {
+      obscuredHideSelector: "#test-badge",
+    });
+    await inj.start();
+    evalCalls = [];
+    await inj.stop();
+
+    expect(
+      evalCalls.some((c) =>
+        c.expr.includes("window.__loadout_badge_gate_test_badges.cleanup()"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("SteamCefBadgeInjector — status detail", () => {
+  it("names the debug port when /json is unreachable", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    const inj = makeInjector(() => true);
+    await inj.start();
+
+    const { connected, detail } = inj.getStatus();
+    expect(connected).toBe(false);
+    expect(detail).toContain("8080");
+    expect(detail).toContain(".cef-enable-remote-debugging");
+    await inj.stop();
+  });
+
+  it("clears the detail once badges can render", async () => {
+    tabsResponse = [
+      tab("SharedJSContext", "https://steamloopback.host/"),
+      tab("Steam Big Picture Mode", "about:blank?createflags=6292738"),
+    ];
+    const inj = makeInjector(() => true);
+    await inj.start();
+    expect(inj.getStatus().detail).toBeUndefined();
+    await inj.stop();
+  });
+});
+
 describe("SteamCefBadgeInjector — health prune", () => {
   it("prunes a dead connection and rediscovers", async () => {
     tabsResponse = [
@@ -243,7 +416,7 @@ describe("SteamCefBadgeInjector — cleanup", () => {
     const inj = makeInjector(() => true);
     await inj.start();
     await inj.stop();
-    expect(inj.getStatus()).toEqual({ connected: false, tabs: 0 });
+    expect(inj.getStatus()).toMatchObject({ connected: false, tabs: 0 });
     // restore real fetch for any later suites
     globalThis.fetch = realFetch;
   });

--- a/packages/steam-cef-badges/src/injector.ts
+++ b/packages/steam-cef-badges/src/injector.ts
@@ -44,6 +44,14 @@ export interface SteamCefBadgeInjectorConfig<TBadgeData> {
   /** Full CSS string injected into every tab (BPM + store). Static. */
   css: string;
   /**
+   * CSS selector for the plugin's badge root(s) in the BPM document, e.g.
+   * `"#protondb-badge-container"`. When set, the injector appends a rule
+   * hiding it while the window is obscured — the Steam menu and Quick
+   * Access menu are separate windows drawn over ours, so the badge has to
+   * hide itself rather than sit behind them. Omit to opt out.
+   */
+  obscuredHideSelector?: string;
+  /**
    * Passive BPM renderer IIFE source. Must define
    * `window[bpmGlobalName] = { cleanup, ... }`. The plugin owns the exact
    * surface; the helper only evaluates the string.
@@ -93,10 +101,102 @@ const SHARED_JS_NAMES = [
   "Steam",
 ];
 const BIG_PICTURE_TITLE = "Steam Big Picture Mode";
-/** Steam splits the BPM UI across the parent BPM tab and per-session
- *  `MainMenu_uid<N>` popups; which hosts the visible React UI is
- *  build-dependent, so both are candidate render targets. */
+/** Per-session `MainMenu_uid<N>` popups. On older builds these could host
+ *  the visible React UI, so they stay as a *fallback* render target — but
+ *  never alongside the real BPM window (see `_pickRenderKeys`). */
 const BPM_PREFIX_TARGETS = ["MainMenu"];
+/**
+ * Steam renders the Big Picture chrome — the Steam menu (`MainMenu_uid<N>`),
+ * the Quick Access menu, notification toasts — as *browser-view popups*,
+ * each its own CEF target whose debug URL carries `browserviewpopup=1`.
+ * The main BPM window (which hosts the library / game-detail React tree)
+ * does not. Title-matching alone can't tell them apart, so this marker is
+ * what keeps a `position: fixed` badge out of the Steam menu overlay.
+ */
+const BROWSER_VIEW_POPUP_MARKER = "browserviewpopup=1";
+
+/** Class the obscured-gate parks on `<html>` while the badge should hide. */
+const OBSCURED_CLASS = "loadout-badges-obscured";
+
+/**
+ * Obscured-gate: hides the badge whenever the window it lives in is covered.
+ *
+ * The Steam menu / Quick Access menu are separate OS-level windows composited
+ * *above* the BPM window, so no `z-index` in our document can get behind them
+ * — the badge has to take itself out of the picture instead. Deliberately
+ * built on nothing but `document.visibilityState`, `document.hasFocus()` and
+ * the `focus`/`blur`/`visibilitychange` events: the badge's own document can
+ * tell it has been covered without knowing *what* covered it, so a Steam UI
+ * reshuffle (renamed popups, new overlays, restructured React tree) can't
+ * break it the way selector- or store-sniffing would.
+ *
+ * Fail-open on `hasFocus`: a document that has never once reported focus is
+ * assumed to be a build where Steam doesn't route focus there, and keeps its
+ * badge rather than hiding it forever.
+ *
+ * Settle delay: opening the Steam menu doesn't produce one clean blur — it
+ * bounces focus between the windows several times in under 100ms (measured
+ * on SteamOS, 5 transitions inside one frame budget). Applying every edge
+ * would strobe the badge, so an edge only lands once the state has held for
+ * {@link OBSCURED_SETTLE_MS}; a burst collapses into a single toggle at its
+ * settled value.
+ *
+ * Exported (with the constant) for tests — otherwise only evaluated over CDP.
+ */
+export const OBSCURED_SETTLE_MS = 250;
+
+export function buildObscuredGateScript(pluginId: string): string {
+  const globalKey = `__loadout_badge_gate_${pluginId.replace(/\W/g, "_")}`;
+  return `
+(function() {
+  if (window.${globalKey}) window.${globalKey}.cleanup();
+
+  var everFocused = false;
+  var applied = null;
+  var timer = null;
+
+  function desired() {
+    if (document.hasFocus()) everFocused = true;
+    return (
+      document.visibilityState === "hidden" ||
+      (everFocused && !document.hasFocus())
+    );
+  }
+
+  function apply() {
+    timer = null;
+    var want = desired();
+    if (want === applied) return;
+    applied = want;
+    document.documentElement.classList.toggle("${OBSCURED_CLASS}", want);
+  }
+
+  // Every edge restarts the timer, so only the settled value is applied.
+  function sync() {
+    desired();
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(apply, ${OBSCURED_SETTLE_MS});
+  }
+
+  window.addEventListener("focus", sync);
+  window.addEventListener("blur", sync);
+  document.addEventListener("visibilitychange", sync);
+
+  window.${globalKey} = {
+    cleanup: function() {
+      if (timer) clearTimeout(timer);
+      window.removeEventListener("focus", sync);
+      window.removeEventListener("blur", sync);
+      document.removeEventListener("visibilitychange", sync);
+      document.documentElement.classList.remove("${OBSCURED_CLASS}");
+      delete window.${globalKey};
+    }
+  };
+
+  apply();
+})();
+`;
+}
 
 export class SteamCefBadgeInjector<TBadgeData> {
   private readonly cfg: Required<
@@ -136,12 +236,21 @@ export class SteamCefBadgeInjector<TBadgeData> {
   private pendingPushAppId: string | null = null;
   private pendingPushSet = false;
 
-  /** Candidate BPM render targets — the parent BPM tab and/or MainMenu
-   *  popups. We inject into and push to all of them; only the visible tab
-   *  composites. Refilled by health-check rediscovery when popups die. */
+  /** The tab(s) that host the BPM library UI — where the badge renders.
+   *  Exactly one tier of candidate wins (see `_pickRenderKeys`); refilled
+   *  by health-check rediscovery when the window dies. */
   private bpmRenderKeys: string[] = [];
 
+  /** Connected-but-not-rendering tabs (the Steam menu popups, and
+   *  SharedJSContext when it isn't the render target). We scrub any badge
+   *  runtime out of these — a Loadout update lands mid-Steam-session, so a
+   *  tab an older build injected into keeps its badge until we remove it. */
+  private purgeKeys: string[] = [];
+
   private injectDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Why the last `_tryConnect` gave up, surfaced through `getStatus()`. */
+  private lastConnectError: string | null = null;
 
   constructor(config: SteamCefBadgeInjectorConfig<TBadgeData>) {
     this.cfg = {
@@ -209,6 +318,7 @@ export class SteamCefBadgeInjector<TBadgeData> {
     }
     this.connections.clear();
     this.bpmRenderKeys = [];
+    this.purgeKeys = [];
     this._connected = false;
   }
 
@@ -229,6 +339,7 @@ export class SteamCefBadgeInjector<TBadgeData> {
     }
     this.connections.clear();
     this.bpmRenderKeys = [];
+    this.purgeKeys = [];
     this._connected = false;
 
     const ok = await this._tryConnect();
@@ -238,12 +349,31 @@ export class SteamCefBadgeInjector<TBadgeData> {
     }
     return {
       success: false,
-      error: "Could not connect to Steam CEF. Is Steam running?",
+      error:
+        this.lastConnectError ?? "Could not connect to Steam CEF. Is Steam running?",
     };
   }
 
-  getStatus(): { connected: boolean; tabs: number } {
-    return { connected: this._connected, tabs: this.connections.size };
+  /** `detail` is the human-readable reason badges aren't showing — the
+   *  "connected" dot alone can't distinguish desktop mode from a Steam
+   *  that never opened its debug port, and both look identical to a user
+   *  who just sees no badges. `undefined` once badges can render. */
+  getStatus(): { connected: boolean; tabs: number; detail?: string } {
+    const detail = this._statusDetail();
+    return {
+      connected: this._connected,
+      tabs: this.connections.size,
+      ...(detail ? { detail } : {}),
+    };
+  }
+
+  private _statusDetail(): string | undefined {
+    if (this.lastConnectError) return this.lastConnectError;
+    if (!this._connected) return "Not connected to Steam.";
+    if (this.bpmRenderKeys.length === 0) {
+      return "Connected, but no Big Picture window was found to draw into.";
+    }
+    return undefined;
   }
 
   getCurrentAppId(): string | null {
@@ -270,7 +400,10 @@ export class SteamCefBadgeInjector<TBadgeData> {
 
   private async _pollCurrentAppId(): Promise<void> {
     if (this.polling) return;
-    const conn = this.connections.get("SharedJSContext");
+    // SharedJSContext owns `tempNavStore` on every build that has one; the
+    // render tab is the fallback for builds that don't expose it there, so
+    // a missing shared context isn't a silent "no badges ever".
+    const conn = this._routeConn();
     if (!conn || !conn.client.connected) return;
 
     this.polling = true;
@@ -291,6 +424,17 @@ export class SteamCefBadgeInjector<TBadgeData> {
     } finally {
       this.polling = false;
     }
+  }
+
+  /** Tab the route is read from: SharedJSContext, else the render tab. */
+  private _routeConn(): CDPConnection | undefined {
+    const shared = this.connections.get("SharedJSContext");
+    if (shared?.client.connected) return shared;
+    for (const key of this.bpmRenderKeys) {
+      const conn = this.connections.get(key);
+      if (conn?.client.connected) return conn;
+    }
+    return undefined;
   }
 
   /** Fetch badge data server-side and push it into the BPM tab(s) via CDP. */
@@ -351,6 +495,8 @@ export class SteamCefBadgeInjector<TBadgeData> {
     // Covers start(), health rediscovery and reconnect() — all funnel here.
     if (!(await this.isGameMode())) {
       this._connected = false;
+      this.lastConnectError =
+        "Steam CEF badges are only available in Gaming Mode.";
       return false;
     }
     try {
@@ -371,6 +517,7 @@ export class SteamCefBadgeInjector<TBadgeData> {
       }
       this.connections.clear();
       this.bpmRenderKeys = [];
+      this.purgeKeys = [];
 
       const exactTargets = [...SHARED_JS_NAMES, BIG_PICTURE_TITLE];
 
@@ -379,12 +526,13 @@ export class SteamCefBadgeInjector<TBadgeData> {
       // an exact/prefix target (which would orphan one socket from
       // health-check pruning, since the two are stored under different keys).
       const connectedTabIds = new Set<string>();
+      const candidates: { key: string; tab: CefTab }[] = [];
 
       for (const tab of tabs) {
         if (!tab.webSocketDebuggerUrl) continue;
 
         const isExact = exactTargets.includes(tab.title);
-        const prefixHit = BPM_PREFIX_TARGETS.find((p) => tab.title.startsWith(p));
+        const prefixHit = BPM_PREFIX_TARGETS.some((p) => tab.title.startsWith(p));
         if (!isExact && !prefixHit) continue;
 
         try {
@@ -396,13 +544,19 @@ export class SteamCefBadgeInjector<TBadgeData> {
             : tab.title;
           this.connections.set(key, conn);
           connectedTabIds.add(tab.id);
-          if (prefixHit === "MainMenu" || tab.title === BIG_PICTURE_TITLE) {
-            this.bpmRenderKeys.push(key);
-          }
+          candidates.push({ key, tab });
           this.log(`Connected to: ${tab.title} (key: ${key})`);
         } catch (err) {
           this.warn(`Failed to connect to ${tab.title}:`, err);
         }
+      }
+
+      this.bpmRenderKeys = this._pickRenderKeys(candidates);
+      this.purgeKeys = candidates
+        .map((c) => c.key)
+        .filter((k) => !this.bpmRenderKeys.includes(k));
+      if (this.bpmRenderKeys.length > 0) {
+        this.log(`Badge render target: ${this.bpmRenderKeys.join(", ")}`);
       }
 
       // Also connect to Steam store tabs (store.steampowered.com).
@@ -422,12 +576,60 @@ export class SteamCefBadgeInjector<TBadgeData> {
 
       this._connected =
         this.connections.has("SharedJSContext") || this.bpmRenderKeys.length > 0;
+      this.lastConnectError = this._connected
+        ? null
+        : "Steam is running but exposed no Big Picture tab to inject into.";
       this._emitState();
       return this._connected;
     } catch {
       this._connected = false;
+      // Overwhelmingly the cause when Steam is up: the debug port was never
+      // opened, so /json refuses the connection.
+      this.lastConnectError =
+        `Steam's CEF debug port (${this.cfg.debugPort}) is not reachable. ` +
+        "Create an empty `.cef-enable-remote-debugging` file in Steam's root " +
+        "(~/.steam/steam or ~/.local/share/Steam) and restart Steam.";
       return false;
     }
+  }
+
+  /**
+   * Pick the tab(s) the badge renders into, in strict preference order —
+   * the first tier that yields anything wins, and the rest are purged.
+   *
+   * The badge is a `position: fixed` child of `document.body`, so it draws
+   * over *whatever* that document shows. Injecting into every candidate
+   * ("only the visible one composites") was wrong: the Steam menu is its
+   * own always-live popup document, so on current SteamOS builds the badge
+   * showed up inside the menu as well as on the game page (issue: badges
+   * injected into the Steam menu).
+   *
+   *   1. The real BPM window — `Steam Big Picture Mode`, and not a
+   *      browser-view popup. This is where the library / game-detail React
+   *      tree lives on current builds.
+   *   2. `MainMenu_uid<N>` popups — legacy builds with no separate BPM
+   *      window, where the popup *was* the whole UI.
+   *   3. SharedJSContext — builds that run the UI in the shared context
+   *      with popups disabled. Without this tier such a setup discovers no
+   *      render target at all and silently shows no badges anywhere.
+   */
+  private _pickRenderKeys(candidates: { key: string; tab: CefTab }[]): string[] {
+    const isPopup = (t: CefTab) => t.url.includes(BROWSER_VIEW_POPUP_MARKER);
+    const isMenu = (t: CefTab) => BPM_PREFIX_TARGETS.some((p) => t.title.startsWith(p));
+
+    // Not keyed off the BPM title alone: if Valve renames the window, a
+    // non-popup candidate still beats the menu popups rather than falling
+    // through to tier 2 and putting the badge back in the Steam menu.
+    const bpmWindow = candidates.filter(
+      (c) => c.key !== "SharedJSContext" && !isPopup(c.tab) && !isMenu(c.tab),
+    );
+    if (bpmWindow.length > 0) return bpmWindow.map((c) => c.key);
+
+    const mainMenu = candidates.filter((c) => isMenu(c.tab));
+    if (mainMenu.length > 0) return mainMenu.map((c) => c.key);
+
+    const shared = candidates.filter((c) => c.key === "SharedJSContext");
+    return shared.map((c) => c.key);
   }
 
   private async _openCDP(wsUrl: string, tabTitle: string): Promise<CDPConnection> {
@@ -463,8 +665,30 @@ export class SteamCefBadgeInjector<TBadgeData> {
     );
   }
 
+  /** Plugin CSS + the rule the obscured-gate toggles. */
+  private _bpmCss(): string {
+    const sel = this.cfg.obscuredHideSelector;
+    if (!sel) return this.cfg.css;
+    return `${this.cfg.css}
+html.${OBSCURED_CLASS} ${sel} { display: none !important; }
+`;
+  }
+
   private async _injectBadgeSystem(): Promise<void> {
-    const css = this.cfg.css;
+    const css = this._bpmCss();
+
+    // Scrub tabs we deliberately don't render into. A Loadout update lands
+    // mid-Steam-session, so a Steam-menu popup an older build injected into
+    // still has its badge + <style> until we take them back out.
+    for (const key of this.purgeKeys) {
+      const conn = this.connections.get(key);
+      if (!conn || !conn.client.connected) continue;
+      try {
+        await this._removeFromTab(conn);
+      } catch {
+        /* best effort — nothing to remove is the common case */
+      }
+    }
 
     // Inject into every candidate BPM render tab — only the visible one
     // composites; hidden tabs update their off-screen DOM harmlessly.
@@ -481,6 +705,9 @@ export class SteamCefBadgeInjector<TBadgeData> {
         try {
           await this._injectCSSToTab(conn, css);
           await this._cdpEvaluate(conn, this.cfg.bpmScript);
+          if (this.cfg.obscuredHideSelector) {
+            await this._cdpEvaluate(conn, buildObscuredGateScript(this.cfg.pluginId));
+          }
           this.log(`Injected badge system into ${t.key}`);
         } catch (err) {
           this.warn(`Failed to inject into ${t.key}:`, err);
@@ -523,19 +750,26 @@ export class SteamCefBadgeInjector<TBadgeData> {
     }
   }
 
+  /** Tear the badge runtime, the obscured-gate and `<style>` back out of one tab. */
+  private _removeFromTab(conn: CDPConnection): Promise<unknown> {
+    const { bpmGlobalName, storeGlobalName, styleId, pluginId } = this.cfg;
+    const gateKey = `__loadout_badge_gate_${pluginId.replace(/\W/g, "_")}`;
+    return this._cdpEvaluate(
+      conn,
+      `
+      if (window.${bpmGlobalName}) { window.${bpmGlobalName}.cleanup(); delete window.${bpmGlobalName}; }
+      if (window.${storeGlobalName}) { window.${storeGlobalName}.cleanup(); delete window.${storeGlobalName}; }
+      if (window.${gateKey}) window.${gateKey}.cleanup();
+      var s = document.getElementById("${styleId}"); if (s) s.remove();
+    `,
+    );
+  }
+
   private async _removeBadgeSystem(): Promise<void> {
-    const { bpmGlobalName, storeGlobalName, styleId } = this.cfg;
     for (const conn of this.connections.values()) {
       if (!conn.client.connected) continue;
       try {
-        await this._cdpEvaluate(
-          conn,
-          `
-          if (window.${bpmGlobalName}) window.${bpmGlobalName}.cleanup();
-          if (window.${storeGlobalName}) window.${storeGlobalName}.cleanup();
-          var s = document.getElementById("${styleId}"); if (s) s.remove();
-        `,
-        );
+        await this._removeFromTab(conn);
       } catch {
         /* best effort */
       }
@@ -556,6 +790,7 @@ export class SteamCefBadgeInjector<TBadgeData> {
         if (!conn.client.connected) {
           this.connections.delete(key);
           this.bpmRenderKeys = this.bpmRenderKeys.filter((k) => k !== key);
+          this.purgeKeys = this.purgeKeys.filter((k) => k !== key);
           this.log(`Pruned dead connection: ${key}`);
         }
       }

--- a/packages/steam-cef-badges/src/injector.ts
+++ b/packages/steam-cef-badges/src/injector.ts
@@ -74,8 +74,14 @@ export interface SteamCefBadgeInjectorConfig<TBadgeData> {
    */
   buildBpmUpdateExpr: (data: TBadgeData | null) => string;
 
-  /** Notified whenever `{connected, tabs}` changes so the plugin can emit. */
-  onStateChange?: (state: { connected: boolean; tabs: number }) => void;
+  /** Notified whenever `{connected, tabs, detail}` changes so the plugin can
+   *  emit. `detail` mirrors `getStatus().detail` — the reason badges aren't
+   *  showing, or `undefined` once they can. */
+  onStateChange?: (state: {
+    connected: boolean;
+    tabs: number;
+    detail?: string;
+  }) => void;
 
   log?: (msg: string, ...args: unknown[]) => void;
   warn?: (msg: string, ...args: unknown[]) => void;
@@ -115,8 +121,53 @@ const BPM_PREFIX_TARGETS = ["MainMenu"];
  */
 const BROWSER_VIEW_POPUP_MARKER = "browserviewpopup=1";
 
-/** Class the obscured-gate parks on `<html>` while the badge should hide. */
-const OBSCURED_CLASS = "loadout-badges-obscured";
+/** Steam's own marker for a Big Picture browser window. */
+const BPM_BROWSER_TYPE = "browserType=4";
+
+/** A chrome popup — the Steam menu, QAM, toasts. Never a render target. */
+function isBrowserViewPopup(tab: CefTab): boolean {
+  return tab.url.includes(BROWSER_VIEW_POPUP_MARKER);
+}
+
+/** A `MainMenu_uid<N>`-style popup by title. */
+function isMenuPopup(tab: CefTab): boolean {
+  return BPM_PREFIX_TARGETS.some((p) => tab.title.startsWith(p));
+}
+
+/**
+ * The main Big Picture window — the one hosting the library / game-detail
+ * DOM. Mirrors `isBigPictureMode` in apps/loadout/src/injector/tabs.ts:
+ * Gaming Mode titles it "Steam Big Picture Mode", desktop BPM titles it
+ * "Steam" and marks it with `browserType=4`. Popups are excluded outright
+ * so a renamed popup can never be mistaken for the window.
+ */
+function isBigPictureWindow(tab: CefTab): boolean {
+  if (isBrowserViewPopup(tab) || isMenuPopup(tab)) return false;
+  if (tab.title === BIG_PICTURE_TITLE) return true;
+  return tab.title === "Steam" && tab.url.includes(BPM_BROWSER_TYPE);
+}
+
+/** Tabs worth opening a socket to: the BPM window, the shared context (for
+ *  route polling) and menu popups (so we can scrub old builds' badges). */
+function isBadgeCandidate(tab: CefTab): boolean {
+  return (
+    isBigPictureWindow(tab) ||
+    SHARED_JS_NAMES.includes(tab.title) ||
+    isMenuPopup(tab)
+  );
+}
+
+/** Per-plugin class the obscured-gate parks on `<html>` while hiding.
+ *  Namespaced: two plugins gate the same document independently, and a
+ *  shared class let either one's teardown un-hide the other's badge. */
+function obscuredClass(safeId: string): string {
+  return `loadout-badges-obscured-${safeId}`;
+}
+
+/** `pluginId` reduced to a JS-identifier-safe token for globals/classes. */
+function safePluginId(pluginId: string): string {
+  return pluginId.replace(/\W/g, "_");
+}
 
 /**
  * Obscured-gate: hides the badge whenever the window it lives in is covered.
@@ -141,18 +192,30 @@ const OBSCURED_CLASS = "loadout-badges-obscured";
  * {@link OBSCURED_SETTLE_MS}; a burst collapses into a single toggle at its
  * settled value.
  *
+ * Re-arm carries state across: `_injectBadgeSystem` re-runs this script on
+ * every rediscovery, and a naive re-arm resets `everFocused` to false. While
+ * the Steam menu is open that reads as "never focused" ⇒ fail-open ⇒ the
+ * class comes off and the badge draws over the menu again — the original bug,
+ * reintroduced by a health blip. So the previous gate's `everFocused` and the
+ * already-applied class are both inherited.
+ *
  * Exported (with the constant) for tests — otherwise only evaluated over CDP.
  */
 export const OBSCURED_SETTLE_MS = 250;
 
 export function buildObscuredGateScript(pluginId: string): string {
-  const globalKey = `__loadout_badge_gate_${pluginId.replace(/\W/g, "_")}`;
+  const safeId = safePluginId(pluginId);
+  const globalKey = `__loadout_badge_gate_${safeId}`;
+  const cls = obscuredClass(safeId);
   return `
 (function() {
-  if (window.${globalKey}) window.${globalKey}.cleanup();
+  var root = document.documentElement;
+  var prev = window.${globalKey};
+  // Inherit across re-arm (see "Re-arm carries state across" above).
+  var everFocused = prev && prev.wasEverFocused ? prev.wasEverFocused() : false;
+  if (prev) prev.cleanup();
 
-  var everFocused = false;
-  var applied = null;
+  var applied = false;
   var timer = null;
 
   function desired() {
@@ -168,7 +231,7 @@ export function buildObscuredGateScript(pluginId: string): string {
     var want = desired();
     if (want === applied) return;
     applied = want;
-    document.documentElement.classList.toggle("${OBSCURED_CLASS}", want);
+    root.classList.toggle("${cls}", want);
   }
 
   // Every edge restarts the timer, so only the settled value is applied.
@@ -183,16 +246,20 @@ export function buildObscuredGateScript(pluginId: string): string {
   document.addEventListener("visibilitychange", sync);
 
   window.${globalKey} = {
+    wasEverFocused: function() { return everFocused; },
     cleanup: function() {
       if (timer) clearTimeout(timer);
       window.removeEventListener("focus", sync);
       window.removeEventListener("blur", sync);
       document.removeEventListener("visibilitychange", sync);
-      document.documentElement.classList.remove("${OBSCURED_CLASS}");
+      root.classList.remove("${cls}");
       delete window.${globalKey};
     }
   };
 
+  // Re-assert immediately: cleanup above dropped any inherited class, and
+  // the inherited everFocused puts it straight back within this same
+  // evaluation, so there is no gap where the badge shows over the menu.
   apply();
 })();
 `;
@@ -251,6 +318,16 @@ export class SteamCefBadgeInjector<TBadgeData> {
 
   /** Why the last `_tryConnect` gave up, surfaced through `getStatus()`. */
   private lastConnectError: string | null = null;
+
+  /** Scrub non-render tabs on the next inject only. The stale badge a purge
+   *  clears is a one-off migration (an update landing mid-Steam-session), so
+   *  it runs once per discovery rather than on every debounced re-inject. */
+  private purgePending = false;
+
+  /** Last `{connected, detail}` handed to `onStateChange`, so failure paths
+   *  can emit the new reason without re-emitting an unchanged one. */
+  private lastEmittedDetail: string | null = null;
+  private lastEmittedConnected: boolean | null = null;
 
   constructor(config: SteamCefBadgeInjectorConfig<TBadgeData>) {
     this.cfg = {
@@ -320,15 +397,19 @@ export class SteamCefBadgeInjector<TBadgeData> {
     this.bpmRenderKeys = [];
     this.purgeKeys = [];
     this._connected = false;
+    this.lastConnectError = null;
   }
 
   /** Manual reconnect (RPC). Returns a Gaming-Mode error in desktop mode. */
   async reconnect(): Promise<{ success: boolean; error?: string }> {
     if (!(await this.isGameMode())) {
-      return {
-        success: false,
-        error: "Steam CEF badges are only available in Gaming Mode.",
-      };
+      // Reflect it in the status too — returning only a toast leaves the dot
+      // reading "Connected (3 tabs)" after a Gaming→Desktop switch.
+      this._connected = false;
+      this.lastConnectError =
+        "Steam CEF badges are only available in Gaming Mode.";
+      this._emitStateIfChanged();
+      return { success: false, error: this.lastConnectError };
     }
     for (const conn of this.connections.values()) {
       try {
@@ -426,15 +507,17 @@ export class SteamCefBadgeInjector<TBadgeData> {
     }
   }
 
-  /** Tab the route is read from: SharedJSContext, else the render tab. */
+  /**
+   * Tab the route is read from. SharedJSContext only — `tempNavStore` lives
+   * there, and in BPM `window.location` is pinned to the entry URL forever.
+   * Falling back to the render tab therefore reads a pathname that can never
+   * match a game route, which would push a `null` update and evict a badge
+   * that was on screen. Health rediscovery reconnects the shared context
+   * instead; until it does, the last-pushed badge simply stays put.
+   */
   private _routeConn(): CDPConnection | undefined {
     const shared = this.connections.get("SharedJSContext");
-    if (shared?.client.connected) return shared;
-    for (const key of this.bpmRenderKeys) {
-      const conn = this.connections.get(key);
-      if (conn?.client.connected) return conn;
-    }
-    return undefined;
+    return shared?.client.connected ? shared : undefined;
   }
 
   /** Fetch badge data server-side and push it into the BPM tab(s) via CDP. */
@@ -497,6 +580,7 @@ export class SteamCefBadgeInjector<TBadgeData> {
       this._connected = false;
       this.lastConnectError =
         "Steam CEF badges are only available in Gaming Mode.";
+      this._emitStateIfChanged();
       return false;
     }
     try {
@@ -519,8 +603,6 @@ export class SteamCefBadgeInjector<TBadgeData> {
       this.bpmRenderKeys = [];
       this.purgeKeys = [];
 
-      const exactTargets = [...SHARED_JS_NAMES, BIG_PICTURE_TITLE];
-
       // Tabs we've already opened a socket to this pass — so the store loop
       // below never opens a second WebSocket to a tab that already matched
       // an exact/prefix target (which would orphan one socket from
@@ -530,18 +612,26 @@ export class SteamCefBadgeInjector<TBadgeData> {
 
       for (const tab of tabs) {
         if (!tab.webSocketDebuggerUrl) continue;
+        if (!isBadgeCandidate(tab)) continue;
 
-        const isExact = exactTargets.includes(tab.title);
-        const prefixHit = BPM_PREFIX_TARGETS.some((p) => tab.title.startsWith(p));
-        if (!isExact && !prefixHit) continue;
+        // A BPM window titled "Steam" is in SHARED_JS_NAMES too — classify it
+        // as the window, or it collapses onto the SharedJSContext key, evicts
+        // the real shared context and is then excluded from tier 1.
+        const key = isBigPictureWindow(tab)
+          ? tab.title
+          : SHARED_JS_NAMES.includes(tab.title)
+            ? "SharedJSContext"
+            : tab.title;
+        // Two tabs can reduce to one key (e.g. "SP" and "Steam" both meaning
+        // SharedJSContext). Keep the first and leave the rest alone rather
+        // than opening a socket we'd immediately orphan.
+        if (this.connections.has(key)) {
+          this.log(`Ignoring duplicate ${key} target: ${tab.title}`);
+          continue;
+        }
 
         try {
           const conn = await this._openCDP(tab.webSocketDebuggerUrl, tab.title);
-          // Collapse SharedJSContext title variants to one canonical key;
-          // MainMenu popups keep their per-session title.
-          const key = SHARED_JS_NAMES.includes(tab.title)
-            ? "SharedJSContext"
-            : tab.title;
           this.connections.set(key, conn);
           connectedTabIds.add(tab.id);
           candidates.push({ key, tab });
@@ -555,9 +645,18 @@ export class SteamCefBadgeInjector<TBadgeData> {
       this.purgeKeys = candidates
         .map((c) => c.key)
         .filter((k) => !this.bpmRenderKeys.includes(k));
-      if (this.bpmRenderKeys.length > 0) {
-        this.log(`Badge render target: ${this.bpmRenderKeys.join(", ")}`);
-      }
+      // Log the whole target list once per discovery: which tab hosts the
+      // visible UI is build-dependent, so a field report of "no badges" is
+      // only diagnosable if we recorded what Steam actually offered.
+      this.log(
+        `Discovered targets: ${tabs.map((t) => `"${t.title}" (${t.url})`).join(", ")}`,
+      );
+      this.log(
+        this.bpmRenderKeys.length > 0
+          ? `Badge render target: ${this.bpmRenderKeys.join(", ")}`
+          : "No badge render target — badges will not appear.",
+      );
+      this.purgePending = true;
 
       // Also connect to Steam store tabs (store.steampowered.com).
       for (const tab of tabs) {
@@ -589,6 +688,7 @@ export class SteamCefBadgeInjector<TBadgeData> {
         `Steam's CEF debug port (${this.cfg.debugPort}) is not reachable. ` +
         "Create an empty `.cef-enable-remote-debugging` file in Steam's root " +
         "(~/.steam/steam or ~/.local/share/Steam) and restart Steam.";
+      this._emitStateIfChanged();
       return false;
     }
   }
@@ -601,35 +701,24 @@ export class SteamCefBadgeInjector<TBadgeData> {
    * over *whatever* that document shows. Injecting into every candidate
    * ("only the visible one composites") was wrong: the Steam menu is its
    * own always-live popup document, so on current SteamOS builds the badge
-   * showed up inside the menu as well as on the game page (issue: badges
-   * injected into the Steam menu).
+   * showed up inside the menu as well as on the game page.
    *
-   *   1. The real BPM window — `Steam Big Picture Mode`, and not a
-   *      browser-view popup. This is where the library / game-detail React
-   *      tree lives on current builds.
+   *   1. The main Big Picture window — see {@link isBigPictureWindow}.
+   *      Hosts the library / game-detail React tree on current builds.
    *   2. `MainMenu_uid<N>` popups — legacy builds with no separate BPM
    *      window, where the popup *was* the whole UI.
-   *   3. SharedJSContext — builds that run the UI in the shared context
-   *      with popups disabled. Without this tier such a setup discovers no
-   *      render target at all and silently shows no badges anywhere.
+   *
+   * There is deliberately no SharedJSContext tier. It is documented as the
+   * invisible page (docs/ui-modding-framework.md, docs/steam-ui-injection.md)
+   * — rendering there draws nothing, and because `_connected` is true
+   * whenever it is present, electing it would also mask the "no render
+   * target" diagnostic that tells the user what is actually wrong.
    */
   private _pickRenderKeys(candidates: { key: string; tab: CefTab }[]): string[] {
-    const isPopup = (t: CefTab) => t.url.includes(BROWSER_VIEW_POPUP_MARKER);
-    const isMenu = (t: CefTab) => BPM_PREFIX_TARGETS.some((p) => t.title.startsWith(p));
-
-    // Not keyed off the BPM title alone: if Valve renames the window, a
-    // non-popup candidate still beats the menu popups rather than falling
-    // through to tier 2 and putting the badge back in the Steam menu.
-    const bpmWindow = candidates.filter(
-      (c) => c.key !== "SharedJSContext" && !isPopup(c.tab) && !isMenu(c.tab),
-    );
+    const bpmWindow = candidates.filter((c) => isBigPictureWindow(c.tab));
     if (bpmWindow.length > 0) return bpmWindow.map((c) => c.key);
 
-    const mainMenu = candidates.filter((c) => isMenu(c.tab));
-    if (mainMenu.length > 0) return mainMenu.map((c) => c.key);
-
-    const shared = candidates.filter((c) => c.key === "SharedJSContext");
-    return shared.map((c) => c.key);
+    return candidates.filter((c) => isMenuPopup(c.tab)).map((c) => c.key);
   }
 
   private async _openCDP(wsUrl: string, tabTitle: string): Promise<CDPConnection> {
@@ -670,7 +759,7 @@ export class SteamCefBadgeInjector<TBadgeData> {
     const sel = this.cfg.obscuredHideSelector;
     if (!sel) return this.cfg.css;
     return `${this.cfg.css}
-html.${OBSCURED_CLASS} ${sel} { display: none !important; }
+html.${obscuredClass(safePluginId(this.cfg.pluginId))} ${sel} { display: none !important; }
 `;
   }
 
@@ -679,8 +768,11 @@ html.${OBSCURED_CLASS} ${sel} { display: none !important; }
 
     // Scrub tabs we deliberately don't render into. A Loadout update lands
     // mid-Steam-session, so a Steam-menu popup an older build injected into
-    // still has its badge + <style> until we take them back out.
-    for (const key of this.purgeKeys) {
+    // still has its badge + <style> until we take them back out. One-off per
+    // discovery — a settings re-inject has nothing new to clear.
+    const purgeKeys = this.purgePending ? this.purgeKeys : [];
+    this.purgePending = false;
+    for (const key of purgeKeys) {
       const conn = this.connections.get(key);
       if (!conn || !conn.client.connected) continue;
       try {
@@ -753,7 +845,7 @@ html.${OBSCURED_CLASS} ${sel} { display: none !important; }
   /** Tear the badge runtime, the obscured-gate and `<style>` back out of one tab. */
   private _removeFromTab(conn: CDPConnection): Promise<unknown> {
     const { bpmGlobalName, storeGlobalName, styleId, pluginId } = this.cfg;
-    const gateKey = `__loadout_badge_gate_${pluginId.replace(/\W/g, "_")}`;
+    const gateKey = `__loadout_badge_gate_${safePluginId(pluginId)}`;
     return this._cdpEvaluate(
       conn,
       `
@@ -799,7 +891,14 @@ html.${OBSCURED_CLASS} ${sel} { display: none !important; }
       this._connected =
         this.connections.has("SharedJSContext") || this.bpmRenderKeys.length > 0;
 
-      if (!this._connected || this.bpmRenderKeys.length === 0) {
+      // Rediscover when we lack a render target OR the shared context — the
+      // latter is the only place the route can be read, so losing it alone
+      // (BPM socket still alive) would otherwise freeze the badge silently.
+      if (
+        !this._connected ||
+        this.bpmRenderKeys.length === 0 ||
+        !this.connections.has("SharedJSContext")
+      ) {
         if (wasConnected && !this._connected) this._emitState();
         // Re-run discovery (gated inside _tryConnect) so a reopened BPM or a
         // freshly-started Steam reconnects without a manual nudge.
@@ -811,10 +910,24 @@ html.${OBSCURED_CLASS} ${sel} { display: none !important; }
     }
   }
 
+  /** Emit only when the user-visible state actually moved. */
+  private _emitStateIfChanged(): void {
+    if (
+      (this._statusDetail() ?? null) === this.lastEmittedDetail &&
+      this._connected === this.lastEmittedConnected
+    ) {
+      return;
+    }
+    this._emitState();
+  }
+
   private _emitState(): void {
+    this.lastEmittedDetail = this._statusDetail() ?? null;
+    this.lastEmittedConnected = this._connected;
     this.cfg.onStateChange?.({
       connected: this._connected,
       tabs: this.connections.size,
+      detail: this._statusDetail(),
     });
   }
 }

--- a/packages/steam-cef-badges/src/injector.ts
+++ b/packages/steam-cef-badges/src/injector.ts
@@ -124,6 +124,9 @@ const BROWSER_VIEW_POPUP_MARKER = "browserviewpopup=1";
 /** Steam's own marker for a Big Picture browser window. */
 const BPM_BROWSER_TYPE = "browserType=4";
 
+/** Ceiling on the rediscovery back-off, in health ticks (~5s each). */
+const MAX_DISCOVERY_SKIPS = 63;
+
 /** A chrome popup — the Steam menu, QAM, toasts. Never a render target. */
 function isBrowserViewPopup(tab: CefTab): boolean {
   return tab.url.includes(BROWSER_VIEW_POPUP_MARKER);
@@ -147,12 +150,40 @@ function isBigPictureWindow(tab: CefTab): boolean {
   return tab.title === "Steam" && tab.url.includes(BPM_BROWSER_TYPE);
 }
 
+/** URL patterns the GamepadUI / shared context is served from. */
+const LOOPBACK_URL_PATTERNS = [
+  "https://steamloopback.host/routes/",
+  "https://steamloopback.host/index.html",
+];
+
+/**
+ * The shared JS context. Mirrors `isSharedJSContext` in
+ * apps/loadout/src/injector/tabs.ts: title alone is not enough, because
+ * `SHARED_JS_NAMES` contains generic titles ("Steam", "SP") that an ordinary
+ * steamcommunity.com tab can also carry. Matching those loosely lets a decoy
+ * claim the key and evict the real context.
+ */
+function isSharedContext(tab: CefTab): boolean {
+  if (!SHARED_JS_NAMES.includes(tab.title)) return false;
+  return LOOPBACK_URL_PATTERNS.some((u) => tab.url.includes(u));
+}
+
+/** How strongly a tab claims the SharedJSContext key. Higher wins, so a
+ *  loosely-matching decoy can never displace the canonical target
+ *  regardless of the order Steam lists them in. */
+function sharedContextRank(tab: CefTab): number {
+  if (tab.title === "SharedJSContext" && isSharedContext(tab)) return 3;
+  if (isSharedContext(tab)) return 2;
+  if (tab.title === "SharedJSContext") return 1;
+  return 0;
+}
+
 /** Tabs worth opening a socket to: the BPM window, the shared context (for
  *  route polling) and menu popups (so we can scrub old builds' badges). */
 function isBadgeCandidate(tab: CefTab): boolean {
   return (
     isBigPictureWindow(tab) ||
-    SHARED_JS_NAMES.includes(tab.title) ||
+    sharedContextRank(tab) > 0 ||
     isMenuPopup(tab)
   );
 }
@@ -324,10 +355,21 @@ export class SteamCefBadgeInjector<TBadgeData> {
    *  it runs once per discovery rather than on every debounced re-inject. */
   private purgePending = false;
 
+  /** Health ticks still to skip before the next discovery attempt. */
+  private discoverySkips = 0;
+  /** Current back-off size. Kept separate from the countdown above — sharing
+   *  one field means the ratchet is read back after being decremented to
+   *  zero, so it never actually grows. Ratchets 1, 3, 7, 15, 31, 63. */
+  private discoveryBackoff = 0;
+
+  /** Guards `_injectBadgeSystem` against overlapping runs. */
+  private injecting = false;
+
   /** Last `{connected, detail}` handed to `onStateChange`, so failure paths
    *  can emit the new reason without re-emitting an unchanged one. */
   private lastEmittedDetail: string | null = null;
   private lastEmittedConnected: boolean | null = null;
+  private lastEmittedTabs: number | null = null;
 
   constructor(config: SteamCefBadgeInjectorConfig<TBadgeData>) {
     this.cfg = {
@@ -398,6 +440,16 @@ export class SteamCefBadgeInjector<TBadgeData> {
     this.purgeKeys = [];
     this._connected = false;
     this.lastConnectError = null;
+    this.currentAppId = null;
+    this.purgePending = false;
+    this.discoverySkips = 0;
+    this.discoveryBackoff = 0;
+    // Announce the shutdown, then forget what we announced — a later start()
+    // must be free to emit the same values again.
+    this._emitStateIfChanged();
+    this.lastEmittedDetail = null;
+    this.lastEmittedConnected = null;
+    this.lastEmittedTabs = null;
   }
 
   /** Manual reconnect (RPC). Returns a Gaming-Mode error in desktop mode. */
@@ -454,6 +506,12 @@ export class SteamCefBadgeInjector<TBadgeData> {
     if (this.bpmRenderKeys.length === 0) {
       return "Connected, but no Big Picture window was found to draw into.";
     }
+    if (!this.connections.has("SharedJSContext")) {
+      // Render target but no route source: the badge can never be told which
+      // game is on screen, so nothing appears. Without this clause the status
+      // reads as healthy while showing no badges at all.
+      return "Connected to the Big Picture window, but not to Steam's shared context — the game you're viewing can't be detected.";
+    }
     return undefined;
   }
 
@@ -481,9 +539,7 @@ export class SteamCefBadgeInjector<TBadgeData> {
 
   private async _pollCurrentAppId(): Promise<void> {
     if (this.polling) return;
-    // SharedJSContext owns `tempNavStore` on every build that has one; the
-    // render tab is the fallback for builds that don't expose it there, so
-    // a missing shared context isn't a silent "no badges ever".
+    // SharedJSContext only — see _routeConn for why there is no fallback.
     const conn = this._routeConn();
     if (!conn || !conn.client.connected) return;
 
@@ -608,28 +664,34 @@ export class SteamCefBadgeInjector<TBadgeData> {
       // an exact/prefix target (which would orphan one socket from
       // health-check pruning, since the two are stored under different keys).
       const connectedTabIds = new Set<string>();
-      const candidates: { key: string; tab: CefTab }[] = [];
 
+      // Classify every tab first, with no I/O, so duplicate keys are resolved
+      // on merit rather than on the order Steam happened to list them in.
+      const claims = new Map<string, { tab: CefTab; rank: number }>();
       for (const tab of tabs) {
         if (!tab.webSocketDebuggerUrl) continue;
         if (!isBadgeCandidate(tab)) continue;
 
         // A BPM window titled "Steam" is in SHARED_JS_NAMES too — classify it
-        // as the window, or it collapses onto the SharedJSContext key, evicts
-        // the real shared context and is then excluded from tier 1.
-        const key = isBigPictureWindow(tab)
-          ? tab.title
-          : SHARED_JS_NAMES.includes(tab.title)
-            ? "SharedJSContext"
-            : tab.title;
-        // Two tabs can reduce to one key (e.g. "SP" and "Steam" both meaning
-        // SharedJSContext). Keep the first and leave the rest alone rather
-        // than opening a socket we'd immediately orphan.
-        if (this.connections.has(key)) {
-          this.log(`Ignoring duplicate ${key} target: ${tab.title}`);
+        // as the window, or it collapses onto the SharedJSContext key and
+        // evicts the real shared context.
+        const isBpm = isBigPictureWindow(tab);
+        const key = isBpm ? tab.title : isMenuPopup(tab) ? tab.title : "SharedJSContext";
+        const rank = isBpm || isMenuPopup(tab) ? 1 : sharedContextRank(tab);
+
+        const held = claims.get(key);
+        if (held && held.rank >= rank) {
+          this.log(`Ignoring weaker ${key} candidate: "${tab.title}" (${tab.url})`);
           continue;
         }
+        if (held) {
+          this.log(`Preferring "${tab.title}" over "${held.tab.title}" for ${key}`);
+        }
+        claims.set(key, { tab, rank });
+      }
 
+      const candidates: { key: string; tab: CefTab }[] = [];
+      for (const [key, { tab }] of claims) {
         try {
           const conn = await this._openCDP(tab.webSocketDebuggerUrl, tab.title);
           this.connections.set(key, conn);
@@ -715,9 +777,16 @@ export class SteamCefBadgeInjector<TBadgeData> {
    * target" diagnostic that tells the user what is actually wrong.
    */
   private _pickRenderKeys(candidates: { key: string; tab: CefTab }[]): string[] {
-    const bpmWindow = candidates.filter((c) => isBigPictureWindow(c.tab));
-    if (bpmWindow.length > 0) return bpmWindow.map((c) => c.key);
+    // Exactly one window: two BPM-shaped tabs (the Gaming-Mode one plus a
+    // desktop `Steam`/browserType=4 window) would otherwise both get a badge
+    // and an independent gate. Prefer the Gaming-Mode title.
+    const windows = candidates.filter((c) => isBigPictureWindow(c.tab));
+    const preferred =
+      windows.find((c) => c.tab.title === BIG_PICTURE_TITLE) ?? windows[0];
+    if (preferred) return [preferred.key];
 
+    // Menu popups stay plural: on legacy builds the UI really was split
+    // across the per-session popups.
     return candidates.filter((c) => isMenuPopup(c.tab)).map((c) => c.key);
   }
 
@@ -764,6 +833,19 @@ html.${obscuredClass(safePluginId(this.cfg.pluginId))} ${sel} { display: none !i
   }
 
   private async _injectBadgeSystem(): Promise<void> {
+    // Re-entrancy guard: a debounced re-inject can land inside _tryConnect's
+    // window between clearing the connections and refilling them, where it
+    // would see no render keys and log a spurious "badge will not appear".
+    if (this.injecting) return;
+    this.injecting = true;
+    try {
+      await this._injectBadgeSystemInner();
+    } finally {
+      this.injecting = false;
+    }
+  }
+
+  private async _injectBadgeSystemInner(): Promise<void> {
     const css = this._bpmCss();
 
     // Scrub tabs we deliberately don't render into. A Loadout update lands
@@ -883,38 +965,67 @@ html.${obscuredClass(safePluginId(this.cfg.pluginId))} ${sel} { display: none !i
           this.connections.delete(key);
           this.bpmRenderKeys = this.bpmRenderKeys.filter((k) => k !== key);
           this.purgeKeys = this.purgeKeys.filter((k) => k !== key);
+          // Real state change — Steam moved, so stop backing off.
+          this.discoverySkips = 0;
+          this.discoveryBackoff = 0;
           this.log(`Pruned dead connection: ${key}`);
         }
       }
 
-      const wasConnected = this._connected;
       this._connected =
         this.connections.has("SharedJSContext") || this.bpmRenderKeys.length > 0;
 
       // Rediscover when we lack a render target OR the shared context — the
       // latter is the only place the route can be read, so losing it alone
       // (BPM socket still alive) would otherwise freeze the badge silently.
-      if (
+      const wants =
         !this._connected ||
         this.bpmRenderKeys.length === 0 ||
-        !this.connections.has("SharedJSContext")
-      ) {
-        if (wasConnected && !this._connected) this._emitState();
+        !this.connections.has("SharedJSContext");
+
+      if (wants && this.discoverySkips > 0) {
+        this.discoverySkips--;
+      } else if (wants) {
         // Re-run discovery (gated inside _tryConnect) so a reopened BPM or a
         // freshly-started Steam reconnects without a manual nudge.
         const ok = await this._tryConnect();
         if (ok) await this._injectBadgeSystem();
+
+        // Back off when a *successful* discovery still leaves us wanting.
+        // That means Steam simply has no such target — retrying every tick
+        // reconnects every socket and re-runs the BPM script, and the badge
+        // script's own cleanup() drops the badge before the async re-push
+        // puts it back, so the badge blinks out once per tick, forever.
+        // A failed connect is a different case (Steam not up yet) and keeps
+        // the plain 5s retry.
+        const stillWants =
+          !this._connected ||
+          this.bpmRenderKeys.length === 0 ||
+          !this.connections.has("SharedJSContext");
+        if (ok && stillWants) {
+          this.discoveryBackoff = Math.min(
+            this.discoveryBackoff * 2 + 1,
+            MAX_DISCOVERY_SKIPS,
+          );
+          this.discoverySkips = this.discoveryBackoff;
+        } else {
+          this.discoveryBackoff = 0;
+          this.discoverySkips = 0;
+        }
       }
+      this._emitStateIfChanged();
     } finally {
       this.healthChecking = false;
     }
   }
 
-  /** Emit only when the user-visible state actually moved. */
+  /** Emit only when the user-visible state actually moved. Compares every
+   *  field in the payload, so adding one here can't silently go unemitted. */
   private _emitStateIfChanged(): void {
     if (
       (this._statusDetail() ?? null) === this.lastEmittedDetail &&
-      this._connected === this.lastEmittedConnected
+      this._connected === this.lastEmittedConnected &&
+      this.connections.size === this.lastEmittedTabs
     ) {
       return;
     }
@@ -924,6 +1035,7 @@ html.${obscuredClass(safePluginId(this.cfg.pluginId))} ${sel} { display: none !i
   private _emitState(): void {
     this.lastEmittedDetail = this._statusDetail() ?? null;
     this.lastEmittedConnected = this._connected;
+    this.lastEmittedTabs = this.connections.size;
     this.cfg.onStateChange?.({
       connected: this._connected,
       tabs: this.connections.size,

--- a/packages/steam-cef-badges/src/obscured-gate.test.ts
+++ b/packages/steam-cef-badges/src/obscured-gate.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect } from "bun:test";
 import { buildObscuredGateScript, OBSCURED_SETTLE_MS } from "./injector";
 
-const CLASS = "loadout-badges-obscured";
+const CLASS = "loadout-badges-obscured-protondb_badges";
 
 type Listener = () => void;
 
@@ -19,6 +19,7 @@ function harness(opts: { focused?: boolean; visible?: boolean } = {}) {
   const winListeners = new Map<string, Listener[]>();
   const docListeners = new Map<string, Listener[]>();
 
+  let toggles = 0;
   let now = 0;
   const timers = new Map<number, { at: number; fn: Listener }>();
   let nextTimer = 1;
@@ -45,11 +46,16 @@ function harness(opts: { focused?: boolean; visible?: boolean } = {}) {
     },
     documentElement: {
       classList: {
+        contains: (c: string) => classes.has(c),
         toggle: (c: string, on_: boolean) => {
+          if (on_ !== classes.has(c)) toggles++;
           if (on_) classes.add(c);
           else classes.delete(c);
         },
-        remove: (c: string) => classes.delete(c),
+        remove: (c: string) => {
+          if (classes.has(c)) toggles++;
+          classes.delete(c);
+        },
       },
     },
   };
@@ -61,10 +67,15 @@ function harness(opts: { focused?: boolean; visible?: boolean } = {}) {
   };
   const clearTimeoutFn = (id: number) => void timers.delete(id);
 
+  const countWinListeners = () =>
+    [...winListeners.values()].reduce((n, l) => n + l.length, 0);
+
   return {
     win,
-    /** Total class toggles applied — the strobe counter. */
-    toggles: 0,
+    /** Every actual class mutation since arming — the strobe counter. */
+    toggles: () => toggles,
+    resetToggles: () => void (toggles = 0),
+    winListeners: countWinListeners,
     run(src: string) {
       new Function("window", "document", "setTimeout", "clearTimeout", src)(
         win,
@@ -92,6 +103,7 @@ function harness(opts: { focused?: boolean; visible?: boolean } = {}) {
       }
     },
     obscured: () => classes.has(CLASS),
+    hasClass: (c: string) => classes.has(c),
     pendingTimers: () => timers.size,
   };
 }
@@ -116,21 +128,44 @@ describe("obscured gate", () => {
     expect(h.obscured()).toBe(true);
   });
 
-  it("swallows a focus burst instead of strobing", () => {
+  it("swallows a focus burst without a single class mutation", () => {
     const h = harness();
     h.run(src);
+    h.resetToggles();
 
     // The measured SteamOS pattern: 5 transitions inside one frame budget,
-    // settling back on focus. Nothing should ever be applied.
+    // settling back on focus. Counting mutations (not just the final state)
+    // is the point — an un-debounced gate ends on the same value while
+    // having strobed the badge on the way there.
     for (const state of [false, true, false, true, false]) {
       h.fire(state ? "focus" : "blur", state);
       h.tick(10);
     }
     h.fire("focus", true);
-    expect(h.obscured()).toBe(false);
+    h.tick(OBSCURED_SETTLE_MS);
 
+    expect(h.toggles()).toBe(0);
+    expect(h.obscured()).toBe(false);
+  });
+
+  it("applies exactly one mutation for a real menu open and close", () => {
+    const h = harness();
+    h.run(src);
+    h.resetToggles();
+
+    // Measured shape: one blur, seconds of silence, one focus.
+    h.fire("blur", false);
+    h.tick(OBSCURED_SETTLE_MS);
+    expect(h.obscured()).toBe(true);
+    expect(h.toggles()).toBe(1);
+
+    h.tick(8000);
+    expect(h.toggles()).toBe(1);
+
+    h.fire("focus", true);
     h.tick(OBSCURED_SETTLE_MS);
     expect(h.obscured()).toBe(false);
+    expect(h.toggles()).toBe(2);
   });
 
   it("restores the badge once focus comes back and settles", () => {
@@ -188,11 +223,50 @@ describe("obscured gate", () => {
   it("re-running the script re-arms rather than double-binding", () => {
     const h = harness();
     h.run(src);
+    const after1 = h.winListeners();
     h.run(src);
+
+    // The listener count is what catches a missing cleanup — a Set-backed
+    // class makes a doubled toggle indistinguishable from a single one.
+    expect(h.winListeners()).toBe(after1);
 
     h.fire("blur", false);
     h.tick(OBSCURED_SETTLE_MS);
     expect(h.obscured()).toBe(true);
     expect(h.pendingTimers()).toBe(0);
+  });
+
+  it("keeps the badge hidden when re-injected while the menu is open", () => {
+    // Regression: a health blip re-injects the gate. A naive re-arm resets
+    // everFocused, which reads as "never focused" ⇒ fail-open ⇒ the class
+    // comes off and the badge draws over the open Steam menu again.
+    const h = harness();
+    h.run(src);
+
+    h.fire("blur", false);
+    h.tick(OBSCURED_SETTLE_MS);
+    expect(h.obscured()).toBe(true);
+
+    h.run(src); // still blurred — menu still open
+    expect(h.obscured()).toBe(true);
+
+    h.tick(OBSCURED_SETTLE_MS * 4);
+    expect(h.obscured()).toBe(true);
+  });
+
+  it("gives each plugin its own class so one teardown can't un-hide another", () => {
+    const h = harness();
+    h.run(src);
+    h.run(buildObscuredGateScript("hltb"));
+
+    h.fire("blur", false);
+    h.tick(OBSCURED_SETTLE_MS);
+    expect(h.obscured()).toBe(true);
+    expect(h.hasClass("loadout-badges-obscured-hltb")).toBe(true);
+
+    // Tearing down HLTB must leave ProtonDB hidden.
+    (h.win["__loadout_badge_gate_hltb"] as { cleanup: () => void }).cleanup();
+    expect(h.hasClass("loadout-badges-obscured-hltb")).toBe(false);
+    expect(h.obscured()).toBe(true);
   });
 });

--- a/packages/steam-cef-badges/src/obscured-gate.test.ts
+++ b/packages/steam-cef-badges/src/obscured-gate.test.ts
@@ -46,7 +46,6 @@ function harness(opts: { focused?: boolean; visible?: boolean } = {}) {
     },
     documentElement: {
       classList: {
-        contains: (c: string) => classes.has(c),
         toggle: (c: string, on_: boolean) => {
           if (on_ !== classes.has(c)) toggles++;
           if (on_) classes.add(c);

--- a/packages/steam-cef-badges/src/obscured-gate.test.ts
+++ b/packages/steam-cef-badges/src/obscured-gate.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The obscured-gate runs as a string inside Steam's CEF, so it can't be
+ * imported and called. These tests evaluate the generated source against a
+ * hand-rolled fake window/document — small enough to keep honest, and it
+ * pins the behaviour that matters: a focus *burst* must not strobe the badge.
+ */
+import { describe, it, expect } from "bun:test";
+import { buildObscuredGateScript, OBSCURED_SETTLE_MS } from "./injector";
+
+const CLASS = "loadout-badges-obscured";
+
+type Listener = () => void;
+
+/** Fake DOM + a controllable clock; only the surface the gate touches. */
+function harness(opts: { focused?: boolean; visible?: boolean } = {}) {
+  let focused = opts.focused ?? true;
+  let visible = opts.visible ?? true;
+  const classes = new Set<string>();
+  const winListeners = new Map<string, Listener[]>();
+  const docListeners = new Map<string, Listener[]>();
+
+  let now = 0;
+  const timers = new Map<number, { at: number; fn: Listener }>();
+  let nextTimer = 1;
+
+  const on = (m: Map<string, Listener[]>) => (evt: string, fn: Listener) => {
+    const list = m.get(evt) ?? [];
+    list.push(fn);
+    m.set(evt, list);
+  };
+  const off = (m: Map<string, Listener[]>) => (evt: string, fn: Listener) => {
+    m.set(evt, (m.get(evt) ?? []).filter((f) => f !== fn));
+  };
+
+  const win: Record<string, unknown> = {
+    addEventListener: on(winListeners),
+    removeEventListener: off(winListeners),
+  };
+  const doc = {
+    addEventListener: on(docListeners),
+    removeEventListener: off(docListeners),
+    hasFocus: () => focused,
+    get visibilityState() {
+      return visible ? "visible" : "hidden";
+    },
+    documentElement: {
+      classList: {
+        toggle: (c: string, on_: boolean) => {
+          if (on_) classes.add(c);
+          else classes.delete(c);
+        },
+        remove: (c: string) => classes.delete(c),
+      },
+    },
+  };
+
+  const setTimeoutFn = (fn: Listener, ms: number) => {
+    const id = nextTimer++;
+    timers.set(id, { at: now + ms, fn });
+    return id;
+  };
+  const clearTimeoutFn = (id: number) => void timers.delete(id);
+
+  return {
+    win,
+    /** Total class toggles applied — the strobe counter. */
+    toggles: 0,
+    run(src: string) {
+      new Function("window", "document", "setTimeout", "clearTimeout", src)(
+        win,
+        doc,
+        setTimeoutFn,
+        clearTimeoutFn,
+      );
+    },
+    fire(evt: "focus" | "blur", state: boolean) {
+      focused = state;
+      for (const fn of winListeners.get(evt) ?? []) fn();
+    },
+    setVisible(v: boolean) {
+      visible = v;
+      for (const fn of docListeners.get("visibilitychange") ?? []) fn();
+    },
+    /** Advance the clock, firing anything due. */
+    tick(ms: number) {
+      now += ms;
+      for (const [id, t] of [...timers]) {
+        if (t.at <= now) {
+          timers.delete(id);
+          t.fn();
+        }
+      }
+    },
+    obscured: () => classes.has(CLASS),
+    pendingTimers: () => timers.size,
+  };
+}
+
+describe("obscured gate", () => {
+  const src = buildObscuredGateScript("protondb-badges");
+
+  it("shows the badge while the window is focused and visible", () => {
+    const h = harness();
+    h.run(src);
+    expect(h.obscured()).toBe(false);
+  });
+
+  it("hides once a blur has held for the settle delay", () => {
+    const h = harness();
+    h.run(src);
+
+    h.fire("blur", false);
+    // Not yet — the edge has to settle first.
+    expect(h.obscured()).toBe(false);
+    h.tick(OBSCURED_SETTLE_MS);
+    expect(h.obscured()).toBe(true);
+  });
+
+  it("swallows a focus burst instead of strobing", () => {
+    const h = harness();
+    h.run(src);
+
+    // The measured SteamOS pattern: 5 transitions inside one frame budget,
+    // settling back on focus. Nothing should ever be applied.
+    for (const state of [false, true, false, true, false]) {
+      h.fire(state ? "focus" : "blur", state);
+      h.tick(10);
+    }
+    h.fire("focus", true);
+    expect(h.obscured()).toBe(false);
+
+    h.tick(OBSCURED_SETTLE_MS);
+    expect(h.obscured()).toBe(false);
+  });
+
+  it("restores the badge once focus comes back and settles", () => {
+    const h = harness();
+    h.run(src);
+
+    h.fire("blur", false);
+    h.tick(OBSCURED_SETTLE_MS);
+    expect(h.obscured()).toBe(true);
+
+    h.fire("focus", true);
+    h.tick(OBSCURED_SETTLE_MS);
+    expect(h.obscured()).toBe(false);
+  });
+
+  it("hides on visibilitychange even without a blur", () => {
+    const h = harness();
+    h.run(src);
+
+    h.setVisible(false);
+    h.tick(OBSCURED_SETTLE_MS);
+    expect(h.obscured()).toBe(true);
+  });
+
+  it("fails open: never-focused documents keep their badge", () => {
+    // A build where Steam doesn't route focus to this document at all.
+    const h = harness({ focused: false });
+    h.run(src);
+    h.fire("blur", false);
+    h.tick(OBSCURED_SETTLE_MS * 4);
+    expect(h.obscured()).toBe(false);
+  });
+
+  it("cleanup removes the class, the listeners and any pending timer", () => {
+    const h = harness();
+    h.run(src);
+
+    h.fire("blur", false);
+    h.tick(OBSCURED_SETTLE_MS);
+    expect(h.obscured()).toBe(true);
+
+    const gate = h.win["__loadout_badge_gate_protondb_badges"] as {
+      cleanup: () => void;
+    };
+    gate.cleanup();
+    expect(h.obscured()).toBe(false);
+    expect(h.pendingTimers()).toBe(0);
+
+    // Listeners are gone: further edges do nothing.
+    h.fire("blur", false);
+    h.tick(OBSCURED_SETTLE_MS * 4);
+    expect(h.obscured()).toBe(false);
+  });
+
+  it("re-running the script re-arms rather than double-binding", () => {
+    const h = harness();
+    h.run(src);
+    h.run(src);
+
+    h.fire("blur", false);
+    h.tick(OBSCURED_SETTLE_MS);
+    expect(h.obscured()).toBe(true);
+    expect(h.pendingTimers()).toBe(0);
+  });
+});

--- a/plugins/hltb/app.tsx
+++ b/plugins/hltb/app.tsx
@@ -96,6 +96,8 @@ const BPM_POSITIONS: ReadonlyArray<HltbSettings["position"]> = [
 interface StatusInfo {
   connected: boolean;
   tabs: number;
+  /** Why badges aren't rendering (Gaming Mode, debug port, no BPM tab). */
+  detail?: string;
 }
 
 // --- Helpers ---
@@ -176,12 +178,14 @@ function HltbPlugin() {
       const d = data as {
         connected?: boolean;
         tabs?: number;
+        detail?: string;
         settings?: HltbSettings;
       };
       if (d.connected !== undefined) {
         setStatus({
           connected: d.connected,
           tabs: d.tabs ?? 0,
+          detail: d.detail,
         });
       }
       if (d.settings) {
@@ -957,6 +961,14 @@ function ConfigCard({
                 ? ` · Connected (${status.tabs} tab${status.tabs !== 1 ? "s" : ""})`
                 : " · Steam CEF not connected"}
             </div>
+            {status.detail && (
+              <div
+                className="text-xs text-[var(--fg-3)]"
+                style={{ marginTop: 2 }}
+              >
+                {status.detail}
+              </div>
+            )}
           </div>
           <Toggle checked={integrationEnabled} onChange={toggleIntegration} />
         </div>

--- a/plugins/hltb/backend.ts
+++ b/plugins/hltb/backend.ts
@@ -307,6 +307,9 @@ export default class HltbBackend implements PluginBackend {
       bpmGlobalName: "__hltb_badges",
       storeGlobalName: "__hltb_store_badges",
       css: this.generateBadgeCSS(),
+      // Hide while the Steam menu / QAM covers the BPM window — they are
+      // separate windows drawn above ours, so we can't sit behind them.
+      obscuredHideSelector: "#hltb-badges-container",
       bpmScript: this.generateBPMScript(),
       buildStoreScript: (d) => this.generateStoreScript(d),
       fetchBadgeData: (appId) => this.getBadgeData(appId),
@@ -1043,8 +1046,18 @@ export default class HltbBackend implements PluginBackend {
 
   // ─── RPC: Status ────────────────────────────────────────────────
 
-  async getStatus(): Promise<{ connected: boolean; tabs: number }> {
-    return this.injector?.getStatus() ?? { connected: false, tabs: 0 };
+  async getStatus(): Promise<{
+    connected: boolean;
+    tabs: number;
+    detail?: string;
+  }> {
+    return (
+      this.injector?.getStatus() ?? {
+        connected: false,
+        tabs: 0,
+        detail: "Badge injection is not running.",
+      }
+    );
   }
 
   async reconnect(): Promise<{ success: boolean; error?: string }> {
@@ -1338,13 +1351,14 @@ export default class HltbBackend implements PluginBackend {
   // ─── State Emission ─────────────────────────────────────────────
 
   private emitState(): void {
-    const { connected, tabs } = this.injector?.getStatus() ?? {
+    const { connected, tabs, detail } = this.injector?.getStatus() ?? {
       connected: false,
       tabs: 0,
+      detail: "Badge injection is not running.",
     };
     this.emit?.({
       event: "stateChanged",
-      data: { connected, tabs, settings: this.settings },
+      data: { connected, tabs, detail, settings: this.settings },
     });
   }
 }

--- a/plugins/protondb-badges/app.tsx
+++ b/plugins/protondb-badges/app.tsx
@@ -814,7 +814,7 @@ function ConfigCards({
           {status.detail && (
             <div className="subsection-desc mt-2">{status.detail}</div>
           )}
-          {!status.connected && (
+          {(!status.connected || status.detail) && (
             <div className="mt-2">
               <Button onClick={onReconnect}>Reconnect</Button>
             </div>

--- a/plugins/protondb-badges/app.tsx
+++ b/plugins/protondb-badges/app.tsx
@@ -63,6 +63,8 @@ interface ProtonDBSettings {
 interface StatusInfo {
   connected: boolean;
   tabs: number;
+  /** Why badges aren't rendering (Gaming Mode, debug port, no BPM tab). */
+  detail?: string;
 }
 
 interface BareInstalledGame {
@@ -254,6 +256,7 @@ function ProtonDBBadges() {
         settings?: ProtonDBSettings;
         connected?: boolean;
         tabs?: number;
+        detail?: string;
       };
       if (d.settings) {
         setSettings(d.settings);
@@ -261,7 +264,11 @@ function ProtonDBBadges() {
       // Backend emits connection state alongside settings on connect /
       // health-check changes — reflect it live in the Steam CEF section.
       if (typeof d.connected === "boolean") {
-        setStatus({ connected: d.connected, tabs: d.tabs ?? 0 });
+        setStatus({
+          connected: d.connected,
+          tabs: d.tabs ?? 0,
+          detail: d.detail,
+        });
       }
     },
   });
@@ -804,6 +811,9 @@ function ConfigCards({
                 : "Disconnected"}
             </span>
           </div>
+          {status.detail && (
+            <div className="subsection-desc mt-2">{status.detail}</div>
+          )}
           {!status.connected && (
             <div className="mt-2">
               <Button onClick={onReconnect}>Reconnect</Button>

--- a/plugins/protondb-badges/backend.ts
+++ b/plugins/protondb-badges/backend.ts
@@ -149,6 +149,9 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
       bpmGlobalName: "__protondb_badges",
       storeGlobalName: "__protondb_store_badges",
       css: this._generateBadgeCSS(),
+      // Hide while the Steam menu / QAM covers the BPM window — they are
+      // separate windows drawn above ours, so we can't sit behind them.
+      obscuredHideSelector: "#protondb-badge-container",
       bpmScript: this._generateBPMScript(),
       buildStoreScript: (d) => this._generateStoreScript(d),
       // Report only — the injected runtime never reads Linux-support, so
@@ -430,8 +433,18 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
 
   // ─── RPC: Steam-CEF status ──────────────────────────────────────
 
-  async getStatus(): Promise<{ connected: boolean; tabs: number }> {
-    return this.injector?.getStatus() ?? { connected: false, tabs: 0 };
+  async getStatus(): Promise<{
+    connected: boolean;
+    tabs: number;
+    detail?: string;
+  }> {
+    return (
+      this.injector?.getStatus() ?? {
+        connected: false,
+        tabs: 0,
+        detail: "Badge injection is not running.",
+      }
+    );
   }
 
   async reconnect(): Promise<{ success: boolean; error?: string }> {
@@ -772,13 +785,14 @@ export default class ProtonDBBadgesBackend implements PluginBackend {
   }
 
   private _emitState(): void {
-    const { connected, tabs } = this.injector?.getStatus() ?? {
+    const { connected, tabs, detail } = this.injector?.getStatus() ?? {
       connected: false,
       tabs: 0,
+      detail: "Badge injection is not running.",
     };
     this.emit?.({
       event: "stateChanged",
-      data: { settings: this.settings, connected, tabs },
+      data: { settings: this.settings, connected, tabs, detail },
     });
   }
 }


### PR DESCRIPTION
## What & why

The ProtonDB and HLTB badges were rendering **inside the Steam menu** — the sidebar that opens on the Steam button — sitting on top of it instead of on the game page. Separately, a user reported seeing **no badges at all**. Both come from how `SteamCefBadgeInjector` picks its render target.

PR #101 injected into every candidate tab, on the reasoning that *"Steam splits the BPM UI across the parent BPM tab and per-session `MainMenu_uid<N>` popups; which hosts the visible React UI is build-dependent, so both are candidate render targets — only the visible tab composites."* That last clause is no longer true. Probing CEF on an OneXPlayer APEX (Steam build `1786661881`):

| target | URL marker | what it is |
|---|---|---|
| `MainMenu_uid2` | `browserviewpopup=1` | **the Steam menu** |
| `QuickAccess_uid2` | `browserviewpopup=1` | QAM |
| `notificationtoasts_uid2` | `browserviewpopup=1` | toasts |
| `Steam Big Picture Mode` | — | library + game detail |
| `SharedJSContext` | — | JS/React host, no visible DOM |

The Steam menu is its own always-live popup window and composites too. The badge is a `position: fixed` child of `document.body`, so in that document it draws over the menu. Confirmed live — both plugins had their `<style>` and runtime globals in `MainMenu_uid2` as well as in the BPM window.

### Render target is now tiered

First non-empty tier wins; everything else is purged.

1. The main Big Picture window — `isBigPictureWindow()`, mirroring `isBigPictureMode()` in `apps/loadout/src/injector/tabs.ts`: titled `Steam Big Picture Mode`, or titled `Steam` with `browserType=4`, and never a browser-view popup.
2. `MainMenu_uid<N>` popups — legacy builds where the popup *was* the whole UI.

There is deliberately **no `SharedJSContext` tier**. It is the invisible page (`docs/ui-modding-framework.md`, `docs/steam-ui-injection.md`), so rendering there draws nothing — and because `_connected` is true whenever it is present, electing it would also mask the "no render target" diagnostic. An earlier revision of this PR had such a tier; review caught it and it is gone.

The `"Steam"` + `browserType=4` case matters beyond desktop BPM: `"Steam"` is in `SHARED_JS_NAMES`, so that window previously collapsed onto the `SharedJSContext` key, **evicted the real shared context**, and was then excluded from the render tier.

For the "no badges at all" report, the fix is diagnostic rather than speculative — see below.

Non-render tabs are scrubbed once per discovery: a Loadout update lands mid-Steam-session, so a menu popup an older build injected into keeps its badge until we take it back out.

`_checkHealth` now also rediscovers when `SharedJSContext` is missing. Previously `_connected` stayed true via the live BPM key, so a dropped shared context — the only place the route can be read — was never reconnected.

### Hiding while obscured

Fixing the target isn't sufficient — the menu is a separate OS-level window composited *above* the BPM window, so no `z-index` in our document can get behind it. The badge has to take itself out of the picture.

The gate reads nothing but `document.visibilityState`, `document.hasFocus()` and `focus`/`blur`/`visibilitychange`, and toggles one class on `<html>` that the plugin CSS hides against. The badge learns it has been covered without knowing *what* covered it, so a Steam UI reshuffle — renamed popups, a restructured React tree, a new overlay — can't break it the way selector- or store-sniffing would. Opt-in per plugin via `obscuredHideSelector`.

Two on-device measurements shaped it:

- **`visibilityState` stays `visible`** on the BPM window throughout. Focus is the only signal that moves — a `visibilitychange`-only gate would never have fired.
- **Opening the menu doesn't produce one clean blur.** It bounces:

  ```
  235.26  blur focus=0 / focus / blur / focus / blur   ← 5 edges in <10ms
  236.94  focus / blur / focus / blur / focus          ← settles back FOCUSED
  ```

  Applying every edge would strobe the badge five times for a net change of nothing. Each edge now restarts a 250ms timer and only the settled value lands, so a burst collapses to a single toggle — or to none.

  A held-open menu is clean by contrast: one blur, **8.1s of silence**, one focus. 250ms sits between the ~10ms burst and the multi-second hold with orders of magnitude of margin either side, so no asymmetric hide/show delay is needed.

`everFocused` makes the focus rule **fail open**: a document that has never once reported focus is assumed to be a build where Steam doesn't route focus there, and keeps its badge rather than hiding it forever. A wrong guess degrades to "badge stays visible", never to "badge never appears".

The gate **inherits state across re-arm**. `_injectBadgeSystem` re-runs the script on every rediscovery, and a naive re-arm resets `everFocused` to `false` — which, with the menu open, reads as "never focused" ⇒ fail-open ⇒ the class comes off and the badge draws over the menu again. A health blip resurrected the exact reported bug. The class is also **per-plugin**: with one shared class, either plugin's teardown un-hid the other's badge.

### Diagnostics

`getStatus()` gains a `detail` string, surfaced under the status dot in both plugins. The dot alone can't separate desktop mode from a Steam that never opened its debug port, and both look identical to a user who just sees no badges. The commonest cause is now named outright — *"Steam's CEF debug port (8080) is not reachable. Create an empty `.cef-enable-remote-debugging` file in Steam's root and restart Steam."* `reconnect()` returns it too, and its desktop-mode gate updates the status dot rather than only returning a toast.

Failure paths emit. `_checkHealth` used to emit *before* `_tryConnect` set the reason, and `_tryConnect` emitted only on success — so the message was reachable only by remounting the panel or pressing Reconnect.

The full CEF target list (titles + URLs) is logged once per discovery. Which tab hosts the visible UI is build-dependent, so a "no badges" field report is only diagnosable if we recorded what Steam actually offered.

## How it was tested

**OneXPlayer APEX, SteamOS, Gaming Mode**, driven over CDP against the running Steam, plus by hand on a game page.

After the change, live target state:

| target | plugin styles | runtimes | gates |
|---|---|---|---|
| `MainMenu_uid2` | **none** | **none** | — |
| `QuickAccess_uid2` | none | none | — |
| `Steam Big Picture Mode` | both (each carrying the hide rule) | both | `protondb_badges`, `hltb` |

Menu open/close verified by hand on a game page, including a 5-second hold. The 8.1s-silence and burst traces above are from an instrumented probe injected into the live BPM window (removed afterwards).

New tests: 11 in `obscured-gate.test.ts` — the generated gate script is evaluated against a fake DOM and a controllable clock, replaying the exact measured 5-edge burst and asserting **zero class mutations**; plus one-mutation-per-menu-cycle, fail-open, cleanup, re-arm-while-blurred, and per-plugin class isolation. The rest are in `injector.test.ts`: tier selection, purge, never rendering into SharedJSContext, the `"Steam"`/`browserType=4` classification, route polling without a shared context, and status detail. **45 pass** across the package.

Two of the original tests passed *vacuously* and were rewritten after review:

- The burst test asserted only the final class state — identical with and without the debounce — and the harness had a `toggles` counter that was never incremented or asserted. It now counts every class mutation, **verified by mutation testing**: stripping the debounce produces 6 mutations with the same final state, so the assertion now fails as it should.
- The re-arm test passed with the gate's `cleanup()` call deleted (two closures, a `Set`-backed class, idempotent double toggle). It now counts listeners.

`plugins/*/app.spec.tsx` has 16 pre-existing failures on this repo; the count is unchanged by this PR (verified against a stashed tree).

No `CHANGELOG.md` entry — per `docs/releasing.md` those are written at release time by cross-referencing merged PRs.

## Review

Two adversarial review rounds. Round 2 mutation-tested the round-1 fixes and found **four of them passed with the fix reverted** — all four are now pinned, each verified by re-running its mutation. It also found two defects round 1 introduced, addressed in `2857745`:

- **Rediscovery spin.** The new `!connections.has("SharedJSContext")` health clause was permanently true on builds exposing no such tab, so discovery re-ran every 5s: measured 5 fetches / 10 sockets / 5 re-injects per 5 ticks. Because the BPM script's own `cleanup()` removes the element before the async re-push restores it, **the badge blinked once per tick, forever**. Now backs off 1→3→7…63 ticks, while a *failed* connect (Steam not up yet) keeps the plain 5s retry.
- **Dedupe dropped the canonical target.** "First claim wins" trusts Steam's target ordering; a community tab titled `Steam` could take the `SharedJSContext` key and permanently starve route polling — with `detail: undefined`. Tabs are now classified without I/O and duplicates resolved on merit, using a `steamloopback.host` URL check mirroring `isSharedJSContext` in `tabs.ts`.

Round-1 findings are addressed in `8646db1` — the gate re-arm bug, the `SharedJSContext` tier, the route fallback that could evict a live badge, and diagnostics never reaching an open panel. That commit message has the full detail. Three of the four were regressions introduced by `8f65bef` in this PR.

## Checklist

- [x] `bun run typecheck` passes (0 errors)
- [x] `bun run lint` passes (0 errors)
- [x] `bun run test` passes — *for the packages touched; see the pre-existing plugin-spec failures noted above*
- [x] Added/updated tests for new backend/lib behaviour
- [ ] Updated docs / `NOTICE` / `THIRD_PARTY_LICENSES.md` if this wraps or bundles third-party code — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnQb3BiAUevxACKGb9LptX
