### PR TITLE
feat(tdp-control): prefer firmware-attributes rails over ryzenadj on AMD [parked — needs ROG Ally / Legion Go]

### DIFF
--- a/packages/devices/src/devices.test.ts
+++ b/packages/devices/src/devices.test.ts
@@ -4,6 +4,7 @@ import {
   matchProfileName,
   effectiveMaxWatts,
   isBatteryLimited,
+  applyFirmwareRange,
   BATTERY_SAFE_MAX_WATTS,
 } from "./devices";
 
@@ -221,6 +222,83 @@ describe("battery safety ceiling", () => {
     // change for that device and is intentional.
     expect(
       effectiveMaxWatts({ acOnline: false, maxTdp: 90, batteryMaxTdp: 65 }),
+    ).toBe(BATTERY_SAFE_MAX_WATTS);
+  });
+});
+
+describe("isFallback", () => {
+  it("is false for a table match", () => {
+    expect(matchDevice("ONEXPLAYER APEX", "AMD").isFallback).toBe(false);
+  });
+
+  it("is true for a vendor fallback", () => {
+    expect(matchDevice("Some Unknown Handheld", "Intel").isFallback).toBe(true);
+    expect(matchDevice("Some Unknown Handheld", "AMD").isFallback).toBe(true);
+    expect(matchDevice("", "Unknown").isFallback).toBe(true);
+  });
+});
+
+// A handheld whose vendor driver implements the kernel's firmware-attributes
+// interface publishes the envelope its firmware will accept. That's the only
+// correct source for a device released after this table was last touched —
+// but it says nothing about thermals, so a matched row keeps its judgment.
+describe("applyFirmwareRange", () => {
+  it("gives an unknown device the firmware's range and derived presets", () => {
+    // The shape an Arc G3 Extreme handheld reports: 8-35 W on PL1.
+    const device = applyFirmwareRange(matchDevice("BRAND NEW HANDHELD", "Intel"), {
+      min: 8,
+      max: 35,
+    });
+
+    expect(device.minTdp).toBe(8);
+    expect(device.maxTdp).toBe(35);
+    expect(device.profiles).toEqual({ Silent: 13, Balanced: 22, Performance: 35 });
+    expect(device.batteryMaxTdp).toBe(28);
+  });
+
+  it("keeps a known device's hand-tuned battery cap", () => {
+    const matched = matchDevice("ROG Ally RC71", "AMD"); // 25 W plugged, 20 W battery
+    const device = applyFirmwareRange(matched, { min: 7, max: 30 });
+
+    expect(device.maxTdp).toBe(30);
+    expect(device.batteryMaxTdp).toBe(20);
+  });
+
+  it("never lets a known device's battery cap exceed the firmware max", () => {
+    const matched = matchDevice("ONEXPLAYER APEX", "AMD"); // 55 W battery cap
+    const device = applyFirmwareRange(matched, { min: 5, max: 40 });
+
+    expect(device.batteryMaxTdp).toBe(40);
+  });
+
+  it("clamps a known device's presets into the firmware's interval", () => {
+    const matched = matchDevice("ONEXPLAYER APEX", "AMD"); // 15 / 30 / 50
+    const device = applyFirmwareRange(matched, { min: 20, max: 40 });
+
+    expect(device.profiles).toEqual({ Silent: 20, Balanced: 30, Performance: 40 });
+  });
+
+  it("leaves the device name and fallback flag alone", () => {
+    const matched = matchDevice("ONEXPLAYER APEX", "AMD");
+    const device = applyFirmwareRange(matched, { min: 8, max: 35 });
+
+    expect(device.name).toBe("OneXPlayer APEX");
+    expect(device.isFallback).toBe(false);
+  });
+
+  it("still defers to the global on-battery ceiling", () => {
+    const device = applyFirmwareRange(matchDevice("BIG UNKNOWN RIG", "AMD"), {
+      min: 10,
+      max: 120,
+    });
+
+    expect(device.batteryMaxTdp).toBe(96);
+    expect(
+      effectiveMaxWatts({
+        acOnline: false,
+        maxTdp: device.maxTdp,
+        batteryMaxTdp: device.batteryMaxTdp,
+      }),
     ).toBe(BATTERY_SAFE_MAX_WATTS);
   });
 });

--- a/packages/devices/src/devices.test.ts
+++ b/packages/devices/src/devices.test.ts
@@ -271,6 +271,26 @@ describe("applyFirmwareRange", () => {
     expect(device.batteryMaxTdp).toBe(40);
   });
 
+  it("never lets an unknown device's battery cap fall under the firmware min", () => {
+    // A narrow firmware envelope is where the 80% fallback goes under the
+    // floor: round(17 * 0.8) = 14, below a 15 W min. Offering a battery
+    // ceiling the rail would reject is worse than offering the floor.
+    const device = applyFirmwareRange(matchDevice("BRAND NEW HANDHELD", "Intel"), {
+      min: 15,
+      max: 17,
+    });
+
+    expect(device.batteryMaxTdp).toBe(15);
+    expect(device.batteryMaxTdp).toBeGreaterThanOrEqual(device.minTdp);
+  });
+
+  it("never lets a known device's battery cap fall under the firmware min", () => {
+    const matched = matchDevice("ROG Ally RC71", "AMD"); // 20 W battery cap
+    const device = applyFirmwareRange(matched, { min: 25, max: 35 });
+
+    expect(device.batteryMaxTdp).toBe(25);
+  });
+
   it("clamps a known device's presets into the firmware's interval", () => {
     const matched = matchDevice("ONEXPLAYER APEX", "AMD"); // 15 / 30 / 50
     const device = applyFirmwareRange(matched, { min: 20, max: 40 });

--- a/packages/devices/src/devices.ts
+++ b/packages/devices/src/devices.ts
@@ -398,14 +398,19 @@ export function applyFirmwareRange(
   const { min, max } = range;
   const clamp = (w: number) => Math.min(Math.max(w, min), max);
   const span = max - min;
+  // Both battery-ceiling paths run through clamp() so neither can land under
+  // the floor. A narrow firmware range makes this reachable: 15–17 W gives
+  // round(17 * 0.8) = 14 on the fallback path, and a known row whose
+  // batteryMaxTdp predates a firmware that raised min would slip under it
+  // too — either way the UI would offer a battery ceiling the rail rejects.
 
   return {
     ...device,
     minTdp: min,
     maxTdp: max,
     batteryMaxTdp: device.isFallback
-      ? Math.round(max * FALLBACK_BATTERY_FRACTION)
-      : Math.min(device.batteryMaxTdp, max),
+      ? clamp(Math.round(max * FALLBACK_BATTERY_FRACTION))
+      : clamp(device.batteryMaxTdp),
     profiles: device.isFallback
       ? {
           Silent: Math.round(min + span * 0.2),

--- a/packages/devices/src/devices.ts
+++ b/packages/devices/src/devices.ts
@@ -280,6 +280,14 @@ const KNOWN_DEVICES: DeviceInfo[] = [
   },
 ];
 
+/**
+ * Share of a firmware-declared max allowed on battery for a device we have no
+ * table row for. Matches the ~80% relationship the hand-tuned rows above use
+ * between `maxTdp` and `batteryMaxTdp`. `BATTERY_SAFE_MAX_WATTS` still caps
+ * the result.
+ */
+const FALLBACK_BATTERY_FRACTION = 0.8;
+
 /** Default ranges when device is unknown. */
 const DEFAULT_AMD: Omit<DeviceInfo, "match"> = {
   name: "Generic AMD",
@@ -321,6 +329,13 @@ export interface DeviceMatch {
   /** Max TDP when on battery (<= maxTdp). */
   batteryMaxTdp: number;
   profiles: Record<string, number>;
+  /**
+   * True when no row in the device table matched and this is a vendor-keyed
+   * guess. Callers that have a better source of truth for the envelope — a
+   * firmware-declared range, say — use this to tell "we know this device"
+   * from "we're guessing from the CPU vendor".
+   */
+  isFallback: boolean;
 }
 
 /**
@@ -340,6 +355,7 @@ export function matchDevice(
         maxTdp: device.maxTdp,
         batteryMaxTdp: device.batteryMaxTdp,
         profiles: { ...device.profiles },
+        isFallback: false,
       };
     }
   }
@@ -355,6 +371,53 @@ export function matchDevice(
     maxTdp: fallback.maxTdp,
     batteryMaxTdp: fallback.batteryMaxTdp,
     profiles: { ...fallback.profiles },
+    isFallback: true,
+  };
+}
+
+/**
+ * Fold a firmware-declared TDP envelope into a device match.
+ *
+ * Handhelds whose vendor driver implements the kernel's `firmware-attributes`
+ * interface publish the exact envelope their firmware will accept
+ * (`min_value`/`max_value` on the PL1 rail). That beats this table: it is
+ * per-unit accurate, and it is the only source of truth for a device that
+ * shipped after the table was last touched.
+ *
+ * What it does NOT beat is the hand-tuned judgment in a matched row. A device
+ * we know about keeps its battery ceiling and its presets — those encode
+ * thermals and runtime, not just what the silicon tolerates — clamped into
+ * the firmware's interval so we never ask for a wattage the rail will reject.
+ * A fallback match has no such judgment to preserve, so its presets are
+ * derived from the range instead. Pure.
+ */
+export function applyFirmwareRange(
+  device: DeviceMatch,
+  range: { min: number; max: number },
+): DeviceMatch {
+  const { min, max } = range;
+  const clamp = (w: number) => Math.min(Math.max(w, min), max);
+  const span = max - min;
+
+  return {
+    ...device,
+    minTdp: min,
+    maxTdp: max,
+    batteryMaxTdp: device.isFallback
+      ? Math.round(max * FALLBACK_BATTERY_FRACTION)
+      : Math.min(device.batteryMaxTdp, max),
+    profiles: device.isFallback
+      ? {
+          Silent: Math.round(min + span * 0.2),
+          Balanced: Math.round(min + span * 0.5),
+          Performance: max,
+        }
+      : Object.fromEntries(
+          Object.entries(device.profiles).map(([name, watts]) => [
+            name,
+            clamp(watts),
+          ]),
+        ),
   };
 }
 

--- a/plugins/fan-control/lib/sensors.test.ts
+++ b/plugins/fan-control/lib/sensors.test.ts
@@ -92,6 +92,25 @@ describe("classifyTempZone()", () => {
     expect(classifyTempZone("xe", "Package")).toBe("gpu");
   });
 
+  // Same rule, same tier, for the substring-matched GPU chips. i915 was
+  // added to GPU_TEMP_CHIPS but checked *below* CPU_LABEL_KEYWORDS, so an
+  // i915 sensor labelled "package" came back as cpu while the equivalent
+  // xe one came back as gpu.
+  it("prefers the i915 chip name over a CPU-ish label", () => {
+    expect(classifyTempZone("i915", "Package")).toBe("gpu");
+  });
+
+  it("prefers the amdgpu chip name over a CPU-ish label", () => {
+    expect(classifyTempZone("amdgpu", "package")).toBe("gpu");
+  });
+
+  it("still lets a CPU chip name win for its own labels", () => {
+    // The GPU chip tier sits below CPU_TEMP_CHIPS, so nothing here can
+    // steal k10temp/coretemp sensors.
+    expect(classifyTempZone("k10temp", "Tctl")).toBe("cpu");
+    expect(classifyTempZone("coretemp", "Package id 0")).toBe("cpu");
+  });
+
   it("classifies junction label as gpu", () => {
     expect(classifyTempZone("something", "junction")).toBe("gpu");
   });

--- a/plugins/fan-control/lib/sensors.test.ts
+++ b/plugins/fan-control/lib/sensors.test.ts
@@ -66,6 +66,32 @@ describe("classifyTempZone()", () => {
     expect(classifyTempZone("amdgpu", "edge")).toBe("gpu");
   });
 
+  it("classifies i915 as gpu", () => {
+    expect(classifyTempZone("i915", "")).toBe("gpu");
+  });
+
+  // Xe/Xe3 graphics (Lunar Lake, Panther Lake / Arc G3) bind the `xe`
+  // driver, whose hwmon chip name is just "xe".
+  it("classifies xe as gpu on an exact chip-name match", () => {
+    expect(classifyTempZone("xe", "")).toBe("gpu");
+    expect(classifyTempZone("XE", "")).toBe("gpu");
+  });
+
+  // "xe" is two characters — matching it as a substring the way the other
+  // GPU chips are matched would claim sensors that have nothing to do with
+  // the GPU, so it is matched exactly instead.
+  it("does not claim an unrelated sensor whose text merely contains 'xe'", () => {
+    expect(classifyTempZone("mychip", "Mixed Zone")).toBe("unknown");
+    expect(classifyTempZone("xenon_board", "")).toBe("unknown");
+  });
+
+  // The chip name settles which engine a sensor belongs to, so it has to
+  // outrank the CPU *label* keywords — an `xe` sensor labelled "package" is
+  // still the GPU's.
+  it("prefers the xe chip name over a CPU-ish label", () => {
+    expect(classifyTempZone("xe", "Package")).toBe("gpu");
+  });
+
   it("classifies junction label as gpu", () => {
     expect(classifyTempZone("something", "junction")).toBe("gpu");
   });

--- a/plugins/fan-control/lib/sensors.ts
+++ b/plugins/fan-control/lib/sensors.ts
@@ -64,11 +64,14 @@ export function classifyTempZone(chipName: string, label: string): TempZone {
 
   if (CPU_TEMP_CHIPS.some((c) => lower.includes(c))) return "cpu";
 
-  // Exact chip-name match, checked in the same tier as CPU_TEMP_CHIPS above:
-  // the chip name is authoritative about which engine a sensor belongs to,
-  // so it must win over the label keywords below (an `xe` sensor labelled
-  // "package" is still the GPU).
-  if (EXACT_GPU_TEMP_CHIPS.includes(chipName.toLowerCase())) return "gpu";
+  // Chip-name match, checked in the same tier as CPU_TEMP_CHIPS above: the
+  // chip name is authoritative about which engine a sensor belongs to, so it
+  // must win over the label keywords below (an `xe` sensor labelled "package"
+  // is still the GPU — and so is an `i915` one, which is why both lists are
+  // consulted here rather than only the exact one).
+  const chip = chipName.toLowerCase();
+  if (EXACT_GPU_TEMP_CHIPS.includes(chip)) return "gpu";
+  if (GPU_TEMP_CHIPS.some((c) => chip.includes(c))) return "gpu";
 
   if (CPU_LABEL_KEYWORDS.some((kw) => lower.includes(kw))) return "cpu";
   if (GPU_TEMP_CHIPS.some((c) => lower.includes(c))) return "gpu";

--- a/plugins/fan-control/lib/sensors.ts
+++ b/plugins/fan-control/lib/sensors.ts
@@ -13,7 +13,18 @@
 export const CPU_TEMP_CHIPS = ["k10temp", "coretemp", "zenpower"];
 
 /** Chip names known to host GPU temperature sensors. */
-export const GPU_TEMP_CHIPS = ["amdgpu", "nvidia", "nouveau", "radeon"];
+export const GPU_TEMP_CHIPS = ["amdgpu", "nvidia", "nouveau", "radeon", "i915"];
+
+/**
+ * Chip names that identify a GPU only on an *exact* match.
+ *
+ * `xe` is the hwmon registered by Intel's Xe DRM driver — the one Xe3
+ * (Panther Lake / Arc G3) graphics bind to. At two characters it is far too
+ * short for the substring matching `GPU_TEMP_CHIPS` uses: it would fire on
+ * any chip or label that merely happens to contain the letters. Same
+ * treatment `acpitz` gets in `classifyTempZone`.
+ */
+export const EXACT_GPU_TEMP_CHIPS = ["xe"];
 
 /** Keywords that hint at a CPU-related temp label. */
 export const CPU_LABEL_KEYWORDS = ["tctl", "tdie", "cpu", "soc", "package"];
@@ -52,6 +63,13 @@ export function classifyTempZone(chipName: string, label: string): TempZone {
   if (NON_CPU_LABEL_KEYWORDS.some((kw) => lower.includes(kw))) return "unknown";
 
   if (CPU_TEMP_CHIPS.some((c) => lower.includes(c))) return "cpu";
+
+  // Exact chip-name match, checked in the same tier as CPU_TEMP_CHIPS above:
+  // the chip name is authoritative about which engine a sensor belongs to,
+  // so it must win over the label keywords below (an `xe` sensor labelled
+  // "package" is still the GPU).
+  if (EXACT_GPU_TEMP_CHIPS.includes(chipName.toLowerCase())) return "gpu";
+
   if (CPU_LABEL_KEYWORDS.some((kw) => lower.includes(kw))) return "cpu";
   if (GPU_TEMP_CHIPS.some((c) => lower.includes(c))) return "gpu";
   if (lower.includes("gpu") || lower.includes("junction") || lower.includes("edge")) return "gpu";

--- a/plugins/tdp-control/backend.ts
+++ b/plugins/tdp-control/backend.ts
@@ -17,6 +17,7 @@ import {
   BATTERY_SAFE_MAX_WATTS,
   effectiveMaxWatts,
   isBatteryLimited,
+  applyFirmwareRange,
 } from "@loadout/devices";
 import {
   readCustomDevice,
@@ -27,6 +28,12 @@ import {
   type CustomDevice,
 } from "./lib/custom-device";
 import { readSavedTdp, writeSavedTdp } from "./lib/saved-tdp";
+import {
+  discoverPowerRails,
+  type PowerRails,
+} from "./lib/firmware-attributes";
+import { discoverRaplConstraints, type RaplConstraints } from "./lib/rapl";
+import { findXeFreqDirs, writeCeilingFirst } from "./lib/gpu";
 import { readCpuBoostPref, writeCpuBoostPref } from "./lib/cpu-boost-pref";
 
 // ---------------------------------------------------------------------------
@@ -43,29 +50,22 @@ const AMD_LEGACY_CPU_BOOST_PATH = "/sys/devices/system/cpu/cpufreq/boost";
 const INTEL_CPU_BOOST_PATH = "/sys/devices/system/cpu/intel_pstate/no_turbo";
 const CPU_ONLINE_PATH = "/sys/devices/system/cpu/online";
 
-const INTEL_RAPL_PATHS = [
-  "/sys/devices/virtual/powercap/intel-rapl-mmio/intel-rapl-mmio:0/constraint_0_power_limit_uw",
-  "/sys/devices/virtual/powercap/intel-rapl/intel-rapl:0/constraint_0_power_limit_uw",
-  "/sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw",
-];
-
-const ROG_ALLY_WMI_PATHS = {
-  legacy: {
-    fppt: "/sys/devices/platform/asus-nb-wmi/ppt_fppt",
-    sppt: "/sys/devices/platform/asus-nb-wmi/ppt_pl2_sppt",
-    spl: "/sys/devices/platform/asus-nb-wmi/ppt_pl1_spl",
-  },
-  armoury: {
-    fppt: "/sys/class/firmware-attributes/asus-armoury/attributes/ppt_fppt/current_value",
-    sppt: "/sys/class/firmware-attributes/asus-armoury/attributes/ppt_pl2_sppt/current_value",
-    spl: "/sys/class/firmware-attributes/asus-armoury/attributes/ppt_pl1_spl/current_value",
-  },
-};
-
-const LEGION_GO_WMI_PATHS = {
-  fppt: "/sys/class/firmware-attributes/lenovo-wmi-other-0/attributes/ppt_pl3_fppt/current_value",
-  sppt: "/sys/class/firmware-attributes/lenovo-wmi-other-0/attributes/ppt_pl2_sppt/current_value",
-  spl: "/sys/class/firmware-attributes/lenovo-wmi-other-0/attributes/ppt_pl1_spl/current_value",
+/**
+ * The pre-`firmware-attributes` ASUS interface, still what older kernels
+ * expose on a ROG Ally. Everything newer — asus-armoury, lenovo-wmi-other-N,
+ * msi-wmi-platform — is found generically by `discoverPowerRails()` instead
+ * of being listed here, which is what lets an unreleased handheld work
+ * without a code change. These flat platform files declare no range, so the
+ * unit is assumed rather than read (see `setTdpViaWmi`).
+ */
+const LEGACY_ASUS_WMI_RAILS: PowerRails = {
+  spl: "/sys/devices/platform/asus-nb-wmi/ppt_pl1_spl",
+  sppt: "/sys/devices/platform/asus-nb-wmi/ppt_pl2_sppt",
+  fppt: "/sys/devices/platform/asus-nb-wmi/ppt_fppt",
+  scale: 1,
+  scaleKnown: false,
+  range: null,
+  source: "asus-nb-wmi (legacy)",
 };
 
 // ---------------------------------------------------------------------------
@@ -103,6 +103,17 @@ async function readFileText(path: string): Promise<string | null> {
     return null;
   }
 }
+
+/**
+ * The real sysfs, in the injectable shape every `./lib` discovery module
+ * takes (`FirmwareAttrDeps` / `RaplDeps` / `GpuFsDeps` are the same pair of
+ * "read, or null" functions). Tests hand those modules an in-memory tree
+ * instead.
+ */
+const sysfsDeps = {
+  readFile: readFileText,
+  listDir: (path: string) => readdir(path).catch(() => null),
+};
 
 async function writeSysfs(path: string, value: string): Promise<void> {
   // The backend runs as root (system service), so a direct write to the
@@ -331,7 +342,7 @@ export default class TdpControlBackend implements PluginBackend {
    * detectMethod(); used by setTdpViaRyzenadj() + testRyzenadjRead().
    */
   private ryzenadjPath = "ryzenadj";
-  private intelRaplPath: string | null = null;
+  private intelRapl: RaplConstraints | null = null;
   private scalingDriver = "";
   private platformProfile: string | null = null;
   private platformProfileChoices: string[] = [];
@@ -342,8 +353,9 @@ export default class TdpControlBackend implements PluginBackend {
 
   private pollInterval?: Timer;
 
-  // WMI TDP paths (for ROG Ally / Legion Go)
-  private wmiPaths: { fppt: string; sppt: string; spl: string } | null = null;
+  // Firmware power rails, discovered from /sys/class/firmware-attributes
+  // (ROG Ally, Legion Go, MSI Claw, …) or the legacy ASUS platform files.
+  private wmiPaths: PowerRails | null = null;
 
   // CPU boost detection
   private cpuBoostPath: string | null = null;
@@ -351,6 +363,11 @@ export default class TdpControlBackend implements PluginBackend {
   // GPU control
   private gpuCardPath: string | null = null;
   private gpuVendor: "AMD" | "Intel" | "Unknown" = "Unknown";
+  /** Which kernel driver backs `gpuCardPath` — the two Intel drivers expose
+   *  entirely different frequency interfaces. */
+  private gpuDriver: "amdgpu" | "i915" | "xe" | null = null;
+  /** Per-GT frequency directories; `xe` only, empty otherwise. */
+  private gpuFreqDirs: string[] = [];
 
   // AC power monitoring
   private acPowerOnline: boolean | null = null;
@@ -423,6 +440,14 @@ export default class TdpControlBackend implements PluginBackend {
       this.detectGpu(),
       this.detectAcPower(),
     ]);
+
+    // detectTdpMethod() may have learned the firmware's real TDP envelope
+    // from the power rails' declared min_value/max_value. Re-derive the range
+    // now it's known — this is what gives a handheld with no entry in
+    // @loadout/devices a correct slider instead of a generic-vendor guess.
+    if (this.wmiPaths?.range) {
+      this.applyDeviceDefaults();
+    }
 
     // After scaling driver is known, detect EPP/governor options
     await Promise.all([
@@ -735,7 +760,7 @@ export default class TdpControlBackend implements PluginBackend {
       supportsSmt: this.supportsSmt,
       supportsCpuBoost: this.supportsCpuBoost,
       ryzenadjAvailable: this.ryzenadjAvailable,
-      intelRaplAvailable: this.intelRaplPath !== null,
+      intelRaplAvailable: this.intelRapl !== null,
       ryzenadjCanRead: this.ryzenadjCanRead,
       gpuVendor: this.gpuVendor,
       supportsGpuControl: this.gpuCardPath !== null,
@@ -1232,9 +1257,24 @@ export default class TdpControlBackend implements PluginBackend {
         await writeSysfs(odClkPath, `s 0 ${minMhz}`);
         await writeSysfs(odClkPath, `s 1 ${maxMhz}`);
         await writeSysfs(odClkPath, "c");
+      } else if (this.gpuVendor === "Intel" && this.gpuDriver === "xe") {
+        // Every GT gets the range — leaving the media GT unbounded would
+        // undercut the point of setting a ceiling at all.
+        for (const dir of this.gpuFreqDirs) {
+          await this.writeIntelFreqPair(
+            `${dir}/min_freq`,
+            `${dir}/max_freq`,
+            minMhz,
+            maxMhz,
+          );
+        }
       } else if (this.gpuVendor === "Intel") {
-        await writeSysfs(`${this.gpuCardPath}/gt_min_freq_mhz`, String(minMhz));
-        await writeSysfs(`${this.gpuCardPath}/gt_max_freq_mhz`, String(maxMhz));
+        await this.writeIntelFreqPair(
+          `${this.gpuCardPath}/gt_min_freq_mhz`,
+          `${this.gpuCardPath}/gt_max_freq_mhz`,
+          minMhz,
+          maxMhz,
+        );
       } else {
         return { success: false, error: "Unknown GPU vendor" };
       }
@@ -1243,6 +1283,32 @@ export default class TdpControlBackend implements PluginBackend {
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       return { success: false, error: msg };
+    }
+  }
+
+  /**
+   * Write an Intel GPU floor/ceiling pair in an order the kernel will accept.
+   *
+   * Both drivers reject a write that would put the floor above the ceiling,
+   * so neither fixed order is safe on its own: raising the whole range needs
+   * the ceiling first, lowering it needs the floor first. Compare against the
+   * ceiling in force and pick.
+   */
+  private async writeIntelFreqPair(
+    minPath: string,
+    maxPath: string,
+    minMhz: number,
+    maxMhz: number,
+  ): Promise<void> {
+    const text = await readFileText(maxPath);
+    const currentMax = text === null ? null : parseInt(text, 10);
+
+    if (writeCeilingFirst(currentMax, minMhz)) {
+      await writeSysfs(maxPath, String(maxMhz));
+      await writeSysfs(minPath, String(minMhz));
+    } else {
+      await writeSysfs(minPath, String(minMhz));
+      await writeSysfs(maxPath, String(maxMhz));
     }
   }
 
@@ -1346,7 +1412,8 @@ export default class TdpControlBackend implements PluginBackend {
 
   private applyDeviceDefaults(): void {
     // A user-defined custom device is the default when present — it overrides
-    // whatever DMI matching would have picked.
+    // whatever DMI matching would have picked, and a firmware-declared range
+    // too: an explicit choice by the user outranks both.
     if (this.customDevice) {
       const d = this.customDevice;
       this.deviceName = d.name;
@@ -1356,7 +1423,15 @@ export default class TdpControlBackend implements PluginBackend {
       this.profiles = { ...d.profiles };
       return;
     }
-    const device = matchDevice(this.dmiProductName, this.cpuVendor);
+    const matched = matchDevice(this.dmiProductName, this.cpuVendor);
+
+    // A firmware-declared envelope outranks the table: it is per-unit exact,
+    // and for a handheld released after the table was last touched it is the
+    // only correct source. Only known once detectTdpMethod() has run, which
+    // is why onLoad re-runs this afterwards.
+    const range = this.wmiPaths?.range;
+    const device = range ? applyFirmwareRange(matched, range) : matched;
+
     this.deviceName = device.name;
     this.minWatts = device.minTdp;
     this.maxWatts = device.maxTdp;
@@ -1402,31 +1477,34 @@ export default class TdpControlBackend implements PluginBackend {
   }
 
   private async detectTdpMethod(): Promise<void> {
-    // 0. Try WMI paths first (higher priority for known devices)
-    if (this.dmiProductName.includes("ROG Ally")) {
-      // Try armoury driver first (newer), then legacy asus-nb-wmi
-      const armouryPaths = ROG_ALLY_WMI_PATHS.armoury;
-      if ((await readFileText(armouryPaths.spl)) !== null) {
-        this.wmiPaths = armouryPaths;
-        this.method = "wmi";
-        console.log("[tdp-control] ROG Ally WMI (armoury) paths detected");
-        return;
-      }
-      const legacyPaths = ROG_ALLY_WMI_PATHS.legacy;
-      if ((await readFileText(legacyPaths.spl)) !== null) {
-        this.wmiPaths = legacyPaths;
-        this.method = "wmi";
-        console.log("[tdp-control] ROG Ally WMI (legacy) paths detected");
-        return;
-      }
+    // 0. Firmware power rails first — the vendor's own interface beats a
+    //    generic one. Discovery is by attribute name across every driver in
+    //    /sys/class/firmware-attributes, so this covers asus-armoury,
+    //    lenovo-wmi-other-N, msi-wmi-platform and whatever ships next
+    //    without a DMI check to maintain. That matters beyond convenience:
+    //    an EC-governed handheld typically also exposes Intel RAPL, but
+    //    RAPL there is locked or immediately overridden by firmware, so
+    //    falling through to it looks like it works and does nothing.
+    const rails = await discoverPowerRails(sysfsDeps);
+    if (rails) {
+      this.wmiPaths = rails;
+      this.method = "wmi";
+      console.log(
+        `[tdp-control] Firmware power rails via ${rails.source}: ` +
+          `spl=${rails.spl}, sppt=${rails.sppt ?? "n/a"}, fppt=${rails.fppt ?? "n/a"}, ` +
+          `range=${rails.range ? `${rails.range.min}-${rails.range.max}W` : "undeclared"}, ` +
+          `unit=${rails.scale === 1000 ? "mW" : "W"}${rails.scaleKnown ? "" : " (assumed)"}`,
+      );
+      return;
     }
-    if (this.dmiProductName.includes("Legion Go")) {
-      if ((await readFileText(LEGION_GO_WMI_PATHS.spl)) !== null) {
-        this.wmiPaths = LEGION_GO_WMI_PATHS;
-        this.method = "wmi";
-        console.log("[tdp-control] Legion Go WMI paths detected");
-        return;
-      }
+    // 0b. Legacy ASUS platform files, for kernels predating asus-armoury.
+    //     Probed unconditionally — the path only exists where the driver is
+    //     bound, which is a better test than a DMI substring.
+    if ((await readFileText(LEGACY_ASUS_WMI_RAILS.spl)) !== null) {
+      this.wmiPaths = LEGACY_ASUS_WMI_RAILS;
+      this.method = "wmi";
+      console.log("[tdp-control] ROG Ally WMI (legacy asus-nb-wmi) paths detected");
+      return;
     }
 
     // 1. Try ryzenadj (AMD only — it writes to the AMD SMU mailbox over
@@ -1463,24 +1541,17 @@ export default class TdpControlBackend implements PluginBackend {
       }
     }
 
-    // 2. Try Intel RAPL sysfs. Probe all candidate paths in parallel
-    //    and pick the first one that returned a value — fan-out is
-    //    safe because reads are independent and the kernel handles
-    //    them on separate fds. Saves 200-400ms on cold start on
-    //    Intel systems where 3 of the 4 paths typically don't exist.
-    //    `INTEL_RAPL_PATHS` is ordered by preference, so picking the
-    //    first non-null hit preserves the existing tie-break.
-    const raplResults = await Promise.all(
-      INTEL_RAPL_PATHS.map(async (path) => ({
-        path,
-        val: await readFileText(path),
-      })),
-    );
-    const raplHit = raplResults.find((r) => r.val !== null);
-    if (raplHit) {
-      this.intelRaplPath = raplHit.path;
+    // 2. Try Intel RAPL powercap. Constraints are resolved by name rather
+    //    than by slot index, and both the sustained and boost limits are
+    //    captured — see ./lib/rapl for why each matters.
+    const rapl = await discoverRaplConstraints(sysfsDeps);
+    if (rapl) {
+      this.intelRapl = rapl;
       this.method = "intel-rapl";
-      console.log(`[tdp-control] Intel RAPL available at ${raplHit.path}`);
+      console.log(
+        `[tdp-control] Intel RAPL available at ${rapl.zone} ` +
+          `(short_term=${rapl.shortTerm ? "yes" : "no"})`,
+      );
       return;
     }
 
@@ -1602,16 +1673,34 @@ export default class TdpControlBackend implements PluginBackend {
         if ((await readFileText(amdOdPath)) !== null) {
           this.gpuCardPath = cardPath;
           this.gpuVendor = "AMD";
+          this.gpuDriver = "amdgpu";
           console.log(`[tdp-control] AMD GPU detected at ${cardPath}`);
           return;
         }
 
-        // Check for Intel GPU (gt_max_freq_mhz)
+        // Check for an i915 Intel GPU (flat gt_max_freq_mhz on the card)
         const intelFreqPath = `${cardPath}/gt_max_freq_mhz`;
         if ((await readFileText(intelFreqPath)) !== null) {
           this.gpuCardPath = cardPath;
           this.gpuVendor = "Intel";
-          console.log(`[tdp-control] Intel GPU detected at ${cardPath}`);
+          this.gpuDriver = "i915";
+          console.log(`[tdp-control] Intel GPU (i915) detected at ${cardPath}`);
+          return;
+        }
+
+        // Check for an xe Intel GPU (per-GT freq dirs). Probed after i915
+        // because the i915 test is a single read against a known path,
+        // where this one walks a directory tree.
+        const xeFreqDirs = await findXeFreqDirs(sysfsDeps, cardPath);
+        if (xeFreqDirs.length > 0) {
+          this.gpuCardPath = cardPath;
+          this.gpuVendor = "Intel";
+          this.gpuDriver = "xe";
+          this.gpuFreqDirs = xeFreqDirs;
+          console.log(
+            `[tdp-control] Intel GPU (xe) detected at ${cardPath}, ` +
+              `${xeFreqDirs.length} GT(s): ${xeFreqDirs.join(", ")}`,
+          );
           return;
         }
       }
@@ -1620,6 +1709,8 @@ export default class TdpControlBackend implements PluginBackend {
     }
     this.gpuCardPath = null;
     this.gpuVendor = "Unknown";
+    this.gpuDriver = null;
+    this.gpuFreqDirs = [];
   }
 
   private async detectAcPower(): Promise<void> {
@@ -1719,18 +1810,31 @@ export default class TdpControlBackend implements PluginBackend {
           cardPath: this.gpuCardPath,
         };
       } else if (this.gpuVendor === "Intel") {
-        const [gtMax, gtMin, gtRP0, gtRPn] = await Promise.all([
-          readFileText(`${this.gpuCardPath}/gt_max_freq_mhz`),
-          readFileText(`${this.gpuCardPath}/gt_min_freq_mhz`),
-          readFileText(`${this.gpuCardPath}/gt_RP0_freq_mhz`),
-          readFileText(`${this.gpuCardPath}/gt_RPn_freq_mhz`),
-        ]);
+        // Both Intel drivers report the same four numbers under different
+        // names: the hardware bounds (RPn/RP0) and the range in force.
+        // Reported from the first GT — it's the render engine, and the UI
+        // shows one range even where a part has several GTs.
+        const freqDir = this.gpuFreqDirs[0];
+        const [max, min, rp0, rpn] =
+          this.gpuDriver === "xe" && freqDir
+            ? await Promise.all([
+                readFileText(`${freqDir}/max_freq`),
+                readFileText(`${freqDir}/min_freq`),
+                readFileText(`${freqDir}/rp0_freq`),
+                readFileText(`${freqDir}/rpn_freq`),
+              ])
+            : await Promise.all([
+                readFileText(`${this.gpuCardPath}/gt_max_freq_mhz`),
+                readFileText(`${this.gpuCardPath}/gt_min_freq_mhz`),
+                readFileText(`${this.gpuCardPath}/gt_RP0_freq_mhz`),
+                readFileText(`${this.gpuCardPath}/gt_RPn_freq_mhz`),
+              ]);
 
         return {
           vendor: "Intel",
-          minFreqMhz: gtRPn ? parseInt(gtRPn, 10) : 0,
-          maxFreqMhz: gtRP0 ? parseInt(gtRP0, 10) : 0,
-          currentMode: `min=${gtMin ?? "?"}MHz max=${gtMax ?? "?"}MHz`,
+          minFreqMhz: rpn ? parseInt(rpn, 10) : 0,
+          maxFreqMhz: rp0 ? parseInt(rp0, 10) : 0,
+          currentMode: `min=${min ?? "?"}MHz max=${max ?? "?"}MHz`,
           cardPath: this.gpuCardPath,
         };
       }
@@ -1748,13 +1852,16 @@ export default class TdpControlBackend implements PluginBackend {
     watts: number;
     source: TdpReadSource;
   } | null> {
-    // 0. Try WMI sysfs (ROG Ally / Legion Go)
+    // 0. Try the firmware power rails (ROG Ally / Legion Go / MSI Claw / …)
     if (this.method === "wmi" && this.wmiPaths) {
       const text = await readFileText(this.wmiPaths.spl);
       if (text !== null) {
-        const milliwatts = parseInt(text, 10);
-        if (!isNaN(milliwatts)) {
-          return { watts: Math.round(milliwatts / 1000), source: "read" };
+        const raw = parseInt(text, 10);
+        if (!isNaN(raw)) {
+          return {
+            watts: Math.round(raw / this.wmiPaths.scale),
+            source: "read",
+          };
         }
       }
     }
@@ -1766,8 +1873,8 @@ export default class TdpControlBackend implements PluginBackend {
     }
 
     // 2. Try Intel RAPL sysfs
-    if (this.method === "intel-rapl" && this.intelRaplPath) {
-      const text = await readFileText(this.intelRaplPath);
+    if (this.method === "intel-rapl" && this.intelRapl) {
+      const text = await readFileText(this.intelRapl.longTerm);
       if (text !== null) {
         const uw = parseInt(text, 10);
         if (!isNaN(uw)) {
@@ -1841,22 +1948,81 @@ export default class TdpControlBackend implements PluginBackend {
     }
   }
 
+  /**
+   * Drive the RAPL package zone to `watts`.
+   *
+   * The short-term (PL2) limit is pinned to the same wattage before the
+   * sustained one, best-effort: left at its firmware default it lets a
+   * base/boost part spend the boost budget no matter where the slider sits,
+   * but plenty of zones expose no short-term constraint or refuse writes to
+   * it, and neither should fail an otherwise good apply.
+   */
   private async setTdpViaIntelRapl(watts: number): Promise<void> {
-    if (!this.intelRaplPath) {
+    const rapl = this.intelRapl;
+    if (!rapl) {
       throw new Error("Intel RAPL path not available");
     }
-    const microwatts = String(watts * 1_000_000);
-    await writeSysfs(this.intelRaplPath, microwatts);
+    const microwatts = String(Math.round(watts * 1_000_000));
+
+    if (rapl.shortTerm) {
+      try {
+        await writeSysfs(rapl.shortTerm, microwatts);
+      } catch (e) {
+        console.warn(`[tdp-control] RAPL short_term not writable: ${e}`);
+      }
+    }
+    await writeSysfs(rapl.longTerm, microwatts);
   }
 
+  /**
+   * Drive the firmware power rails to `watts`.
+   *
+   * Only the sustained rail (SPL/PL1) is required: MSI's driver exposes just
+   * PL1 + PL2, and the old code's unconditional write of all three threw on
+   * anything that didn't have a PL3. The boost rails are pinned to the same
+   * wattage rather than left alone, so a firmware-default PL2 can't spend the
+   * whole envelope the moment load arrives.
+   *
+   * Rails are written boost-first so the sustained limit — the one we read
+   * back and the one that governs — lands last and wins any firmware
+   * cross-validation between them.
+   */
   private async setTdpViaWmi(watts: number): Promise<void> {
-    if (!this.wmiPaths) {
+    const rails = this.wmiPaths;
+    if (!rails) {
       throw new Error("WMI paths not available");
     }
-    const milliwatts = String(watts * 1000);
-    await writeSysfs(this.wmiPaths.fppt, milliwatts);
-    await writeSysfs(this.wmiPaths.sppt, milliwatts);
-    await writeSysfs(this.wmiPaths.spl, milliwatts);
+
+    const write = (path: string) =>
+      writeSysfs(path, String(Math.round(watts * rails.scale)));
+
+    // Boost rails are best-effort: a firmware that rejects or omits them is
+    // still perfectly controllable through the sustained rail.
+    for (const path of [rails.fppt, rails.sppt]) {
+      if (!path) continue;
+      try {
+        await write(path);
+      } catch (e) {
+        console.warn(`[tdp-control] boost rail ${path} not writable: ${e}`);
+      }
+    }
+
+    try {
+      await write(rails.spl);
+    } catch (e) {
+      // The unit is only a guess on interfaces that declare no max_value.
+      // Rather than leave the device uncontrollable on a bad guess, flip the
+      // scale once and latch whichever one the firmware accepts.
+      if (rails.scaleKnown) throw e;
+      const flipped = rails.scale === 1 ? 1000 : 1;
+      console.warn(
+        `[tdp-control] ${rails.spl} rejected ${watts * rails.scale}; ` +
+          `retrying as ${watts * flipped} (unit was assumed, not declared)`,
+      );
+      await writeSysfs(rails.spl, String(Math.round(watts * flipped)));
+      rails.scale = flipped;
+      rails.scaleKnown = true;
+    }
   }
 
   // -----------------------------------------------------------------------

--- a/plugins/tdp-control/backend.ts
+++ b/plugins/tdp-control/backend.ts
@@ -1501,7 +1501,11 @@ export default class TdpControlBackend implements PluginBackend {
     //     Probed unconditionally — the path only exists where the driver is
     //     bound, which is a better test than a DMI substring.
     if ((await readFileText(LEGACY_ASUS_WMI_RAILS.spl)) !== null) {
-      this.wmiPaths = LEGACY_ASUS_WMI_RAILS;
+      // Copy, don't alias: setTdpViaWmi learns `scale`/`scaleKnown` from a
+      // successful write and stores it back on this object. Handing out the
+      // module-level const would leak that learned state into every other
+      // instance (and across tests) instead of keeping it per-controller.
+      this.wmiPaths = { ...LEGACY_ASUS_WMI_RAILS };
       this.method = "wmi";
       console.log("[tdp-control] ROG Ally WMI (legacy asus-nb-wmi) paths detected");
       return;
@@ -2010,16 +2014,26 @@ export default class TdpControlBackend implements PluginBackend {
     try {
       await write(rails.spl);
     } catch (e) {
-      // The unit is only a guess on interfaces that declare no max_value.
-      // Rather than leave the device uncontrollable on a bad guess, flip the
-      // scale once and latch whichever one the firmware accepts.
-      if (rails.scaleKnown) throw e;
+      // Flip the unit once and latch whichever one the firmware accepts.
+      //
+      // This runs even when `scaleKnown` is true. "Known" means inferred
+      // from max_value, and a rejected write is precisely the evidence that
+      // the inference was wrong — gating the retry on it left the only
+      // devices with a declared range (asus-armoury, lenovo-wmi-other-N)
+      // with no recovery at all, which is the wrong way round. If the flip
+      // is also rejected the original error is what propagates, so trying
+      // costs nothing beyond one extra failed write.
       const flipped = rails.scale === 1 ? 1000 : 1;
       console.warn(
         `[tdp-control] ${rails.spl} rejected ${watts * rails.scale}; ` +
-          `retrying as ${watts * flipped} (unit was assumed, not declared)`,
+          `retrying as ${watts * flipped} (unit was ` +
+          `${rails.scaleKnown ? "declared — the declaration looks wrong" : "assumed, not declared"})`,
       );
-      await writeSysfs(rails.spl, String(Math.round(watts * flipped)));
+      try {
+        await writeSysfs(rails.spl, String(Math.round(watts * flipped)));
+      } catch {
+        throw e;
+      }
       rails.scale = flipped;
       rails.scaleKnown = true;
     }

--- a/plugins/tdp-control/lib/firmware-attributes.test.ts
+++ b/plugins/tdp-control/lib/firmware-attributes.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "bun:test";
+import {
+  discoverPowerRails,
+  inferWattScale,
+  pickAttribute,
+  FIRMWARE_ATTRIBUTES_DIR,
+  type FirmwareAttrDeps,
+} from "./firmware-attributes";
+
+/**
+ * In-memory sysfs: directories are keys mapping to their entry basenames,
+ * files are keys mapping to their contents. Anything absent reads as null,
+ * the same contract the backend's readFileText / readdir wrappers provide.
+ */
+function fakeFs(tree: {
+  dirs: Record<string, string[]>;
+  files: Record<string, string>;
+}): FirmwareAttrDeps {
+  return {
+    readFile: async (path) => tree.files[path] ?? null,
+    listDir: async (path) => tree.dirs[path] ?? null,
+  };
+}
+
+/** The real shape of a vendor driver's attribute tree, in watts. */
+function driverTree(
+  driver: string,
+  attrs: string[],
+  range: { min: number; max: number } | null = { min: 8, max: 35 },
+) {
+  const base = `${FIRMWARE_ATTRIBUTES_DIR}/${driver}/attributes`;
+  const files: Record<string, string> = {};
+  for (const attr of attrs) {
+    files[`${base}/${attr}/current_value`] = "15\n";
+    if (range) {
+      files[`${base}/${attr}/min_value`] = `${range.min}\n`;
+      files[`${base}/${attr}/max_value`] = `${range.max}\n`;
+    }
+  }
+  return {
+    dirs: {
+      [FIRMWARE_ATTRIBUTES_DIR]: [driver],
+      [base]: attrs,
+    },
+    files,
+  };
+}
+
+describe("pickAttribute", () => {
+  it("returns the first candidate that exists", () => {
+    expect(pickAttribute(["ppt_fppt", "ppt_pl3_fppt"], ["ppt_pl3_fppt", "ppt_fppt"])).toBe(
+      "ppt_pl3_fppt",
+    );
+  });
+
+  it("returns null when none exist", () => {
+    expect(pickAttribute(["ppt_pl1_spl"], ["ppt_pl2_sppt"])).toBeNull();
+  });
+});
+
+describe("inferWattScale", () => {
+  // The `ppt_*` attributes are watts on every driver we know of; reading the
+  // declared ceiling means a vendor that chose milliwatts still works.
+  it("reads a two-digit ceiling as watts", () => {
+    expect(inferWattScale(35)).toEqual({ scale: 1, known: true });
+  });
+
+  it("reads a five-digit ceiling as milliwatts", () => {
+    expect(inferWattScale(35000)).toEqual({ scale: 1000, known: true });
+  });
+
+  it("assumes watts, and says so, when nothing is declared", () => {
+    expect(inferWattScale(null)).toEqual({ scale: 1, known: false });
+  });
+});
+
+describe("discoverPowerRails", () => {
+  it("finds MSI's PL1 + PL2 and reports the absent PL3 as null", async () => {
+    // msi-wmi-platform (MSI Claw, incl. the Arc G3 Extreme Claw 8 EX)
+    // exposes no fast rail — the old code wrote all three unconditionally.
+    const rails = await discoverPowerRails(
+      fakeFs(driverTree("msi-wmi-platform", ["ppt_pl1_spl", "ppt_pl2_sppt"])),
+    );
+    const base = `${FIRMWARE_ATTRIBUTES_DIR}/msi-wmi-platform/attributes`;
+
+    expect(rails).toEqual({
+      spl: `${base}/ppt_pl1_spl/current_value`,
+      sppt: `${base}/ppt_pl2_sppt/current_value`,
+      fppt: null,
+      scale: 1,
+      scaleKnown: true,
+      range: { min: 8, max: 35 },
+      source: "msi-wmi-platform",
+    });
+  });
+
+  it("finds ASUS's armoury rails, PL3 under its ppt_fppt spelling", async () => {
+    const rails = await discoverPowerRails(
+      fakeFs(
+        driverTree("asus-armoury", ["ppt_pl1_spl", "ppt_pl2_sppt", "ppt_fppt"], {
+          min: 7,
+          max: 30,
+        }),
+      ),
+    );
+    expect(rails?.source).toBe("asus-armoury");
+    expect(rails?.fppt).toContain("ppt_fppt/current_value");
+    expect(rails?.range).toEqual({ min: 7, max: 30 });
+  });
+
+  it("finds Lenovo's rails, PL3 under its ppt_pl3_fppt spelling", async () => {
+    const rails = await discoverPowerRails(
+      fakeFs(
+        driverTree("lenovo-wmi-other-0", ["ppt_pl1_spl", "ppt_pl2_sppt", "ppt_pl3_fppt"]),
+      ),
+    );
+    expect(rails?.source).toBe("lenovo-wmi-other-0");
+    expect(rails?.fppt).toContain("ppt_pl3_fppt/current_value");
+  });
+
+  it("converts a milliwatt-declared range into watts", async () => {
+    const rails = await discoverPowerRails(
+      fakeFs(
+        driverTree("hypothetical-wmi", ["ppt_pl1_spl"], { min: 8000, max: 35000 }),
+      ),
+    );
+    expect(rails?.scale).toBe(1000);
+    expect(rails?.range).toEqual({ min: 8, max: 35 });
+  });
+
+  it("reports no range when the driver declares none", async () => {
+    const rails = await discoverPowerRails(
+      fakeFs(driverTree("bare-wmi", ["ppt_pl1_spl"], null)),
+    );
+    expect(rails?.range).toBeNull();
+    expect(rails?.scaleKnown).toBe(false);
+  });
+
+  it("ignores a degenerate range where min equals max", async () => {
+    const rails = await discoverPowerRails(
+      fakeFs(driverTree("stuck-wmi", ["ppt_pl1_spl"], { min: 15, max: 15 })),
+    );
+    expect(rails?.range).toBeNull();
+  });
+
+  it("skips a driver with no sustained rail and keeps looking", async () => {
+    // A boost limit with nothing to steer underneath is not controllable.
+    const boostOnly = driverTree("boost-only-wmi", ["ppt_pl2_sppt"]);
+    const real = driverTree("zz-real-wmi", ["ppt_pl1_spl"]);
+    const rails = await discoverPowerRails(
+      fakeFs({
+        dirs: {
+          ...boostOnly.dirs,
+          ...real.dirs,
+          [FIRMWARE_ATTRIBUTES_DIR]: ["boost-only-wmi", "zz-real-wmi"],
+        },
+        files: { ...boostOnly.files, ...real.files },
+      }),
+    );
+    expect(rails?.source).toBe("zz-real-wmi");
+  });
+
+  it("returns null when the class directory doesn't exist", async () => {
+    expect(await discoverPowerRails(fakeFs({ dirs: {}, files: {} }))).toBeNull();
+  });
+
+  it("returns null when no driver exposes power rails", async () => {
+    const other = driverTree("thinklmi", ["boot_order"]);
+    expect(await discoverPowerRails(fakeFs(other))).toBeNull();
+  });
+
+  it("picks the same driver every boot when several qualify", async () => {
+    const a = driverTree("aaa-wmi", ["ppt_pl1_spl"]);
+    const z = driverTree("zzz-wmi", ["ppt_pl1_spl"]);
+    const tree = {
+      dirs: { ...a.dirs, ...z.dirs, [FIRMWARE_ATTRIBUTES_DIR]: ["zzz-wmi", "aaa-wmi"] },
+      files: { ...a.files, ...z.files },
+    };
+    expect((await discoverPowerRails(fakeFs(tree)))?.source).toBe("aaa-wmi");
+  });
+});

--- a/plugins/tdp-control/lib/firmware-attributes.ts
+++ b/plugins/tdp-control/lib/firmware-attributes.ts
@@ -1,0 +1,175 @@
+/**
+ * Discovery for the kernel's `firmware-attributes` power-limit interface —
+ * the vendor-neutral way modern handheld firmware exposes its TDP rails.
+ *
+ * Every vendor driver implementing it lays the same tree out:
+ *
+ *     /sys/class/firmware-attributes/<driver>/attributes/<attr>/
+ *         current_value  min_value  max_value  scalar_increment  type
+ *
+ * and, crucially, they agree on the attribute *names* for the power rails
+ * even though the driver directory differs per vendor:
+ *
+ *     asus-armoury         ROG Ally / Ally X
+ *     lenovo-wmi-other-N   Legion Go
+ *     msi-wmi-platform     MSI Claw (incl. the Arc G3 Extreme Claw 8 EX)
+ *
+ * Matching on the attribute names rather than the driver name is what lets a
+ * handheld we've never seen work on day one — the previous approach hardcoded
+ * two driver paths behind a DMI check for "ROG Ally" / "Legion Go", so every
+ * other device silently fell through to Intel RAPL (commonly locked or
+ * overridden by the EC on these machines: the slider moved, nothing happened).
+ *
+ * The interface is self-describing — `min_value`/`max_value` state the
+ * envelope the firmware will actually accept — so a device with no entry in
+ * `@loadout/devices` still gets a correct slider range, and we learn the
+ * rail's unit instead of assuming it.
+ *
+ * I/O is injected (`FirmwareAttrDeps`) so the whole module is unit-testable
+ * without sysfs, the same pattern `plugins/wifi/lib/recovery.ts` uses.
+ */
+
+export const FIRMWARE_ATTRIBUTES_DIR = "/sys/class/firmware-attributes";
+
+/**
+ * Attribute names per power rail, most-preferred first.
+ *
+ * SPL (PL1, sustained) is the rail we actually steer and the one a device
+ * must expose to be usable. SPPT (PL2, boost) and FPPT (PL3, fast) are
+ * written alongside it when present so a boost limit can't blow past the
+ * sustained one — MSI exposes only PL1 + PL2, ASUS and Lenovo expose all
+ * three under different PL3 spellings.
+ */
+export const PPT_RAIL_ATTRS = {
+  spl: ["ppt_pl1_spl"],
+  sppt: ["ppt_pl2_sppt"],
+  fppt: ["ppt_pl3_fppt", "ppt_fppt"],
+} as const;
+
+export interface WattRange {
+  min: number;
+  max: number;
+}
+
+/** The set of power-limit sysfs files to drive, plus what we learned about them. */
+export interface PowerRails {
+  /** Sustained limit (PL1/SPL) — always present; the rail we steer. */
+  spl: string;
+  /** Boost limit (PL2/SPPT), or null when the firmware exposes none. */
+  sppt: string | null;
+  /** Fast limit (PL3/FPPT), or null when the firmware exposes none. */
+  fppt: string | null;
+  /** Multiplier from watts to the unit these files expect (1 = W, 1000 = mW). */
+  scale: number;
+  /**
+   * True when `scale` came from a firmware-declared `max_value` rather than
+   * being assumed. Callers use this to decide whether a rejected write is
+   * worth retrying in the other unit.
+   */
+  scaleKnown: boolean;
+  /** Envelope the firmware declares for the SPL rail, in watts. */
+  range: WattRange | null;
+  /** Driver directory (or a label for the legacy path) — for logs. */
+  source: string;
+}
+
+export interface FirmwareAttrDeps {
+  /** Read a file, or null when it doesn't exist / can't be read. */
+  readFile: (path: string) => Promise<string | null>;
+  /** Entry basenames of a directory, or null when it doesn't exist. */
+  listDir: (path: string) => Promise<string[] | null>;
+}
+
+/**
+ * A declared ceiling at or above this is read as milliwatts.
+ *
+ * The two units are separated by three orders of magnitude and the plausible
+ * ranges don't come close to overlapping: no handheld sustains 1000 W, and no
+ * firmware caps a rail at under 1 W. `ppt_*` attributes are watts on every
+ * driver we know of, but reading the declared ceiling means we don't have to
+ * bet on that holding for the next vendor.
+ */
+export const MILLIWATT_MIN_CEILING = 1000;
+
+/** Infer the watts→attribute-unit multiplier from a declared ceiling. Pure. */
+export function inferWattScale(maxValue: number | null): {
+  scale: number;
+  known: boolean;
+} {
+  if (maxValue === null || !Number.isFinite(maxValue)) {
+    return { scale: 1, known: false };
+  }
+  return maxValue >= MILLIWATT_MIN_CEILING
+    ? { scale: 1000, known: true }
+    : { scale: 1, known: true };
+}
+
+/** First candidate present in `available`, or null. Pure. */
+export function pickAttribute(
+  available: readonly string[],
+  candidates: readonly string[],
+): string | null {
+  return candidates.find((name) => available.includes(name)) ?? null;
+}
+
+function parseIntOrNull(text: string | null): number | null {
+  if (text === null) return null;
+  const n = parseInt(text.trim(), 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+/**
+ * Scan `/sys/class/firmware-attributes` for a driver exposing the `ppt_*`
+ * power rails and describe them. Returns null when no driver does.
+ *
+ * Drivers are visited in sorted order so a machine with more than one
+ * resolves the same way every boot.
+ */
+export async function discoverPowerRails(
+  deps: FirmwareAttrDeps,
+): Promise<PowerRails | null> {
+  const drivers = await deps.listDir(FIRMWARE_ATTRIBUTES_DIR);
+  if (!drivers) return null;
+
+  for (const driver of [...drivers].sort()) {
+    const attrsDir = `${FIRMWARE_ATTRIBUTES_DIR}/${driver}/attributes`;
+    const available = await deps.listDir(attrsDir);
+    if (!available) continue;
+
+    const spl = pickAttribute(available, PPT_RAIL_ATTRS.spl);
+    // No sustained rail means nothing to steer — a driver exposing only a
+    // boost limit isn't usable, so keep looking.
+    if (!spl) continue;
+
+    const sppt = pickAttribute(available, PPT_RAIL_ATTRS.sppt);
+    const fppt = pickAttribute(available, PPT_RAIL_ATTRS.fppt);
+    const valuePath = (attr: string) => `${attrsDir}/${attr}/current_value`;
+
+    const [minText, maxText] = await Promise.all([
+      deps.readFile(`${attrsDir}/${spl}/min_value`),
+      deps.readFile(`${attrsDir}/${spl}/max_value`),
+    ]);
+    const rawMin = parseIntOrNull(minText);
+    const rawMax = parseIntOrNull(maxText);
+    const { scale, known } = inferWattScale(rawMax);
+
+    // A range is only useful if it's a real interval — a driver reporting
+    // min === max (or nothing at all) leaves the device database in charge.
+    const range =
+      rawMin !== null && rawMax !== null && rawMax > rawMin
+        ? { min: Math.round(rawMin / scale), max: Math.round(rawMax / scale) }
+        : null;
+
+    return {
+      spl: valuePath(spl),
+      sppt: sppt ? valuePath(sppt) : null,
+      fppt: fppt ? valuePath(fppt) : null,
+      scale,
+      scaleKnown: known,
+      range,
+      source: driver,
+    };
+  }
+
+  return null;
+}

--- a/plugins/tdp-control/lib/gpu.test.ts
+++ b/plugins/tdp-control/lib/gpu.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "bun:test";
+import { findXeFreqDirs, writeCeilingFirst, type GpuFsDeps } from "./gpu";
+
+function fakeFs(tree: {
+  dirs: Record<string, string[]>;
+  files: Record<string, string>;
+}): GpuFsDeps {
+  return {
+    readFile: async (path) => tree.files[path] ?? null,
+    listDir: async (path) => tree.dirs[path] ?? null,
+  };
+}
+
+const CARD = "/sys/class/drm/card0";
+
+/** An `xe` card exposing one freq0 dir per (tile, gt) pair given. */
+function xeCard(gts: Array<[string, string]>) {
+  const dirs: Record<string, string[]> = {};
+  const files: Record<string, string> = {};
+  const tiles = [...new Set(gts.map(([tile]) => tile))];
+  dirs[`${CARD}/device`] = [...tiles, "power", "uevent"];
+  for (const tile of tiles) {
+    dirs[`${CARD}/device/${tile}`] = gts.filter(([t]) => t === tile).map(([, gt]) => gt);
+  }
+  for (const [tile, gt] of gts) {
+    files[`${CARD}/device/${tile}/${gt}/freq0/max_freq`] = "2300\n";
+  }
+  return { dirs, files };
+}
+
+describe("findXeFreqDirs", () => {
+  it("finds every GT on a multi-GT part, in tile-then-GT order", async () => {
+    // Panther Lake exposes a render GT and a media GT — bounding only the
+    // first would leave the other running free.
+    const dirs = await findXeFreqDirs(
+      fakeFs(xeCard([["tile0", "gt1"], ["tile0", "gt0"]])),
+      CARD,
+    );
+    expect(dirs).toEqual([
+      `${CARD}/device/tile0/gt0/freq0`,
+      `${CARD}/device/tile0/gt1/freq0`,
+    ]);
+  });
+
+  it("walks multiple tiles", async () => {
+    const dirs = await findXeFreqDirs(
+      fakeFs(xeCard([["tile1", "gt0"], ["tile0", "gt0"]])),
+      CARD,
+    );
+    expect(dirs).toEqual([
+      `${CARD}/device/tile0/gt0/freq0`,
+      `${CARD}/device/tile1/gt0/freq0`,
+    ]);
+  });
+
+  it("skips a GT with no freq0 knobs", async () => {
+    const tree = xeCard([["tile0", "gt0"], ["tile0", "gt1"]]);
+    delete tree.files[`${CARD}/device/tile0/gt1/freq0/max_freq`];
+    expect(await findXeFreqDirs(fakeFs(tree), CARD)).toEqual([
+      `${CARD}/device/tile0/gt0/freq0`,
+    ]);
+  });
+
+  it("returns nothing for an i915 card (no tile dirs)", async () => {
+    const tree = {
+      dirs: { [`${CARD}/device`]: ["power", "uevent"] },
+      files: { [`${CARD}/gt_max_freq_mhz`]: "2300\n" },
+    };
+    expect(await findXeFreqDirs(fakeFs(tree), CARD)).toEqual([]);
+  });
+
+  it("returns nothing when the device dir doesn't exist", async () => {
+    expect(await findXeFreqDirs(fakeFs({ dirs: {}, files: {} }), CARD)).toEqual([]);
+  });
+});
+
+describe("writeCeilingFirst", () => {
+  // Either fixed order wedges half the time: the kernel rejects a write that
+  // would leave the floor above the ceiling.
+  it("raises the ceiling first when the new floor clears the old ceiling", () => {
+    expect(writeCeilingFirst(500, 800)).toBe(true);
+  });
+
+  it("lowers the floor first when the new floor fits under the old ceiling", () => {
+    expect(writeCeilingFirst(2000, 300)).toBe(false);
+  });
+
+  it("treats an equal floor and ceiling as no reordering needed", () => {
+    expect(writeCeilingFirst(800, 800)).toBe(false);
+  });
+
+  it("assumes a raise when the current ceiling can't be read", () => {
+    expect(writeCeilingFirst(null, 800)).toBe(true);
+    expect(writeCeilingFirst(NaN, 800)).toBe(true);
+  });
+});

--- a/plugins/tdp-control/lib/gpu.ts
+++ b/plugins/tdp-control/lib/gpu.ts
@@ -1,0 +1,69 @@
+/**
+ * GPU frequency-interface helpers.
+ *
+ * Intel's two DRM drivers expose completely different trees for the same
+ * four numbers, and which one a machine uses is a function of its silicon:
+ *
+ *   i915  <card>/gt_{min,max,RP0,RPn}_freq_mhz
+ *   xe    <card>/device/tile<N>/gt<M>/freq0/{min,max,rp0,rpn}_freq
+ *
+ * `xe` is what Xe/Xe3 graphics bind to, so every Lunar Lake and Panther Lake
+ * part — including the Arc G3 Extreme handhelds — lands there. Probing only
+ * the i915 layout left `gpuVendor` as "Unknown" on those devices and hid the
+ * GPU panel outright.
+ *
+ * I/O is injected so this is unit-testable without /sys.
+ */
+
+export interface GpuFsDeps {
+  /** Read a file, or null when it doesn't exist / can't be read. */
+  readFile: (path: string) => Promise<string | null>;
+  /** Entry basenames of a directory, or null when it doesn't exist. */
+  listDir: (path: string) => Promise<string[] | null>;
+}
+
+/**
+ * Frequency-control directories for an `xe` card, one per graphics tile/GT,
+ * in stable tile-then-GT order. Empty when the card isn't an `xe` device.
+ *
+ * The tree is walked rather than assuming `tile0/gt0`: a Panther Lake part
+ * exposes a render GT and a media GT, and leaving the second one unbounded
+ * would undercut the point of setting a ceiling.
+ */
+export async function findXeFreqDirs(
+  deps: GpuFsDeps,
+  cardPath: string,
+): Promise<string[]> {
+  const deviceDir = `${cardPath}/device`;
+  const entries = (await deps.listDir(deviceDir)) ?? [];
+  const dirs: string[] = [];
+
+  for (const tile of entries.filter((e) => /^tile\d+$/.test(e)).sort()) {
+    const tileDir = `${deviceDir}/${tile}`;
+    const gts = (await deps.listDir(tileDir)) ?? [];
+    for (const gt of gts.filter((e) => /^gt\d+$/.test(e)).sort()) {
+      const freqDir = `${tileDir}/${gt}/freq0`;
+      if ((await deps.readFile(`${freqDir}/max_freq`)) !== null) {
+        dirs.push(freqDir);
+      }
+    }
+  }
+  return dirs;
+}
+
+/**
+ * Whether a floor/ceiling pair must be written ceiling-first. Pure.
+ *
+ * Both Intel drivers reject a write that would leave the floor above the
+ * ceiling, so neither fixed order is safe: raising the whole range needs the
+ * ceiling moved up first, lowering it needs the floor moved down first. An
+ * unreadable current ceiling is treated as "raise" — that's the order that
+ * can't wedge on a range we couldn't inspect.
+ */
+export function writeCeilingFirst(
+  currentMax: number | null,
+  minMhz: number,
+): boolean {
+  if (currentMax === null || Number.isNaN(currentMax)) return true;
+  return minMhz > currentMax;
+}

--- a/plugins/tdp-control/lib/rapl.test.ts
+++ b/plugins/tdp-control/lib/rapl.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "bun:test";
+import {
+  discoverRaplConstraints,
+  resolveZoneConstraints,
+  INTEL_RAPL_ZONES,
+  type RaplDeps,
+} from "./rapl";
+
+function fakeFs(files: Record<string, string>): RaplDeps {
+  return { readFile: async (path) => files[path] ?? null };
+}
+
+/** A package zone with the named constraints, in the given slot order. */
+function zoneFiles(zone: string, names: string[]) {
+  const files: Record<string, string> = {};
+  names.forEach((name, i) => {
+    files[`${zone}/constraint_${i}_name`] = `${name}\n`;
+    files[`${zone}/constraint_${i}_power_limit_uw`] = "15000000\n";
+  });
+  return files;
+}
+
+const MMIO = INTEL_RAPL_ZONES[0]!;
+const MSR = INTEL_RAPL_ZONES[1]!;
+
+describe("resolveZoneConstraints", () => {
+  it("resolves both limits by name", async () => {
+    const zone = MMIO;
+    const got = await resolveZoneConstraints(
+      fakeFs(zoneFiles(zone, ["long_term", "short_term"])),
+      zone,
+    );
+    expect(got).toEqual({
+      zone,
+      longTerm: `${zone}/constraint_0_power_limit_uw`,
+      shortTerm: `${zone}/constraint_1_power_limit_uw`,
+    });
+  });
+
+  // Slot order is conventional, not guaranteed — reading the name is the
+  // whole point of resolving rather than assuming index 0 is PL1.
+  it("resolves correctly when the constraints are in the other order", async () => {
+    const zone = MMIO;
+    const got = await resolveZoneConstraints(
+      fakeFs(zoneFiles(zone, ["short_term", "long_term"])),
+      zone,
+    );
+    expect(got?.longTerm).toBe(`${zone}/constraint_1_power_limit_uw`);
+    expect(got?.shortTerm).toBe(`${zone}/constraint_0_power_limit_uw`);
+  });
+
+  it("ignores constraints it doesn't steer, like peak_power", async () => {
+    const zone = MMIO;
+    const got = await resolveZoneConstraints(
+      fakeFs(zoneFiles(zone, ["long_term", "peak_power"])),
+      zone,
+    );
+    expect(got?.longTerm).toBe(`${zone}/constraint_0_power_limit_uw`);
+    expect(got?.shortTerm).toBeNull();
+  });
+
+  it("reports a missing short-term limit as null rather than failing", async () => {
+    const zone = MMIO;
+    const got = await resolveZoneConstraints(fakeFs(zoneFiles(zone, ["long_term"])), zone);
+    expect(got?.shortTerm).toBeNull();
+  });
+
+  // Pre-name behaviour: an unnamed zone still works off slot 0.
+  it("falls back to slot 0 when no constraint is named", async () => {
+    const zone = MMIO;
+    const got = await resolveZoneConstraints(
+      fakeFs({ [`${zone}/constraint_0_power_limit_uw`]: "15000000\n" }),
+      zone,
+    );
+    expect(got?.longTerm).toBe(`${zone}/constraint_0_power_limit_uw`);
+  });
+
+  it("returns null for a zone with named constraints but no long_term", async () => {
+    const zone = MMIO;
+    expect(
+      await resolveZoneConstraints(fakeFs(zoneFiles(zone, ["short_term"])), zone),
+    ).toBeNull();
+  });
+
+  it("returns null for a zone that doesn't exist", async () => {
+    expect(await resolveZoneConstraints(fakeFs({}), MMIO)).toBeNull();
+  });
+});
+
+describe("discoverRaplConstraints", () => {
+  it("prefers the MMIO zone over the MSR one", async () => {
+    const got = await discoverRaplConstraints(
+      fakeFs({
+        ...zoneFiles(MMIO, ["long_term", "short_term"]),
+        ...zoneFiles(MSR, ["long_term", "short_term"]),
+      }),
+    );
+    expect(got?.zone).toBe(MMIO);
+  });
+
+  it("falls through to the next zone when the preferred one is absent", async () => {
+    const got = await discoverRaplConstraints(
+      fakeFs(zoneFiles(MSR, ["long_term", "short_term"])),
+    );
+    expect(got?.zone).toBe(MSR);
+  });
+
+  it("returns null when no zone exposes a sustained limit", async () => {
+    expect(await discoverRaplConstraints(fakeFs({}))).toBeNull();
+  });
+});

--- a/plugins/tdp-control/lib/rapl.ts
+++ b/plugins/tdp-control/lib/rapl.ts
@@ -1,0 +1,103 @@
+/**
+ * Intel RAPL powercap discovery.
+ *
+ * RAPL is the fallback for Intel devices whose vendor driver exposes no
+ * firmware power rails (see `./firmware-attributes`). A powercap zone looks
+ * like:
+ *
+ *     <zone>/constraint_0_name            "long_term"
+ *     <zone>/constraint_0_power_limit_uw
+ *     <zone>/constraint_1_name            "short_term"
+ *     <zone>/constraint_1_power_limit_uw
+ *
+ * Two things this gets right that reading `constraint_0_power_limit_uw`
+ * directly does not:
+ *
+ *  - **Which constraint is which is named, not positional.** The ordering is
+ *    conventional, not guaranteed, and a zone may expose "peak_power" or
+ *    "short_term" first. Resolve by `constraint_N_name`.
+ *  - **The short-term limit matters.** Steering PL1 alone leaves PL2 at its
+ *    firmware default, so a chip with a base/boost split — Panther Lake ships
+ *    35 W base against a much higher boost ceiling — spends the boost budget
+ *    regardless of where the slider sits.
+ *
+ * I/O is injected so this is unit-testable without /sys.
+ */
+
+/**
+ * Candidate package zones, most-preferred first. The MMIO variant is
+ * preferred where present: it is the interface the firmware itself uses, and
+ * it survives on parts where the MSR view is locked.
+ */
+export const INTEL_RAPL_ZONES = [
+  "/sys/devices/virtual/powercap/intel-rapl-mmio/intel-rapl-mmio:0",
+  "/sys/devices/virtual/powercap/intel-rapl/intel-rapl:0",
+  "/sys/class/powercap/intel-rapl:0",
+];
+
+/** How many `constraint_N_*` slots to probe within a zone. */
+export const RAPL_MAX_CONSTRAINTS = 4;
+
+export interface RaplConstraints {
+  /** Zone directory the constraints belong to. */
+  zone: string;
+  /** Sustained limit (PL1) in microwatts — the rail we steer. */
+  longTerm: string;
+  /** Boost limit (PL2) in microwatts, when the zone exposes one. */
+  shortTerm: string | null;
+}
+
+export interface RaplDeps {
+  /** Read a file, or null when it doesn't exist / can't be read. */
+  readFile: (path: string) => Promise<string | null>;
+}
+
+const LIMIT_SUFFIX = "_power_limit_uw";
+
+/**
+ * Resolve a zone's power-limit files by constraint name.
+ *
+ * Returns null when the zone exposes no writable sustained limit. When no
+ * constraint is *named* but slot 0 has a limit file, slot 0 is taken as the
+ * sustained limit — the positional assumption the kernel's own convention
+ * makes, and what this code did before names were consulted.
+ */
+export async function resolveZoneConstraints(
+  deps: RaplDeps,
+  zone: string,
+): Promise<RaplConstraints | null> {
+  let longTerm: string | null = null;
+  let shortTerm: string | null = null;
+  let anyNamed = false;
+
+  for (let i = 0; i < RAPL_MAX_CONSTRAINTS; i++) {
+    const limit = `${zone}/constraint_${i}${LIMIT_SUFFIX}`;
+    if ((await deps.readFile(limit)) === null) continue;
+
+    const name = (await deps.readFile(`${zone}/constraint_${i}_name`))?.trim();
+    if (name) anyNamed = true;
+    if (name === "long_term" && !longTerm) longTerm = limit;
+    else if (name === "short_term" && !shortTerm) shortTerm = limit;
+  }
+
+  if (!longTerm && !anyNamed) {
+    const slot0 = `${zone}/constraint_0${LIMIT_SUFFIX}`;
+    if ((await deps.readFile(slot0)) !== null) longTerm = slot0;
+  }
+
+  return longTerm ? { zone, longTerm, shortTerm } : null;
+}
+
+/** First candidate zone exposing a sustained power limit, or null. */
+export async function discoverRaplConstraints(
+  deps: RaplDeps,
+): Promise<RaplConstraints | null> {
+  // Probed in preference order rather than in parallel: the whole point of
+  // the ordering is the tie-break, and a hit on the first candidate makes
+  // the rest moot.
+  for (const zone of INTEL_RAPL_ZONES) {
+    const resolved = await resolveZoneConstraints(deps, zone);
+    if (resolved) return resolved;
+  }
+  return null;
+}

--- a/plugins/wifi/lib/recovery.test.ts
+++ b/plugins/wifi/lib/recovery.test.ts
@@ -4,6 +4,7 @@ import {
   findWifiDevice,
   modulesForDriver,
   findModuleHolders,
+  filterLoadedModules,
   readRfkill,
   detectDriverInfo,
   getWifiDevice,
@@ -88,6 +89,16 @@ function makeHarness(init?: { rfkillAbsent?: boolean }) {
 
 type Harness = ReturnType<typeof makeHarness>;
 
+/**
+ * `/proc/modules` for a pre-Wi-Fi-7 Intel radio: iwlmvm is the loaded
+ * opmode, iwlmld isn't present. unloadModules filters the driver map down
+ * to this before shelling out to modprobe.
+ */
+const IWLMVM_PROC_MODULES = [
+  "iwlmvm 851968 0 - Live 0x0",
+  "iwlwifi 479232 1 iwlmvm, Live 0x0",
+].join("\n");
+
 /** Wire up /sys links for a live Intel card on `iface`. */
 function linkIntel(h: Harness, iface = "wlan0") {
   h.links[`/sys/class/net/${iface}/device/driver`] = "../../../bus/pci/drivers/iwlwifi";
@@ -131,9 +142,11 @@ describe("parseNmDeviceStatus / findWifiDevice", () => {
 });
 
 describe("modulesForDriver", () => {
-  it("unloads iwlmvm before iwlwifi for Intel (the 'in use' lesson)", () => {
+  it("unloads both Intel opmodes before iwlwifi (the 'in use' lesson)", () => {
+    // Wi-Fi 7 radios bind iwlmld where older ones bind iwlmvm; whichever
+    // isn't loaded is dropped by unloadModules before modprobe sees it.
     expect(modulesForDriver({ driver: "iwlwifi" })).toEqual({
-      unload: ["iwlmvm", "iwlwifi"],
+      unload: ["iwlmld", "iwlmvm", "iwlwifi"],
       load: "iwlwifi",
     });
   });
@@ -143,6 +156,24 @@ describe("modulesForDriver", () => {
       unload: ["mt7921e"],
       load: "mt7921e",
     });
+  });
+});
+
+describe("filterLoadedModules", () => {
+  const PROC = ["iwlmld 262144 0 - Live 0x0", "iwlwifi 589824 1 iwlmld, Live 0x0"].join("\n");
+
+  it("keeps only loaded modules, in the caller's order", () => {
+    expect(
+      filterLoadedModules({ procModules: PROC, modules: ["iwlmld", "iwlmvm", "iwlwifi"] }),
+    ).toEqual(["iwlmld", "iwlwifi"]);
+  });
+
+  it("returns nothing when none of the modules are loaded", () => {
+    expect(filterLoadedModules({ procModules: PROC, modules: ["mt7921e"] })).toEqual([]);
+  });
+
+  it("treats an empty /proc/modules as nothing loaded", () => {
+    expect(filterLoadedModules({ procModules: "", modules: ["iwlwifi"] })).toEqual([]);
   });
 });
 
@@ -261,6 +292,7 @@ describe("recover", () => {
     const h = makeHarness();
     h.nmState = "wlan0:wifi:unavailable";
     linkIntel(h);
+    h.files["/proc/modules"] = IWLMVM_PROC_MODULES;
     h.onModprobe = (cmd) => {
       // Unload removes the device entirely; load brings it back renamed —
       // exactly what happened live on the Apex (wlan0 → wlan1).
@@ -296,6 +328,7 @@ describe("recover", () => {
   it("falls back to the persisted driver when the interface has vanished", async () => {
     const h = makeHarness();
     h.nmState = "lo:loopback:connected (externally)"; // no wifi row at all
+    h.files["/proc/modules"] = IWLMVM_PROC_MODULES;
     h.onModprobe = (cmd) => {
       if (cmd[1] !== "-r") h.nmState = "wlan0:wifi:disconnected";
       return { stdout: "", stderr: "", exitCode: 0 };
@@ -315,6 +348,37 @@ describe("recover", () => {
     expect(res.stage).toBe("precheck");
     expect(res.detail).toContain("No WiFi driver known");
     expect(modprobeCalls(h)).toEqual([]);
+  });
+
+  // Regression: Intel Wi-Fi 7 parts (BE2xx, as in the current Intel
+  // handhelds) load iwlmld, not iwlmvm. `modprobe -r iwlmld iwlmvm iwlwifi`
+  // would fail with "not found" — which isn't an "in use" error, so the
+  // holders retry below never fires and recovery burns a PCI reset it
+  // didn't need. The unload list is filtered against /proc/modules first.
+  it("unloads a Wi-Fi 7 radio's iwlmld without touching the absent iwlmvm", async () => {
+    const h = makeHarness();
+    h.nmState = "";
+    h.files["/proc/modules"] = [
+      "iwlmld 262144 0 - Live 0x0",
+      "iwlwifi 589824 1 iwlmld, Live 0x0",
+    ].join("\n");
+    h.onModprobe = (cmd) => {
+      if (cmd[1] !== "-r") h.nmState = "wlan0:wifi:disconnected";
+      return { stdout: "", stderr: "", exitCode: 0 };
+    };
+
+    const res = await recover({
+      deps: h.deps,
+      lastKnown: { driver: "iwlwifi", pciAddress: null, iface: "wlan0", updatedAt: 0 },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(modprobeCalls(h)).toEqual([
+      ["modprobe", "-r", "iwlmld", "iwlwifi"],
+      ["modprobe", "iwlwifi"],
+    ]);
+    // No PCI tier: the cheap reload was enough.
+    expect(h.writes).toEqual([]);
   });
 
   it("retries an 'in use' unload with the /proc/modules holders", async () => {

--- a/plugins/wifi/lib/recovery.test.ts
+++ b/plugins/wifi/lib/recovery.test.ts
@@ -175,6 +175,40 @@ describe("filterLoadedModules", () => {
   it("treats an empty /proc/modules as nothing loaded", () => {
     expect(filterLoadedModules({ procModules: "", modules: ["iwlwifi"] })).toEqual([]);
   });
+
+  it("matches a hyphenated driver name against underscored /proc/modules", () => {
+    // /proc/modules always prints underscores; a driver name arriving from
+    // sysfs (or DRIVER_MODULES) often has hyphens. Comparing them literally
+    // filtered the list down to nothing, and unloadModules reads an empty
+    // list as "nothing to unload" — silently skipping the cheap reload tier
+    // and pushing recovery on to a PCI reset it didn't need.
+    const proc = "hid_oxp 16384 0 - Live 0x0";
+    expect(filterLoadedModules({ procModules: proc, modules: ["hid-oxp"] })).toEqual([
+      "hid-oxp",
+    ]);
+  });
+
+  it("matches an underscored module against a hyphenated /proc/modules line", () => {
+    const proc = "some-mod 16384 0 - Live 0x0";
+    expect(filterLoadedModules({ procModules: proc, modules: ["some_mod"] })).toEqual([
+      "some_mod",
+    ]);
+  });
+});
+
+describe("findModuleHolders", () => {
+  it("finds holders regardless of hyphen/underscore spelling", () => {
+    const proc = "hid_oxp 16384 2 hid_multitouch,oxp_sensors, Live 0x0";
+    expect(findModuleHolders({ procModules: proc, module: "hid-oxp" })).toEqual([
+      "hid_multitouch",
+      "oxp_sensors",
+    ]);
+  });
+
+  it("returns nothing when the module holds no one", () => {
+    const proc = "iwlmld 262144 0 - Live 0x0";
+    expect(findModuleHolders({ procModules: proc, module: "iwlmld" })).toEqual([]);
+  });
 });
 
 describe("findModuleHolders", () => {

--- a/plugins/wifi/lib/recovery.ts
+++ b/plugins/wifi/lib/recovery.ts
@@ -108,13 +108,26 @@ export function modulesForDriver(opts: { driver: string }): { unload: string[]; 
 }
 
 /**
+ * Kernel module names are interchangeable in `-` and `_` form: modprobe
+ * accepts either, but /proc/modules *always* prints underscores. Driver
+ * names reach us from the sysfs driver directory and from DRIVER_MODULES,
+ * where the hyphen form is common (`iwl-mld`, `hid-oxp`). Comparing the two
+ * spellings literally silently matches nothing, so normalise before any
+ * name comparison against /proc/modules.
+ */
+function normalizeModuleName(name: string): string {
+  return name.replace(/-/g, "_");
+}
+
+/**
  * Modules holding `module` per /proc/modules (4th column, "used by":
  * a comma-separated list, or "-" when nothing holds it).
  */
 export function findModuleHolders(opts: { procModules: string; module: string }): string[] {
+  const wanted = normalizeModuleName(opts.module);
   for (const line of opts.procModules.split("\n")) {
     const fields = line.trim().split(/\s+/);
-    if (fields[0] !== opts.module) continue;
+    if (!fields[0] || normalizeModuleName(fields[0]) !== wanted) continue;
     const usedBy = fields[3];
     if (!usedBy || usedBy === "-") return [];
     return usedBy.split(",").filter((name) => name.length > 0);
@@ -139,9 +152,9 @@ export function filterLoadedModules(opts: {
   const loaded = new Set<string>();
   for (const line of opts.procModules.split("\n")) {
     const name = line.trim().split(/\s+/)[0];
-    if (name) loaded.add(name);
+    if (name) loaded.add(normalizeModuleName(name));
   }
-  return opts.modules.filter((module) => loaded.has(module));
+  return opts.modules.filter((module) => loaded.has(normalizeModuleName(module)));
 }
 
 // --- impure orchestration ----------------------------------------------------

--- a/plugins/wifi/lib/recovery.ts
+++ b/plugins/wifi/lib/recovery.ts
@@ -88,13 +88,19 @@ export function findWifiDevice(rows: NmDeviceRow[]): { device: string; state: st
 
 /**
  * Driver → module list. `unload` is ordered top-down (dependents first):
- * Intel's opmode module iwlmvm holds iwlwifi, so `modprobe -r iwlwifi`
- * alone fails with "Module iwlwifi is in use". Loading the base module
+ * Intel's opmode module holds iwlwifi, so `modprobe -r iwlwifi` alone
+ * fails with "Module iwlwifi is in use". Loading the base module
  * auto-pulls its dependents back. Unmapped drivers get the identity
  * mapping plus the generic /proc/modules holders fallback in recover().
+ *
+ * Which opmode is loaded depends on the radio: Wi-Fi 7 parts (BE2xx, as
+ * shipped in the current Intel handhelds) bind `iwlmld`, everything
+ * older binds `iwlmvm`. Both are listed — `unloadModules` drops whichever
+ * one isn't actually loaded before calling modprobe, so the list is a
+ * superset rather than an assertion about this machine.
  */
 export const DRIVER_MODULES: Record<string, { unload: string[]; load: string }> = {
-  iwlwifi: { unload: ["iwlmvm", "iwlwifi"], load: "iwlwifi" },
+  iwlwifi: { unload: ["iwlmld", "iwlmvm", "iwlwifi"], load: "iwlwifi" },
 };
 
 export function modulesForDriver(opts: { driver: string }): { unload: string[]; load: string } {
@@ -114,6 +120,28 @@ export function findModuleHolders(opts: { procModules: string; module: string })
     return usedBy.split(",").filter((name) => name.length > 0);
   }
   return [];
+}
+
+/**
+ * Keep only those `modules` that /proc/modules says are loaded, preserving
+ * the caller's order. Pure.
+ *
+ * `modprobe -r` fails the whole invocation when *any* named module isn't
+ * loaded, and it reports that as "not found" rather than "in use" — so an
+ * over-broad unload list would fail the cheap module-reload tier before the
+ * holders fallback below ever got a chance to run, pushing recovery on to a
+ * PCI reset it didn't need.
+ */
+export function filterLoadedModules(opts: {
+  procModules: string;
+  modules: string[];
+}): string[] {
+  const loaded = new Set<string>();
+  for (const line of opts.procModules.split("\n")) {
+    const name = line.trim().split(/\s+/)[0];
+    if (name) loaded.add(name);
+  }
+  return opts.modules.filter((module) => loaded.has(module));
 }
 
 // --- impure orchestration ----------------------------------------------------
@@ -208,22 +236,34 @@ export async function detectDriverInfo(opts: {
 }
 
 /**
- * `modprobe -r` the module list; on an "in use" failure for a driver we
- * don't have in the map, look up the holders in /proc/modules and retry
- * once with them prepended (the generic form of the iwlmvm lesson).
+ * `modprobe -r` the module list, minus any entry that isn't currently
+ * loaded; on an "in use" failure for a driver we don't have in the map,
+ * look up the holders in /proc/modules and retry once with them prepended
+ * (the generic form of the iwlmvm lesson).
  */
 async function unloadModules(opts: {
   deps: RecoveryDeps;
   unload: string[];
 }): Promise<{ ok: boolean; detail: string }> {
-  const { deps, unload } = opts;
+  const { deps } = opts;
   const describe = (r: RunResult) => r.stderr.trim() || `modprobe -r exited ${r.exitCode}`;
+
+  // An unreadable /proc/modules leaves the caller's list untouched — the
+  // filter is an optimisation, and guessing "nothing is loaded" from a
+  // failed read would skip a real unload.
+  const procModules = await deps.readFile("/proc/modules").catch(() => "");
+  const unload = procModules
+    ? filterLoadedModules({ procModules, modules: opts.unload })
+    : opts.unload;
+  if (unload.length === 0) {
+    deps.log?.("No mapped modules are loaded — nothing to unload.");
+    return { ok: true, detail: "" };
+  }
 
   const first = await boundedRun({ deps, cmd: ["modprobe", "-r", ...unload], timeoutMs: 15_000 });
   if (first.exitCode === 0) return { ok: true, detail: "" };
 
   if (/in use/i.test(first.stderr)) {
-    const procModules = await deps.readFile("/proc/modules").catch(() => "");
     const holders = unload
       .flatMap((module) => findModuleHolders({ procModules, module }))
       .filter((holder) => !unload.includes(holder));


### PR DESCRIPTION
> **Parked — draft, not intended to merge as-is.** Needs a ROG Ally or a
> Legion Go to validate, and we have no tester on either. Everything in
> this branch that could be shipped without that hardware has been split
> out and merged or opened separately:
>
> - #254 — Wi-Fi 7 `iwlmld` recovery
> - #255 — Intel `i915`/`xe` GPU temperature sensors
> - #256 — Intel handheld TDP + GPU control (AMD paths untouched)
>
> What remains here is the one change that alters behaviour on AMD
> handhelds we can't test.

## What's left in this PR

Making generic `firmware-attributes` discovery outrank `ryzenadj` on
**every** AMD device, rather than only on non-AMD as #256 ships it.

Two coupled effects:

1. **Precedence.** ROG Ally and Legion Go stop using their DMI-matched
   paths and get generically discovered rails instead. Other AMD
   handhelds that expose `firmware-attributes` — msi-wmi-platform, and
   whatever ships next — start preferring those rails over ryzenadj.

2. **Write unit.** Discovered rails infer `scale` from `max_value`
   (= 1, i.e. watts, on asus-armoury and lenovo-wmi-other-N) instead of
   assuming milliwatts. On those devices that is a 1000× change in what
   gets written.

## Why it's probably right, and still parked

Effect 2 looks like a genuine bug fix rather than a regression: `main`
writes `watts * 1000` to `asus-armoury` rails whose `current_value` takes
watts, so a modern-kernel ROG Ally appears to be **broken today** — the
write is rejected and the old read-back path would have reported 0 W.

But "appears" is doing real work in that sentence. Confirming it needs
the hardware. And #256 already carries a cheaper safety net for the same
failure: the DMI-matched paths retry in the other unit when a write is
rejected, which rescues that device without any precedence change.

So the value left in this PR is the generic path for *future* AMD
handhelds, not a fix for a known-broken one. That isn't worth changing
detection order on shipped hardware, unverified.

## To pick this up later

Wanted: a ROG Ally or Legion Go on a kernel with `asus-armoury` /
`lenovo-wmi-other-N` bound. Useful evidence, in order:

1. `cat /sys/class/firmware-attributes/*/attributes/ppt_pl1_spl/max_value`
   — settles the unit question outright.
2. Whether the TDP slider works at all on `main` today.
3. Whether #256's retry-in-the-other-unit path recovers it.

If (1) says watts and (3) works, this PR can probably be closed rather
than merged.
