### PR TITLE
fix(fan-control): classify Intel i915 / xe GPU temperature sensors

### DIFF
--- a/plugins/fan-control/lib/sensors.test.ts
+++ b/plugins/fan-control/lib/sensors.test.ts
@@ -66,6 +66,51 @@ describe("classifyTempZone()", () => {
     expect(classifyTempZone("amdgpu", "edge")).toBe("gpu");
   });
 
+  it("classifies i915 as gpu", () => {
+    expect(classifyTempZone("i915", "")).toBe("gpu");
+  });
+
+  // Xe/Xe3 graphics (Lunar Lake, Panther Lake / Arc G3) bind the `xe`
+  // driver, whose hwmon chip name is just "xe".
+  it("classifies xe as gpu on an exact chip-name match", () => {
+    expect(classifyTempZone("xe", "")).toBe("gpu");
+    expect(classifyTempZone("XE", "")).toBe("gpu");
+  });
+
+  // "xe" is two characters — matching it as a substring the way the other
+  // GPU chips are matched would claim sensors that have nothing to do with
+  // the GPU, so it is matched exactly instead.
+  it("does not claim an unrelated sensor whose text merely contains 'xe'", () => {
+    expect(classifyTempZone("mychip", "Mixed Zone")).toBe("unknown");
+    expect(classifyTempZone("xenon_board", "")).toBe("unknown");
+  });
+
+  // The chip name settles which engine a sensor belongs to, so it has to
+  // outrank the CPU *label* keywords — an `xe` sensor labelled "package" is
+  // still the GPU's.
+  it("prefers the xe chip name over a CPU-ish label", () => {
+    expect(classifyTempZone("xe", "Package")).toBe("gpu");
+  });
+
+  // Same rule, same tier, for the substring-matched GPU chips. i915 was
+  // added to GPU_TEMP_CHIPS but checked *below* CPU_LABEL_KEYWORDS, so an
+  // i915 sensor labelled "package" came back as cpu while the equivalent
+  // xe one came back as gpu.
+  it("prefers the i915 chip name over a CPU-ish label", () => {
+    expect(classifyTempZone("i915", "Package")).toBe("gpu");
+  });
+
+  it("prefers the amdgpu chip name over a CPU-ish label", () => {
+    expect(classifyTempZone("amdgpu", "package")).toBe("gpu");
+  });
+
+  it("still lets a CPU chip name win for its own labels", () => {
+    // The GPU chip tier sits below CPU_TEMP_CHIPS, so nothing here can
+    // steal k10temp/coretemp sensors.
+    expect(classifyTempZone("k10temp", "Tctl")).toBe("cpu");
+    expect(classifyTempZone("coretemp", "Package id 0")).toBe("cpu");
+  });
+
   it("classifies junction label as gpu", () => {
     expect(classifyTempZone("something", "junction")).toBe("gpu");
   });

--- a/plugins/fan-control/lib/sensors.ts
+++ b/plugins/fan-control/lib/sensors.ts
@@ -13,7 +13,18 @@
 export const CPU_TEMP_CHIPS = ["k10temp", "coretemp", "zenpower"];
 
 /** Chip names known to host GPU temperature sensors. */
-export const GPU_TEMP_CHIPS = ["amdgpu", "nvidia", "nouveau", "radeon"];
+export const GPU_TEMP_CHIPS = ["amdgpu", "nvidia", "nouveau", "radeon", "i915"];
+
+/**
+ * Chip names that identify a GPU only on an *exact* match.
+ *
+ * `xe` is the hwmon registered by Intel's Xe DRM driver — the one Xe3
+ * (Panther Lake / Arc G3) graphics bind to. At two characters it is far too
+ * short for the substring matching `GPU_TEMP_CHIPS` uses: it would fire on
+ * any chip or label that merely happens to contain the letters. Same
+ * treatment `acpitz` gets in `classifyTempZone`.
+ */
+export const EXACT_GPU_TEMP_CHIPS = ["xe"];
 
 /** Keywords that hint at a CPU-related temp label. */
 export const CPU_LABEL_KEYWORDS = ["tctl", "tdie", "cpu", "soc", "package"];
@@ -52,6 +63,16 @@ export function classifyTempZone(chipName: string, label: string): TempZone {
   if (NON_CPU_LABEL_KEYWORDS.some((kw) => lower.includes(kw))) return "unknown";
 
   if (CPU_TEMP_CHIPS.some((c) => lower.includes(c))) return "cpu";
+
+  // Chip-name match, checked in the same tier as CPU_TEMP_CHIPS above: the
+  // chip name is authoritative about which engine a sensor belongs to, so it
+  // must win over the label keywords below (an `xe` sensor labelled "package"
+  // is still the GPU — and so is an `i915` one, which is why both lists are
+  // consulted here rather than only the exact one).
+  const chip = chipName.toLowerCase();
+  if (EXACT_GPU_TEMP_CHIPS.includes(chip)) return "gpu";
+  if (GPU_TEMP_CHIPS.some((c) => chip.includes(c))) return "gpu";
+
   if (CPU_LABEL_KEYWORDS.some((kw) => lower.includes(kw))) return "cpu";
   if (GPU_TEMP_CHIPS.some((c) => lower.includes(c))) return "gpu";
   if (lower.includes("gpu") || lower.includes("junction") || lower.includes("edge")) return "gpu";


### PR DESCRIPTION
Split 2 of 3 out of #253. This touches `plugins/fan-control/` only.

## The problem

Intel graphics register hwmon under `i915` (older) or `xe` (the Xe/Xe3 driver — Lunar Lake, Panther Lake / Arc G3). Neither was in the GPU chip lists, so a fan curve keyed to GPU temperature had nothing to read on an Intel handheld.

## The fix

`xe` is two characters — far too short for the substring matching the other chips use, since it would fire on any chip or label that merely contains those letters. It gets an exact-match tier instead, the same treatment `acpitz` already gets.

Both GPU chip lists are then consulted in the same tier as `CPU_TEMP_CHIPS`, above the label keywords: the chip name settles which engine a sensor belongs to, so an `i915` or `xe` sensor labelled "package" is the GPU's, not the CPU's.

## One behaviour change on AMD, called out

Promoting the substring list to that tier also reclassifies an `amdgpu` sensor labelled `package` as gpu rather than cpu. That's correct by the same rule, but it is a change, and it's the only line here that touches existing hardware — so here is why it's safe, with the evidence.

**The thermal watchdog is unaffected.** `getCpuTempCOrNull` takes the max across `cpu | gpu | soc` (`plugins/fan-control/backend.ts:945`), so the safety watchdog reads the same hottest sensor whether it is labelled cpu or gpu. This is categorically unlike the `steamdeck_hwmon` "Battery Temp" regression, which moved a sensor *into* the watchdog's set; moving one *within* the set is inert.

**The fan curve has a narrow residual case.** `backend.ts:882` (and the UI path at `:448`) resolve `temps.find(t => t.zone === "cpu")?.tempC ?? temps[0]?.tempC ?? 0`. If an `amdgpu`/"package" sensor were a device's *only* cpu-zone sensor, the curve would fall through to `temps[0]` — after the `zoneSortWeight` sort, the first gpu sensor in hwmon enumeration order, possibly a cooler `amdgpu/edge`. Fans would lag. Not a cook risk, since the watchdog floors still engage, and it requires a device with no `k10temp` and no `acpitz`, which SteamOS handhelds always have. Untested — there is no coverage of that fallback.

`k10temp` and `coretemp` are checked first and are unaffected; there's a test pinning that precedence.

## Testing

28 tests in `sensors.test.ts` pass, including the i915-vs-xe consistency case and the CPU-chip precedence guard. Not exercised on Intel hardware.

## Related

No open issue tracks this — it came out of the Intel handheld work in #253.
