### PR TITLE
fix(fan-control): persist the global fan mode across restarts

### DIFF
--- a/plugins/fan-control/app.spec.tsx
+++ b/plugins/fan-control/app.spec.tsx
@@ -168,6 +168,47 @@ describe("fan-control plugin", () => {
     });
   });
 
+  it("tracks the live duty in the slider while a preset drives the fan", async () => {
+    // A preset puts the hardware in manual mode but the *curve* owns the
+    // duty, rewriting it every 2s. The slider used to keep showing the
+    // user's last manual value (or its 50/100 default), so it disagreed
+    // with the "Fan speed" row right above it.
+    callMock.mockImplementation((method: string) => {
+      if (method === "getFanInfo")
+        return Promise.resolve({
+          ...mockFanInfo,
+          mode: "manual" as const,
+          activePreset: "silent",
+          fans: [{ index: 0, rpm: 1500, pwm: 77, percent: 30 }],
+        });
+      if (method === "getCustomCurve") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    const container = createContainer();
+    const { mount } = await import("./app");
+    mount(container);
+
+    await waitFor(() => {
+      const slider = container.querySelector('input[type="range"]');
+      expect(slider).not.toBeNull();
+      expect(Number((slider as HTMLInputElement).value)).toBe(30);
+    });
+
+    // And it follows the curve as the duty moves.
+    const handler = eventHandlers.get("fan-update");
+    expect(handler).toBeDefined();
+    handler?.({
+      ...mockFanInfo,
+      mode: "manual" as const,
+      activePreset: "silent",
+      fans: [{ index: 0, rpm: 2600, pwm: 140, percent: 55 }],
+    });
+    await waitFor(() => {
+      const slider = container.querySelector('input[type="range"]');
+      expect(Number((slider as HTMLInputElement).value)).toBe(55);
+    });
+  });
+
   it("shows unavailable message when no fan hardware", async () => {
     callMock.mockImplementation((method: string) => {
       if (method === "getFanInfo")

--- a/plugins/fan-control/app.tsx
+++ b/plugins/fan-control/app.tsx
@@ -198,6 +198,15 @@ function FanControl() {
         setCustomActive(true);
         setActivePreset(null);
       }
+      // While a preset or the custom curve is driving, the slider is a
+      // readout, not a setting: the curve rewrites the duty every 2s and
+      // the user's last manual value has nothing to do with what the fan
+      // is doing. Track the live percent so it agrees with the "Fan speed"
+      // row above it (issue #265 follow-up).
+      const live = info.fans?.[0]?.percent;
+      if ((info.activePreset || info.customCurveActive) && typeof live === "number") {
+        setSliderValue(live);
+      }
       setLoading(false);
     },
   });
@@ -928,7 +937,8 @@ function FanHomeWidget() {
   //     percent field on direct hwmon paths).
   const [manualSpeed, setManualSpeed] = useState(50);
   const [autoDuty, setAutoDuty] = useState(0);
-  const [, setActivePreset] = useState<string | null>(null);
+  const [activePreset, setActivePreset] = useState<string | null>(null);
+  const [customActive, setCustomActive] = useState(false);
   const [error, setError] = useState(false);
   const { gameProfiles, boundToGame, persistGameProfile } = usePerGameProfiles(
     call,
@@ -995,6 +1005,7 @@ function FanHomeWidget() {
       if (info.cpuTempC > 0) setTempC(info.cpuTempC);
       if (info.mode) setMode(info.mode);
       setActivePreset(info.activePreset ?? null);
+      setCustomActive(Boolean(info.customCurveActive));
     }, [deriveAutoDuty]),
   });
 
@@ -1009,6 +1020,8 @@ function FanHomeWidget() {
   }
 
   const displayRpm = rpm ?? 0;
+  /** A built-in preset or the user's curve is rewriting the duty every 2s. */
+  const curveDriven = activePreset !== null || customActive;
   const sliderDisabled = mode !== "manual";
   // Match TDP's chip semantics so per-game state reads identically across
   // the two performance widgets.
@@ -1049,7 +1062,10 @@ function FanHomeWidget() {
       </div>
 
       <Slider
-        value={mode === "manual" ? manualSpeed : autoDuty}
+        // A preset/custom curve reports hardware mode "manual" (it owns
+        // pwm_enable), but the duty is the curve's, not the user's — so
+        // show the live value rather than a stale manualSpeed.
+        value={mode === "manual" && !curveDriven ? manualSpeed : autoDuty}
         min={0}
         max={100}
         step={1}

--- a/plugins/fan-control/backend.test.ts
+++ b/plugins/fan-control/backend.test.ts
@@ -71,6 +71,10 @@ type FanBackendInternals = {
   restoreGlobalMode(): Promise<void>;
   restoredGlobalMode: boolean;
   lastUserSpeedPwm: number | null;
+  lastUserRequestedPercent: number | null;
+  fanIntentEpoch: number;
+  applyGlobalMode(mode: unknown): Promise<void>;
+  profileEngine: { getActiveAppId(): number | null };
 };
 const internals = (b: FanControlBackend): FanBackendInternals =>
   b as unknown as FanBackendInternals;
@@ -1572,9 +1576,28 @@ describe("FanControlBackend", () => {
             exited: Promise.resolve(0),
           })) as typeof Bun.spawn,
       );
+      // A real sensor, so the floor is driven by the temperature below and
+      // not by getCpuTempCOrNull() returning null — which silently sent
+      // every setFanSpeed in this block down the "temperature unavailable,
+      // failsafe to MAX" path and made the 95 C case pass for the wrong
+      // reason.
+      internals(backend).tempSensors = [
+        {
+          inputPath: "/sys/class/hwmon/hwmon0/temp1_input",
+          label: "Tctl",
+          zone: "cpu",
+          chipName: "k10temp",
+        },
+      ];
       // Cool enough that the safety floor never rewrites the value.
       mockReadFile.mockImplementation(() => Promise.resolve("45000"));
     });
+
+    /** The duty last written to hardware, as a percent. */
+    const writtenPercent = () => {
+      const pwm = internals(backend).lastUserSpeedPwm;
+      return pwm === null ? null : Math.round((pwm / 255) * 100);
+    };
 
     afterEach(() => {
       readStorageSpy.mockRestore();
@@ -1613,12 +1636,15 @@ describe("FanControlBackend", () => {
       expect(internals(backend).curveInterval).toBeDefined();
     });
 
-    it("restores a saved manual speed", async () => {
+    it("restores a saved manual speed, at that speed", async () => {
       persisted = { globalMode: { kind: "manual", percent: 65 } };
       await internals(backend).restoreGlobalMode();
 
       expect(internals(backend).manualModeRequested).toBe("manual");
       expect(internals(backend).activePreset).toBeNull();
+      // The saved duty must actually reach the hardware write — asserting
+      // only the mode let a restore that wrote any other percent pass.
+      expect(writtenPercent()).toBe(65);
     });
 
     it("restores nothing when no mode was ever saved", async () => {
@@ -1632,7 +1658,17 @@ describe("FanControlBackend", () => {
     });
 
     it("ignores a malformed saved mode instead of throwing during load", async () => {
+      // An unknown preset name is caught by the sanitiser. Asserting only
+      // activePreset would also pass without it, since applyPreset bails on
+      // the FAN_CURVES lookup — so pin a shape that WOULD reach hardware if
+      // the value were used raw.
+      persisted = { globalMode: { kind: "manual", percent: "80" } };
+      await internals(backend).restoreGlobalMode();
+      expect(writtenPercent()).toBeNull();
+      expect(internals(backend).manualModeRequested).toBeNull();
+
       persisted = { globalMode: { kind: "preset", name: "turbo" } };
+      internals(backend).restoredGlobalMode = false;
       await internals(backend).restoreGlobalMode();
       expect(internals(backend).activePreset).toBeNull();
     });
@@ -1712,6 +1748,112 @@ describe("FanControlBackend", () => {
       expect(persisted.globalMode).toEqual({ kind: "manual", percent: 35 });
     });
 
+    it("restores from onLoad, not just when called directly", async () => {
+      // The #265 fix itself: the wiring from plugin load to restore. Every
+      // other restore test calls the private method by hand, so deleting
+      // `await this.restoreGlobalMode()` from the scanner's onFound left
+      // the whole suite green.
+      persisted = { globalMode: { kind: "preset", name: "performance" } };
+      const fresh = new FanControlBackend();
+      const internalsFresh = internals(fresh);
+      // Hardware the scanner will find on its first pass.
+      internalsFresh.scanHardware = () => {
+        internalsFresh.activeFanDevice = {
+          dir: "/sys/class/hwmon/hwmon0",
+          chipName: "test",
+          fans: [
+            {
+              index: 1,
+              inputPath: "/sys/class/hwmon/hwmon0/fan1_input",
+              pwmPath: "/sys/class/hwmon/hwmon0/pwm1",
+              pwmEnablePath: "/sys/class/hwmon/hwmon0/pwm1_enable",
+            },
+          ],
+          hasPwmControl: true,
+        };
+        return Promise.resolve(true);
+      };
+      try {
+        await fresh.onLoad();
+        expect(internalsFresh.activePreset).toBe("performance");
+        expect(internalsFresh.curveInterval).toBeDefined();
+      } finally {
+        clearInterval(internalsFresh.interval);
+        clearInterval(internalsFresh.curveInterval);
+        await fresh.onUnload();
+      }
+    });
+
+    it("never leaves a preset flagged active without a curve loop", async () => {
+      // The safety watchdog skips its own write whenever activePreset or
+      // customCurveActive is set, trusting the curve loop to write instead
+      // (safetyWatchdogTick). If a superseded or failed apply leaves the
+      // flag set with no loop, nothing writes at all while the SoC is hot.
+      const superseded = backend.applyPreset("silent", { persist: false });
+      await backend.setFanMode("manual", { persist: false });
+      await superseded;
+
+      const flagged =
+        internals(backend).activePreset !== null ||
+        internals(backend).customCurveActive;
+      const looping = internals(backend).curveInterval !== undefined;
+      expect(flagged).toBe(looping);
+    });
+
+    it("leaves no preset flagged when the mode write fails", async () => {
+      // Same invariant, via the failure path: applyPreset used to set
+      // activePreset before the hardware write and never roll it back.
+      spawnSpy.mockImplementation(
+        (() =>
+          asSpawned({
+            stdout: new ReadableStream({ start(c) { c.close(); } }),
+            stderr: new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("denied")); c.close(); } }),
+            stdin: null,
+            exited: Promise.resolve(1),
+          })) as typeof Bun.spawn,
+      );
+      await backend.applyPreset("silent");
+
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).curveInterval).toBeUndefined();
+    });
+
+    it("does not launder a per-game duty into the saved manual speed", async () => {
+      // setFanMode("manual") used to persist from lastUserSpeedPwm, which
+      // carries whatever was last *written* — including a profile's duty and
+      // the safety floor. Tapping Manual mid-game then saved the game's 90%
+      // as the user's global preference.
+      await backend.setFanSpeed(40);
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 40 });
+
+      await backend.setFanSpeed(90, { persist: false }); // a per-game profile
+      await backend.setFanMode("manual");
+
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 40 });
+    });
+
+    it("does not launder a safety-raised duty into the saved manual speed", async () => {
+      await backend.setFanSpeed(20);
+      // Now run hot enough for the floor to raise the applied duty to 100.
+      mockReadFile.mockImplementation(() => Promise.resolve("95000"));
+      await backend.setFanSpeed(20, { persist: false });
+      expect(writtenPercent()).toBe(100); // the floor really did fire
+
+      await backend.setFanMode("manual");
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 20 });
+    });
+
+    it("records a superseded user tap all the same", async () => {
+      // Persisting on success meant a tap superseded mid-apply — by a
+      // per-game profile, or the user's own next tap — was applied but
+      // never recorded, so the next boot restored a mode they had left.
+      const tap = backend.applyPreset("silent");
+      await backend.setFanSpeed(55, { persist: false });
+      await tap;
+
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+    });
+
     it("lets a newer intent win over an in-flight preset apply", async () => {
       // Reproduces the on-device failure: exit-restore and the next
       // profile's apply are separate awaited chains, so a game *switch*
@@ -1725,6 +1867,19 @@ describe("FanControlBackend", () => {
       expect(internals(backend).activePreset).toBeNull();
       expect(internals(backend).curveInterval).toBeUndefined();
       expect(internals(backend).manualModeRequested).toBe("manual");
+    });
+
+    it("does not let a stale manual write override a newer Auto", async () => {
+      // applyUserFanSpeed mutates shared state after awaiting the safety
+      // floor (several sensor reads). Without an epoch check, a slider drag
+      // that lost the race still went on to flip pwm_enable back to manual
+      // and write its duty — silently undoing the Auto the user had just
+      // chosen, with nothing to correct it afterwards.
+      const stale = backend.setFanSpeed(30, { persist: false });
+      await backend.setFanMode("auto", { persist: false });
+      await stale;
+
+      expect(internals(backend).manualModeRequested).toBe("auto");
     });
 
     it("lets a newer intent win over an in-flight custom-curve apply", async () => {

--- a/plugins/fan-control/backend.test.ts
+++ b/plugins/fan-control/backend.test.ts
@@ -1854,6 +1854,180 @@ describe("FanControlBackend", () => {
       expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
     });
 
+    it("still returns to the saved mode when a profile was bound at restore time", async () => {
+      // The bound-profile skip used to latch "already restored", so on a
+      // late-driver host the saved preset was cancelled for the whole
+      // session — #265 reintroduced by the guard meant to protect it.
+      persisted = { globalMode: { kind: "preset", name: "silent" } };
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(730, "Test Game", { mode: "manual", speed: 90 });
+      await backend.handleGameLaunch(730, "Test Game");
+
+      // Driver shows up late; a profile already owns the fan.
+      await internals(backend).restoreGlobalMode();
+      expect(internals(backend).activePreset).toBeNull();
+
+      await backend.handleGameExit(730);
+      expect(internals(backend).activePreset).toBe("silent");
+      expect(internals(backend).curveInterval).toBeDefined();
+    });
+
+    it("keeps a restored manual duty across a game", async () => {
+      // The restore wrote the duty but never recorded it as the user's
+      // requested percent, so the first launch snapshotted {manual, null}
+      // and exiting left the fan on the game's duty.
+      persisted = { globalMode: { kind: "manual", percent: 60 } };
+      await internals(backend).restoreGlobalMode();
+      expect(writtenPercent()).toBe(60);
+
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(730, "Test Game", { mode: "manual", speed: 90 });
+      await backend.handleGameLaunch(730, "Test Game");
+      expect(writtenPercent()).toBe(90);
+
+      await backend.handleGameExit(730);
+      expect(writtenPercent()).toBe(60);
+    });
+
+    it("treats a restored duty as the user's own for a later Manual tap", async () => {
+      // The restore records the duty as the user's requested percent.
+      // Without that, tapping Manual after a restart persisted
+      // {manual, null} — which restores nothing on the boot after.
+      persisted = { globalMode: { kind: "manual", percent: 60 } };
+      await internals(backend).restoreGlobalMode();
+
+      await backend.setFanMode("manual");
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 60 });
+    });
+
+    it("tapping Manual while a preset runs ends the preset, not just storage", async () => {
+      // setFanMode("manual") persisted {manual, …} but left the curve loop
+      // running and the preset flagged, so the UI kept showing Silent while
+      // storage said otherwise — and the next boot restored neither.
+      await backend.applyPreset("silent");
+      expect(internals(backend).curveInterval).toBeDefined();
+
+      await backend.setFanMode("manual");
+
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).curveInterval).toBeUndefined();
+    });
+
+    it("snapshots the mode the user chose, not the one mid-apply", async () => {
+      // currentGlobalMode() used to read the live flags, which still hold
+      // the *previous* mode for the whole apply window — so a game
+      // launching mid-apply snapshotted the old preset and exiting restored
+      // the wrong one.
+      await backend.applyPreset("silent");
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(730, "Test Game", { mode: "manual", speed: 90 });
+
+      const switching = backend.applyPreset("performance");
+      await backend.handleGameLaunch(730, "Test Game");
+      await switching;
+
+      await backend.handleGameExit(730);
+      expect(internals(backend).activePreset).toBe("performance");
+    });
+
+    it("merges into storage rather than clobbering the other keys", async () => {
+      // persistGlobalMode uses mutatePluginStorage precisely so a concurrent
+      // custom-curve or per-game save can't be lost. A bare write would
+      // pass every other test in this block.
+      persisted = {
+        customCurve: [{ tempC: 50, percent: 20 }],
+        profiles: [{ appId: 1, gameName: "G", payload: { mode: "auto" } }],
+        perGameEnabled: true,
+      };
+      await backend.applyPreset("silent");
+
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+      expect(persisted.customCurve).toEqual([{ tempC: 50, percent: 20 }]);
+      expect(persisted.profiles).toHaveLength(1);
+      expect(persisted.perGameEnabled).toBe(true);
+    });
+
+    it("restores the custom curve, not just presets", async () => {
+      persisted = {
+        globalMode: { kind: "custom" },
+        customCurve: [
+          { tempC: 40, percent: 10 },
+          { tempC: 80, percent: 90 },
+        ],
+      };
+      await internals(backend).restoreGlobalMode();
+
+      expect(internals(backend).customCurveActive).toBe(true);
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).curveInterval).toBeDefined();
+    });
+
+    it("restores auto mode", async () => {
+      // Worth restoring rather than assuming: several drivers come up in
+      // manual, so "auto" has to be re-asserted.
+      persisted = { globalMode: { kind: "auto" } };
+      await internals(backend).restoreGlobalMode();
+
+      expect(internals(backend).manualModeRequested).toBe("auto");
+      expect(internals(backend).curveInterval).toBeUndefined();
+    });
+
+    it("restores on an ectool-only host, which the hardware scanner never reports", async () => {
+      // scanHardware() returns false when ectool is the only write path, so
+      // the scanner's onFound — and the restore hanging off it — never fire.
+      persisted = { globalMode: { kind: "preset", name: "silent" } };
+      const fresh = new FanControlBackend();
+      const fi = internals(fresh);
+      fi.scanHardware = () => {
+        fi.useEctool = true;
+        fi.activeFanDevice = null;
+        return Promise.resolve(false);
+      };
+      try {
+        await fresh.onLoad();
+        expect(fi.activePreset).toBe("silent");
+      } finally {
+        clearInterval(fi.interval);
+        clearInterval(fi.curveInterval);
+        await fresh.onUnload();
+      }
+    });
+
+    it("does not revert a choice the user makes during the storage read", async () => {
+      // The late-driver restore runs up to 30s in, with RPCs live. Reading
+      // storage is an await; a tap landing in that window must win. The read
+      // is held open deliberately — resolving it on the microtask queue let
+      // the restore finish first and the test passed without the guard.
+      persisted = { globalMode: { kind: "preset", name: "silent" } };
+      let releaseRead: (() => void) | undefined;
+      const readHeld = new Promise<void>((resolve) => {
+        releaseRead = resolve;
+      });
+      readStorageSpy.mockImplementation(
+        (() =>
+          readHeld.then(() => persisted)) as typeof storage.readPluginStorage,
+      );
+
+      try {
+        const restoring = internals(backend).restoreGlobalMode();
+        // persist:false so the tap doesn't itself read the held storage —
+        // it still bumps the epoch, which is what the guard keys on.
+        await backend.setFanMode("auto", { persist: false });
+        releaseRead?.();
+        await restoring;
+      } finally {
+        // The spy is re-created per test but keeps its implementation, so a
+        // held read would hang every test after this one.
+        releaseRead?.();
+        readStorageSpy.mockImplementation(
+          (() => Promise.resolve(persisted)) as typeof storage.readPluginStorage,
+        );
+      }
+
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).manualModeRequested).toBe("auto");
+    });
+
     it("lets a newer intent win over an in-flight preset apply", async () => {
       // Reproduces the on-device failure: exit-restore and the next
       // profile's apply are separate awaited chains, so a game *switch*

--- a/plugins/fan-control/backend.test.ts
+++ b/plugins/fan-control/backend.test.ts
@@ -1667,6 +1667,70 @@ describe("FanControlBackend", () => {
       await backend.handleGameExit(730);
       expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
     });
+
+    it("puts the user back on their curve when a game with a profile exits", async () => {
+      // Found on-device: the restore worked, then a per-game profile applied
+      // a second later and the snapshot could only put back a *duty*, so the
+      // user sat at a fixed speed until the next backend restart.
+      await backend.applyPreset("silent");
+      expect(internals(backend).activePreset).toBe("silent");
+
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(730, "Test Game", {
+        mode: "manual",
+        speed: 90,
+      });
+
+      await backend.handleGameLaunch(730, "Test Game");
+      // The game's manual profile owns the fan while it runs.
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).manualModeRequested).toBe("manual");
+
+      await backend.handleGameExit(730);
+      // ...and the curve is running again afterwards, not a static duty.
+      expect(internals(backend).activePreset).toBe("silent");
+      expect(internals(backend).curveInterval).toBeDefined();
+      // Still the user's choice on disk — the round trip wrote nothing.
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+    });
+
+    it("restores a manual global choice through the same path", async () => {
+      // A manual speed is itself a global mode, so it round-trips via
+      // applyGlobalMode rather than the raw mode+speed fallback.
+      await backend.setFanSpeed(35);
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(731, "Other Game", {
+        mode: "manual",
+        speed: 80,
+      });
+
+      await backend.handleGameLaunch(731, "Other Game");
+      await backend.handleGameExit(731);
+
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).manualModeRequested).toBe("manual");
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 35 });
+    });
+
+    it("falls back to the mode+speed snapshot when nothing global was active", async () => {
+      // No preset, no custom curve, no manual choice — currentGlobalMode()
+      // is null, so the snapshot's mode/speed is all there is to put back.
+      // This path must behave exactly as it did before the globalMode field
+      // existed.
+      expect(internals(backend).manualModeRequested).toBeNull();
+
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(731, "Other Game", {
+        mode: "manual",
+        speed: 80,
+      });
+      await backend.handleGameLaunch(731, "Other Game");
+      await backend.handleGameExit(731);
+
+      expect(internals(backend).activePreset).toBeNull();
+      // Nothing global was ever chosen, so nothing was written for it.
+      expect(persisted.globalMode).toBeUndefined();
+    });
   });
 
 });

--- a/plugins/fan-control/backend.test.ts
+++ b/plugins/fan-control/backend.test.ts
@@ -68,6 +68,9 @@ type FanBackendInternals = {
   setFanSpeedInternal(percent: number): Promise<{ success: boolean; error?: string }>;
   safetyWatchdogTick(): Promise<void>;
   getCpuTempCOrNull(): Promise<number | null>;
+  restoreGlobalMode(): Promise<void>;
+  restoredGlobalMode: boolean;
+  lastUserSpeedPwm: number | null;
 };
 const internals = (b: FanControlBackend): FanBackendInternals =>
   b as unknown as FanBackendInternals;
@@ -1523,4 +1526,147 @@ describe("FanControlBackend", () => {
       expect(temps[0].tempC).toBe(0);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Issue #265: the global mode (preset / custom / manual / auto) has to
+  // survive a reboot or a `loadout.service` restart. Before this, applyPreset
+  // only set in-memory state, so the curve loop never restarted and the UI
+  // fell back to whatever pwm1_enable said — manual, on drivers like oxp_ec.
+  // ---------------------------------------------------------------------------
+
+  describe("global mode persistence (#265)", () => {
+    let readStorageSpy: ReturnType<typeof spyOn>;
+    let writeStorageSpy: ReturnType<typeof spyOn>;
+    let persisted: Record<string, unknown>;
+
+    beforeEach(() => {
+      persisted = {};
+      readStorageSpy = spyOn(storage, "readPluginStorage").mockImplementation(
+        (() => Promise.resolve(persisted)) as typeof storage.readPluginStorage,
+      );
+      writeStorageSpy = spyOn(storage, "writePluginStorage").mockImplementation(
+        ((_id: string, data: Record<string, unknown>) => {
+          persisted = data;
+          return Promise.resolve();
+        }) as typeof storage.writePluginStorage,
+      );
+      internals(backend).activeFanDevice = {
+        dir: "/sys/class/hwmon/hwmon0",
+        chipName: "test",
+        fans: [
+          {
+            index: 1,
+            inputPath: "/sys/class/hwmon/hwmon0/fan1_input",
+            pwmPath: "/sys/class/hwmon/hwmon0/pwm1",
+            pwmEnablePath: "/sys/class/hwmon/hwmon0/pwm1_enable",
+          },
+        ],
+        hasPwmControl: true,
+      };
+      spawnSpy.mockImplementation(
+        (() =>
+          asSpawned({
+            stdout: new ReadableStream({ start(c) { c.close(); } }),
+            stderr: new ReadableStream({ start(c) { c.close(); } }),
+            stdin: null,
+            exited: Promise.resolve(0),
+          })) as typeof Bun.spawn,
+      );
+      // Cool enough that the safety floor never rewrites the value.
+      mockReadFile.mockImplementation(() => Promise.resolve("45000"));
+    });
+
+    afterEach(() => {
+      readStorageSpy.mockRestore();
+      writeStorageSpy.mockRestore();
+    });
+
+    it("persists a preset selection", async () => {
+      await backend.applyPreset("silent");
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+    });
+
+    it("persists the custom curve and each manual/auto choice", async () => {
+      await backend.applyCustomCurve();
+      expect(persisted.globalMode).toEqual({ kind: "custom" });
+
+      await backend.setFanSpeed(70);
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 70 });
+
+      await backend.setFanMode("auto");
+      expect(persisted.globalMode).toEqual({ kind: "auto" });
+    });
+
+    it("saves the requested speed, not a safety-raised one", async () => {
+      // 95 °C forces the safety floor well above the user's 20%. Persisting
+      // the floor would have the user reboot into fans they never chose.
+      mockReadFile.mockImplementation(() => Promise.resolve("95000"));
+      await backend.setFanSpeed(20);
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 20 });
+    });
+
+    it("restores a saved preset once fan hardware is found", async () => {
+      persisted = { globalMode: { kind: "preset", name: "performance" } };
+      await internals(backend).restoreGlobalMode();
+
+      expect(internals(backend).activePreset).toBe("performance");
+      expect(internals(backend).curveInterval).toBeDefined();
+    });
+
+    it("restores a saved manual speed", async () => {
+      persisted = { globalMode: { kind: "manual", percent: 65 } };
+      await internals(backend).restoreGlobalMode();
+
+      expect(internals(backend).manualModeRequested).toBe("manual");
+      expect(internals(backend).activePreset).toBeNull();
+    });
+
+    it("restores nothing when no mode was ever saved", async () => {
+      persisted = {};
+      await internals(backend).restoreGlobalMode();
+
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).curveInterval).toBeUndefined();
+      // And doesn't write a mode back out just for having looked.
+      expect(persisted.globalMode).toBeUndefined();
+    });
+
+    it("ignores a malformed saved mode instead of throwing during load", async () => {
+      persisted = { globalMode: { kind: "preset", name: "turbo" } };
+      await internals(backend).restoreGlobalMode();
+      expect(internals(backend).activePreset).toBeNull();
+    });
+
+    it("restores only once, however often the hardware scanner re-fires", async () => {
+      persisted = { globalMode: { kind: "preset", name: "silent" } };
+      await internals(backend).restoreGlobalMode();
+      internals(backend).activePreset = null;
+      await internals(backend).restoreGlobalMode();
+      // Second call is a no-op: a rescan must not stomp a selection the user
+      // has changed since the first one.
+      expect(internals(backend).activePreset).toBeNull();
+    });
+
+    it("does not let a per-game profile overwrite the user's global choice", async () => {
+      // The crux of the persist:false wiring, driven through the real
+      // PerGameEngine rather than by passing the flag by hand: a game
+      // applying its own fan profile must not promote that setting to the
+      // system default, or the next boot would restore the game's fans.
+      await backend.applyPreset("silent");
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(730, "Test Game", {
+        mode: "manual",
+        speed: 90,
+      });
+      await backend.handleGameLaunch(730, "Test Game");
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+
+      // Exiting restores the pre-game snapshot — also not a user choice.
+      await backend.handleGameExit(730);
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+    });
+  });
+
 });

--- a/plugins/fan-control/backend.test.ts
+++ b/plugins/fan-control/backend.test.ts
@@ -1712,6 +1712,37 @@ describe("FanControlBackend", () => {
       expect(persisted.globalMode).toEqual({ kind: "manual", percent: 35 });
     });
 
+    it("lets a newer intent win over an in-flight preset apply", async () => {
+      // Reproduces the on-device failure: exit-restore and the next
+      // profile's apply are separate awaited chains, so a game *switch*
+      // interleaves them. Without the epoch guard the restore's
+      // startCurveLoop lands after the profile's setFanSpeed stopped it, and
+      // the curve drives the fan while the profile is meant to own it.
+      const restore = backend.applyPreset("silent", { persist: false });
+      await backend.setFanSpeed(48, { persist: false });
+      await restore;
+
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).curveInterval).toBeUndefined();
+      expect(internals(backend).manualModeRequested).toBe("manual");
+    });
+
+    it("lets a newer intent win over an in-flight custom-curve apply", async () => {
+      const restore = backend.applyCustomCurve({ persist: false });
+      await backend.setFanSpeed(48, { persist: false });
+      await restore;
+
+      expect(internals(backend).customCurveActive).toBe(false);
+      expect(internals(backend).curveInterval).toBeUndefined();
+    });
+
+    it("still starts the curve loop when nothing supersedes it", async () => {
+      // The guard must not break the ordinary path.
+      await backend.applyPreset("silent");
+      expect(internals(backend).activePreset).toBe("silent");
+      expect(internals(backend).curveInterval).toBeDefined();
+    });
+
     it("falls back to the mode+speed snapshot when nothing global was active", async () => {
       // No preset, no custom curve, no manual choice — currentGlobalMode()
       // is null, so the snapshot's mode/speed is all there is to put back.

--- a/plugins/fan-control/backend.ts
+++ b/plugins/fan-control/backend.ts
@@ -256,9 +256,20 @@ export default class FanControlBackend implements PluginBackend {
    */
   private fanIntentEpoch = 0;
 
+  /**
+   * The last duty the *user* asked for, before the safety floor and before
+   * any per-game profile. Distinct from `lastUserSpeedPwm`, which the
+   * watchdog needs as the last value actually written: that one is the
+   * floor-raised PWM and is set on every write, including profile applies.
+   * Persisting from it laundered a game's duty — or a hot moment's 100% —
+   * into the user's saved global preference.
+   */
+  private lastUserRequestedPercent: number | null = null;
+
   // Issue #265. The user's persisted global choice, restored once fan
-  // hardware is detected. Guarded so the retry scanner — which re-fires
-  // onFound after every successful rescan — only restores on the first.
+  // hardware is detected. The scanner latches and fires onFound at most
+  // once, so the guard is not for it: it is for the two independent
+  // callers — that onFound, and the ectool path in onLoad.
   private restoredGlobalMode = false;
 
   // Per-game state. The engine owns the {profiles, perGameEnabled, snapshot,
@@ -352,6 +363,13 @@ export default class FanControlBackend implements PluginBackend {
       },
     });
     await this.hardwareScanner.start();
+
+    // scanHardware() reports "found" only for a hwmon PWM or RPM-target
+    // device — deliberately not for ectool (see its comment). So on a host
+    // where ectool is the only write path, onFound never fires and the
+    // restore above never runs, while every user choice still persists.
+    // restoreGlobalMode's own guard makes the double call a no-op.
+    if (this.useEctool) await this.restoreGlobalMode();
 
     // Emit fan status updates every 2 seconds. Also runs the safety
     // watchdog on the same cadence — independent of the curve loop and
@@ -514,17 +532,41 @@ export default class FanControlBackend implements PluginBackend {
    */
   private async restoreGlobalMode(): Promise<void> {
     if (this.restoredGlobalMode) return;
+    // Set before the first await: two callers (the hardware scanner's
+    // onFound and the ectool path in onLoad) can both reach here.
     this.restoredGlobalMode = true;
 
-    let mode: GlobalFanMode | null = null;
-    try {
-      const stored = await readPluginStorage<{ globalMode?: unknown }>(PLUGIN_ID);
-      mode = sanitiseGlobalMode(stored.globalMode);
-    } catch (err) {
-      console.error("[fan-control] Failed to read saved fan mode:", err);
+    // A game whose profile is already bound owns the fan. On the late-driver
+    // path this runs up to 30s after startup, by which time a launch may
+    // have applied a profile — restoring over it would hand the fan back to
+    // the global curve while the game is still running.
+    if (this.profileEngine.getActiveAppId() !== null) {
+      console.log(
+        "[fan-control] Skipping saved-mode restore — a per-game profile is active",
+      );
       return;
     }
+
+    const epoch = this.fanIntentEpoch;
+    const stored = await readPluginStorage<{ globalMode?: unknown }>(PLUGIN_ID);
+    const mode = sanitiseGlobalMode(stored.globalMode);
     if (!mode) return;
+    // The storage read is an await, and RPCs are live by the time the late
+    // rescan fires: a user tapping Auto in that window must not be reverted.
+    if (this.supersededSince(epoch)) return;
+
+    if (mode.kind === "manual" && mode.percent === null) {
+      // "Manual" with no duty. Asserting it would stop Valve's
+      // jupiter-fan-control on the RPM-target path without writing a target
+      // to replace it — and that hardware has no safety watchdog either
+      // (see safetyWatchdogTick's guard), so nothing would own the fan.
+      // There is no duty worth restoring, so leave the firmware's default.
+      console.log(
+        "[fan-control] Saved mode is manual with no speed — leaving the fan as the firmware set it",
+      );
+      return;
+    }
+
     await this.applyGlobalMode(mode);
   }
 
@@ -587,13 +629,7 @@ export default class FanControlBackend implements PluginBackend {
     }
     if (this.customCurveActive) return { kind: "custom" };
     if (this.manualModeRequested === "manual") {
-      return {
-        kind: "manual",
-        percent:
-          this.lastUserSpeedPwm !== null
-            ? pwmToPercent(this.lastUserSpeedPwm)
-            : null,
-      };
+      return { kind: "manual", percent: this.lastUserRequestedPercent };
     }
     if (this.manualModeRequested === "auto") return { kind: "auto" };
     return null;
@@ -726,17 +762,17 @@ export default class FanControlBackend implements PluginBackend {
     percent: number,
     { persist = true }: { persist?: boolean } = {},
   ): Promise<{ success: boolean; error?: string }> {
-    const result = await this.applyUserFanSpeed(percent);
-    if (result.success && persist) {
+    if (persist) {
       // The *requested* percent, not the safety-floor-raised one applied
       // below: baking a hot-moment override into the saved preference would
-      // have the user come back to fans they never asked for.
-      await this.persistGlobalMode({
-        kind: "manual",
-        percent: clampPercent(percent),
-      });
+      // have the user come back to fans they never asked for. Recorded
+      // before the write so a superseded call still reflects the user's
+      // choice (see applyPreset).
+      const requested = clampPercent(percent);
+      this.lastUserRequestedPercent = requested;
+      await this.persistGlobalMode({ kind: "manual", percent: requested });
     }
-    return result;
+    return this.applyUserFanSpeed(percent);
   }
 
   /** The user-facing write: safety floor, curve-loop teardown, mode flip.
@@ -744,10 +780,15 @@ export default class FanControlBackend implements PluginBackend {
    *  the safety watchdog and curve loop use. */
   private async applyUserFanSpeed(percent: number): Promise<{ success: boolean; error?: string }> {
     // Newer intent than any preset/curve apply still awaiting I/O.
-    this.fanIntentEpoch++;
+    const epoch = ++this.fanIntentEpoch;
     // Safety override (issue #97): user's value first, then the floor
     // can only RAISE it. Fails safe to 100% on any temp-read error.
     const safePercent = await this.applySafetyFloor(percent);
+    // The floor read spawns sensor reads, so a newer intent can land while
+    // we wait. Without this an older call went on to stop the newer one's
+    // curve loop and null its flags, leaving a loop running with no flags
+    // set — which makes the watchdog and the loop both write every tick.
+    if (this.supersededSince(epoch)) return { success: true };
     const clamped = clampPercent(safePercent);
     const pwmValue = percentToPwm(clamped);
 
@@ -821,23 +862,21 @@ export default class FanControlBackend implements PluginBackend {
     mode: "auto" | "manual",
     { persist = true }: { persist?: boolean } = {},
   ): Promise<{ success: boolean; error?: string }> {
-    const result = await this.applyUserFanMode(mode);
-    if (result.success && persist) {
+    if (persist) {
       await this.persistGlobalMode(
         mode === "auto"
           ? { kind: "auto" }
           : {
               kind: "manual",
               // Flipping to manual without naming a speed: carry the last
-              // duty the user asked for, if there is one.
-              percent:
-                this.lastUserSpeedPwm !== null
-                  ? pwmToPercent(this.lastUserSpeedPwm)
-                  : null,
+              // duty the *user* asked for, if there is one. Never
+              // lastUserSpeedPwm — that carries whatever was last written,
+              // including a per-game profile's duty and the safety floor.
+              percent: this.lastUserRequestedPercent,
             },
       );
     }
-    return result;
+    return this.applyUserFanMode(mode);
   }
 
   private async applyUserFanMode(
@@ -904,9 +943,16 @@ export default class FanControlBackend implements PluginBackend {
     }
 
     const epoch = ++this.fanIntentEpoch;
-    this.activePreset = name;
-    this.customCurveActive = false;
     console.log(`[fan-control] Applying preset: ${name}`);
+
+    // Persist at the point of intent, before any I/O. Persisting on success
+    // instead meant a tap that got superseded mid-apply — by a per-game
+    // profile, or by the user's own next tap — was applied but never
+    // recorded, and left storage to whichever chain happened to finish last.
+    if (persist) {
+      this.lastUserRequestedPercent = null;
+      await this.persistGlobalMode({ kind: "preset", name });
+    }
 
     // Set to manual mode first
     const modeResult = await this.setFanModeInternal("manual");
@@ -916,11 +962,17 @@ export default class FanControlBackend implements PluginBackend {
     // Apply curve immediately, then start a loop
     await this.applyCurve(curve);
     if (this.supersededSince(epoch)) return { success: true };
-    this.startCurveLoop(curve);
 
-    // Persist last: only a preset that actually took effect is worth
-    // restoring on the next boot (issue #265).
-    if (persist) await this.persistGlobalMode({ kind: "preset", name });
+    // Commit point. activePreset/customCurveActive are set here, with the
+    // loop, and never optimistically on entry — the safety watchdog skips
+    // its own write when either flag is set, on the understanding that the
+    // curve loop owns the fan (see safetyWatchdogTick). Setting them early
+    // broke that: a superseded or failed apply left the flag set with no
+    // loop running, so at >=75 C the watchdog flagged engaged and wrote
+    // nothing at all.
+    this.activePreset = name;
+    this.customCurveActive = false;
+    this.startCurveLoop(curve);
 
     return { success: true };
   }
@@ -958,8 +1010,13 @@ export default class FanControlBackend implements PluginBackend {
     }
 
     if (this.customCurveActive) {
+      // Restarting the loop is an intent of its own: without an epoch, a
+      // per-game profile applying "auto" during the applyCurve await had its
+      // loop teardown undone here, leaving a curve running against
+      // pwm_enable=2 with customCurveActive already false.
+      const epoch = ++this.fanIntentEpoch;
       await this.applyCurve(curve);
-      this.startCurveLoop(curve);
+      if (!this.supersededSince(epoch)) this.startCurveLoop(curve);
     }
 
     return { success: true, curve: curve.map((p) => ({ ...p })) };
@@ -974,22 +1031,25 @@ export default class FanControlBackend implements PluginBackend {
   ): Promise<{ success: boolean; error?: string }> {
     const curve = this.customCurve;
     const epoch = ++this.fanIntentEpoch;
-    this.activePreset = null;
-    this.customCurveActive = true;
     console.log("[fan-control] Applying custom fan curve");
 
-    const modeResult = await this.setFanModeInternal("manual");
-    if (!modeResult.success) {
-      this.customCurveActive = false;
-      return modeResult;
+    if (persist) {
+      this.lastUserRequestedPercent = null;
+      await this.persistGlobalMode({ kind: "custom" });
     }
+
+    const modeResult = await this.setFanModeInternal("manual");
+    if (!modeResult.success) return modeResult;
     if (this.supersededSince(epoch)) return { success: true };
 
     await this.applyCurve(curve);
     if (this.supersededSince(epoch)) return { success: true };
-    this.startCurveLoop(curve);
 
-    if (persist) await this.persistGlobalMode({ kind: "custom" });
+    // Commit point — see the note in applyPreset. No rollback-on-failure
+    // needed now that the flags are only set once the loop is starting.
+    this.activePreset = null;
+    this.customCurveActive = true;
+    this.startCurveLoop(curve);
 
     return { success: true };
   }

--- a/plugins/fan-control/backend.ts
+++ b/plugins/fan-control/backend.ts
@@ -114,6 +114,14 @@ function toRpcProfile(entry: {
 interface FanModeSnapshot {
   mode: "auto" | "manual";
   speed: number | null;
+  /**
+   * The global mode in effect when the game launched. Without it, exiting a
+   * game restored a bare duty — so a user on the Silent curve came back to a
+   * fixed manual speed and stayed there until the next backend restart
+   * (issue #265 follow-on). In-memory only; the engine never persists
+   * snapshots, so this needs no sanitising on read.
+   */
+  globalMode: GlobalFanMode | null;
 }
 
 interface FanInfoResult {
@@ -269,6 +277,15 @@ export default class FanControlBackend implements PluginBackend {
     onRestore: async (snap) => {
       // Same reasoning as onApply: restoring the pre-game snapshot is not a
       // user choice, so it must not be written to storage.
+      //
+      // Prefer the captured global mode: a preset or custom curve has to be
+      // re-applied as a *curve* (restarting the loop), which a mode+speed
+      // snapshot can't express — restoring that alone left the user pinned
+      // at whatever duty the curve happened to be at when the game started.
+      if (snap.globalMode) {
+        await this.applyGlobalMode(snap.globalMode);
+        return;
+      }
       if (snap.mode === "manual" && typeof snap.speed === "number") {
         await this.setFanSpeed(snap.speed, { persist: false });
       } else {
@@ -493,7 +510,17 @@ export default class FanControlBackend implements PluginBackend {
       return;
     }
     if (!mode) return;
+    await this.applyGlobalMode(mode);
+  }
 
+  /**
+   * Re-assert a global mode without recording it — shared by the on-load
+   * restore and by the per-game engine's onRestore when a game exits.
+   *
+   * Always `persist: false`: neither caller represents a fresh user choice,
+   * and writing here would let a game exit overwrite what the user picked.
+   */
+  private async applyGlobalMode(mode: GlobalFanMode): Promise<void> {
     try {
       switch (mode.kind) {
         case "preset":
@@ -520,8 +547,28 @@ export default class FanControlBackend implements PluginBackend {
           break;
       }
     } catch (err) {
-      console.error("[fan-control] Failed to restore saved fan mode:", err);
+      console.error("[fan-control] Failed to apply fan mode:", err);
     }
+  }
+
+  /** The global mode implied by current in-memory state, for snapshotting
+   *  before a per-game profile takes over. */
+  private currentGlobalMode(): GlobalFanMode | null {
+    if (this.activePreset !== null) {
+      return { kind: "preset", name: this.activePreset };
+    }
+    if (this.customCurveActive) return { kind: "custom" };
+    if (this.manualModeRequested === "manual") {
+      return {
+        kind: "manual",
+        percent:
+          this.lastUserSpeedPwm !== null
+            ? pwmToPercent(this.lastUserSpeedPwm)
+            : null,
+      };
+    }
+    if (this.manualModeRequested === "auto") return { kind: "auto" };
+    return null;
   }
 
   async getFanInfo(): Promise<FanInfoResult> {
@@ -1674,6 +1721,8 @@ export default class FanControlBackend implements PluginBackend {
     const info = await this.getFanInfo();
     const mode = info.mode === "manual" ? "manual" : "auto";
     const percent = info.fans[0]?.percent ?? null;
-    return { mode, speed: percent };
+    // globalMode is what actually gets restored on exit when set; mode/speed
+    // stay as the fallback for a snapshot taken with no global mode active.
+    return { mode, speed: percent, globalMode: this.currentGlobalMode() };
   }
 }

--- a/plugins/fan-control/backend.ts
+++ b/plugins/fan-control/backend.ts
@@ -266,6 +266,17 @@ export default class FanControlBackend implements PluginBackend {
    */
   private lastUserRequestedPercent: number | null = null;
 
+  /**
+   * The user's global choice as we last knew it — read from storage at load,
+   * or recorded by the last persist. Kept explicitly rather than inferred
+   * from activePreset/customCurveActive/manualModeRequested, because those
+   * describe *what is driving the fan right now*, which is a different
+   * question: during an apply they still describe the previous mode, and
+   * while a per-game profile is bound they describe the game's setting.
+   * Inferring from them made the per-game snapshot capture the wrong mode.
+   */
+  private globalModeIntent: GlobalFanMode | null = null;
+
   // Issue #265. The user's persisted global choice, restored once fan
   // hardware is detected. The scanner latches and fires onFound at most
   // once, so the guard is not for it: it is for the two independent
@@ -308,8 +319,12 @@ export default class FanControlBackend implements PluginBackend {
       // re-applied as a *curve* (restarting the loop), which a mode+speed
       // snapshot can't express — restoring that alone left the user pinned
       // at whatever duty the curve happened to be at when the game started.
-      if (snap.globalMode) {
-        await this.applyGlobalMode(snap.globalMode);
+      // `?? globalModeIntent` covers a snapshot taken before the mode was
+      // known — a game already running when the late-driver restore reads
+      // storage. Without it that session never gets back to the saved mode.
+      const target = snap.globalMode ?? this.globalModeIntent;
+      if (target) {
+        await this.applyGlobalMode(target);
         return;
       }
       if (snap.mode === "manual" && typeof snap.speed === "number") {
@@ -510,6 +525,7 @@ export default class FanControlBackend implements PluginBackend {
    * custom-curve save into the same file can't lost-update it.
    */
   private async persistGlobalMode(mode: GlobalFanMode): Promise<void> {
+    this.globalModeIntent = mode;
     try {
       await mutatePluginStorage<Record<string, unknown>>(PLUGIN_ID, (existing) => ({
         ...existing,
@@ -536,21 +552,26 @@ export default class FanControlBackend implements PluginBackend {
     // onFound and the ectool path in onLoad) can both reach here.
     this.restoredGlobalMode = true;
 
-    // A game whose profile is already bound owns the fan. On the late-driver
-    // path this runs up to 30s after startup, by which time a launch may
-    // have applied a profile — restoring over it would hand the fan back to
-    // the global curve while the game is still running.
-    if (this.profileEngine.getActiveAppId() !== null) {
-      console.log(
-        "[fan-control] Skipping saved-mode restore — a per-game profile is active",
-      );
-      return;
-    }
-
     const epoch = this.fanIntentEpoch;
     const stored = await readPluginStorage<{ globalMode?: unknown }>(PLUGIN_ID);
     const mode = sanitiseGlobalMode(stored.globalMode);
     if (!mode) return;
+
+    // Record the intent before any decision not to apply it now. Skipping
+    // the apply must not lose the choice: it is what a per-game profile
+    // hands back to when its game exits.
+    this.globalModeIntent = mode;
+
+    // A game whose profile is already bound owns the fan. Restoring over it
+    // would hand the fan back to the global curve mid-game; the intent
+    // recorded above is what puts the user back on it at exit.
+    if (this.profileEngine.getActiveAppId() !== null) {
+      console.log(
+        "[fan-control] Deferring saved-mode restore — a per-game profile is active",
+      );
+      return;
+    }
+
     // The storage read is an await, and RPCs are live by the time the late
     // rescan fires: a user tapping Auto in that window must not be reverted.
     if (this.supersededSince(epoch)) return;
@@ -593,6 +614,10 @@ export default class FanControlBackend implements PluginBackend {
             `[fan-control] Restoring manual mode${mode.percent !== null ? ` at ${mode.percent}%` : ""}`,
           );
           if (mode.percent !== null) {
+            // Record it as the user's requested duty too: without this the
+            // first game launch snapshots {manual, null} and exiting leaves
+            // the fan at the game's duty instead of the restored one.
+            this.lastUserRequestedPercent = mode.percent;
             await this.setFanSpeed(mode.percent, { persist: false });
           } else {
             await this.setFanMode("manual", { persist: false });
@@ -624,15 +649,7 @@ export default class FanControlBackend implements PluginBackend {
   /** The global mode implied by current in-memory state, for snapshotting
    *  before a per-game profile takes over. */
   private currentGlobalMode(): GlobalFanMode | null {
-    if (this.activePreset !== null) {
-      return { kind: "preset", name: this.activePreset };
-    }
-    if (this.customCurveActive) return { kind: "custom" };
-    if (this.manualModeRequested === "manual") {
-      return { kind: "manual", percent: this.lastUserRequestedPercent };
-    }
-    if (this.manualModeRequested === "auto") return { kind: "auto" };
-    return null;
+    return this.globalModeIntent;
   }
 
   async getFanInfo(): Promise<FanInfoResult> {
@@ -883,11 +900,14 @@ export default class FanControlBackend implements PluginBackend {
     mode: "auto" | "manual",
   ): Promise<{ success: boolean; error?: string }> {
     this.fanIntentEpoch++;
-    if (mode === "auto") {
-      this.stopCurveLoop();
-      this.activePreset = null;
-      this.customCurveActive = false;
-    }
+    // Both directions end curve control: "auto" hands the fan to the
+    // kernel/EC, "manual" hands it to the user's own duty. Leaving the loop
+    // running under "manual" meant tapping Manual while a preset was active
+    // rewrote storage to {manual, ...} while the preset kept driving the fan
+    // and the UI kept showing it selected.
+    this.stopCurveLoop();
+    this.activePreset = null;
+    this.customCurveActive = false;
     this.manualModeRequested = mode;
 
     // RPM-target path: no pwm_enable to flip — "manual" means we own
@@ -1016,7 +1036,12 @@ export default class FanControlBackend implements PluginBackend {
       // pwm_enable=2 with customCurveActive already false.
       const epoch = ++this.fanIntentEpoch;
       await this.applyCurve(curve);
-      if (!this.supersededSince(epoch)) this.startCurveLoop(curve);
+      // customCurveActive is re-read: a preset applied during the await
+      // commits its own flags at the end, so the value we branched on above
+      // can be stale and we would start the custom loop over the preset's.
+      if (!this.supersededSince(epoch) && this.customCurveActive) {
+        this.startCurveLoop(curve);
+      }
     }
 
     return { success: true, curve: curve.map((p) => ({ ...p })) };

--- a/plugins/fan-control/backend.ts
+++ b/plugins/fan-control/backend.ts
@@ -23,6 +23,7 @@ import {
   type PresetName,
 } from "./lib/fan-curves";
 import { DEFAULT_CUSTOM_CURVE, sanitiseCurve } from "./lib/custom-curve";
+import { sanitiseGlobalMode, type GlobalFanMode } from "./lib/global-mode";
 import { readPluginStorage, mutatePluginStorage } from "@loadout/plugin-storage";
 import {
   classifyTempZone,
@@ -232,6 +233,11 @@ export default class FanControlBackend implements PluginBackend {
   // stay hidden.
   private manualModeRequested: "auto" | "manual" | null = null;
 
+  // Issue #265. The user's persisted global choice, restored once fan
+  // hardware is detected. Guarded so the retry scanner — which re-fires
+  // onFound after every successful rescan — only restores on the first.
+  private restoredGlobalMode = false;
+
   // Per-game state. The engine owns the {profiles, perGameEnabled, snapshot,
   // boundAppId} state machine — we just wire in the apply/snapshot/restore
   // operations and delegate the RPC surface.
@@ -245,10 +251,13 @@ export default class FanControlBackend implements PluginBackend {
     guard: () => Boolean(this.activeFanDevice?.hasPwmControl) || this.useEctool,
     onSnapshot: () => this.captureModeSnapshot(),
     onApply: async (payload, ctx) => {
+      // persist:false — this is the *game's* profile, not the user's global
+      // choice. Persisting here would promote a per-game setting to the
+      // system default the next time the plugin loaded (issue #265).
       if (payload.mode === "manual" && typeof payload.speed === "number") {
-        await this.setFanSpeed(payload.speed);
+        await this.setFanSpeed(payload.speed, { persist: false });
       } else {
-        await this.setFanMode(payload.mode);
+        await this.setFanMode(payload.mode, { persist: false });
       }
       console.log(
         `[fan-control] Applied per-game profile for ${ctx.gameName || `App ${ctx.appId}`}: ${payload.mode}` +
@@ -258,10 +267,12 @@ export default class FanControlBackend implements PluginBackend {
       );
     },
     onRestore: async (snap) => {
+      // Same reasoning as onApply: restoring the pre-game snapshot is not a
+      // user choice, so it must not be written to storage.
       if (snap.mode === "manual" && typeof snap.speed === "number") {
-        await this.setFanSpeed(snap.speed);
+        await this.setFanSpeed(snap.speed, { persist: false });
       } else {
-        await this.setFanMode("auto");
+        await this.setFanMode("auto", { persist: false });
       }
     },
   });
@@ -302,6 +313,9 @@ export default class FanControlBackend implements PluginBackend {
       scan: () => this.scanHardware(),
       intervalMs: 30_000,
       onFound: async () => {
+        // Restore before the first emit so the UI's opening state already
+        // reflects the saved mode rather than the driver's power-on default.
+        await this.restoreGlobalMode();
         this.emit?.({ event: "fan-update", data: await this.getFanInfo() });
       },
     });
@@ -439,6 +453,77 @@ export default class FanControlBackend implements PluginBackend {
   }
 
   /** Returns comprehensive fan status. */
+  /**
+   * Record the user's global choice. Best-effort: a storage failure must not
+   * fail the fan operation the user actually asked for, so it logs and
+   * continues. mutatePluginStorage is used (not a bare write) so a concurrent
+   * custom-curve save into the same file can't lost-update it.
+   */
+  private async persistGlobalMode(mode: GlobalFanMode): Promise<void> {
+    try {
+      await mutatePluginStorage<Record<string, unknown>>(PLUGIN_ID, (existing) => ({
+        ...existing,
+        globalMode: mode,
+      }));
+    } catch (err) {
+      console.error("[fan-control] Failed to persist fan mode:", err);
+    }
+  }
+
+  /**
+   * Re-apply the persisted global choice. Called from the hardware
+   * scanner's onFound, not from onLoad directly: a preset means writing
+   * PWM, and on hosts where the driver module (oxpec and friends) lands
+   * after our service starts there is nothing to write to yet.
+   *
+   * Deliberately does nothing when no mode was saved — an install that has
+   * never chosen one keeps the pre-#265 behaviour of leaving the fans to
+   * whatever the firmware set.
+   */
+  private async restoreGlobalMode(): Promise<void> {
+    if (this.restoredGlobalMode) return;
+    this.restoredGlobalMode = true;
+
+    let mode: GlobalFanMode | null = null;
+    try {
+      const stored = await readPluginStorage<{ globalMode?: unknown }>(PLUGIN_ID);
+      mode = sanitiseGlobalMode(stored.globalMode);
+    } catch (err) {
+      console.error("[fan-control] Failed to read saved fan mode:", err);
+      return;
+    }
+    if (!mode) return;
+
+    try {
+      switch (mode.kind) {
+        case "preset":
+          console.log(`[fan-control] Restoring saved preset: ${mode.name}`);
+          await this.applyPreset(mode.name, { persist: false });
+          break;
+        case "custom":
+          console.log("[fan-control] Restoring saved custom curve");
+          await this.applyCustomCurve({ persist: false });
+          break;
+        case "manual":
+          console.log(
+            `[fan-control] Restoring manual mode${mode.percent !== null ? ` at ${mode.percent}%` : ""}`,
+          );
+          if (mode.percent !== null) {
+            await this.setFanSpeed(mode.percent, { persist: false });
+          } else {
+            await this.setFanMode("manual", { persist: false });
+          }
+          break;
+        case "auto":
+          console.log("[fan-control] Restoring auto mode");
+          await this.setFanMode("auto", { persist: false });
+          break;
+      }
+    } catch (err) {
+      console.error("[fan-control] Failed to restore saved fan mode:", err);
+    }
+  }
+
   async getFanInfo(): Promise<FanInfoResult> {
     if (!this.activeFanDevice && !this.useEctool) {
       return this.unavailableFanInfo();
@@ -557,7 +642,32 @@ export default class FanControlBackend implements PluginBackend {
   }
 
   /** Sets fan speed as a percentage (0-100). Enforces safety limits. */
-  async setFanSpeed(percent: number): Promise<{ success: boolean; error?: string }> {
+  /**
+   * Set a manual fan duty. `persist` is false for writes we make on the
+   * user's behalf (per-game profiles, restoring a saved mode) so they can't
+   * be mistaken for a new global choice — see {@link persistGlobalMode}.
+   */
+  async setFanSpeed(
+    percent: number,
+    { persist = true }: { persist?: boolean } = {},
+  ): Promise<{ success: boolean; error?: string }> {
+    const result = await this.applyUserFanSpeed(percent);
+    if (result.success && persist) {
+      // The *requested* percent, not the safety-floor-raised one applied
+      // below: baking a hot-moment override into the saved preference would
+      // have the user come back to fans they never asked for.
+      await this.persistGlobalMode({
+        kind: "manual",
+        percent: clampPercent(percent),
+      });
+    }
+    return result;
+  }
+
+  /** The user-facing write: safety floor, curve-loop teardown, mode flip.
+   *  Distinct from setFanSpeedInternal below, which is the bare duty write
+   *  the safety watchdog and curve loop use. */
+  private async applyUserFanSpeed(percent: number): Promise<{ success: boolean; error?: string }> {
     // Safety override (issue #97): user's value first, then the floor
     // can only RAISE it. Fails safe to 100% on any temp-read error.
     const safePercent = await this.applySafetyFloor(percent);
@@ -628,8 +738,34 @@ export default class FanControlBackend implements PluginBackend {
     }
   }
 
-  /** Sets fan mode: "auto" (kernel-controlled) or "manual" (user-controlled). */
-  async setFanMode(mode: "auto" | "manual"): Promise<{ success: boolean; error?: string }> {
+  /** Sets fan mode: "auto" (kernel-controlled) or "manual" (user-controlled).
+   *  See {@link setFanSpeed} for what `persist` is doing here. */
+  async setFanMode(
+    mode: "auto" | "manual",
+    { persist = true }: { persist?: boolean } = {},
+  ): Promise<{ success: boolean; error?: string }> {
+    const result = await this.applyUserFanMode(mode);
+    if (result.success && persist) {
+      await this.persistGlobalMode(
+        mode === "auto"
+          ? { kind: "auto" }
+          : {
+              kind: "manual",
+              // Flipping to manual without naming a speed: carry the last
+              // duty the user asked for, if there is one.
+              percent:
+                this.lastUserSpeedPwm !== null
+                  ? pwmToPercent(this.lastUserSpeedPwm)
+                  : null,
+            },
+      );
+    }
+    return result;
+  }
+
+  private async applyUserFanMode(
+    mode: "auto" | "manual",
+  ): Promise<{ success: boolean; error?: string }> {
     if (mode === "auto") {
       this.stopCurveLoop();
       this.activePreset = null;
@@ -682,6 +818,7 @@ export default class FanControlBackend implements PluginBackend {
   /** Applies a fan curve preset. Starts a loop that adjusts speed based on temperature. */
   async applyPreset(
     name: PresetName,
+    { persist = true }: { persist?: boolean } = {},
   ): Promise<{ success: boolean; error?: string }> {
     const curve = FAN_CURVES[name];
     if (!curve) {
@@ -699,6 +836,10 @@ export default class FanControlBackend implements PluginBackend {
     // Apply curve immediately, then start a loop
     await this.applyCurve(curve);
     this.startCurveLoop(curve);
+
+    // Persist last: only a preset that actually took effect is worth
+    // restoring on the next boot (issue #265).
+    if (persist) await this.persistGlobalMode({ kind: "preset", name });
 
     return { success: true };
   }
@@ -747,7 +888,9 @@ export default class FanControlBackend implements PluginBackend {
    * Makes the saved custom curve the active control mode. Same shape as
    * applyPreset — switch to manual, apply once, then run the curve loop.
    */
-  async applyCustomCurve(): Promise<{ success: boolean; error?: string }> {
+  async applyCustomCurve(
+    { persist = true }: { persist?: boolean } = {},
+  ): Promise<{ success: boolean; error?: string }> {
     const curve = this.customCurve;
     this.activePreset = null;
     this.customCurveActive = true;
@@ -761,6 +904,8 @@ export default class FanControlBackend implements PluginBackend {
 
     await this.applyCurve(curve);
     this.startCurveLoop(curve);
+
+    if (persist) await this.persistGlobalMode({ kind: "custom" });
 
     return { success: true };
   }

--- a/plugins/fan-control/backend.ts
+++ b/plugins/fan-control/backend.ts
@@ -241,6 +241,21 @@ export default class FanControlBackend implements PluginBackend {
   // stay hidden.
   private manualModeRequested: "auto" | "manual" | null = null;
 
+  /**
+   * Bumped by every call that expresses a new fan-control intent (preset,
+   * custom curve, manual speed, mode flip). Long chains capture it on entry
+   * and bail before mutating shared state if a newer intent has landed.
+   *
+   * Found on device: `handleGameExit` and `handleGameLaunch` are separate
+   * awaited chains driven independently by the injector's fan-out, so a game
+   * *switch* interleaves the exit-restore with the next profile's apply. The
+   * restore's `startCurveLoop` ran after the profile's `setFanSpeed` had
+   * already stopped it, leaving the curve driving the fan while the profile
+   * was supposed to own it — and the UI showing a preset that wasn't
+   * actually in charge.
+   */
+  private fanIntentEpoch = 0;
+
   // Issue #265. The user's persisted global choice, restored once fan
   // hardware is detected. Guarded so the retry scanner — which re-fires
   // onFound after every successful rescan — only restores on the first.
@@ -551,6 +566,19 @@ export default class FanControlBackend implements PluginBackend {
     }
   }
 
+  /**
+   * True when a newer fan intent landed while this one was awaiting I/O.
+   * The caller must then stop touching shared state — no curve loop, no
+   * persist — and leave the winner's state alone.
+   */
+  private supersededSince(epoch: number): boolean {
+    if (epoch === this.fanIntentEpoch) return false;
+    console.log(
+      "[fan-control] Fan intent superseded mid-apply — leaving the newer one in charge",
+    );
+    return true;
+  }
+
   /** The global mode implied by current in-memory state, for snapshotting
    *  before a per-game profile takes over. */
   private currentGlobalMode(): GlobalFanMode | null {
@@ -715,6 +743,8 @@ export default class FanControlBackend implements PluginBackend {
    *  Distinct from setFanSpeedInternal below, which is the bare duty write
    *  the safety watchdog and curve loop use. */
   private async applyUserFanSpeed(percent: number): Promise<{ success: boolean; error?: string }> {
+    // Newer intent than any preset/curve apply still awaiting I/O.
+    this.fanIntentEpoch++;
     // Safety override (issue #97): user's value first, then the floor
     // can only RAISE it. Fails safe to 100% on any temp-read error.
     const safePercent = await this.applySafetyFloor(percent);
@@ -813,6 +843,7 @@ export default class FanControlBackend implements PluginBackend {
   private async applyUserFanMode(
     mode: "auto" | "manual",
   ): Promise<{ success: boolean; error?: string }> {
+    this.fanIntentEpoch++;
     if (mode === "auto") {
       this.stopCurveLoop();
       this.activePreset = null;
@@ -872,6 +903,7 @@ export default class FanControlBackend implements PluginBackend {
       return { success: false, error: `Unknown preset: ${name}` };
     }
 
+    const epoch = ++this.fanIntentEpoch;
     this.activePreset = name;
     this.customCurveActive = false;
     console.log(`[fan-control] Applying preset: ${name}`);
@@ -879,9 +911,11 @@ export default class FanControlBackend implements PluginBackend {
     // Set to manual mode first
     const modeResult = await this.setFanModeInternal("manual");
     if (!modeResult.success) return modeResult;
+    if (this.supersededSince(epoch)) return { success: true };
 
     // Apply curve immediately, then start a loop
     await this.applyCurve(curve);
+    if (this.supersededSince(epoch)) return { success: true };
     this.startCurveLoop(curve);
 
     // Persist last: only a preset that actually took effect is worth
@@ -939,6 +973,7 @@ export default class FanControlBackend implements PluginBackend {
     { persist = true }: { persist?: boolean } = {},
   ): Promise<{ success: boolean; error?: string }> {
     const curve = this.customCurve;
+    const epoch = ++this.fanIntentEpoch;
     this.activePreset = null;
     this.customCurveActive = true;
     console.log("[fan-control] Applying custom fan curve");
@@ -948,8 +983,10 @@ export default class FanControlBackend implements PluginBackend {
       this.customCurveActive = false;
       return modeResult;
     }
+    if (this.supersededSince(epoch)) return { success: true };
 
     await this.applyCurve(curve);
+    if (this.supersededSince(epoch)) return { success: true };
     this.startCurveLoop(curve);
 
     if (persist) await this.persistGlobalMode({ kind: "custom" });

--- a/plugins/fan-control/lib/global-mode.test.ts
+++ b/plugins/fan-control/lib/global-mode.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "bun:test";
+import { sanitiseGlobalMode } from "./global-mode";
+
+describe("sanitiseGlobalMode", () => {
+  it("round-trips each mode the backend persists", () => {
+    expect(sanitiseGlobalMode({ kind: "preset", name: "silent" })).toEqual({
+      kind: "preset",
+      name: "silent",
+    });
+    expect(sanitiseGlobalMode({ kind: "custom" })).toEqual({ kind: "custom" });
+    expect(sanitiseGlobalMode({ kind: "auto" })).toEqual({ kind: "auto" });
+    expect(sanitiseGlobalMode({ kind: "manual", percent: 42 })).toEqual({
+      kind: "manual",
+      percent: 42,
+    });
+  });
+
+  it("rejects an unknown preset name rather than restoring a bogus curve", () => {
+    expect(sanitiseGlobalMode({ kind: "preset", name: "turbo" })).toBeNull();
+    expect(sanitiseGlobalMode({ kind: "preset" })).toBeNull();
+    expect(sanitiseGlobalMode({ kind: "preset", name: 3 })).toBeNull();
+  });
+
+  it("keeps manual intent when the percent is missing or unusable", () => {
+    // The auto-vs-manual choice still stands even with no duty to write —
+    // the backend re-asserts the mode and skips the speed.
+    expect(sanitiseGlobalMode({ kind: "manual" })).toEqual({
+      kind: "manual",
+      percent: null,
+    });
+    expect(sanitiseGlobalMode({ kind: "manual", percent: "80" })).toEqual({
+      kind: "manual",
+      percent: null,
+    });
+    expect(sanitiseGlobalMode({ kind: "manual", percent: NaN })).toEqual({
+      kind: "manual",
+      percent: null,
+    });
+  });
+
+  it("clamps and rounds an out-of-range percent", () => {
+    // Storage is user-editable JSON, so a hand-typed 900 must not reach the
+    // PWM write path.
+    expect(sanitiseGlobalMode({ kind: "manual", percent: 900 })).toEqual({
+      kind: "manual",
+      percent: 100,
+    });
+    expect(sanitiseGlobalMode({ kind: "manual", percent: -20 })).toEqual({
+      kind: "manual",
+      percent: 0,
+    });
+    expect(sanitiseGlobalMode({ kind: "manual", percent: 55.6 })).toEqual({
+      kind: "manual",
+      percent: 56,
+    });
+  });
+
+  it("returns null for absent or malformed values", () => {
+    expect(sanitiseGlobalMode(undefined)).toBeNull();
+    expect(sanitiseGlobalMode(null)).toBeNull();
+    expect(sanitiseGlobalMode("silent")).toBeNull();
+    expect(sanitiseGlobalMode(42)).toBeNull();
+    expect(sanitiseGlobalMode([])).toBeNull();
+    expect(sanitiseGlobalMode({})).toBeNull();
+    expect(sanitiseGlobalMode({ kind: "nonsense" })).toBeNull();
+  });
+});

--- a/plugins/fan-control/lib/global-mode.test.ts
+++ b/plugins/fan-control/lib/global-mode.test.ts
@@ -1,7 +1,20 @@
 import { describe, it, expect } from "bun:test";
 import { sanitiseGlobalMode } from "./global-mode";
+import { FAN_CURVES } from "./fan-curves";
 
 describe("sanitiseGlobalMode", () => {
+  it("accepts every preset the curve table defines", () => {
+    // Derived, not hand-listed: PRESET_NAMES used to be a copy of these
+    // keys, so adding a fourth preset silently made it non-restorable —
+    // rejected here before applyPreset ever saw it.
+    for (const name of Object.keys(FAN_CURVES)) {
+      expect(sanitiseGlobalMode({ kind: "preset", name })).toEqual({
+        kind: "preset",
+        name: name as never,
+      });
+    }
+  });
+
   it("round-trips each mode the backend persists", () => {
     expect(sanitiseGlobalMode({ kind: "preset", name: "silent" })).toEqual({
       kind: "preset",

--- a/plugins/fan-control/lib/global-mode.ts
+++ b/plugins/fan-control/lib/global-mode.ts
@@ -14,9 +14,12 @@
  * game's fan setting to the user's default.
  */
 
-import type { PresetName } from "./fan-curves";
+import { FAN_CURVES, type PresetName } from "./fan-curves";
 
-const PRESET_NAMES: readonly string[] = ["silent", "balanced", "performance"];
+/** Derived, not hand-listed: a hand-copied list silently made any newly
+ *  added preset non-restorable — rejected here before applyPreset ever
+ *  saw it. */
+const PRESET_NAMES: readonly string[] = Object.keys(FAN_CURVES);
 
 export type GlobalFanMode =
   /** One of the built-in curves. */

--- a/plugins/fan-control/lib/global-mode.ts
+++ b/plugins/fan-control/lib/global-mode.ts
@@ -1,0 +1,69 @@
+/**
+ * The user's global fan-control choice, persisted across restarts.
+ *
+ * Issue #265: `applyPreset` only ever set `activePreset` in memory, so a
+ * reboot (or a `loadout.service` restart) dropped the selection. Nothing
+ * restarted the curve loop, and `getFanInfo` fell back to reading
+ * `pwm1_enable` — which drivers like `oxp_ec` initialise to 1 (manual) —
+ * so a user who had picked "Silent" came back to a fixed manual duty.
+ *
+ * "Global" is the operative word: this is what the user chose for the
+ * system, distinct from the per-game profiles the PerGameEngine owns. A
+ * per-game profile applying on launch must NOT overwrite it, or exiting
+ * the game (or rebooting after playing one) would silently promote that
+ * game's fan setting to the user's default.
+ */
+
+import type { PresetName } from "./fan-curves";
+
+const PRESET_NAMES: readonly string[] = ["silent", "balanced", "performance"];
+
+export type GlobalFanMode =
+  /** One of the built-in curves. */
+  | { kind: "preset"; name: PresetName }
+  /** The user's own curve, whose points persist separately as `customCurve`. */
+  | { kind: "custom" }
+  /**
+   * Manual duty. `percent` is null when the user flipped to manual without
+   * naming a speed — restoring then only re-asserts the mode, since we have
+   * no duty to write.
+   */
+  | { kind: "manual"; percent: number | null }
+  /** Kernel/EC-controlled. Worth persisting: several drivers come up in
+   *  manual, so "auto" has to be re-asserted rather than assumed. */
+  | { kind: "auto" };
+
+/**
+ * Parse a persisted value back into a {@link GlobalFanMode}, or null when it
+ * is absent or malformed.
+ *
+ * Plugin storage is user-editable JSON, so this trusts nothing — same
+ * posture as `sanitiseCurve`. A bad value restores nothing rather than
+ * throwing during `onLoad` and taking the whole plugin down with it.
+ */
+export function sanitiseGlobalMode(input: unknown): GlobalFanMode | null {
+  if (typeof input !== "object" || input === null) return null;
+  const raw = input as Record<string, unknown>;
+
+  switch (raw.kind) {
+    case "preset":
+      return typeof raw.name === "string" && PRESET_NAMES.includes(raw.name)
+        ? { kind: "preset", name: raw.name as PresetName }
+        : null;
+    case "custom":
+      return { kind: "custom" };
+    case "auto":
+      return { kind: "auto" };
+    case "manual": {
+      // Absent/!finite percent degrades to "manual, no duty" rather than
+      // discarding the mode — the user's auto-vs-manual intent still stands.
+      const pct = raw.percent;
+      if (typeof pct !== "number" || !Number.isFinite(pct)) {
+        return { kind: "manual", percent: null };
+      }
+      return { kind: "manual", percent: Math.max(0, Math.min(100, Math.round(pct))) };
+    }
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Fixes #265.

## The bug

Reported on an OXP APEX / Bazzite: pick "Silent", reboot, and the fan is back on a fixed manual duty.

`applyPreset` set `activePreset` in memory and started the curve loop but wrote nothing to plugin storage, and `onLoad` restored only per-game profiles and the custom curve's *points*. After a restart nothing was running the curve, and `getFanInfo` fell back to reading `pwm1_enable` — which drivers like `oxp_ec` initialise to `1` (manual) — so the UI showed a static manual speed.

The reporter's root-cause analysis was exact and I verified each part against the code before writing anything. This is their proposed fix.

## What it does

The user's global choice now persists as a tagged union and is restored on load:

```ts
type GlobalFanMode =
  | { kind: "preset"; name: PresetName }
  | { kind: "custom" }
  | { kind: "manual"; percent: number | null }
  | { kind: "auto" };
```

Four details worth review attention:

**Restored from the hardware scanner's `onFound`, not `onLoad`.** Applying a preset means writing PWM, and on hosts where the driver module (oxpec and friends) lands after our service starts there is nothing to write to yet — the scanner already retries every 30s for exactly that case. Guarded with a flag so a later rescan can't stomp a selection the user has changed since the first restore.

**Per-game profiles must not write it.** The `PerGameEngine` drives the same `setFanSpeed`/`setFanMode` entry points, so persisting unconditionally would promote a game's fan profile to the system default the next time the plugin loaded — and exiting the game wouldn't undo it, because the restore path goes through the same methods. All four engine call sites now pass `persist: false`, as does the restore itself.

**The requested speed is saved, not the safety-floor-raised one.** `setFanSpeed` applies the #97 safety floor, which can raise the duty well above what the user asked for. Persisting that would bake a moment at 95 °C into the saved preference and restore it on the next boot.

**Storage is user-editable JSON**, so the value is sanitised on read exactly as `sanitiseCurve` does for the curve: an unknown preset name restores nothing rather than throwing during `onLoad`, and a hand-typed `percent: 900` is clamped before it can reach a PWM write.

An install that has never chosen a mode keeps the previous behaviour of leaving the fans to whatever the firmware set.

## Structural note

`setFanSpeed`'s body moved to a private `applyUserFanSpeed` so the public entry can persist on success — note this is *not* the existing `setFanSpeedInternal`, which is the bare duty write the safety watchdog and curve loop use, and which must keep bypassing all of this. Same shape for `setFanMode` → `applyUserFanMode`.

## Testing

Full backend suite (3264), typecheck and lint clean. 14 new tests: the sanitiser in `lib/global-mode.test.ts`, and behaviour in `backend.test.ts` covering persistence of each mode, restore-on-hardware-found, restore-once, the malformed-value path, and the safety-floor distinction.

The per-game test drives the real engine through `handleGameLaunch`/`handleGameExit` rather than passing `persist: false` by hand — mutation-checked by reverting the two engine call sites, which fails the test.

**Not yet verified on device.** This is plugin-only, so it deploys via `prepare-plugins.sh` without a binary rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bknnb7AaRitj1mMh6rjUoZ