### PR TITLE
fix(wifi): unload iwlmld so Wi-Fi 7 radios recover without a PCI reset

### DIFF
--- a/plugins/wifi/lib/recovery.test.ts
+++ b/plugins/wifi/lib/recovery.test.ts
@@ -209,9 +209,7 @@ describe("findModuleHolders", () => {
     const proc = "iwlmld 262144 0 - Live 0x0";
     expect(findModuleHolders({ procModules: proc, module: "iwlmld" })).toEqual([]);
   });
-});
 
-describe("findModuleHolders", () => {
   const PROC_MODULES = [
     "iwlmvm 851968 0 - Live 0x0000000000000000",
     "iwlwifi 479232 1 iwlmvm, Live 0x0000000000000000",

--- a/plugins/wifi/lib/recovery.test.ts
+++ b/plugins/wifi/lib/recovery.test.ts
@@ -4,6 +4,7 @@ import {
   findWifiDevice,
   modulesForDriver,
   findModuleHolders,
+  filterLoadedModules,
   readRfkill,
   detectDriverInfo,
   getWifiDevice,
@@ -88,6 +89,16 @@ function makeHarness(init?: { rfkillAbsent?: boolean }) {
 
 type Harness = ReturnType<typeof makeHarness>;
 
+/**
+ * `/proc/modules` for a pre-Wi-Fi-7 Intel radio: iwlmvm is the loaded
+ * opmode, iwlmld isn't present. unloadModules filters the driver map down
+ * to this before shelling out to modprobe.
+ */
+const IWLMVM_PROC_MODULES = [
+  "iwlmvm 851968 0 - Live 0x0",
+  "iwlwifi 479232 1 iwlmvm, Live 0x0",
+].join("\n");
+
 /** Wire up /sys links for a live Intel card on `iface`. */
 function linkIntel(h: Harness, iface = "wlan0") {
   h.links[`/sys/class/net/${iface}/device/driver`] = "../../../bus/pci/drivers/iwlwifi";
@@ -131,9 +142,11 @@ describe("parseNmDeviceStatus / findWifiDevice", () => {
 });
 
 describe("modulesForDriver", () => {
-  it("unloads iwlmvm before iwlwifi for Intel (the 'in use' lesson)", () => {
+  it("unloads both Intel opmodes before iwlwifi (the 'in use' lesson)", () => {
+    // Wi-Fi 7 radios bind iwlmld where older ones bind iwlmvm; whichever
+    // isn't loaded is dropped by unloadModules before modprobe sees it.
     expect(modulesForDriver({ driver: "iwlwifi" })).toEqual({
-      unload: ["iwlmvm", "iwlwifi"],
+      unload: ["iwlmld", "iwlmvm", "iwlwifi"],
       load: "iwlwifi",
     });
   });
@@ -143,6 +156,58 @@ describe("modulesForDriver", () => {
       unload: ["mt7921e"],
       load: "mt7921e",
     });
+  });
+});
+
+describe("filterLoadedModules", () => {
+  const PROC = ["iwlmld 262144 0 - Live 0x0", "iwlwifi 589824 1 iwlmld, Live 0x0"].join("\n");
+
+  it("keeps only loaded modules, in the caller's order", () => {
+    expect(
+      filterLoadedModules({ procModules: PROC, modules: ["iwlmld", "iwlmvm", "iwlwifi"] }),
+    ).toEqual(["iwlmld", "iwlwifi"]);
+  });
+
+  it("returns nothing when none of the modules are loaded", () => {
+    expect(filterLoadedModules({ procModules: PROC, modules: ["mt7921e"] })).toEqual([]);
+  });
+
+  it("treats an empty /proc/modules as nothing loaded", () => {
+    expect(filterLoadedModules({ procModules: "", modules: ["iwlwifi"] })).toEqual([]);
+  });
+
+  it("matches a hyphenated driver name against underscored /proc/modules", () => {
+    // /proc/modules always prints underscores; a driver name arriving from
+    // sysfs (or DRIVER_MODULES) often has hyphens. Comparing them literally
+    // filtered the list down to nothing, and unloadModules reads an empty
+    // list as "nothing to unload" — silently skipping the cheap reload tier
+    // and pushing recovery on to a PCI reset it didn't need.
+    const proc = "hid_oxp 16384 0 - Live 0x0";
+    expect(filterLoadedModules({ procModules: proc, modules: ["hid-oxp"] })).toEqual([
+      "hid-oxp",
+    ]);
+  });
+
+  it("matches an underscored module against a hyphenated /proc/modules line", () => {
+    const proc = "some-mod 16384 0 - Live 0x0";
+    expect(filterLoadedModules({ procModules: proc, modules: ["some_mod"] })).toEqual([
+      "some_mod",
+    ]);
+  });
+});
+
+describe("findModuleHolders", () => {
+  it("finds holders regardless of hyphen/underscore spelling", () => {
+    const proc = "hid_oxp 16384 2 hid_multitouch,oxp_sensors, Live 0x0";
+    expect(findModuleHolders({ procModules: proc, module: "hid-oxp" })).toEqual([
+      "hid_multitouch",
+      "oxp_sensors",
+    ]);
+  });
+
+  it("returns nothing when the module holds no one", () => {
+    const proc = "iwlmld 262144 0 - Live 0x0";
+    expect(findModuleHolders({ procModules: proc, module: "iwlmld" })).toEqual([]);
   });
 });
 
@@ -261,6 +326,7 @@ describe("recover", () => {
     const h = makeHarness();
     h.nmState = "wlan0:wifi:unavailable";
     linkIntel(h);
+    h.files["/proc/modules"] = IWLMVM_PROC_MODULES;
     h.onModprobe = (cmd) => {
       // Unload removes the device entirely; load brings it back renamed —
       // exactly what happened live on the Apex (wlan0 → wlan1).
@@ -296,6 +362,7 @@ describe("recover", () => {
   it("falls back to the persisted driver when the interface has vanished", async () => {
     const h = makeHarness();
     h.nmState = "lo:loopback:connected (externally)"; // no wifi row at all
+    h.files["/proc/modules"] = IWLMVM_PROC_MODULES;
     h.onModprobe = (cmd) => {
       if (cmd[1] !== "-r") h.nmState = "wlan0:wifi:disconnected";
       return { stdout: "", stderr: "", exitCode: 0 };
@@ -315,6 +382,37 @@ describe("recover", () => {
     expect(res.stage).toBe("precheck");
     expect(res.detail).toContain("No WiFi driver known");
     expect(modprobeCalls(h)).toEqual([]);
+  });
+
+  // Regression: Intel Wi-Fi 7 parts (BE2xx, as in the current Intel
+  // handhelds) load iwlmld, not iwlmvm. `modprobe -r iwlmld iwlmvm iwlwifi`
+  // would fail with "not found" — which isn't an "in use" error, so the
+  // holders retry below never fires and recovery burns a PCI reset it
+  // didn't need. The unload list is filtered against /proc/modules first.
+  it("unloads a Wi-Fi 7 radio's iwlmld without touching the absent iwlmvm", async () => {
+    const h = makeHarness();
+    h.nmState = "";
+    h.files["/proc/modules"] = [
+      "iwlmld 262144 0 - Live 0x0",
+      "iwlwifi 589824 1 iwlmld, Live 0x0",
+    ].join("\n");
+    h.onModprobe = (cmd) => {
+      if (cmd[1] !== "-r") h.nmState = "wlan0:wifi:disconnected";
+      return { stdout: "", stderr: "", exitCode: 0 };
+    };
+
+    const res = await recover({
+      deps: h.deps,
+      lastKnown: { driver: "iwlwifi", pciAddress: null, iface: "wlan0", updatedAt: 0 },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(modprobeCalls(h)).toEqual([
+      ["modprobe", "-r", "iwlmld", "iwlwifi"],
+      ["modprobe", "iwlwifi"],
+    ]);
+    // No PCI tier: the cheap reload was enough.
+    expect(h.writes).toEqual([]);
   });
 
   it("retries an 'in use' unload with the /proc/modules holders", async () => {

--- a/plugins/wifi/lib/recovery.ts
+++ b/plugins/wifi/lib/recovery.ts
@@ -88,13 +88,19 @@ export function findWifiDevice(rows: NmDeviceRow[]): { device: string; state: st
 
 /**
  * Driver → module list. `unload` is ordered top-down (dependents first):
- * Intel's opmode module iwlmvm holds iwlwifi, so `modprobe -r iwlwifi`
- * alone fails with "Module iwlwifi is in use". Loading the base module
+ * Intel's opmode module holds iwlwifi, so `modprobe -r iwlwifi` alone
+ * fails with "Module iwlwifi is in use". Loading the base module
  * auto-pulls its dependents back. Unmapped drivers get the identity
  * mapping plus the generic /proc/modules holders fallback in recover().
+ *
+ * Which opmode is loaded depends on the radio: Wi-Fi 7 parts (BE2xx, as
+ * shipped in the current Intel handhelds) bind `iwlmld`, everything
+ * older binds `iwlmvm`. Both are listed — `unloadModules` drops whichever
+ * one isn't actually loaded before calling modprobe, so the list is a
+ * superset rather than an assertion about this machine.
  */
 export const DRIVER_MODULES: Record<string, { unload: string[]; load: string }> = {
-  iwlwifi: { unload: ["iwlmvm", "iwlwifi"], load: "iwlwifi" },
+  iwlwifi: { unload: ["iwlmld", "iwlmvm", "iwlwifi"], load: "iwlwifi" },
 };
 
 export function modulesForDriver(opts: { driver: string }): { unload: string[]; load: string } {
@@ -102,18 +108,53 @@ export function modulesForDriver(opts: { driver: string }): { unload: string[]; 
 }
 
 /**
+ * Kernel module names are interchangeable in `-` and `_` form: modprobe
+ * accepts either, but /proc/modules *always* prints underscores. Driver
+ * names reach us from the sysfs driver directory and from DRIVER_MODULES,
+ * where the hyphen form is common (`iwl-mld`, `hid-oxp`). Comparing the two
+ * spellings literally silently matches nothing, so normalise before any
+ * name comparison against /proc/modules.
+ */
+function normalizeModuleName(name: string): string {
+  return name.replace(/-/g, "_");
+}
+
+/**
  * Modules holding `module` per /proc/modules (4th column, "used by":
  * a comma-separated list, or "-" when nothing holds it).
  */
 export function findModuleHolders(opts: { procModules: string; module: string }): string[] {
+  const wanted = normalizeModuleName(opts.module);
   for (const line of opts.procModules.split("\n")) {
     const fields = line.trim().split(/\s+/);
-    if (fields[0] !== opts.module) continue;
+    if (!fields[0] || normalizeModuleName(fields[0]) !== wanted) continue;
     const usedBy = fields[3];
     if (!usedBy || usedBy === "-") return [];
     return usedBy.split(",").filter((name) => name.length > 0);
   }
   return [];
+}
+
+/**
+ * Keep only those `modules` that /proc/modules says are loaded, preserving
+ * the caller's order. Pure.
+ *
+ * `modprobe -r` fails the whole invocation when *any* named module isn't
+ * loaded, and it reports that as "not found" rather than "in use" — so an
+ * over-broad unload list would fail the cheap module-reload tier before the
+ * holders fallback below ever got a chance to run, pushing recovery on to a
+ * PCI reset it didn't need.
+ */
+export function filterLoadedModules(opts: {
+  procModules: string;
+  modules: string[];
+}): string[] {
+  const loaded = new Set<string>();
+  for (const line of opts.procModules.split("\n")) {
+    const name = line.trim().split(/\s+/)[0];
+    if (name) loaded.add(normalizeModuleName(name));
+  }
+  return opts.modules.filter((module) => loaded.has(normalizeModuleName(module)));
 }
 
 // --- impure orchestration ----------------------------------------------------
@@ -208,22 +249,34 @@ export async function detectDriverInfo(opts: {
 }
 
 /**
- * `modprobe -r` the module list; on an "in use" failure for a driver we
- * don't have in the map, look up the holders in /proc/modules and retry
- * once with them prepended (the generic form of the iwlmvm lesson).
+ * `modprobe -r` the module list, minus any entry that isn't currently
+ * loaded; on an "in use" failure for a driver we don't have in the map,
+ * look up the holders in /proc/modules and retry once with them prepended
+ * (the generic form of the iwlmvm lesson).
  */
 async function unloadModules(opts: {
   deps: RecoveryDeps;
   unload: string[];
 }): Promise<{ ok: boolean; detail: string }> {
-  const { deps, unload } = opts;
+  const { deps } = opts;
   const describe = (r: RunResult) => r.stderr.trim() || `modprobe -r exited ${r.exitCode}`;
+
+  // An unreadable /proc/modules leaves the caller's list untouched — the
+  // filter is an optimisation, and guessing "nothing is loaded" from a
+  // failed read would skip a real unload.
+  const procModules = await deps.readFile("/proc/modules").catch(() => "");
+  const unload = procModules
+    ? filterLoadedModules({ procModules, modules: opts.unload })
+    : opts.unload;
+  if (unload.length === 0) {
+    deps.log?.("No mapped modules are loaded — nothing to unload.");
+    return { ok: true, detail: "" };
+  }
 
   const first = await boundedRun({ deps, cmd: ["modprobe", "-r", ...unload], timeoutMs: 15_000 });
   if (first.exitCode === 0) return { ok: true, detail: "" };
 
   if (/in use/i.test(first.stderr)) {
-    const procModules = await deps.readFile("/proc/modules").catch(() => "");
     const holders = unload
       .flatMap((module) => findModuleHolders({ procModules, module }))
       .filter((holder) => !unload.includes(holder));

--- a/plugins/wifi/lib/recovery.ts
+++ b/plugins/wifi/lib/recovery.ts
@@ -277,9 +277,14 @@ async function unloadModules(opts: {
   if (first.exitCode === 0) return { ok: true, detail: "" };
 
   if (/in use/i.test(first.stderr)) {
+    // Normalised on both sides like every other /proc/modules comparison:
+    // holders come from that file (underscored) while `unload` may carry the
+    // hyphen spelling, and a missed dedupe here would put the same module
+    // twice on the retry command line.
+    const unloadNames = new Set(unload.map(normalizeModuleName));
     const holders = unload
       .flatMap((module) => findModuleHolders({ procModules, module }))
-      .filter((holder) => !unload.includes(holder));
+      .filter((holder) => !unloadNames.has(normalizeModuleName(holder)));
     if (holders.length > 0) {
       deps.log?.(`modprobe -r blocked by holders [${holders.join(", ")}] — retrying with them.`);
       const retry = await boundedRun({


### PR DESCRIPTION
Split 1 of 3 out of #253, which had grown well past its description. This touches `plugins/wifi/` only, and needs no Intel handheld to be useful.

## The problem

Intel's Wi-Fi 7 parts (BE2xx) bind the `iwlmld` opmode, not `iwlmvm` — and they're a common card in AMD handhelds too, not just Intel ones. `DRIVER_MODULES` hardcoded `iwlmvm`, so `modprobe -r iwlmvm iwlwifi` failed with "not found". That isn't an "in use" error, so the generic `/proc/modules` holders fallback never got its turn, and recovery escalated straight to the costlier PCI-reset tier.

## The fix

Filter the mapped unload list against what `/proc/modules` says is actually loaded before shelling out, and list both opmodes. The map becomes a hint rather than an assertion about this machine, so a future opmode degrades to the holders fallback instead of failing the cheap tier outright.

Module names are also normalised between `-` and `_` on both sides of every `/proc/modules` comparison. That file always prints underscores; driver names arrive from sysfs with hyphens. Compared literally, the filter returned `[]` — which `unloadModules` reads as "nothing to unload", silently skipping the very tier this PR is about.

## Testing

46 tests in `recovery.test.ts` pass, including new coverage for both spelling directions and for `findModuleHolders`. Not exercised on a real Wi-Fi 7 radio — I don't have one.

## Related

Related to #244 (Wi-Fi power saving unreliable on Intel `iwlwifi` with NetworkManager). Same plugin and the same hardware family, but a different code path: #244 is about power-save state being re-enabled after boot in `powersave.ts`, whereas this PR is about module unload during recovery in `recovery.ts`. **This PR does not fix #244.**
