### PR TITLE
feat(tdp-control): support Intel handhelds

### DIFF
--- a/packages/devices/src/devices.test.ts
+++ b/packages/devices/src/devices.test.ts
@@ -4,6 +4,7 @@ import {
   matchProfileName,
   effectiveMaxWatts,
   isBatteryLimited,
+  applyFirmwareRange,
   BATTERY_SAFE_MAX_WATTS,
 } from "./devices";
 
@@ -221,6 +222,103 @@ describe("battery safety ceiling", () => {
     // change for that device and is intentional.
     expect(
       effectiveMaxWatts({ acOnline: false, maxTdp: 90, batteryMaxTdp: 65 }),
+    ).toBe(BATTERY_SAFE_MAX_WATTS);
+  });
+});
+
+describe("isFallback", () => {
+  it("is false for a table match", () => {
+    expect(matchDevice("ONEXPLAYER APEX", "AMD").isFallback).toBe(false);
+  });
+
+  it("is true for a vendor fallback", () => {
+    expect(matchDevice("Some Unknown Handheld", "Intel").isFallback).toBe(true);
+    expect(matchDevice("Some Unknown Handheld", "AMD").isFallback).toBe(true);
+    expect(matchDevice("", "Unknown").isFallback).toBe(true);
+  });
+});
+
+// A handheld whose vendor driver implements the kernel's firmware-attributes
+// interface publishes the envelope its firmware will accept. That's the only
+// correct source for a device released after this table was last touched —
+// but it says nothing about thermals, so a matched row keeps its judgment.
+describe("applyFirmwareRange", () => {
+  it("gives an unknown device the firmware's range and derived presets", () => {
+    // The shape an Arc G3 Extreme handheld reports: 8-35 W on PL1.
+    const device = applyFirmwareRange(matchDevice("BRAND NEW HANDHELD", "Intel"), {
+      min: 8,
+      max: 35,
+    });
+
+    expect(device.minTdp).toBe(8);
+    expect(device.maxTdp).toBe(35);
+    expect(device.profiles).toEqual({ Silent: 13, Balanced: 22, Performance: 35 });
+    expect(device.batteryMaxTdp).toBe(28);
+  });
+
+  it("keeps a known device's hand-tuned battery cap", () => {
+    const matched = matchDevice("ROG Ally RC71", "AMD"); // 25 W plugged, 20 W battery
+    const device = applyFirmwareRange(matched, { min: 7, max: 30 });
+
+    expect(device.maxTdp).toBe(30);
+    expect(device.batteryMaxTdp).toBe(20);
+  });
+
+  it("never lets a known device's battery cap exceed the firmware max", () => {
+    const matched = matchDevice("ONEXPLAYER APEX", "AMD"); // 55 W battery cap
+    const device = applyFirmwareRange(matched, { min: 5, max: 40 });
+
+    expect(device.batteryMaxTdp).toBe(40);
+  });
+
+  it("never lets an unknown device's battery cap fall under the firmware min", () => {
+    // A narrow firmware envelope is where the 80% fallback goes under the
+    // floor: round(17 * 0.8) = 14, below a 15 W min. Offering a battery
+    // ceiling the rail would reject is worse than offering the floor.
+    const device = applyFirmwareRange(matchDevice("BRAND NEW HANDHELD", "Intel"), {
+      min: 15,
+      max: 17,
+    });
+
+    expect(device.batteryMaxTdp).toBe(15);
+    expect(device.batteryMaxTdp).toBeGreaterThanOrEqual(device.minTdp);
+  });
+
+  it("never lets a known device's battery cap fall under the firmware min", () => {
+    const matched = matchDevice("ROG Ally RC71", "AMD"); // 20 W battery cap
+    const device = applyFirmwareRange(matched, { min: 25, max: 35 });
+
+    expect(device.batteryMaxTdp).toBe(25);
+  });
+
+  it("clamps a known device's presets into the firmware's interval", () => {
+    const matched = matchDevice("ONEXPLAYER APEX", "AMD"); // 15 / 30 / 50
+    const device = applyFirmwareRange(matched, { min: 20, max: 40 });
+
+    expect(device.profiles).toEqual({ Silent: 20, Balanced: 30, Performance: 40 });
+  });
+
+  it("leaves the device name and fallback flag alone", () => {
+    const matched = matchDevice("ONEXPLAYER APEX", "AMD");
+    const device = applyFirmwareRange(matched, { min: 8, max: 35 });
+
+    expect(device.name).toBe("OneXPlayer APEX");
+    expect(device.isFallback).toBe(false);
+  });
+
+  it("still defers to the global on-battery ceiling", () => {
+    const device = applyFirmwareRange(matchDevice("BIG UNKNOWN RIG", "AMD"), {
+      min: 10,
+      max: 120,
+    });
+
+    expect(device.batteryMaxTdp).toBe(96);
+    expect(
+      effectiveMaxWatts({
+        acOnline: false,
+        maxTdp: device.maxTdp,
+        batteryMaxTdp: device.batteryMaxTdp,
+      }),
     ).toBe(BATTERY_SAFE_MAX_WATTS);
   });
 });

--- a/packages/devices/src/devices.ts
+++ b/packages/devices/src/devices.ts
@@ -280,6 +280,14 @@ const KNOWN_DEVICES: DeviceInfo[] = [
   },
 ];
 
+/**
+ * Share of a firmware-declared max allowed on battery for a device we have no
+ * table row for. Matches the ~80% relationship the hand-tuned rows above use
+ * between `maxTdp` and `batteryMaxTdp`. `BATTERY_SAFE_MAX_WATTS` still caps
+ * the result.
+ */
+const FALLBACK_BATTERY_FRACTION = 0.8;
+
 /** Default ranges when device is unknown. */
 const DEFAULT_AMD: Omit<DeviceInfo, "match"> = {
   name: "Generic AMD",
@@ -321,6 +329,13 @@ export interface DeviceMatch {
   /** Max TDP when on battery (<= maxTdp). */
   batteryMaxTdp: number;
   profiles: Record<string, number>;
+  /**
+   * True when no row in the device table matched and this is a vendor-keyed
+   * guess. Callers that have a better source of truth for the envelope — a
+   * firmware-declared range, say — use this to tell "we know this device"
+   * from "we're guessing from the CPU vendor".
+   */
+  isFallback: boolean;
 }
 
 /**
@@ -340,6 +355,7 @@ export function matchDevice(
         maxTdp: device.maxTdp,
         batteryMaxTdp: device.batteryMaxTdp,
         profiles: { ...device.profiles },
+        isFallback: false,
       };
     }
   }
@@ -355,6 +371,58 @@ export function matchDevice(
     maxTdp: fallback.maxTdp,
     batteryMaxTdp: fallback.batteryMaxTdp,
     profiles: { ...fallback.profiles },
+    isFallback: true,
+  };
+}
+
+/**
+ * Fold a firmware-declared TDP envelope into a device match.
+ *
+ * Handhelds whose vendor driver implements the kernel's `firmware-attributes`
+ * interface publish the exact envelope their firmware will accept
+ * (`min_value`/`max_value` on the PL1 rail). That beats this table: it is
+ * per-unit accurate, and it is the only source of truth for a device that
+ * shipped after the table was last touched.
+ *
+ * What it does NOT beat is the hand-tuned judgment in a matched row. A device
+ * we know about keeps its battery ceiling and its presets — those encode
+ * thermals and runtime, not just what the silicon tolerates — clamped into
+ * the firmware's interval so we never ask for a wattage the rail will reject.
+ * A fallback match has no such judgment to preserve, so its presets are
+ * derived from the range instead. Pure.
+ */
+export function applyFirmwareRange(
+  device: DeviceMatch,
+  range: { min: number; max: number },
+): DeviceMatch {
+  const { min, max } = range;
+  const clamp = (w: number) => Math.min(Math.max(w, min), max);
+  const span = max - min;
+  // Both battery-ceiling paths run through clamp() so neither can land under
+  // the floor. A narrow firmware range makes this reachable: 15–17 W gives
+  // round(17 * 0.8) = 14 on the fallback path, and a known row whose
+  // batteryMaxTdp predates a firmware that raised min would slip under it
+  // too — either way the UI would offer a battery ceiling the rail rejects.
+
+  return {
+    ...device,
+    minTdp: min,
+    maxTdp: max,
+    batteryMaxTdp: device.isFallback
+      ? clamp(Math.round(max * FALLBACK_BATTERY_FRACTION))
+      : clamp(device.batteryMaxTdp),
+    profiles: device.isFallback
+      ? {
+          Silent: Math.round(min + span * 0.2),
+          Balanced: Math.round(min + span * 0.5),
+          Performance: max,
+        }
+      : Object.fromEntries(
+          Object.entries(device.profiles).map(([name, watts]) => [
+            name,
+            clamp(watts),
+          ]),
+        ),
   };
 }
 

--- a/plugins/tdp-control/backend.ts
+++ b/plugins/tdp-control/backend.ts
@@ -175,6 +175,25 @@ async function isAmdCpu(): Promise<boolean> {
 }
 
 /**
+ * The positive counterpart to `isAmdCpu`, and deliberately not `!isAmdCpu()`.
+ *
+ * Both fail closed to false, which is what we want at the one place this is
+ * used: generic firmware-rail discovery. An unreadable /proc/cpuinfo on an
+ * AMD ROG Ally would make `!isAmdCpu()` true and route it through the new
+ * discovery path — exactly the AMD behaviour change this PR promises not to
+ * make. Requiring a positive GenuineIntel keeps an unknown CPU on the old
+ * detection order.
+ */
+async function isIntelCpu(): Promise<boolean> {
+  try {
+    const t = await Bun.file(CPUINFO_PATH).text();
+    return /\bGenuineIntel\b/.test(t);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Resolve the bundled `ryzenadj` binary shipped with this plugin, if one is
  * present for the current architecture. Returns the absolute path or `null`.
  *
@@ -1519,7 +1538,12 @@ export default class TdpControlBackend implements PluginBackend {
     //    on ROG Ally / Legion Go hardware we have no way to test, so that
     //    reordering is a separate PR rather than a side effect of adding
     //    Intel support.
-    if (!amd) {
+    //
+    //    Gated on a *positive* Intel result rather than !amd: both probes
+    //    fail closed, so an unreadable /proc/cpuinfo keeps every machine on
+    //    the old detection order instead of routing an AMD handheld into
+    //    the new path.
+    if (await isIntelCpu()) {
       const rails = await discoverPowerRails(sysfsDeps);
       if (rails) {
         this.wmiPaths = rails;
@@ -2052,15 +2076,21 @@ export default class TdpControlBackend implements PluginBackend {
       writeSysfs(path, String(Math.round(watts * rails.scale)));
 
     // Boost rails are best-effort: a firmware that rejects or omits them is
-    // still perfectly controllable through the sustained rail.
-    for (const path of [rails.fppt, rails.sppt]) {
-      if (!path) continue;
-      try {
-        await write(path);
-      } catch (e) {
-        console.warn(`[tdp-control] boost rail ${path} not writable: ${e}`);
+    // still perfectly controllable through the sustained rail. (This is a
+    // deliberate loosening of the old behaviour, which threw on any failed
+    // rail write — MSI's driver exposes only PL1 + PL2, so an unconditional
+    // write of all three failed outright on anything without a PL3.)
+    const writeBoostRails = async () => {
+      for (const path of [rails.fppt, rails.sppt]) {
+        if (!path) continue;
+        try {
+          await write(path);
+        } catch (e) {
+          console.warn(`[tdp-control] boost rail ${path} not writable: ${e}`);
+        }
       }
-    }
+    };
+    await writeBoostRails();
 
     try {
       await write(rails.spl);
@@ -2087,6 +2117,12 @@ export default class TdpControlBackend implements PluginBackend {
       }
       rails.scale = flipped;
       rails.scaleKnown = true;
+      // The boost rails were written in the unit we've just disproved, so
+      // they're sitting at whatever the firmware made of a 1000×-wrong
+      // number. Re-write them now that `rails.scale` is right, otherwise
+      // PL1 lands correctly while PL2/PL3 keep firmware defaults for this
+      // apply and the boost limit we were trying to pin does nothing.
+      await writeBoostRails();
     }
   }
 

--- a/plugins/tdp-control/backend.ts
+++ b/plugins/tdp-control/backend.ts
@@ -17,6 +17,7 @@ import {
   BATTERY_SAFE_MAX_WATTS,
   effectiveMaxWatts,
   isBatteryLimited,
+  applyFirmwareRange,
 } from "@loadout/devices";
 import {
   readCustomDevice,
@@ -27,6 +28,12 @@ import {
   type CustomDevice,
 } from "./lib/custom-device";
 import { readSavedTdp, writeSavedTdp } from "./lib/saved-tdp";
+import {
+  discoverPowerRails,
+  type PowerRails,
+} from "./lib/firmware-attributes";
+import { discoverRaplConstraints, type RaplConstraints } from "./lib/rapl";
+import { findXeFreqDirs, writeCeilingFirst } from "./lib/gpu";
 import { readCpuBoostPref, writeCpuBoostPref } from "./lib/cpu-boost-pref";
 
 // ---------------------------------------------------------------------------
@@ -43,29 +50,48 @@ const AMD_LEGACY_CPU_BOOST_PATH = "/sys/devices/system/cpu/cpufreq/boost";
 const INTEL_CPU_BOOST_PATH = "/sys/devices/system/cpu/intel_pstate/no_turbo";
 const CPU_ONLINE_PATH = "/sys/devices/system/cpu/online";
 
-const INTEL_RAPL_PATHS = [
-  "/sys/devices/virtual/powercap/intel-rapl-mmio/intel-rapl-mmio:0/constraint_0_power_limit_uw",
-  "/sys/devices/virtual/powercap/intel-rapl/intel-rapl:0/constraint_0_power_limit_uw",
-  "/sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw",
-];
-
-const ROG_ALLY_WMI_PATHS = {
-  legacy: {
-    fppt: "/sys/devices/platform/asus-nb-wmi/ppt_fppt",
-    sppt: "/sys/devices/platform/asus-nb-wmi/ppt_pl2_sppt",
-    spl: "/sys/devices/platform/asus-nb-wmi/ppt_pl1_spl",
-  },
+/**
+ * The two handhelds this plugin has always special-cased by DMI name,
+ * carried over unchanged from before `discoverPowerRails()` existed.
+ *
+ * Deliberately kept rather than folded into generic discovery: these are
+ * AMD devices that work today, and re-ordering their detection is a
+ * behaviour change on hardware we can't test. Generic discovery running
+ * ahead of them on AMD is a separate PR. The milliwatt unit is the one
+ * these paths have always been written in, so `scale` reproduces exactly
+ * what shipped — but `scaleKnown: false` lets `setTdpViaWmi` recover if a
+ * firmware rejects it (see there), which the old unconditional
+ * `watts * 1000` could not.
+ */
+const ROG_ALLY_WMI_RAILS: { armoury: PowerRails; legacy: PowerRails } = {
   armoury: {
-    fppt: "/sys/class/firmware-attributes/asus-armoury/attributes/ppt_fppt/current_value",
-    sppt: "/sys/class/firmware-attributes/asus-armoury/attributes/ppt_pl2_sppt/current_value",
     spl: "/sys/class/firmware-attributes/asus-armoury/attributes/ppt_pl1_spl/current_value",
+    sppt: "/sys/class/firmware-attributes/asus-armoury/attributes/ppt_pl2_sppt/current_value",
+    fppt: "/sys/class/firmware-attributes/asus-armoury/attributes/ppt_fppt/current_value",
+    scale: 1000,
+    scaleKnown: false,
+    range: null,
+    source: "asus-armoury (DMI-matched)",
+  },
+  legacy: {
+    spl: "/sys/devices/platform/asus-nb-wmi/ppt_pl1_spl",
+    sppt: "/sys/devices/platform/asus-nb-wmi/ppt_pl2_sppt",
+    fppt: "/sys/devices/platform/asus-nb-wmi/ppt_fppt",
+    scale: 1000,
+    scaleKnown: false,
+    range: null,
+    source: "asus-nb-wmi (legacy)",
   },
 };
 
-const LEGION_GO_WMI_PATHS = {
-  fppt: "/sys/class/firmware-attributes/lenovo-wmi-other-0/attributes/ppt_pl3_fppt/current_value",
-  sppt: "/sys/class/firmware-attributes/lenovo-wmi-other-0/attributes/ppt_pl2_sppt/current_value",
+const LEGION_GO_WMI_RAILS: PowerRails = {
   spl: "/sys/class/firmware-attributes/lenovo-wmi-other-0/attributes/ppt_pl1_spl/current_value",
+  sppt: "/sys/class/firmware-attributes/lenovo-wmi-other-0/attributes/ppt_pl2_sppt/current_value",
+  fppt: "/sys/class/firmware-attributes/lenovo-wmi-other-0/attributes/ppt_pl3_fppt/current_value",
+  scale: 1000,
+  scaleKnown: false,
+  range: null,
+  source: "lenovo-wmi-other-0 (DMI-matched)",
 };
 
 // ---------------------------------------------------------------------------
@@ -103,6 +129,17 @@ async function readFileText(path: string): Promise<string | null> {
     return null;
   }
 }
+
+/**
+ * The real sysfs, in the injectable shape every `./lib` discovery module
+ * takes (`FirmwareAttrDeps` / `RaplDeps` / `GpuFsDeps` are the same pair of
+ * "read, or null" functions). Tests hand those modules an in-memory tree
+ * instead.
+ */
+const sysfsDeps = {
+  readFile: readFileText,
+  listDir: (path: string) => readdir(path).catch(() => null),
+};
 
 async function writeSysfs(path: string, value: string): Promise<void> {
   // The backend runs as root (system service), so a direct write to the
@@ -331,7 +368,7 @@ export default class TdpControlBackend implements PluginBackend {
    * detectMethod(); used by setTdpViaRyzenadj() + testRyzenadjRead().
    */
   private ryzenadjPath = "ryzenadj";
-  private intelRaplPath: string | null = null;
+  private intelRapl: RaplConstraints | null = null;
   private scalingDriver = "";
   private platformProfile: string | null = null;
   private platformProfileChoices: string[] = [];
@@ -342,8 +379,9 @@ export default class TdpControlBackend implements PluginBackend {
 
   private pollInterval?: Timer;
 
-  // WMI TDP paths (for ROG Ally / Legion Go)
-  private wmiPaths: { fppt: string; sppt: string; spl: string } | null = null;
+  // Firmware power rails, discovered from /sys/class/firmware-attributes
+  // (ROG Ally, Legion Go, MSI Claw, …) or the legacy ASUS platform files.
+  private wmiPaths: PowerRails | null = null;
 
   // CPU boost detection
   private cpuBoostPath: string | null = null;
@@ -351,6 +389,11 @@ export default class TdpControlBackend implements PluginBackend {
   // GPU control
   private gpuCardPath: string | null = null;
   private gpuVendor: "AMD" | "Intel" | "Unknown" = "Unknown";
+  /** Which kernel driver backs `gpuCardPath` — the two Intel drivers expose
+   *  entirely different frequency interfaces. */
+  private gpuDriver: "amdgpu" | "i915" | "xe" | null = null;
+  /** Per-GT frequency directories; `xe` only, empty otherwise. */
+  private gpuFreqDirs: string[] = [];
 
   // AC power monitoring
   private acPowerOnline: boolean | null = null;
@@ -423,6 +466,14 @@ export default class TdpControlBackend implements PluginBackend {
       this.detectGpu(),
       this.detectAcPower(),
     ]);
+
+    // detectTdpMethod() may have learned the firmware's real TDP envelope
+    // from the power rails' declared min_value/max_value. Re-derive the range
+    // now it's known — this is what gives a handheld with no entry in
+    // @loadout/devices a correct slider instead of a generic-vendor guess.
+    if (this.wmiPaths?.range) {
+      this.applyDeviceDefaults();
+    }
 
     // After scaling driver is known, detect EPP/governor options
     await Promise.all([
@@ -735,7 +786,7 @@ export default class TdpControlBackend implements PluginBackend {
       supportsSmt: this.supportsSmt,
       supportsCpuBoost: this.supportsCpuBoost,
       ryzenadjAvailable: this.ryzenadjAvailable,
-      intelRaplAvailable: this.intelRaplPath !== null,
+      intelRaplAvailable: this.intelRapl !== null,
       ryzenadjCanRead: this.ryzenadjCanRead,
       gpuVendor: this.gpuVendor,
       supportsGpuControl: this.gpuCardPath !== null,
@@ -1232,9 +1283,24 @@ export default class TdpControlBackend implements PluginBackend {
         await writeSysfs(odClkPath, `s 0 ${minMhz}`);
         await writeSysfs(odClkPath, `s 1 ${maxMhz}`);
         await writeSysfs(odClkPath, "c");
+      } else if (this.gpuVendor === "Intel" && this.gpuDriver === "xe") {
+        // Every GT gets the range — leaving the media GT unbounded would
+        // undercut the point of setting a ceiling at all.
+        for (const dir of this.gpuFreqDirs) {
+          await this.writeIntelFreqPair(
+            `${dir}/min_freq`,
+            `${dir}/max_freq`,
+            minMhz,
+            maxMhz,
+          );
+        }
       } else if (this.gpuVendor === "Intel") {
-        await writeSysfs(`${this.gpuCardPath}/gt_min_freq_mhz`, String(minMhz));
-        await writeSysfs(`${this.gpuCardPath}/gt_max_freq_mhz`, String(maxMhz));
+        await this.writeIntelFreqPair(
+          `${this.gpuCardPath}/gt_min_freq_mhz`,
+          `${this.gpuCardPath}/gt_max_freq_mhz`,
+          minMhz,
+          maxMhz,
+        );
       } else {
         return { success: false, error: "Unknown GPU vendor" };
       }
@@ -1243,6 +1309,32 @@ export default class TdpControlBackend implements PluginBackend {
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       return { success: false, error: msg };
+    }
+  }
+
+  /**
+   * Write an Intel GPU floor/ceiling pair in an order the kernel will accept.
+   *
+   * Both drivers reject a write that would put the floor above the ceiling,
+   * so neither fixed order is safe on its own: raising the whole range needs
+   * the ceiling first, lowering it needs the floor first. Compare against the
+   * ceiling in force and pick.
+   */
+  private async writeIntelFreqPair(
+    minPath: string,
+    maxPath: string,
+    minMhz: number,
+    maxMhz: number,
+  ): Promise<void> {
+    const text = await readFileText(maxPath);
+    const currentMax = text === null ? null : parseInt(text, 10);
+
+    if (writeCeilingFirst(currentMax, minMhz)) {
+      await writeSysfs(maxPath, String(maxMhz));
+      await writeSysfs(minPath, String(minMhz));
+    } else {
+      await writeSysfs(minPath, String(minMhz));
+      await writeSysfs(maxPath, String(maxMhz));
     }
   }
 
@@ -1346,7 +1438,8 @@ export default class TdpControlBackend implements PluginBackend {
 
   private applyDeviceDefaults(): void {
     // A user-defined custom device is the default when present — it overrides
-    // whatever DMI matching would have picked.
+    // whatever DMI matching would have picked, and a firmware-declared range
+    // too: an explicit choice by the user outranks both.
     if (this.customDevice) {
       const d = this.customDevice;
       this.deviceName = d.name;
@@ -1356,7 +1449,15 @@ export default class TdpControlBackend implements PluginBackend {
       this.profiles = { ...d.profiles };
       return;
     }
-    const device = matchDevice(this.dmiProductName, this.cpuVendor);
+    const matched = matchDevice(this.dmiProductName, this.cpuVendor);
+
+    // A firmware-declared envelope outranks the table: it is per-unit exact,
+    // and for a handheld released after the table was last touched it is the
+    // only correct source. Only known once detectTdpMethod() has run, which
+    // is why onLoad re-runs this afterwards.
+    const range = this.wmiPaths?.range;
+    const device = range ? applyFirmwareRange(matched, range) : matched;
+
     this.deviceName = device.name;
     this.minWatts = device.minTdp;
     this.maxWatts = device.maxTdp;
@@ -1402,27 +1503,60 @@ export default class TdpControlBackend implements PluginBackend {
   }
 
   private async detectTdpMethod(): Promise<void> {
-    // 0. Try WMI paths first (higher priority for known devices)
+    const amd = await isAmdCpu();
+
+    // 0. Firmware power rails, discovered generically by attribute name
+    //    across every driver in /sys/class/firmware-attributes — covering
+    //    asus-armoury, lenovo-wmi-other-N, msi-wmi-platform and whatever
+    //    ships next without a DMI check to maintain.
+    //
+    //    NON-AMD ONLY, deliberately. On Intel this is the whole point: an
+    //    EC-governed handheld typically also exposes Intel RAPL, but RAPL
+    //    there is locked or immediately overridden by firmware, so falling
+    //    through to it looks like it works and does nothing. On AMD, the
+    //    DMI-matched paths below and ryzenadj are what ships today and
+    //    works; letting generic discovery outrank them changes behaviour
+    //    on ROG Ally / Legion Go hardware we have no way to test, so that
+    //    reordering is a separate PR rather than a side effect of adding
+    //    Intel support.
+    if (!amd) {
+      const rails = await discoverPowerRails(sysfsDeps);
+      if (rails) {
+        this.wmiPaths = rails;
+        this.method = "wmi";
+        console.log(
+          `[tdp-control] Firmware power rails via ${rails.source}: ` +
+            `spl=${rails.spl}, sppt=${rails.sppt ?? "n/a"}, fppt=${rails.fppt ?? "n/a"}, ` +
+            `range=${rails.range ? `${rails.range.min}-${rails.range.max}W` : "undeclared"}, ` +
+            `unit=${rails.scale === 1000 ? "mW" : "W"}${rails.scaleKnown ? "" : " (assumed)"}`,
+        );
+        return;
+      }
+    }
+
+    // 0a. ROG Ally, then Legion Go — DMI-matched, in the order they have
+    //     always been probed. Copy rather than alias the module-level
+    //     consts: setTdpViaWmi learns `scale`/`scaleKnown` from a write and
+    //     stores it back, which would otherwise leak across instances.
     if (this.dmiProductName.includes("ROG Ally")) {
-      // Try armoury driver first (newer), then legacy asus-nb-wmi
-      const armouryPaths = ROG_ALLY_WMI_PATHS.armoury;
-      if ((await readFileText(armouryPaths.spl)) !== null) {
-        this.wmiPaths = armouryPaths;
+      const armoury = ROG_ALLY_WMI_RAILS.armoury;
+      if ((await readFileText(armoury.spl)) !== null) {
+        this.wmiPaths = { ...armoury };
         this.method = "wmi";
         console.log("[tdp-control] ROG Ally WMI (armoury) paths detected");
         return;
       }
-      const legacyPaths = ROG_ALLY_WMI_PATHS.legacy;
-      if ((await readFileText(legacyPaths.spl)) !== null) {
-        this.wmiPaths = legacyPaths;
+      const legacy = ROG_ALLY_WMI_RAILS.legacy;
+      if ((await readFileText(legacy.spl)) !== null) {
+        this.wmiPaths = { ...legacy };
         this.method = "wmi";
         console.log("[tdp-control] ROG Ally WMI (legacy) paths detected");
         return;
       }
     }
     if (this.dmiProductName.includes("Legion Go")) {
-      if ((await readFileText(LEGION_GO_WMI_PATHS.spl)) !== null) {
-        this.wmiPaths = LEGION_GO_WMI_PATHS;
+      if ((await readFileText(LEGION_GO_WMI_RAILS.spl)) !== null) {
+        this.wmiPaths = { ...LEGION_GO_WMI_RAILS };
         this.method = "wmi";
         console.log("[tdp-control] Legion Go WMI paths detected");
         return;
@@ -1435,7 +1569,6 @@ export default class TdpControlBackend implements PluginBackend {
     //    https://github.com/FlyGoat/RyzenAdj v0.19.0 via this plugin's build-ryzenadj.sh)
     //    so we work out-of-box on stock SteamOS where ryzenadj isn't packaged.
     //    Fall back to a system install on $PATH (Bazzite/Arch with AUR).
-    const amd = await isAmdCpu();
     if (amd) {
       const bundled = resolveBundledRyzenadj();
       const onPath = await commandExists("ryzenadj");
@@ -1463,24 +1596,17 @@ export default class TdpControlBackend implements PluginBackend {
       }
     }
 
-    // 2. Try Intel RAPL sysfs. Probe all candidate paths in parallel
-    //    and pick the first one that returned a value — fan-out is
-    //    safe because reads are independent and the kernel handles
-    //    them on separate fds. Saves 200-400ms on cold start on
-    //    Intel systems where 3 of the 4 paths typically don't exist.
-    //    `INTEL_RAPL_PATHS` is ordered by preference, so picking the
-    //    first non-null hit preserves the existing tie-break.
-    const raplResults = await Promise.all(
-      INTEL_RAPL_PATHS.map(async (path) => ({
-        path,
-        val: await readFileText(path),
-      })),
-    );
-    const raplHit = raplResults.find((r) => r.val !== null);
-    if (raplHit) {
-      this.intelRaplPath = raplHit.path;
+    // 2. Try Intel RAPL powercap. Constraints are resolved by name rather
+    //    than by slot index, and both the sustained and boost limits are
+    //    captured — see ./lib/rapl for why each matters.
+    const rapl = await discoverRaplConstraints(sysfsDeps);
+    if (rapl) {
+      this.intelRapl = rapl;
       this.method = "intel-rapl";
-      console.log(`[tdp-control] Intel RAPL available at ${raplHit.path}`);
+      console.log(
+        `[tdp-control] Intel RAPL available at ${rapl.zone} ` +
+          `(short_term=${rapl.shortTerm ? "yes" : "no"})`,
+      );
       return;
     }
 
@@ -1602,16 +1728,34 @@ export default class TdpControlBackend implements PluginBackend {
         if ((await readFileText(amdOdPath)) !== null) {
           this.gpuCardPath = cardPath;
           this.gpuVendor = "AMD";
+          this.gpuDriver = "amdgpu";
           console.log(`[tdp-control] AMD GPU detected at ${cardPath}`);
           return;
         }
 
-        // Check for Intel GPU (gt_max_freq_mhz)
+        // Check for an i915 Intel GPU (flat gt_max_freq_mhz on the card)
         const intelFreqPath = `${cardPath}/gt_max_freq_mhz`;
         if ((await readFileText(intelFreqPath)) !== null) {
           this.gpuCardPath = cardPath;
           this.gpuVendor = "Intel";
-          console.log(`[tdp-control] Intel GPU detected at ${cardPath}`);
+          this.gpuDriver = "i915";
+          console.log(`[tdp-control] Intel GPU (i915) detected at ${cardPath}`);
+          return;
+        }
+
+        // Check for an xe Intel GPU (per-GT freq dirs). Probed after i915
+        // because the i915 test is a single read against a known path,
+        // where this one walks a directory tree.
+        const xeFreqDirs = await findXeFreqDirs(sysfsDeps, cardPath);
+        if (xeFreqDirs.length > 0) {
+          this.gpuCardPath = cardPath;
+          this.gpuVendor = "Intel";
+          this.gpuDriver = "xe";
+          this.gpuFreqDirs = xeFreqDirs;
+          console.log(
+            `[tdp-control] Intel GPU (xe) detected at ${cardPath}, ` +
+              `${xeFreqDirs.length} GT(s): ${xeFreqDirs.join(", ")}`,
+          );
           return;
         }
       }
@@ -1620,6 +1764,8 @@ export default class TdpControlBackend implements PluginBackend {
     }
     this.gpuCardPath = null;
     this.gpuVendor = "Unknown";
+    this.gpuDriver = null;
+    this.gpuFreqDirs = [];
   }
 
   private async detectAcPower(): Promise<void> {
@@ -1719,18 +1865,31 @@ export default class TdpControlBackend implements PluginBackend {
           cardPath: this.gpuCardPath,
         };
       } else if (this.gpuVendor === "Intel") {
-        const [gtMax, gtMin, gtRP0, gtRPn] = await Promise.all([
-          readFileText(`${this.gpuCardPath}/gt_max_freq_mhz`),
-          readFileText(`${this.gpuCardPath}/gt_min_freq_mhz`),
-          readFileText(`${this.gpuCardPath}/gt_RP0_freq_mhz`),
-          readFileText(`${this.gpuCardPath}/gt_RPn_freq_mhz`),
-        ]);
+        // Both Intel drivers report the same four numbers under different
+        // names: the hardware bounds (RPn/RP0) and the range in force.
+        // Reported from the first GT — it's the render engine, and the UI
+        // shows one range even where a part has several GTs.
+        const freqDir = this.gpuFreqDirs[0];
+        const [max, min, rp0, rpn] =
+          this.gpuDriver === "xe" && freqDir
+            ? await Promise.all([
+                readFileText(`${freqDir}/max_freq`),
+                readFileText(`${freqDir}/min_freq`),
+                readFileText(`${freqDir}/rp0_freq`),
+                readFileText(`${freqDir}/rpn_freq`),
+              ])
+            : await Promise.all([
+                readFileText(`${this.gpuCardPath}/gt_max_freq_mhz`),
+                readFileText(`${this.gpuCardPath}/gt_min_freq_mhz`),
+                readFileText(`${this.gpuCardPath}/gt_RP0_freq_mhz`),
+                readFileText(`${this.gpuCardPath}/gt_RPn_freq_mhz`),
+              ]);
 
         return {
           vendor: "Intel",
-          minFreqMhz: gtRPn ? parseInt(gtRPn, 10) : 0,
-          maxFreqMhz: gtRP0 ? parseInt(gtRP0, 10) : 0,
-          currentMode: `min=${gtMin ?? "?"}MHz max=${gtMax ?? "?"}MHz`,
+          minFreqMhz: rpn ? parseInt(rpn, 10) : 0,
+          maxFreqMhz: rp0 ? parseInt(rp0, 10) : 0,
+          currentMode: `min=${min ?? "?"}MHz max=${max ?? "?"}MHz`,
           cardPath: this.gpuCardPath,
         };
       }
@@ -1748,13 +1907,16 @@ export default class TdpControlBackend implements PluginBackend {
     watts: number;
     source: TdpReadSource;
   } | null> {
-    // 0. Try WMI sysfs (ROG Ally / Legion Go)
+    // 0. Try the firmware power rails (ROG Ally / Legion Go / MSI Claw / …)
     if (this.method === "wmi" && this.wmiPaths) {
       const text = await readFileText(this.wmiPaths.spl);
       if (text !== null) {
-        const milliwatts = parseInt(text, 10);
-        if (!isNaN(milliwatts)) {
-          return { watts: Math.round(milliwatts / 1000), source: "read" };
+        const raw = parseInt(text, 10);
+        if (!isNaN(raw)) {
+          return {
+            watts: Math.round(raw / this.wmiPaths.scale),
+            source: "read",
+          };
         }
       }
     }
@@ -1766,8 +1928,8 @@ export default class TdpControlBackend implements PluginBackend {
     }
 
     // 2. Try Intel RAPL sysfs
-    if (this.method === "intel-rapl" && this.intelRaplPath) {
-      const text = await readFileText(this.intelRaplPath);
+    if (this.method === "intel-rapl" && this.intelRapl) {
+      const text = await readFileText(this.intelRapl.longTerm);
       if (text !== null) {
         const uw = parseInt(text, 10);
         if (!isNaN(uw)) {
@@ -1841,22 +2003,91 @@ export default class TdpControlBackend implements PluginBackend {
     }
   }
 
+  /**
+   * Drive the RAPL package zone to `watts`.
+   *
+   * The short-term (PL2) limit is pinned to the same wattage before the
+   * sustained one, best-effort: left at its firmware default it lets a
+   * base/boost part spend the boost budget no matter where the slider sits,
+   * but plenty of zones expose no short-term constraint or refuse writes to
+   * it, and neither should fail an otherwise good apply.
+   */
   private async setTdpViaIntelRapl(watts: number): Promise<void> {
-    if (!this.intelRaplPath) {
+    const rapl = this.intelRapl;
+    if (!rapl) {
       throw new Error("Intel RAPL path not available");
     }
-    const microwatts = String(watts * 1_000_000);
-    await writeSysfs(this.intelRaplPath, microwatts);
+    const microwatts = String(Math.round(watts * 1_000_000));
+
+    if (rapl.shortTerm) {
+      try {
+        await writeSysfs(rapl.shortTerm, microwatts);
+      } catch (e) {
+        console.warn(`[tdp-control] RAPL short_term not writable: ${e}`);
+      }
+    }
+    await writeSysfs(rapl.longTerm, microwatts);
   }
 
+  /**
+   * Drive the firmware power rails to `watts`.
+   *
+   * Only the sustained rail (SPL/PL1) is required: MSI's driver exposes just
+   * PL1 + PL2, and the old code's unconditional write of all three threw on
+   * anything that didn't have a PL3. The boost rails are pinned to the same
+   * wattage rather than left alone, so a firmware-default PL2 can't spend the
+   * whole envelope the moment load arrives.
+   *
+   * Rails are written boost-first so the sustained limit — the one we read
+   * back and the one that governs — lands last and wins any firmware
+   * cross-validation between them.
+   */
   private async setTdpViaWmi(watts: number): Promise<void> {
-    if (!this.wmiPaths) {
+    const rails = this.wmiPaths;
+    if (!rails) {
       throw new Error("WMI paths not available");
     }
-    const milliwatts = String(watts * 1000);
-    await writeSysfs(this.wmiPaths.fppt, milliwatts);
-    await writeSysfs(this.wmiPaths.sppt, milliwatts);
-    await writeSysfs(this.wmiPaths.spl, milliwatts);
+
+    const write = (path: string) =>
+      writeSysfs(path, String(Math.round(watts * rails.scale)));
+
+    // Boost rails are best-effort: a firmware that rejects or omits them is
+    // still perfectly controllable through the sustained rail.
+    for (const path of [rails.fppt, rails.sppt]) {
+      if (!path) continue;
+      try {
+        await write(path);
+      } catch (e) {
+        console.warn(`[tdp-control] boost rail ${path} not writable: ${e}`);
+      }
+    }
+
+    try {
+      await write(rails.spl);
+    } catch (e) {
+      // Flip the unit once and latch whichever one the firmware accepts.
+      //
+      // This runs even when `scaleKnown` is true. "Known" means inferred
+      // from max_value, and a rejected write is precisely the evidence that
+      // the inference was wrong — gating the retry on it left the only
+      // devices with a declared range (asus-armoury, lenovo-wmi-other-N)
+      // with no recovery at all, which is the wrong way round. If the flip
+      // is also rejected the original error is what propagates, so trying
+      // costs nothing beyond one extra failed write.
+      const flipped = rails.scale === 1 ? 1000 : 1;
+      console.warn(
+        `[tdp-control] ${rails.spl} rejected ${watts * rails.scale}; ` +
+          `retrying as ${watts * flipped} (unit was ` +
+          `${rails.scaleKnown ? "declared — the declaration looks wrong" : "assumed, not declared"})`,
+      );
+      try {
+        await writeSysfs(rails.spl, String(Math.round(watts * flipped)));
+      } catch {
+        throw e;
+      }
+      rails.scale = flipped;
+      rails.scaleKnown = true;
+    }
   }
 
   // -----------------------------------------------------------------------

--- a/plugins/tdp-control/lib/firmware-attributes.test.ts
+++ b/plugins/tdp-control/lib/firmware-attributes.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "bun:test";
+import {
+  discoverPowerRails,
+  inferWattScale,
+  pickAttribute,
+  FIRMWARE_ATTRIBUTES_DIR,
+  type FirmwareAttrDeps,
+} from "./firmware-attributes";
+
+/**
+ * In-memory sysfs: directories are keys mapping to their entry basenames,
+ * files are keys mapping to their contents. Anything absent reads as null,
+ * the same contract the backend's readFileText / readdir wrappers provide.
+ */
+function fakeFs(tree: {
+  dirs: Record<string, string[]>;
+  files: Record<string, string>;
+}): FirmwareAttrDeps {
+  return {
+    readFile: async (path) => tree.files[path] ?? null,
+    listDir: async (path) => tree.dirs[path] ?? null,
+  };
+}
+
+/** The real shape of a vendor driver's attribute tree, in watts. */
+function driverTree(
+  driver: string,
+  attrs: string[],
+  range: { min: number; max: number } | null = { min: 8, max: 35 },
+) {
+  const base = `${FIRMWARE_ATTRIBUTES_DIR}/${driver}/attributes`;
+  const files: Record<string, string> = {};
+  for (const attr of attrs) {
+    files[`${base}/${attr}/current_value`] = "15\n";
+    if (range) {
+      files[`${base}/${attr}/min_value`] = `${range.min}\n`;
+      files[`${base}/${attr}/max_value`] = `${range.max}\n`;
+    }
+  }
+  return {
+    dirs: {
+      [FIRMWARE_ATTRIBUTES_DIR]: [driver],
+      [base]: attrs,
+    },
+    files,
+  };
+}
+
+describe("pickAttribute", () => {
+  it("returns the first candidate that exists", () => {
+    expect(pickAttribute(["ppt_fppt", "ppt_pl3_fppt"], ["ppt_pl3_fppt", "ppt_fppt"])).toBe(
+      "ppt_pl3_fppt",
+    );
+  });
+
+  it("returns null when none exist", () => {
+    expect(pickAttribute(["ppt_pl1_spl"], ["ppt_pl2_sppt"])).toBeNull();
+  });
+});
+
+describe("inferWattScale", () => {
+  // The `ppt_*` attributes are watts on every driver we know of; reading the
+  // declared ceiling means a vendor that chose milliwatts still works.
+  it("reads a two-digit ceiling as watts", () => {
+    expect(inferWattScale(35)).toEqual({ scale: 1, known: true });
+  });
+
+  it("reads a five-digit ceiling as milliwatts", () => {
+    expect(inferWattScale(35000)).toEqual({ scale: 1000, known: true });
+  });
+
+  it("assumes watts, and says so, when nothing is declared", () => {
+    expect(inferWattScale(null)).toEqual({ scale: 1, known: false });
+  });
+});
+
+describe("discoverPowerRails", () => {
+  it("finds MSI's PL1 + PL2 and reports the absent PL3 as null", async () => {
+    // msi-wmi-platform (MSI Claw, incl. the Arc G3 Extreme Claw 8 EX)
+    // exposes no fast rail — the old code wrote all three unconditionally.
+    const rails = await discoverPowerRails(
+      fakeFs(driverTree("msi-wmi-platform", ["ppt_pl1_spl", "ppt_pl2_sppt"])),
+    );
+    const base = `${FIRMWARE_ATTRIBUTES_DIR}/msi-wmi-platform/attributes`;
+
+    expect(rails).toEqual({
+      spl: `${base}/ppt_pl1_spl/current_value`,
+      sppt: `${base}/ppt_pl2_sppt/current_value`,
+      fppt: null,
+      scale: 1,
+      scaleKnown: true,
+      range: { min: 8, max: 35 },
+      source: "msi-wmi-platform",
+    });
+  });
+
+  it("finds ASUS's armoury rails, PL3 under its ppt_fppt spelling", async () => {
+    const rails = await discoverPowerRails(
+      fakeFs(
+        driverTree("asus-armoury", ["ppt_pl1_spl", "ppt_pl2_sppt", "ppt_fppt"], {
+          min: 7,
+          max: 30,
+        }),
+      ),
+    );
+    expect(rails?.source).toBe("asus-armoury");
+    expect(rails?.fppt).toContain("ppt_fppt/current_value");
+    expect(rails?.range).toEqual({ min: 7, max: 30 });
+  });
+
+  it("finds Lenovo's rails, PL3 under its ppt_pl3_fppt spelling", async () => {
+    const rails = await discoverPowerRails(
+      fakeFs(
+        driverTree("lenovo-wmi-other-0", ["ppt_pl1_spl", "ppt_pl2_sppt", "ppt_pl3_fppt"]),
+      ),
+    );
+    expect(rails?.source).toBe("lenovo-wmi-other-0");
+    expect(rails?.fppt).toContain("ppt_pl3_fppt/current_value");
+  });
+
+  it("converts a milliwatt-declared range into watts", async () => {
+    const rails = await discoverPowerRails(
+      fakeFs(
+        driverTree("hypothetical-wmi", ["ppt_pl1_spl"], { min: 8000, max: 35000 }),
+      ),
+    );
+    expect(rails?.scale).toBe(1000);
+    expect(rails?.range).toEqual({ min: 8, max: 35 });
+  });
+
+  it("reports no range when the driver declares none", async () => {
+    const rails = await discoverPowerRails(
+      fakeFs(driverTree("bare-wmi", ["ppt_pl1_spl"], null)),
+    );
+    expect(rails?.range).toBeNull();
+    expect(rails?.scaleKnown).toBe(false);
+  });
+
+  it("ignores a degenerate range where min equals max", async () => {
+    const rails = await discoverPowerRails(
+      fakeFs(driverTree("stuck-wmi", ["ppt_pl1_spl"], { min: 15, max: 15 })),
+    );
+    expect(rails?.range).toBeNull();
+  });
+
+  it("skips a driver with no sustained rail and keeps looking", async () => {
+    // A boost limit with nothing to steer underneath is not controllable.
+    const boostOnly = driverTree("boost-only-wmi", ["ppt_pl2_sppt"]);
+    const real = driverTree("zz-real-wmi", ["ppt_pl1_spl"]);
+    const rails = await discoverPowerRails(
+      fakeFs({
+        dirs: {
+          ...boostOnly.dirs,
+          ...real.dirs,
+          [FIRMWARE_ATTRIBUTES_DIR]: ["boost-only-wmi", "zz-real-wmi"],
+        },
+        files: { ...boostOnly.files, ...real.files },
+      }),
+    );
+    expect(rails?.source).toBe("zz-real-wmi");
+  });
+
+  it("returns null when the class directory doesn't exist", async () => {
+    expect(await discoverPowerRails(fakeFs({ dirs: {}, files: {} }))).toBeNull();
+  });
+
+  it("returns null when no driver exposes power rails", async () => {
+    const other = driverTree("thinklmi", ["boot_order"]);
+    expect(await discoverPowerRails(fakeFs(other))).toBeNull();
+  });
+
+  it("picks the same driver every boot when several qualify", async () => {
+    const a = driverTree("aaa-wmi", ["ppt_pl1_spl"]);
+    const z = driverTree("zzz-wmi", ["ppt_pl1_spl"]);
+    const tree = {
+      dirs: { ...a.dirs, ...z.dirs, [FIRMWARE_ATTRIBUTES_DIR]: ["zzz-wmi", "aaa-wmi"] },
+      files: { ...a.files, ...z.files },
+    };
+    expect((await discoverPowerRails(fakeFs(tree)))?.source).toBe("aaa-wmi");
+  });
+});

--- a/plugins/tdp-control/lib/firmware-attributes.test.ts
+++ b/plugins/tdp-control/lib/firmware-attributes.test.ts
@@ -160,6 +160,37 @@ describe("discoverPowerRails", () => {
     expect(rails?.source).toBe("zz-real-wmi");
   });
 
+  it("skips a driver whose rail directory has no readable current_value", async () => {
+    // A stub or read-only driver can publish the attribute directory with
+    // nothing behind it. Claiming those rails would latch method="wmi" and
+    // starve the Intel RAPL fallback, losing TDP control on a device the
+    // old code drove fine.
+    const stub = driverTree("stub-wmi", ["ppt_pl1_spl"]);
+    delete stub.files[
+      `${FIRMWARE_ATTRIBUTES_DIR}/stub-wmi/attributes/ppt_pl1_spl/current_value`
+    ];
+    const real = driverTree("zz-real-wmi", ["ppt_pl1_spl"]);
+    const rails = await discoverPowerRails(
+      fakeFs({
+        dirs: {
+          ...stub.dirs,
+          ...real.dirs,
+          [FIRMWARE_ATTRIBUTES_DIR]: ["stub-wmi", "zz-real-wmi"],
+        },
+        files: { ...stub.files, ...real.files },
+      }),
+    );
+    expect(rails?.source).toBe("zz-real-wmi");
+  });
+
+  it("returns null when the only rail directory is unreadable", async () => {
+    const stub = driverTree("stub-wmi", ["ppt_pl1_spl"]);
+    delete stub.files[
+      `${FIRMWARE_ATTRIBUTES_DIR}/stub-wmi/attributes/ppt_pl1_spl/current_value`
+    ];
+    expect(await discoverPowerRails(fakeFs(stub))).toBeNull();
+  });
+
   it("returns null when the class directory doesn't exist", async () => {
     expect(await discoverPowerRails(fakeFs({ dirs: {}, files: {} }))).toBeNull();
   });

--- a/plugins/tdp-control/lib/firmware-attributes.ts
+++ b/plugins/tdp-control/lib/firmware-attributes.ts
@@ -145,6 +145,14 @@ export async function discoverPowerRails(
     const fppt = pickAttribute(available, PPT_RAIL_ATTRS.fppt);
     const valuePath = (attr: string) => `${attrsDir}/${attr}/current_value`;
 
+    // The attribute *directory* existing is not enough: a stub or read-only
+    // driver can publish `ppt_pl1_spl/` with no readable `current_value`.
+    // Claiming those rails would latch method="wmi" and starve the Intel
+    // RAPL fallback at step 2 of detectTdpMethod — a device that works on
+    // the old code would lose TDP control entirely. Read it first, the way
+    // the DMI-matched probes in backend.ts do.
+    if ((await deps.readFile(valuePath(spl))) === null) continue;
+
     const [minText, maxText] = await Promise.all([
       deps.readFile(`${attrsDir}/${spl}/min_value`),
       deps.readFile(`${attrsDir}/${spl}/max_value`),

--- a/plugins/tdp-control/lib/firmware-attributes.ts
+++ b/plugins/tdp-control/lib/firmware-attributes.ts
@@ -1,0 +1,175 @@
+/**
+ * Discovery for the kernel's `firmware-attributes` power-limit interface —
+ * the vendor-neutral way modern handheld firmware exposes its TDP rails.
+ *
+ * Every vendor driver implementing it lays the same tree out:
+ *
+ *     /sys/class/firmware-attributes/<driver>/attributes/<attr>/
+ *         current_value  min_value  max_value  scalar_increment  type
+ *
+ * and, crucially, they agree on the attribute *names* for the power rails
+ * even though the driver directory differs per vendor:
+ *
+ *     asus-armoury         ROG Ally / Ally X
+ *     lenovo-wmi-other-N   Legion Go
+ *     msi-wmi-platform     MSI Claw (incl. the Arc G3 Extreme Claw 8 EX)
+ *
+ * Matching on the attribute names rather than the driver name is what lets a
+ * handheld we've never seen work on day one — the previous approach hardcoded
+ * two driver paths behind a DMI check for "ROG Ally" / "Legion Go", so every
+ * other device silently fell through to Intel RAPL (commonly locked or
+ * overridden by the EC on these machines: the slider moved, nothing happened).
+ *
+ * The interface is self-describing — `min_value`/`max_value` state the
+ * envelope the firmware will actually accept — so a device with no entry in
+ * `@loadout/devices` still gets a correct slider range, and we learn the
+ * rail's unit instead of assuming it.
+ *
+ * I/O is injected (`FirmwareAttrDeps`) so the whole module is unit-testable
+ * without sysfs, the same pattern `plugins/wifi/lib/recovery.ts` uses.
+ */
+
+export const FIRMWARE_ATTRIBUTES_DIR = "/sys/class/firmware-attributes";
+
+/**
+ * Attribute names per power rail, most-preferred first.
+ *
+ * SPL (PL1, sustained) is the rail we actually steer and the one a device
+ * must expose to be usable. SPPT (PL2, boost) and FPPT (PL3, fast) are
+ * written alongside it when present so a boost limit can't blow past the
+ * sustained one — MSI exposes only PL1 + PL2, ASUS and Lenovo expose all
+ * three under different PL3 spellings.
+ */
+export const PPT_RAIL_ATTRS = {
+  spl: ["ppt_pl1_spl"],
+  sppt: ["ppt_pl2_sppt"],
+  fppt: ["ppt_pl3_fppt", "ppt_fppt"],
+} as const;
+
+export interface WattRange {
+  min: number;
+  max: number;
+}
+
+/** The set of power-limit sysfs files to drive, plus what we learned about them. */
+export interface PowerRails {
+  /** Sustained limit (PL1/SPL) — always present; the rail we steer. */
+  spl: string;
+  /** Boost limit (PL2/SPPT), or null when the firmware exposes none. */
+  sppt: string | null;
+  /** Fast limit (PL3/FPPT), or null when the firmware exposes none. */
+  fppt: string | null;
+  /** Multiplier from watts to the unit these files expect (1 = W, 1000 = mW). */
+  scale: number;
+  /**
+   * True when `scale` came from a firmware-declared `max_value` rather than
+   * being assumed. Callers use this to decide whether a rejected write is
+   * worth retrying in the other unit.
+   */
+  scaleKnown: boolean;
+  /** Envelope the firmware declares for the SPL rail, in watts. */
+  range: WattRange | null;
+  /** Driver directory (or a label for the legacy path) — for logs. */
+  source: string;
+}
+
+export interface FirmwareAttrDeps {
+  /** Read a file, or null when it doesn't exist / can't be read. */
+  readFile: (path: string) => Promise<string | null>;
+  /** Entry basenames of a directory, or null when it doesn't exist. */
+  listDir: (path: string) => Promise<string[] | null>;
+}
+
+/**
+ * A declared ceiling at or above this is read as milliwatts.
+ *
+ * The two units are separated by three orders of magnitude and the plausible
+ * ranges don't come close to overlapping: no handheld sustains 1000 W, and no
+ * firmware caps a rail at under 1 W. `ppt_*` attributes are watts on every
+ * driver we know of, but reading the declared ceiling means we don't have to
+ * bet on that holding for the next vendor.
+ */
+export const MILLIWATT_MIN_CEILING = 1000;
+
+/** Infer the watts→attribute-unit multiplier from a declared ceiling. Pure. */
+export function inferWattScale(maxValue: number | null): {
+  scale: number;
+  known: boolean;
+} {
+  if (maxValue === null || !Number.isFinite(maxValue)) {
+    return { scale: 1, known: false };
+  }
+  return maxValue >= MILLIWATT_MIN_CEILING
+    ? { scale: 1000, known: true }
+    : { scale: 1, known: true };
+}
+
+/** First candidate present in `available`, or null. Pure. */
+export function pickAttribute(
+  available: readonly string[],
+  candidates: readonly string[],
+): string | null {
+  return candidates.find((name) => available.includes(name)) ?? null;
+}
+
+function parseIntOrNull(text: string | null): number | null {
+  if (text === null) return null;
+  const n = parseInt(text.trim(), 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+/**
+ * Scan `/sys/class/firmware-attributes` for a driver exposing the `ppt_*`
+ * power rails and describe them. Returns null when no driver does.
+ *
+ * Drivers are visited in sorted order so a machine with more than one
+ * resolves the same way every boot.
+ */
+export async function discoverPowerRails(
+  deps: FirmwareAttrDeps,
+): Promise<PowerRails | null> {
+  const drivers = await deps.listDir(FIRMWARE_ATTRIBUTES_DIR);
+  if (!drivers) return null;
+
+  for (const driver of [...drivers].sort()) {
+    const attrsDir = `${FIRMWARE_ATTRIBUTES_DIR}/${driver}/attributes`;
+    const available = await deps.listDir(attrsDir);
+    if (!available) continue;
+
+    const spl = pickAttribute(available, PPT_RAIL_ATTRS.spl);
+    // No sustained rail means nothing to steer — a driver exposing only a
+    // boost limit isn't usable, so keep looking.
+    if (!spl) continue;
+
+    const sppt = pickAttribute(available, PPT_RAIL_ATTRS.sppt);
+    const fppt = pickAttribute(available, PPT_RAIL_ATTRS.fppt);
+    const valuePath = (attr: string) => `${attrsDir}/${attr}/current_value`;
+
+    const [minText, maxText] = await Promise.all([
+      deps.readFile(`${attrsDir}/${spl}/min_value`),
+      deps.readFile(`${attrsDir}/${spl}/max_value`),
+    ]);
+    const rawMin = parseIntOrNull(minText);
+    const rawMax = parseIntOrNull(maxText);
+    const { scale, known } = inferWattScale(rawMax);
+
+    // A range is only useful if it's a real interval — a driver reporting
+    // min === max (or nothing at all) leaves the device database in charge.
+    const range =
+      rawMin !== null && rawMax !== null && rawMax > rawMin
+        ? { min: Math.round(rawMin / scale), max: Math.round(rawMax / scale) }
+        : null;
+
+    return {
+      spl: valuePath(spl),
+      sppt: sppt ? valuePath(sppt) : null,
+      fppt: fppt ? valuePath(fppt) : null,
+      scale,
+      scaleKnown: known,
+      range,
+      source: driver,
+    };
+  }
+
+  return null;
+}

--- a/plugins/tdp-control/lib/gpu.test.ts
+++ b/plugins/tdp-control/lib/gpu.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "bun:test";
+import { findXeFreqDirs, writeCeilingFirst, type GpuFsDeps } from "./gpu";
+
+function fakeFs(tree: {
+  dirs: Record<string, string[]>;
+  files: Record<string, string>;
+}): GpuFsDeps {
+  return {
+    readFile: async (path) => tree.files[path] ?? null,
+    listDir: async (path) => tree.dirs[path] ?? null,
+  };
+}
+
+const CARD = "/sys/class/drm/card0";
+
+/** An `xe` card exposing one freq0 dir per (tile, gt) pair given. */
+function xeCard(gts: Array<[string, string]>) {
+  const dirs: Record<string, string[]> = {};
+  const files: Record<string, string> = {};
+  const tiles = [...new Set(gts.map(([tile]) => tile))];
+  dirs[`${CARD}/device`] = [...tiles, "power", "uevent"];
+  for (const tile of tiles) {
+    dirs[`${CARD}/device/${tile}`] = gts.filter(([t]) => t === tile).map(([, gt]) => gt);
+  }
+  for (const [tile, gt] of gts) {
+    files[`${CARD}/device/${tile}/${gt}/freq0/max_freq`] = "2300\n";
+  }
+  return { dirs, files };
+}
+
+describe("findXeFreqDirs", () => {
+  it("finds every GT on a multi-GT part, in tile-then-GT order", async () => {
+    // Panther Lake exposes a render GT and a media GT — bounding only the
+    // first would leave the other running free.
+    const dirs = await findXeFreqDirs(
+      fakeFs(xeCard([["tile0", "gt1"], ["tile0", "gt0"]])),
+      CARD,
+    );
+    expect(dirs).toEqual([
+      `${CARD}/device/tile0/gt0/freq0`,
+      `${CARD}/device/tile0/gt1/freq0`,
+    ]);
+  });
+
+  it("walks multiple tiles", async () => {
+    const dirs = await findXeFreqDirs(
+      fakeFs(xeCard([["tile1", "gt0"], ["tile0", "gt0"]])),
+      CARD,
+    );
+    expect(dirs).toEqual([
+      `${CARD}/device/tile0/gt0/freq0`,
+      `${CARD}/device/tile1/gt0/freq0`,
+    ]);
+  });
+
+  it("skips a GT with no freq0 knobs", async () => {
+    const tree = xeCard([["tile0", "gt0"], ["tile0", "gt1"]]);
+    delete tree.files[`${CARD}/device/tile0/gt1/freq0/max_freq`];
+    expect(await findXeFreqDirs(fakeFs(tree), CARD)).toEqual([
+      `${CARD}/device/tile0/gt0/freq0`,
+    ]);
+  });
+
+  it("returns nothing for an i915 card (no tile dirs)", async () => {
+    const tree = {
+      dirs: { [`${CARD}/device`]: ["power", "uevent"] },
+      files: { [`${CARD}/gt_max_freq_mhz`]: "2300\n" },
+    };
+    expect(await findXeFreqDirs(fakeFs(tree), CARD)).toEqual([]);
+  });
+
+  it("returns nothing when the device dir doesn't exist", async () => {
+    expect(await findXeFreqDirs(fakeFs({ dirs: {}, files: {} }), CARD)).toEqual([]);
+  });
+});
+
+describe("writeCeilingFirst", () => {
+  // Either fixed order wedges half the time: the kernel rejects a write that
+  // would leave the floor above the ceiling.
+  it("raises the ceiling first when the new floor clears the old ceiling", () => {
+    expect(writeCeilingFirst(500, 800)).toBe(true);
+  });
+
+  it("lowers the floor first when the new floor fits under the old ceiling", () => {
+    expect(writeCeilingFirst(2000, 300)).toBe(false);
+  });
+
+  it("treats an equal floor and ceiling as no reordering needed", () => {
+    expect(writeCeilingFirst(800, 800)).toBe(false);
+  });
+
+  it("assumes a raise when the current ceiling can't be read", () => {
+    expect(writeCeilingFirst(null, 800)).toBe(true);
+    expect(writeCeilingFirst(NaN, 800)).toBe(true);
+  });
+});

--- a/plugins/tdp-control/lib/gpu.ts
+++ b/plugins/tdp-control/lib/gpu.ts
@@ -1,0 +1,69 @@
+/**
+ * GPU frequency-interface helpers.
+ *
+ * Intel's two DRM drivers expose completely different trees for the same
+ * four numbers, and which one a machine uses is a function of its silicon:
+ *
+ *   i915  <card>/gt_{min,max,RP0,RPn}_freq_mhz
+ *   xe    <card>/device/tile<N>/gt<M>/freq0/{min,max,rp0,rpn}_freq
+ *
+ * `xe` is what Xe/Xe3 graphics bind to, so every Lunar Lake and Panther Lake
+ * part — including the Arc G3 Extreme handhelds — lands there. Probing only
+ * the i915 layout left `gpuVendor` as "Unknown" on those devices and hid the
+ * GPU panel outright.
+ *
+ * I/O is injected so this is unit-testable without /sys.
+ */
+
+export interface GpuFsDeps {
+  /** Read a file, or null when it doesn't exist / can't be read. */
+  readFile: (path: string) => Promise<string | null>;
+  /** Entry basenames of a directory, or null when it doesn't exist. */
+  listDir: (path: string) => Promise<string[] | null>;
+}
+
+/**
+ * Frequency-control directories for an `xe` card, one per graphics tile/GT,
+ * in stable tile-then-GT order. Empty when the card isn't an `xe` device.
+ *
+ * The tree is walked rather than assuming `tile0/gt0`: a Panther Lake part
+ * exposes a render GT and a media GT, and leaving the second one unbounded
+ * would undercut the point of setting a ceiling.
+ */
+export async function findXeFreqDirs(
+  deps: GpuFsDeps,
+  cardPath: string,
+): Promise<string[]> {
+  const deviceDir = `${cardPath}/device`;
+  const entries = (await deps.listDir(deviceDir)) ?? [];
+  const dirs: string[] = [];
+
+  for (const tile of entries.filter((e) => /^tile\d+$/.test(e)).sort()) {
+    const tileDir = `${deviceDir}/${tile}`;
+    const gts = (await deps.listDir(tileDir)) ?? [];
+    for (const gt of gts.filter((e) => /^gt\d+$/.test(e)).sort()) {
+      const freqDir = `${tileDir}/${gt}/freq0`;
+      if ((await deps.readFile(`${freqDir}/max_freq`)) !== null) {
+        dirs.push(freqDir);
+      }
+    }
+  }
+  return dirs;
+}
+
+/**
+ * Whether a floor/ceiling pair must be written ceiling-first. Pure.
+ *
+ * Both Intel drivers reject a write that would leave the floor above the
+ * ceiling, so neither fixed order is safe: raising the whole range needs the
+ * ceiling moved up first, lowering it needs the floor moved down first. An
+ * unreadable current ceiling is treated as "raise" — that's the order that
+ * can't wedge on a range we couldn't inspect.
+ */
+export function writeCeilingFirst(
+  currentMax: number | null,
+  minMhz: number,
+): boolean {
+  if (currentMax === null || Number.isNaN(currentMax)) return true;
+  return minMhz > currentMax;
+}

--- a/plugins/tdp-control/lib/rapl.test.ts
+++ b/plugins/tdp-control/lib/rapl.test.ts
@@ -75,11 +75,27 @@ describe("resolveZoneConstraints", () => {
     expect(got?.longTerm).toBe(`${zone}/constraint_0_power_limit_uw`);
   });
 
-  it("returns null for a zone with named constraints but no long_term", async () => {
+  it("refuses to pin the sustained rail to short_term", async () => {
+    // Slot 0 is the short_term limit here, so the positional fallback must
+    // NOT claim it — capping boost while believing we capped sustained draw
+    // is worse than reporting no RAPL control at all.
     const zone = MMIO;
     expect(
       await resolveZoneConstraints(fakeFs(zoneFiles(zone, ["short_term"])), zone),
     ).toBeNull();
+  });
+
+  it("falls back to slot 0 when constraints are named but none is long_term", async () => {
+    // A zone that names peak_power/short_term but no long_term used to
+    // resolve to null, losing TDP control on a device the old positional
+    // code handled fine.
+    const zone = MMIO;
+    const got = await resolveZoneConstraints(
+      fakeFs(zoneFiles(zone, ["peak_power", "short_term"])),
+      zone,
+    );
+    expect(got?.longTerm).toBe(`${zone}/constraint_0_power_limit_uw`);
+    expect(got?.shortTerm).toBe(`${zone}/constraint_1_power_limit_uw`);
   });
 
   it("returns null for a zone that doesn't exist", async () => {

--- a/plugins/tdp-control/lib/rapl.test.ts
+++ b/plugins/tdp-control/lib/rapl.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "bun:test";
+import {
+  discoverRaplConstraints,
+  resolveZoneConstraints,
+  INTEL_RAPL_ZONES,
+  type RaplDeps,
+} from "./rapl";
+
+function fakeFs(files: Record<string, string>): RaplDeps {
+  return { readFile: async (path) => files[path] ?? null };
+}
+
+/** A package zone with the named constraints, in the given slot order. */
+function zoneFiles(zone: string, names: string[]) {
+  const files: Record<string, string> = {};
+  names.forEach((name, i) => {
+    files[`${zone}/constraint_${i}_name`] = `${name}\n`;
+    files[`${zone}/constraint_${i}_power_limit_uw`] = "15000000\n";
+  });
+  return files;
+}
+
+const MMIO = INTEL_RAPL_ZONES[0]!;
+const MSR = INTEL_RAPL_ZONES[1]!;
+
+describe("resolveZoneConstraints", () => {
+  it("resolves both limits by name", async () => {
+    const zone = MMIO;
+    const got = await resolveZoneConstraints(
+      fakeFs(zoneFiles(zone, ["long_term", "short_term"])),
+      zone,
+    );
+    expect(got).toEqual({
+      zone,
+      longTerm: `${zone}/constraint_0_power_limit_uw`,
+      shortTerm: `${zone}/constraint_1_power_limit_uw`,
+    });
+  });
+
+  // Slot order is conventional, not guaranteed — reading the name is the
+  // whole point of resolving rather than assuming index 0 is PL1.
+  it("resolves correctly when the constraints are in the other order", async () => {
+    const zone = MMIO;
+    const got = await resolveZoneConstraints(
+      fakeFs(zoneFiles(zone, ["short_term", "long_term"])),
+      zone,
+    );
+    expect(got?.longTerm).toBe(`${zone}/constraint_1_power_limit_uw`);
+    expect(got?.shortTerm).toBe(`${zone}/constraint_0_power_limit_uw`);
+  });
+
+  it("ignores constraints it doesn't steer, like peak_power", async () => {
+    const zone = MMIO;
+    const got = await resolveZoneConstraints(
+      fakeFs(zoneFiles(zone, ["long_term", "peak_power"])),
+      zone,
+    );
+    expect(got?.longTerm).toBe(`${zone}/constraint_0_power_limit_uw`);
+    expect(got?.shortTerm).toBeNull();
+  });
+
+  it("reports a missing short-term limit as null rather than failing", async () => {
+    const zone = MMIO;
+    const got = await resolveZoneConstraints(fakeFs(zoneFiles(zone, ["long_term"])), zone);
+    expect(got?.shortTerm).toBeNull();
+  });
+
+  // Pre-name behaviour: an unnamed zone still works off slot 0.
+  it("falls back to slot 0 when no constraint is named", async () => {
+    const zone = MMIO;
+    const got = await resolveZoneConstraints(
+      fakeFs({ [`${zone}/constraint_0_power_limit_uw`]: "15000000\n" }),
+      zone,
+    );
+    expect(got?.longTerm).toBe(`${zone}/constraint_0_power_limit_uw`);
+  });
+
+  it("returns null for a zone with named constraints but no long_term", async () => {
+    const zone = MMIO;
+    expect(
+      await resolveZoneConstraints(fakeFs(zoneFiles(zone, ["short_term"])), zone),
+    ).toBeNull();
+  });
+
+  it("returns null for a zone that doesn't exist", async () => {
+    expect(await resolveZoneConstraints(fakeFs({}), MMIO)).toBeNull();
+  });
+});
+
+describe("discoverRaplConstraints", () => {
+  it("prefers the MMIO zone over the MSR one", async () => {
+    const got = await discoverRaplConstraints(
+      fakeFs({
+        ...zoneFiles(MMIO, ["long_term", "short_term"]),
+        ...zoneFiles(MSR, ["long_term", "short_term"]),
+      }),
+    );
+    expect(got?.zone).toBe(MMIO);
+  });
+
+  it("falls through to the next zone when the preferred one is absent", async () => {
+    const got = await discoverRaplConstraints(
+      fakeFs(zoneFiles(MSR, ["long_term", "short_term"])),
+    );
+    expect(got?.zone).toBe(MSR);
+  });
+
+  it("returns null when no zone exposes a sustained limit", async () => {
+    expect(await discoverRaplConstraints(fakeFs({}))).toBeNull();
+  });
+});

--- a/plugins/tdp-control/lib/rapl.ts
+++ b/plugins/tdp-control/lib/rapl.ts
@@ -68,21 +68,29 @@ export async function resolveZoneConstraints(
 ): Promise<RaplConstraints | null> {
   let longTerm: string | null = null;
   let shortTerm: string | null = null;
-  let anyNamed = false;
 
   for (let i = 0; i < RAPL_MAX_CONSTRAINTS; i++) {
     const limit = `${zone}/constraint_${i}${LIMIT_SUFFIX}`;
     if ((await deps.readFile(limit)) === null) continue;
 
     const name = (await deps.readFile(`${zone}/constraint_${i}_name`))?.trim();
-    if (name) anyNamed = true;
     if (name === "long_term" && !longTerm) longTerm = limit;
     else if (name === "short_term" && !shortTerm) shortTerm = limit;
   }
 
-  if (!longTerm && !anyNamed) {
+  // Fall back to slot 0 whenever no long_term was found — not only when
+  // nothing was named at all. A zone that names its constraints but has no
+  // `long_term` among them (say only `short_term` / `peak_power`) would
+  // otherwise resolve to null and lose TDP control entirely, where the
+  // positional convention still gives the right file.
+  if (!longTerm) {
     const slot0 = `${zone}/constraint_0${LIMIT_SUFFIX}`;
-    if ((await deps.readFile(slot0)) !== null) longTerm = slot0;
+    // Don't hand back the very file we already identified as the boost
+    // limit: pinning the sustained rail to short_term would silently cap
+    // boost instead of the sustained draw.
+    if (slot0 !== shortTerm && (await deps.readFile(slot0)) !== null) {
+      longTerm = slot0;
+    }
   }
 
   return longTerm ? { zone, longTerm, shortTerm } : null;

--- a/plugins/tdp-control/lib/rapl.ts
+++ b/plugins/tdp-control/lib/rapl.ts
@@ -1,0 +1,103 @@
+/**
+ * Intel RAPL powercap discovery.
+ *
+ * RAPL is the fallback for Intel devices whose vendor driver exposes no
+ * firmware power rails (see `./firmware-attributes`). A powercap zone looks
+ * like:
+ *
+ *     <zone>/constraint_0_name            "long_term"
+ *     <zone>/constraint_0_power_limit_uw
+ *     <zone>/constraint_1_name            "short_term"
+ *     <zone>/constraint_1_power_limit_uw
+ *
+ * Two things this gets right that reading `constraint_0_power_limit_uw`
+ * directly does not:
+ *
+ *  - **Which constraint is which is named, not positional.** The ordering is
+ *    conventional, not guaranteed, and a zone may expose "peak_power" or
+ *    "short_term" first. Resolve by `constraint_N_name`.
+ *  - **The short-term limit matters.** Steering PL1 alone leaves PL2 at its
+ *    firmware default, so a chip with a base/boost split — Panther Lake ships
+ *    35 W base against a much higher boost ceiling — spends the boost budget
+ *    regardless of where the slider sits.
+ *
+ * I/O is injected so this is unit-testable without /sys.
+ */
+
+/**
+ * Candidate package zones, most-preferred first. The MMIO variant is
+ * preferred where present: it is the interface the firmware itself uses, and
+ * it survives on parts where the MSR view is locked.
+ */
+export const INTEL_RAPL_ZONES = [
+  "/sys/devices/virtual/powercap/intel-rapl-mmio/intel-rapl-mmio:0",
+  "/sys/devices/virtual/powercap/intel-rapl/intel-rapl:0",
+  "/sys/class/powercap/intel-rapl:0",
+];
+
+/** How many `constraint_N_*` slots to probe within a zone. */
+export const RAPL_MAX_CONSTRAINTS = 4;
+
+export interface RaplConstraints {
+  /** Zone directory the constraints belong to. */
+  zone: string;
+  /** Sustained limit (PL1) in microwatts — the rail we steer. */
+  longTerm: string;
+  /** Boost limit (PL2) in microwatts, when the zone exposes one. */
+  shortTerm: string | null;
+}
+
+export interface RaplDeps {
+  /** Read a file, or null when it doesn't exist / can't be read. */
+  readFile: (path: string) => Promise<string | null>;
+}
+
+const LIMIT_SUFFIX = "_power_limit_uw";
+
+/**
+ * Resolve a zone's power-limit files by constraint name.
+ *
+ * Returns null when the zone exposes no writable sustained limit. When no
+ * constraint is *named* but slot 0 has a limit file, slot 0 is taken as the
+ * sustained limit — the positional assumption the kernel's own convention
+ * makes, and what this code did before names were consulted.
+ */
+export async function resolveZoneConstraints(
+  deps: RaplDeps,
+  zone: string,
+): Promise<RaplConstraints | null> {
+  let longTerm: string | null = null;
+  let shortTerm: string | null = null;
+  let anyNamed = false;
+
+  for (let i = 0; i < RAPL_MAX_CONSTRAINTS; i++) {
+    const limit = `${zone}/constraint_${i}${LIMIT_SUFFIX}`;
+    if ((await deps.readFile(limit)) === null) continue;
+
+    const name = (await deps.readFile(`${zone}/constraint_${i}_name`))?.trim();
+    if (name) anyNamed = true;
+    if (name === "long_term" && !longTerm) longTerm = limit;
+    else if (name === "short_term" && !shortTerm) shortTerm = limit;
+  }
+
+  if (!longTerm && !anyNamed) {
+    const slot0 = `${zone}/constraint_0${LIMIT_SUFFIX}`;
+    if ((await deps.readFile(slot0)) !== null) longTerm = slot0;
+  }
+
+  return longTerm ? { zone, longTerm, shortTerm } : null;
+}
+
+/** First candidate zone exposing a sustained power limit, or null. */
+export async function discoverRaplConstraints(
+  deps: RaplDeps,
+): Promise<RaplConstraints | null> {
+  // Probed in preference order rather than in parallel: the whole point of
+  // the ordering is the tie-break, and a hit on the first candidate makes
+  // the rest moot.
+  for (const zone of INTEL_RAPL_ZONES) {
+    const resolved = await resolveZoneConstraints(deps, zone);
+    if (resolved) return resolved;
+  }
+  return null;
+}


### PR DESCRIPTION
> **Draft — not for merge yet.** The Intel paths have never run on Intel hardware. Holding this open for OneXPlayer community testing before it lands.

Split 3 of 3 out of #253, and the substantial one.

## The problem

TDP control did **nothing** on an Intel handheld. The plugin drives wattage through `ryzenadj`, which writes the AMD SMU mailbox over MMIO — on an Intel CPU that's a no-op then an error — so the whole feature was dead on Arc G3 / Xe3-class devices.

## What's added

Three new pure modules, each unit-tested:

- **`lib/firmware-attributes.ts`** — discovers power rails by attribute name across every driver in `/sys/class/firmware-attributes`. A handheld whose vendor driver implements the interface publishes the exact envelope its firmware accepts (`min_value`/`max_value` on PL1): per-unit exact, and the only correct source for a device that shipped after our device table was last touched. `applyFirmwareRange()` folds that envelope into a device match — a known row keeps its hand-tuned battery cap and presets clamped into the firmware interval, while a fallback match derives presets from the range.
- **`lib/rapl.ts`** — Intel RAPL powercap, resolving constraints by name rather than by slot index, and capturing both the sustained and boost limits.
- **`lib/gpu.ts`** — Intel GPU frequency control via the `xe`/`i915` sysfs knobs, alongside the existing AMD path.

## AMD is deliberately unchanged

This is the whole reason #253 was split. Generic rail discovery runs **only on a positively identified Intel CPU** — not merely "not AMD", so an unreadable `/proc/cpuinfo` keeps every machine on the old detection order. ROG Ally and Legion Go keep their DMI-matched paths, probed in the same order and written in the same milliwatt unit; ryzenadj keeps its precedence everywhere else.

Letting generic discovery outrank ryzenadj on all AMD devices is a real improvement, but it changes behaviour on hardware neither of us can test. That idea is written up in #253 rather than riding along with Intel support.

There are two deliberate differences on the DMI-matched paths, both stated here rather than left implicit:

1. They carry `scaleKnown: false`, so a write the firmware rejects is retried once in the other unit and latches whichever is accepted, rather than throwing. That can only fire where the old unconditional `watts * 1000` already failed outright — which appears to be the state a modern-kernel ROG Ally is in today, since `asus-armoury`'s ppt rails take watts and we send milliwatts. On a healthy write nothing changes. If the flip is also rejected, the original error propagates.
2. A failed *boost* rail (`fppt`/`sppt`) write is warned and skipped instead of thrown. MSI's driver exposes only PL1 + PL2, so the old unconditional write of all three failed outright on anything without a PL3. Only observable where a write already fails.

## Review fixes

A review pass found four things, now fixed:

- `discoverPowerRails` matched on the attribute *directory* name and never read `current_value`, so a stub or read-only driver publishing an empty `ppt_pl1_spl/` would latch `method="wmi"` and starve the Intel RAPL fallback — losing TDP control on a device that works on `main`.
- The unit-flip retry left the boost rails written in the unit it had just disproved, so PL1 landed correctly while PL2/PL3 kept firmware defaults for that apply.
- Generic discovery is gated on a positive `GenuineIntel` rather than `!isAmdCpu()`. Both probes fail closed, so an unreadable `/proc/cpuinfo` on an AMD ROG Ally would otherwise have routed it into the new path — precisely the AMD change this PR promises not to make.
- `resolveZoneConstraints` fell back to slot 0 only when nothing was named, so a zone naming `peak_power`/`short_term` but no `long_term` resolved to null where `main` took `constraint_0`. It now falls back whenever `long_term` is missing, but never to the file already identified as `short_term`.

## Testing

Backend 3260 pass, UI 532 pass, typecheck clean. The pure helpers are covered: firmware-attributes parsing, RAPL constraint resolution, GPU frequency writes, and `applyFirmwareRange`.

**Not verified on hardware** — I have no Intel handheld. The Intel paths are the ones wanting a real device, so OneXPlayer community testing would land here.

## Related

No open issue tracks Intel handheld support — this came out of the work in #253.
