### PR TITLE
fix(fan-control): remember the selected fan mode across restarts

### DIFF
--- a/plugins/fan-control/app.spec.tsx
+++ b/plugins/fan-control/app.spec.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 // module for the partial-mock spread. (bun's mock.module is not hoisted,
 // unlike vitest's vi.mock — static imports evaluate first.)
 import * as actualUi from "@loadout/ui";
-import { waitFor, fireEvent } from "../../test/render";
+import { waitFor, fireEvent, act } from "../../test/render";
 
 const callMock = mock((_method: string) => Promise.resolve(null));
 const eventHandlers = new Map<string, (data: unknown) => void>();
@@ -206,6 +206,87 @@ describe("fan-control plugin", () => {
     await waitFor(() => {
       const slider = container.querySelector('input[type="range"]');
       expect(Number((slider as HTMLInputElement).value)).toBe(55);
+    });
+  });
+
+  it("keeps a fresh selection when a stale tick contradicts it", async () => {
+    // fan-update is emitted on a 2s cadence, so one is often already in
+    // flight when the user taps. Mirroring the backend unconditionally would
+    // let that tick undo the tap. The window is why clearing is safe.
+    // Presets only render in Manual mode.
+    const manualInfo = { ...mockFanInfo, mode: "manual" as const };
+    callMock.mockImplementation((method: string) => {
+      if (method === "getFanInfo") return Promise.resolve(manualInfo);
+      if (method === "getCustomCurve") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    const container = createContainer();
+    const { mount } = await import("./app");
+    mount(container);
+
+    const silent = await waitFor(() => {
+      const btn = Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Silent"),
+      );
+      if (!btn) throw new Error("Silent button not yet rendered");
+      return btn;
+    });
+    fireEvent.click(silent);
+    await waitFor(() => {
+      expect(callMock).toHaveBeenCalledWith("applyPreset", "silent");
+    });
+
+    // A tick from before the tap: the backend hasn't applied it yet.
+    // Flushed inside act() and asserted synchronously — waitFor would
+    // satisfy a "nothing changed" assertion on its first poll, before React
+    // had even processed the update, and pass whatever the handler did.
+    await act(async () => {
+      eventHandlers.get("fan-update")?.({
+        ...manualInfo,
+        activePreset: null,
+        customCurveActive: false,
+      });
+    });
+
+    // The selection stands.
+    expect(container.textContent).toContain("Active preset");
+  });
+
+  it("clears the preset when something else takes the fan", async () => {
+    // A per-game profile applying on game launch clears activePreset in the
+    // backend. The panel used to only ever *assert* a selection, never clear
+    // it, so it kept showing the preset until it was remounted — reported on
+    // device as "the fans kicked in at 80% but the UI didn't update until I
+    // switched plugins and came back".
+    callMock.mockImplementation((method: string) => {
+      if (method === "getFanInfo")
+        return Promise.resolve({
+          ...mockFanInfo,
+          mode: "manual" as const,
+          activePreset: "silent",
+          fans: [{ index: 0, rpm: 1500, pwm: 77, percent: 30 }],
+        });
+      if (method === "getCustomCurve") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    const container = createContainer();
+    const { mount } = await import("./app");
+    mount(container);
+    await waitFor(() => {
+      expect(container.textContent).toContain("Active preset");
+    });
+
+    // The game's profile takes over: no preset, manual duty at 80%.
+    eventHandlers.get("fan-update")?.({
+      ...mockFanInfo,
+      mode: "manual" as const,
+      activePreset: null,
+      customCurveActive: false,
+      fans: [{ index: 0, rpm: 4200, pwm: 204, percent: 80 }],
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).not.toContain("Active preset");
     });
   });
 

--- a/plugins/fan-control/app.spec.tsx
+++ b/plugins/fan-control/app.spec.tsx
@@ -46,6 +46,10 @@ const mockFanInfo = {
   available: true,
   activePreset: null,
   customCurveActive: false,
+  // The real backend always sends these; without them displayDuty correctly
+  // refuses to trust fans[].percent.
+  reportsDuty: true,
+  commandedPercent: null,
   usingEctool: false,
   warning: null,
 };

--- a/plugins/fan-control/app.spec.tsx
+++ b/plugins/fan-control/app.spec.tsx
@@ -209,6 +209,44 @@ describe("fan-control plugin", () => {
     });
   });
 
+  it("does not drive the slider to 0 on hardware that can't report duty", async () => {
+    // ectool hosts and the Deck's RPM-target path leave fans[].percent at a
+    // hard 0 — there is no PWM to read back. Syncing the slider from it would
+    // snap the readout to 0% every tick while the fan is plainly spinning,
+    // making the manual slider unusable on exactly the two devices Loadout
+    // targets. The backend sends what it last commanded instead.
+    const noDutyInfo = {
+      ...mockFanInfo,
+      mode: "manual" as const,
+      reportsDuty: false,
+      commandedPercent: 60,
+      fans: [{ index: 0, rpm: 3200, pwm: 0, percent: 0 }],
+    };
+    callMock.mockImplementation((method: string) => {
+      if (method === "getFanInfo") return Promise.resolve(noDutyInfo);
+      if (method === "getCustomCurve") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    const container = createContainer();
+    const { mount } = await import("./app");
+    mount(container);
+
+    const slider = await waitFor(() => {
+      const el = container.querySelector('input[type="range"]');
+      if (!el) throw new Error("slider not yet rendered");
+      return el as HTMLInputElement;
+    });
+    expect(Number(slider.value)).toBe(60);
+
+    await act(async () => {
+      eventHandlers.get("fan-update")?.({ ...noDutyInfo, commandedPercent: 75 });
+    });
+
+    expect(
+      Number((container.querySelector('input[type="range"]') as HTMLInputElement).value),
+    ).toBe(75);
+  });
+
   it("follows a per-game profile's duty in the slider, with no preset active", async () => {
     // The reported case: launching a game applied its profile at 80%, the RPM
     // readout followed, and the slider stayed on the stale manual value until

--- a/plugins/fan-control/app.spec.tsx
+++ b/plugins/fan-control/app.spec.tsx
@@ -209,6 +209,47 @@ describe("fan-control plugin", () => {
     });
   });
 
+  it("follows a per-game profile's duty in the slider, with no preset active", async () => {
+    // The reported case: launching a game applied its profile at 80%, the RPM
+    // readout followed, and the slider stayed on the stale manual value until
+    // the panel was remounted. No preset or custom curve is involved, so
+    // gating the sync on those flags missed it entirely.
+    const manualInfo = { ...mockFanInfo, mode: "manual" as const };
+    callMock.mockImplementation((method: string) => {
+      if (method === "getFanInfo")
+        return Promise.resolve({
+          ...manualInfo,
+          fans: [{ index: 0, rpm: 2400, pwm: 128, percent: 50 }],
+        });
+      if (method === "getCustomCurve") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    const container = createContainer();
+    const { mount } = await import("./app");
+    mount(container);
+
+    const slider = await waitFor(() => {
+      const el = container.querySelector('input[type="range"]');
+      if (!el) throw new Error("slider not yet rendered");
+      return el as HTMLInputElement;
+    });
+    expect(Number(slider.value)).toBe(50);
+
+    // A per-game profile takes the fan to 80%.
+    await act(async () => {
+      eventHandlers.get("fan-update")?.({
+        ...manualInfo,
+        activePreset: null,
+        customCurveActive: false,
+        fans: [{ index: 0, rpm: 4200, pwm: 204, percent: 80 }],
+      });
+    });
+
+    expect(
+      Number((container.querySelector('input[type="range"]') as HTMLInputElement).value),
+    ).toBe(80);
+  });
+
   it("keeps a fresh selection when a stale tick contradicts it", async () => {
     // fan-update is emitted on a 2s cadence, so one is often already in
     // flight when the user taps. Mirroring the backend unconditionally would

--- a/plugins/fan-control/app.spec.tsx
+++ b/plugins/fan-control/app.spec.tsx
@@ -168,6 +168,47 @@ describe("fan-control plugin", () => {
     });
   });
 
+  it("tracks the live duty in the slider while a preset drives the fan", async () => {
+    // A preset puts the hardware in manual mode but the *curve* owns the
+    // duty, rewriting it every 2s. The slider used to keep showing the
+    // user's last manual value (or its 50/100 default), so it disagreed
+    // with the "Fan speed" row right above it.
+    callMock.mockImplementation((method: string) => {
+      if (method === "getFanInfo")
+        return Promise.resolve({
+          ...mockFanInfo,
+          mode: "manual" as const,
+          activePreset: "silent",
+          fans: [{ index: 0, rpm: 1500, pwm: 77, percent: 30 }],
+        });
+      if (method === "getCustomCurve") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    const container = createContainer();
+    const { mount } = await import("./app");
+    mount(container);
+
+    await waitFor(() => {
+      const slider = container.querySelector('input[type="range"]');
+      expect(slider).not.toBeNull();
+      expect(Number((slider as HTMLInputElement).value)).toBe(30);
+    });
+
+    // And it follows the curve as the duty moves.
+    const handler = eventHandlers.get("fan-update");
+    expect(handler).toBeDefined();
+    handler?.({
+      ...mockFanInfo,
+      mode: "manual" as const,
+      activePreset: "silent",
+      fans: [{ index: 0, rpm: 2600, pwm: 140, percent: 55 }],
+    });
+    await waitFor(() => {
+      const slider = container.querySelector('input[type="range"]');
+      expect(Number((slider as HTMLInputElement).value)).toBe(55);
+    });
+  });
+
   it("shows unavailable message when no fan hardware", async () => {
     callMock.mockImplementation((method: string) => {
       if (method === "getFanInfo")

--- a/plugins/fan-control/app.tsx
+++ b/plugins/fan-control/app.tsx
@@ -84,6 +84,23 @@ type Preset = "silent" | "balanced" | "performance";
 const OPTIMISTIC_MS = 2500;
 
 /**
+ * Tracks a local selection so incoming events can't undo it. Both components
+ * mirror backend state and both need this, so it lives in one place rather
+ * than as a ref plus an inline Date.now() comparison repeated at four sites.
+ */
+function useOptimisticWindow() {
+  const atRef = useRef(0);
+  return {
+    /** Mark a selection the user just made. */
+    stamp: useCallback(() => {
+      atRef.current = Date.now();
+    }, []),
+    /** True when the user's own choice should still win over an event. */
+    isFresh: useCallback(() => Date.now() - atRef.current <= OPTIMISTIC_MS, []),
+  };
+}
+
+/**
  * The duty to display. `fans[0].percent` is a real reading only where the
  * hardware exposes a PWM to read back; on ectool and the Deck's RPM-target
  * path it is hard 0, so showing it would read 0% with the fan plainly
@@ -92,7 +109,11 @@ const OPTIMISTIC_MS = 2500;
  */
 function displayDuty(info: FanInfo | null): number | null {
   if (!info) return null;
-  if (info.reportsDuty === false) return info.commandedPercent ?? null;
+  // Absent, not just false: reportsDuty is optional on the wire, and a
+  // payload without it carrying percent 0 is indistinguishable from hardware
+  // that can't report — which is the case that snaps sliders to 0. Trust a
+  // reading only when the backend has said it is one.
+  if (info.reportsDuty !== true) return info.commandedPercent ?? null;
   const live = info.fans?.[0]?.percent;
   return typeof live === "number" ? live : (info.commandedPercent ?? null);
 }
@@ -193,11 +214,7 @@ function FanControl() {
   const [sliderValue, setSliderValue] = useState(50);
   const [activePreset, setActivePreset] = useState<Preset | null>(null);
   const [customActive, setCustomActive] = useState(false);
-  // When the user last made a selection locally. Events are emitted on a 2s
-  // cadence, so one already in flight when they tap would otherwise undo the
-  // optimistic update. Inside this window we keep our own answer; outside it
-  // the backend is authoritative — see the fan-update handler.
-  const localSelectAtRef = useRef(0);
+  const { stamp: stampSelection, isFresh: selectionFresh } = useOptimisticWindow();
   const [customPoints, setCustomPoints] = useState<FanCurvePoint[]>(() =>
     DEFAULT_CUSTOM_CURVE.map((p) => ({ ...p })),
   );
@@ -222,7 +239,7 @@ function FanControl() {
       // preset until the panel was remounted. The optimistic window below is
       // what protects a fresh tap from a tick already in flight; outside it
       // the backend is the truth.
-      if (Date.now() - localSelectAtRef.current > OPTIMISTIC_MS) {
+      if (!selectionFresh()) {
         setActivePreset(info.activePreset ? (info.activePreset as Preset) : null);
         setCustomActive(Boolean(info.customCurveActive));
       }
@@ -234,7 +251,7 @@ function FanControl() {
       // a game's profile applied 80%, the RPM readout followed it, and the
       // slider sat at the stale manual value until the panel was remounted.
       const duty = displayDuty(info);
-      if (duty !== null && Date.now() - localSelectAtRef.current > OPTIMISTIC_MS) {
+      if (duty !== null && !selectionFresh()) {
         setSliderValue(duty);
       }
       setLoading(false);
@@ -264,7 +281,7 @@ function FanControl() {
 
   const handleSetMode = useCallback(
     async (mode: "auto" | "manual") => {
-      localSelectAtRef.current = Date.now();
+      stampSelection();
       await call("setFanMode", mode);
       if (mode === "auto") {
         setActivePreset(null);
@@ -274,39 +291,39 @@ function FanControl() {
         persistGameProfile("manual", sliderValue);
       }
     },
-    [call, persistGameProfile, sliderValue],
+    [call, persistGameProfile, sliderValue, stampSelection],
   );
 
   const handleSetSpeed = useCallback(
     async (percent: number) => {
-      localSelectAtRef.current = Date.now();
+      stampSelection();
       setSliderValue(percent);
       setActivePreset(null);
       setCustomActive(false);
       await call("setFanSpeed", percent);
       persistGameProfile("manual", percent);
     },
-    [call, persistGameProfile],
+    [call, persistGameProfile, stampSelection],
   );
 
   const handleApplyPreset = useCallback(
     async (preset: Preset) => {
-      localSelectAtRef.current = Date.now();
+      stampSelection();
       setActivePreset(preset);
       setCustomActive(false);
       await call("applyPreset", preset);
       persistGameProfile("manual", sliderValue);
     },
-    [call, persistGameProfile, sliderValue],
+    [call, persistGameProfile, sliderValue, stampSelection],
   );
 
   const handleSelectCustom = useCallback(async () => {
-    localSelectAtRef.current = Date.now();
+    stampSelection();
     setActivePreset(null);
     setCustomActive(true);
     await call("applyCustomCurve").catch(() => {});
     persistGameProfile("manual", sliderValue);
-  }, [call, persistGameProfile, sliderValue]);
+  }, [call, persistGameProfile, sliderValue, stampSelection]);
 
   // Persist edited points to the backend. setCustomCurve sanitises and
   // returns the canonical curve, which we adopt so the UI never drifts
@@ -542,8 +559,8 @@ function FanControl() {
               <Slider
                 value={sliderValue}
                 onChange={(val) => {
-                  // handleSetSpeed stamps localSelectAtRef synchronously, so
-                  // the readout sync above can't yank the thumb mid-drag.
+                  // handleSetSpeed stamps the optimistic window synchronously,
+                  // so the readout sync above can't yank the thumb mid-drag.
                   setSliderValue(val);
                   handleSetSpeed(val);
                 }}
@@ -980,9 +997,7 @@ function FanHomeWidget() {
     currentGame,
   );
   const slidingRef = useRef(false);
-  /** See OPTIMISTIC_MS — the widget mirrors backend state too, so a fresh
-   *  tap here needs the same protection from an in-flight tick. */
-  const localSelectAtRef = useRef(0);
+  const { stamp: stampSelection, isFresh: selectionFresh } = useOptimisticWindow();
   // Note on auto-mode duty: the backend can only report a live duty %
   // when it has direct hwmon PWM-register access. On ectool-only paths
   // (e.g. OXP Apex), `info.fans[0].percent` is hardcoded 0 because
@@ -1037,18 +1052,18 @@ function FanHomeWidget() {
         if (
           duty !== null &&
           !slidingRef.current &&
-          Date.now() - localSelectAtRef.current > OPTIMISTIC_MS
+          !selectionFresh()
         ) {
           setManualSpeed(duty);
         }
       }
       if (info.cpuTempC > 0) setTempC(info.cpuTempC);
-      if (Date.now() - localSelectAtRef.current > OPTIMISTIC_MS) {
+      if (!selectionFresh()) {
         if (info.mode) setMode(info.mode);
         setActivePreset(info.activePreset ?? null);
         setCustomActive(Boolean(info.customCurveActive));
       }
-    }, [deriveAutoDuty]),
+    }, [deriveAutoDuty, selectionFresh]),
   });
 
   if (error) {
@@ -1118,7 +1133,7 @@ function FanHomeWidget() {
         }}
         onCommit={(val) => {
           slidingRef.current = false;
-          localSelectAtRef.current = Date.now();
+          stampSelection();
           setManualSpeed(val);
           call("setFanSpeed", val).catch(() => {});
           persistGameProfile("manual", val);
@@ -1132,7 +1147,7 @@ function FanHomeWidget() {
             // Optimistic — flip the local mode immediately so the slider
             // re-binds to autoDuty on the next render. The stamp is what
             // stops an already-in-flight event bouncing it straight back.
-            localSelectAtRef.current = Date.now();
+            stampSelection();
             setMode("auto");
             call("setFanMode", "auto").catch(() => {});
             persistGameProfile("auto");
@@ -1144,7 +1159,7 @@ function FanHomeWidget() {
         <SegmentedItem
           active={mode === "manual"}
           onSelect={() => {
-            localSelectAtRef.current = Date.now();
+            stampSelection();
             setMode("manual");
             call("setFanMode", "manual").catch(() => {});
             persistGameProfile("manual", manualSpeed);

--- a/plugins/fan-control/app.tsx
+++ b/plugins/fan-control/app.tsx
@@ -169,6 +169,12 @@ function FanControl() {
   const [sliderValue, setSliderValue] = useState(50);
   const [activePreset, setActivePreset] = useState<Preset | null>(null);
   const [customActive, setCustomActive] = useState(false);
+  // When the user last made a selection locally. Events are emitted on a 2s
+  // cadence, so one already in flight when they tap would otherwise undo the
+  // optimistic update. Inside this window we keep our own answer; outside it
+  // the backend is authoritative — see the fan-update handler.
+  const localSelectAtRef = useRef(0);
+  const OPTIMISTIC_MS = 2500;
   const [customPoints, setCustomPoints] = useState<FanCurvePoint[]>(() =>
     DEFAULT_CUSTOM_CURVE.map((p) => ({ ...p })),
   );
@@ -187,16 +193,15 @@ function FanControl() {
     handler: (data) => {
       const info = data as FanInfo;
       setFanInfo(info);
-      // Each tick only asserts a positive selection (preset XOR custom),
-      // never clears to "none" — the click handlers own clearing, so a
-      // stale 2 s-cadence event can't wipe an optimistic selection.
-      if (info.activePreset) {
-        setActivePreset(info.activePreset as Preset);
-        setCustomActive(false);
-      }
-      if (info.customCurveActive) {
-        setCustomActive(true);
-        setActivePreset(null);
+      // Mirror the backend, clearing included. This used to only ever assert
+      // a positive selection, so when something else took the fan — a
+      // per-game profile applying on game launch — the UI kept showing the
+      // preset until the panel was remounted. The optimistic window below is
+      // what protects a fresh tap from a tick already in flight; outside it
+      // the backend is the truth.
+      if (Date.now() - localSelectAtRef.current > OPTIMISTIC_MS) {
+        setActivePreset(info.activePreset ? (info.activePreset as Preset) : null);
+        setCustomActive(Boolean(info.customCurveActive));
       }
       // While a preset or the custom curve is driving, the slider is a
       // readout, not a setting: the curve rewrites the duty every 2s and
@@ -236,6 +241,7 @@ function FanControl() {
 
   const handleSetMode = useCallback(
     async (mode: "auto" | "manual") => {
+      localSelectAtRef.current = Date.now();
       await call("setFanMode", mode);
       if (mode === "auto") {
         setActivePreset(null);
@@ -250,6 +256,7 @@ function FanControl() {
 
   const handleSetSpeed = useCallback(
     async (percent: number) => {
+      localSelectAtRef.current = Date.now();
       setSliderValue(percent);
       setActivePreset(null);
       setCustomActive(false);
@@ -261,6 +268,7 @@ function FanControl() {
 
   const handleApplyPreset = useCallback(
     async (preset: Preset) => {
+      localSelectAtRef.current = Date.now();
       setActivePreset(preset);
       setCustomActive(false);
       await call("applyPreset", preset);
@@ -270,6 +278,7 @@ function FanControl() {
   );
 
   const handleSelectCustom = useCallback(async () => {
+    localSelectAtRef.current = Date.now();
     setActivePreset(null);
     setCustomActive(true);
     await call("applyCustomCurve").catch(() => {});

--- a/plugins/fan-control/app.tsx
+++ b/plugins/fan-control/app.tsx
@@ -203,13 +203,18 @@ function FanControl() {
         setActivePreset(info.activePreset ? (info.activePreset as Preset) : null);
         setCustomActive(Boolean(info.customCurveActive));
       }
-      // While a preset or the custom curve is driving, the slider is a
-      // readout, not a setting: the curve rewrites the duty every 2s and
-      // the user's last manual value has nothing to do with what the fan
-      // is doing. Track the live percent so it agrees with the "Fan speed"
-      // row above it (issue #265 follow-up).
+      // The slider reads out the duty the fan is actually running at,
+      // except while the user is working it. A curve rewrites the duty every
+      // 2s, a per-game profile sets its own, and the safety floor can raise
+      // either — none of which the user's last manual value describes. Gating
+      // this on "a curve is driving" was wrong for exactly the case reported:
+      // a game's profile applied 80%, the RPM readout followed it, and the
+      // slider sat at the stale manual value until the panel was remounted.
       const live = info.fans?.[0]?.percent;
-      if ((info.activePreset || info.customCurveActive) && typeof live === "number") {
+      if (
+        typeof live === "number" &&
+        Date.now() - localSelectAtRef.current > OPTIMISTIC_MS
+      ) {
         setSliderValue(live);
       }
       setLoading(false);
@@ -519,6 +524,8 @@ function FanControl() {
               <Slider
                 value={sliderValue}
                 onChange={(val) => {
+                  // handleSetSpeed stamps localSelectAtRef synchronously, so
+                  // the readout sync above can't yank the thumb mid-drag.
                   setSliderValue(val);
                   handleSetSpeed(val);
                 }}

--- a/plugins/fan-control/app.tsx
+++ b/plugins/fan-control/app.tsx
@@ -65,6 +65,8 @@ interface FanInfo {
   fanCount: number;
   available: boolean;
   activePreset: string | null;
+  reportsDuty?: boolean;
+  commandedPercent?: number | null;
   customCurveActive: boolean;
   usingEctool: boolean;
   warning: string | null;
@@ -72,6 +74,28 @@ interface FanInfo {
 }
 
 type Preset = "silent" | "balanced" | "performance";
+
+/**
+ * How long a local selection stays authoritative over incoming events.
+ * fan-update is emitted on an unconditional 2s cadence, so one already in
+ * flight when the user taps would otherwise undo the optimistic update. A
+ * backend change swallowed inside the window is re-asserted by the next tick.
+ */
+const OPTIMISTIC_MS = 2500;
+
+/**
+ * The duty to display. `fans[0].percent` is a real reading only where the
+ * hardware exposes a PWM to read back; on ectool and the Deck's RPM-target
+ * path it is hard 0, so showing it would read 0% with the fan plainly
+ * spinning — and, worse, drive the slider to 0 on every tick. There we show
+ * what we last commanded instead.
+ */
+function displayDuty(info: FanInfo | null): number | null {
+  if (!info) return null;
+  if (info.reportsDuty === false) return info.commandedPercent ?? null;
+  const live = info.fans?.[0]?.percent;
+  return typeof live === "number" ? live : (info.commandedPercent ?? null);
+}
 
 const PRESETS: { key: Preset; label: string; description: string }[] = [
   { key: "silent", label: "Silent", description: "Quiet, ramps up gently" },
@@ -174,7 +198,6 @@ function FanControl() {
   // optimistic update. Inside this window we keep our own answer; outside it
   // the backend is authoritative — see the fan-update handler.
   const localSelectAtRef = useRef(0);
-  const OPTIMISTIC_MS = 2500;
   const [customPoints, setCustomPoints] = useState<FanCurvePoint[]>(() =>
     DEFAULT_CUSTOM_CURVE.map((p) => ({ ...p })),
   );
@@ -210,12 +233,9 @@ function FanControl() {
       // this on "a curve is driving" was wrong for exactly the case reported:
       // a game's profile applied 80%, the RPM readout followed it, and the
       // slider sat at the stale manual value until the panel was remounted.
-      const live = info.fans?.[0]?.percent;
-      if (
-        typeof live === "number" &&
-        Date.now() - localSelectAtRef.current > OPTIMISTIC_MS
-      ) {
-        setSliderValue(live);
+      const duty = displayDuty(info);
+      if (duty !== null && Date.now() - localSelectAtRef.current > OPTIMISTIC_MS) {
+        setSliderValue(duty);
       }
       setLoading(false);
     },
@@ -226,10 +246,8 @@ function FanControl() {
     call("getFanInfo").then((info) => {
       const data = info as FanInfo;
       setFanInfo(data);
-      const primary = data.fans[0];
-      if (primary) {
-        setSliderValue(primary.percent);
-      }
+      const duty = displayDuty(data);
+      if (duty !== null) setSliderValue(duty);
       setActivePreset(data.activePreset ? (data.activePreset as Preset) : null);
       setCustomActive(Boolean(data.customCurveActive));
       setLoading(false);
@@ -962,6 +980,9 @@ function FanHomeWidget() {
     currentGame,
   );
   const slidingRef = useRef(false);
+  /** See OPTIMISTIC_MS — the widget mirrors backend state too, so a fresh
+   *  tap here needs the same protection from an in-flight tick. */
+  const localSelectAtRef = useRef(0);
   // Note on auto-mode duty: the backend can only report a live duty %
   // when it has direct hwmon PWM-register access. On ectool-only paths
   // (e.g. OXP Apex), `info.fans[0].percent` is hardcoded 0 because
@@ -979,9 +1000,8 @@ function FanHomeWidget() {
   // Returns the backend's PWM-derived `percent` directly. Will be 0 on
   // ectool-only hardware where the EC's duty isn't readable.
   const deriveAutoDuty = useCallback((info: FanInfo): number => {
-    const first = info.fans?.[0];
-    if (!first) return 0;
-    return Math.max(0, Math.min(100, first.percent));
+    const duty = displayDuty(info);
+    return duty === null ? 0 : Math.max(0, Math.min(100, duty));
   }, []);
 
   useEffect(() => {
@@ -990,12 +1010,8 @@ function FanHomeWidget() {
       const primary = info.fans[0];
       if (primary) {
         setRpm(primary.rpm);
-        // Seed manualSpeed from the live percent only if the backend
-        // can actually report it (direct hwmon). On ectool we leave the
-        // 50 default so the slider doesn't snap to 0 when the user
-        // flips to Manual.
-        const reported = primary.percent;
-        if (reported > 0) setManualSpeed(reported);
+        const seeded = displayDuty(info);
+        if (seeded !== null) setManualSpeed(seeded);
         setAutoDuty(deriveAutoDuty(info));
       }
       setTempC(info.cpuTempC > 0 ? info.cpuTempC : null);
@@ -1011,17 +1027,27 @@ function FanHomeWidget() {
       const primary = info.fans?.[0];
       if (primary) {
         setRpm(primary.rpm);
-        // Always refresh the auto-duty estimate. The render-time selector
-        // below picks whether to display it (mode === "auto") or the
-        // user's manualSpeed (mode === "manual"). This keeps the slider
-        // ticking in auto without ever clobbering the user's manual
-        // value with a derived guess that won't match their PWM%.
         setAutoDuty(deriveAutoDuty(info));
+        // manualSpeed was written only at mount and by the user's own drag,
+        // so a per-game profile applying its duty on game launch left this
+        // slider stale while the RPM metric above it moved — the same bug
+        // fixed in the panel. Mirrored here too, except while the user is
+        // dragging or has just tapped.
+        const duty = displayDuty(info);
+        if (
+          duty !== null &&
+          !slidingRef.current &&
+          Date.now() - localSelectAtRef.current > OPTIMISTIC_MS
+        ) {
+          setManualSpeed(duty);
+        }
       }
       if (info.cpuTempC > 0) setTempC(info.cpuTempC);
-      if (info.mode) setMode(info.mode);
-      setActivePreset(info.activePreset ?? null);
-      setCustomActive(Boolean(info.customCurveActive));
+      if (Date.now() - localSelectAtRef.current > OPTIMISTIC_MS) {
+        if (info.mode) setMode(info.mode);
+        setActivePreset(info.activePreset ?? null);
+        setCustomActive(Boolean(info.customCurveActive));
+      }
     }, [deriveAutoDuty]),
   });
 
@@ -1092,6 +1118,7 @@ function FanHomeWidget() {
         }}
         onCommit={(val) => {
           slidingRef.current = false;
+          localSelectAtRef.current = Date.now();
           setManualSpeed(val);
           call("setFanSpeed", val).catch(() => {});
           persistGameProfile("manual", val);
@@ -1103,9 +1130,9 @@ function FanHomeWidget() {
           active={mode === "auto"}
           onSelect={() => {
             // Optimistic — flip the local mode immediately so the slider
-            // re-binds to autoDuty on the next render. The fan-update
-            // event lands up to 2 s later and would otherwise leave the
-            // slider stuck on the user's manual value during that gap.
+            // re-binds to autoDuty on the next render. The stamp is what
+            // stops an already-in-flight event bouncing it straight back.
+            localSelectAtRef.current = Date.now();
             setMode("auto");
             call("setFanMode", "auto").catch(() => {});
             persistGameProfile("auto");
@@ -1117,6 +1144,7 @@ function FanHomeWidget() {
         <SegmentedItem
           active={mode === "manual"}
           onSelect={() => {
+            localSelectAtRef.current = Date.now();
             setMode("manual");
             call("setFanMode", "manual").catch(() => {});
             persistGameProfile("manual", manualSpeed);

--- a/plugins/fan-control/app.tsx
+++ b/plugins/fan-control/app.tsx
@@ -198,6 +198,15 @@ function FanControl() {
         setCustomActive(true);
         setActivePreset(null);
       }
+      // While a preset or the custom curve is driving, the slider is a
+      // readout, not a setting: the curve rewrites the duty every 2s and
+      // the user's last manual value has nothing to do with what the fan
+      // is doing. Track the live percent so it agrees with the "Fan speed"
+      // row above it (issue #265 follow-up).
+      const live = info.fans?.[0]?.percent;
+      if ((info.activePreset || info.customCurveActive) && typeof live === "number") {
+        setSliderValue(live);
+      }
       setLoading(false);
     },
   });
@@ -928,7 +937,8 @@ function FanHomeWidget() {
   //     percent field on direct hwmon paths).
   const [manualSpeed, setManualSpeed] = useState(50);
   const [autoDuty, setAutoDuty] = useState(0);
-  const [, setActivePreset] = useState<string | null>(null);
+  const [activePreset, setActivePreset] = useState<string | null>(null);
+  const [customActive, setCustomActive] = useState(false);
   const [error, setError] = useState(false);
   const { gameProfiles, boundToGame, persistGameProfile } = usePerGameProfiles(
     call,
@@ -995,6 +1005,7 @@ function FanHomeWidget() {
       if (info.cpuTempC > 0) setTempC(info.cpuTempC);
       if (info.mode) setMode(info.mode);
       setActivePreset(info.activePreset ?? null);
+      setCustomActive(Boolean(info.customCurveActive));
     }, [deriveAutoDuty]),
   });
 
@@ -1009,6 +1020,8 @@ function FanHomeWidget() {
   }
 
   const displayRpm = rpm ?? 0;
+  /** A built-in preset or the user's curve is rewriting the duty every 2s. */
+  const curveDriven = activePreset !== null || customActive;
   const sliderDisabled = mode !== "manual";
   // Match TDP's chip semantics so per-game state reads identically across
   // the two performance widgets.
@@ -1049,7 +1062,10 @@ function FanHomeWidget() {
       </div>
 
       <Slider
-        value={mode === "manual" ? manualSpeed : autoDuty}
+        // A preset/custom curve reports hardware mode "manual" (it owns
+        // pwm_enable), but the duty is the curve's, not the user's — so
+        // show the live value rather than a stale manualSpeed.
+        value={mode === "manual" && !curveDriven ? manualSpeed : autoDuty}
         min={0}
         max={100}
         step={1}

--- a/plugins/fan-control/backend.test.ts
+++ b/plugins/fan-control/backend.test.ts
@@ -78,8 +78,8 @@ type FanBackendInternals = {
   curveGen: number;
   useEctool: boolean;
   lastUserSpeedPwm: number | null;
-  lastUserRequestedPercent: number | null;
-  fanIntentEpoch: number;
+  lastCommandedPwm: number | null;
+  rpmTargetPath?: string;
   applyGlobalMode(mode: unknown): Promise<void>;
   profileEngine: { getActiveAppId(): number | null };
 };
@@ -1925,6 +1925,17 @@ describe("FanControlBackend", () => {
       persisted = { globalMode: { kind: "manual", percent: 45 } };
       const fresh = new FanControlBackend();
       const fi = internals(fresh);
+      // A real sensor on the fresh instance: without one getCpuTempCOrNull
+      // returns null and every write fails safe to MAX, so the duty asserted
+      // below would be 255 regardless of what the restore did.
+      fi.tempSensors = [
+        {
+          inputPath: "/sys/class/hwmon/hwmon0/temp1_input",
+          label: "Tctl",
+          zone: "cpu",
+          chipName: "k10temp",
+        },
+      ];
       try {
         // First pass: ectool only, no hwmon device.
         fi.useEctool = true;
@@ -1946,14 +1957,217 @@ describe("FanControlBackend", () => {
           ],
           hasPwmControl: true,
         };
+        const writes: { path: string; valuePromise: Promise<string> }[] = [];
+        spawnSpy.mockImplementation(
+          ((cmd: SpawnArgv, opts: { stdin?: ReadableStream<Uint8Array> }) => {
+            if (cmd[0] === "tee") {
+              const valuePromise = (async () => {
+                if (!opts?.stdin) return "";
+                const reader = opts.stdin.getReader();
+                let out = "";
+                for (;;) {
+                  const { value, done } = await reader.read();
+                  if (done) break;
+                  if (value) out += new TextDecoder().decode(value);
+                }
+                return out;
+              })();
+              writes.push({ path: cmd[1] ?? "", valuePromise });
+            }
+            return asSpawned({
+              stdout: new ReadableStream({ start(c) { c.close(); } }),
+              stderr: new ReadableStream({ start(c) { c.close(); } }),
+              stdin: null,
+              exited: Promise.resolve(0),
+            });
+          }) as typeof Bun.spawn,
+        );
+
         await fi.restoreGlobalMode();
 
         expect(fi.restoredVia).toBe("hwmon");
-        expect(fi.manualModeRequested).toBe("manual");
+        // The point of the tri-state: the duty reaches the device that now
+        // owns the fan. 45% of 255 = 115. Asserting manualModeRequested
+        // alone passed even when the hwmon write never happened, because the
+        // ectool pass had already set it.
+        const duties = await Promise.all(
+          writes.filter((w) => w.path.endsWith("/pwm1")).map((w) => w.valuePromise),
+        );
+        expect(duties).toContain("115");
       } finally {
         clearInterval(fi.interval);
         clearInterval(fi.curveInterval);
       }
+    });
+
+    it("applies a choice made during the ectool window to the hwmon device", async () => {
+      // The user-choice guard has to outrank the *stored* value without
+      // blocking the re-apply — otherwise tapping Manual during the ectool
+      // window leaves the hwmon device, which ends up owning the fan, never
+      // receiving it.
+      persisted = { globalMode: { kind: "manual", percent: 45 } };
+      const fresh = new FanControlBackend();
+      const fi = internals(fresh);
+      fi.tempSensors = [
+        {
+          inputPath: "/sys/class/hwmon/hwmon0/temp1_input",
+          label: "Tctl",
+          zone: "cpu",
+          chipName: "k10temp",
+        },
+      ];
+      try {
+        fi.useEctool = true;
+        fi.activeFanDevice = null;
+        await fi.restoreGlobalMode();
+
+        // The user picks something else before the driver shows up.
+        await fresh.setFanSpeed(30);
+
+        fi.activeFanDevice = {
+          dir: "/sys/class/hwmon/hwmon0",
+          chipName: "test",
+          fans: [
+            {
+              index: 1,
+              inputPath: "/sys/class/hwmon/hwmon0/fan1_input",
+              pwmPath: "/sys/class/hwmon/hwmon0/pwm1",
+              pwmEnablePath: "/sys/class/hwmon/hwmon0/pwm1_enable",
+            },
+          ],
+          hasPwmControl: true,
+        };
+        const writes: { path: string; valuePromise: Promise<string> }[] = [];
+        spawnSpy.mockImplementation(
+          ((cmd: SpawnArgv, opts: { stdin?: ReadableStream<Uint8Array> }) => {
+            if (cmd[0] === "tee") {
+              const valuePromise = (async () => {
+                if (!opts?.stdin) return "";
+                const reader = opts.stdin.getReader();
+                let out = "";
+                for (;;) {
+                  const { value, done } = await reader.read();
+                  if (done) break;
+                  if (value) out += new TextDecoder().decode(value);
+                }
+                return out;
+              })();
+              writes.push({ path: cmd[1] ?? "", valuePromise });
+            }
+            return asSpawned({
+              stdout: new ReadableStream({ start(c) { c.close(); } }),
+              stderr: new ReadableStream({ start(c) { c.close(); } }),
+              stdin: null,
+              exited: Promise.resolve(0),
+            });
+          }) as typeof Bun.spawn,
+        );
+
+        await fi.restoreGlobalMode();
+
+        // The user's 30%, not the stored 45%. percentToPwm rounds 30% to 77.
+        const duties = await Promise.all(
+          writes.filter((w) => w.path.endsWith("/pwm1")).map((w) => w.valuePromise),
+        );
+        expect(duties).toContain("77");
+        expect(duties).not.toContain("115");
+      } finally {
+        clearInterval(fi.interval);
+        clearInterval(fi.curveInterval);
+      }
+    });
+
+    it("reports the duty the curve commanded, not just the user's", async () => {
+      // commandedPercent is what hardware that can't read its duty back shows
+      // in the UI. Reading it off lastUserSpeedPwm meant a preset's curve —
+      // which writes through setFanSpeedInternal — left it frozen at the last
+      // manual value, or null, exactly where the readout is needed most.
+      expect(internals(backend).lastUserSpeedPwm).toBeNull();
+
+      await backend.applyPreset("silent");
+
+      const info = await backend.getFanInfo();
+      expect(info.commandedPercent).not.toBeNull();
+      expect(internals(backend).lastUserSpeedPwm).toBeNull();
+    });
+
+    it("stops reporting a commanded duty once the fan is handed back to auto", async () => {
+      await backend.setFanSpeed(40);
+      expect((await backend.getFanInfo()).commandedPercent).toBe(40);
+
+      await backend.setFanMode("auto");
+      // The EC owns the duty now; a stale figure would have the UI showing a
+      // fabricated value for a fan we aren't driving.
+      expect((await backend.getFanInfo()).commandedPercent).toBeNull();
+    });
+
+    it("keeps the safety floor on RPM-target hardware", async () => {
+      // Persisting a manual mode means a Deck can now boot unattended with
+      // jupiter-fan-control stopped and no curve loop — where before, manual
+      // only lasted while the user was in the UI. The watchdog skipped that
+      // hardware entirely, so nothing supervised the fan.
+      internals(backend).activeFanDevice = {
+        dir: "/sys/class/hwmon/hwmon0",
+        chipName: "steamdeck_hwmon",
+        fans: [
+          {
+            index: 1,
+            inputPath: "/sys/class/hwmon/hwmon0/fan1_input",
+            pwmPath: null,
+            pwmEnablePath: null,
+            rpmTargetPath: "/sys/class/hwmon/hwmon0/fan1_target",
+          },
+        ],
+        hasPwmControl: false,
+        hasRpmTargetControl: true,
+      };
+      const writes: string[] = [];
+      spawnSpy.mockImplementation(
+        ((cmd: SpawnArgv) => {
+          if (cmd[0] === "tee") writes.push(cmd[1] ?? "");
+          return asSpawned({
+            stdout: new ReadableStream({ start(c) { c.close(); } }),
+            stderr: new ReadableStream({ start(c) { c.close(); } }),
+            stdin: null,
+            exited: Promise.resolve(0),
+          });
+        }) as typeof Bun.spawn,
+      );
+      mockReadFile.mockImplementation(() => Promise.resolve("88000")); // hot
+
+      await internals(backend).safetyWatchdogTick();
+
+      expect(internals(backend).safetyEngaged).toBe(true);
+      expect(writes.some((w) => w.endsWith("fan1_target"))).toBe(true);
+    });
+
+    it("a tick queued at unload cannot write after the fan is handed back", async () => {
+      // onUnload used to clearInterval directly, which neither bumps the
+      // generation nor clears the flags — so a tick already queued on the op
+      // lock passed both checks and wrote pwm_enable=1 plus a duty after
+      // restoreOriginalModes had given the fan back.
+      await backend.applyPreset("silent");
+      const b = internals(backend);
+      const gen = b.curveGen;
+
+      await backend.onUnload();
+
+      const writes: string[] = [];
+      spawnSpy.mockImplementation(
+        ((cmd: SpawnArgv) => {
+          if (cmd[0] === "tee") writes.push(cmd[1] ?? "");
+          return asSpawned({
+            stdout: new ReadableStream({ start(c) { c.close(); } }),
+            stderr: new ReadableStream({ start(c) { c.close(); } }),
+            stdin: null,
+            exited: Promise.resolve(0),
+          });
+        }) as typeof Bun.spawn,
+      );
+      await b._serialize(() => b.runCurveTick(gen, FAN_CURVES.silent));
+
+      expect(writes).toEqual([]);
+      expect(b.activePreset).toBeNull();
     });
 
     it("tells the UI whether fans[].percent is a real reading", async () => {
@@ -1990,17 +2204,24 @@ describe("FanControlBackend", () => {
     it("never leaves a preset flagged active without a curve loop", async () => {
       // The safety watchdog skips its own write whenever activePreset or
       // customCurveActive is set, trusting the curve loop to write instead
-      // (safetyWatchdogTick). If a superseded or failed apply leaves the
-      // flag set with no loop, nothing writes at all while the SoC is hot.
-      const superseded = backend.applyPreset("silent", { persist: false });
-      await backend.setFanMode("manual", { persist: false });
-      await superseded;
+      // (safetyWatchdogTick). A flag set with no loop running therefore
+      // silences the safety floor entirely.
+      //
+      // Asserted positively rather than as `flagged === looping`, which both
+      // -false satisfies: apply a preset, then check the flag and the loop
+      // agree in the state where the flag is actually set.
+      await backend.applyPreset("silent");
+      expect(internals(backend).activePreset).toBe("silent");
+      expect(internals(backend).curveInterval).toBeDefined();
 
-      const flagged =
-        internals(backend).activePreset !== null ||
-        internals(backend).customCurveActive;
-      const looping = internals(backend).curveInterval !== undefined;
-      expect(flagged).toBe(looping);
+      // ...and after something supersedes it, neither is left behind. The
+      // superseding call takes the lock second, which is the order that
+      // actually occurs — a preset apply already in flight when the user
+      // taps Manual.
+      await backend.setFanMode("manual");
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).customCurveActive).toBe(false);
+      expect(internals(backend).curveInterval).toBeUndefined();
     });
 
     it("leaves no preset flagged when the mode write fails", async () => {

--- a/plugins/fan-control/backend.test.ts
+++ b/plugins/fan-control/backend.test.ts
@@ -15,6 +15,7 @@ import type { Subprocess } from "bun";
 import * as fsp from "fs/promises";
 import * as fs from "fs";
 import * as storage from "@loadout/plugin-storage";
+import { FAN_CURVES } from "./lib/fan-curves";
 
 // Standalone mock fns the test bodies configure via `.mockImplementation`
 // / `.mockClear`. The spies installed in beforeEach delegate to these,
@@ -42,6 +43,7 @@ type HwmonDeviceLike = {
   chipName: string;
   fans: FanDeviceLike[];
   hasPwmControl: boolean;
+  hasRpmTargetControl?: boolean;
 };
 type TempSensorLike = {
   inputPath: string;
@@ -69,7 +71,12 @@ type FanBackendInternals = {
   safetyWatchdogTick(): Promise<void>;
   getCpuTempCOrNull(): Promise<number | null>;
   restoreGlobalMode(): Promise<void>;
-  restoredGlobalMode: boolean;
+  runCurveTick(gen: number, curve: { tempC: number; percent: number }[]): Promise<void>;
+  _serialize<T>(fn: () => Promise<T>): Promise<T>;
+  restoredVia: "none" | "ectool" | "hwmon";
+  lastCurveWriteAt: number;
+  curveGen: number;
+  useEctool: boolean;
   lastUserSpeedPwm: number | null;
   lastUserRequestedPercent: number | null;
   fanIntentEpoch: number;
@@ -907,6 +914,10 @@ describe("FanControlBackend", () => {
     it("does NOT write when the custom curve is active — the curve loop owns the write", async () => {
       setupFanAndSensor();
       internals(backend).customCurveActive = true;
+      // A loop that is demonstrably still writing. Without this the watchdog
+      // treats the loop as stalled and takes the write itself, which is the
+      // point of the check below.
+      internals(backend).lastCurveWriteAt = Date.now();
       mockReadFile.mockImplementation(() => Promise.resolve("82000")); // hot, ≥ WARM_C
       const writes = captureTeeWrites();
 
@@ -914,6 +925,24 @@ describe("FanControlBackend", () => {
 
       // Watchdog only flags engaged; it leaves the single write to the loop.
       expect(writes).toEqual([]);
+      expect(internals(backend).safetyEngaged).toBe(true);
+    });
+
+    it("DOES write when a curve is flagged but its loop has stalled", async () => {
+      // The curve loop's write goes through the op lock, so a stalled
+      // operation — a `tee` blocked on a wedged EC, `systemctl stop` waiting
+      // out a unit timeout — silences it. Deferring unconditionally would
+      // silence the safety floor along with it, which is exactly what this
+      // watchdog exists outside the lock to prevent.
+      setupFanAndSensor();
+      internals(backend).customCurveActive = true;
+      internals(backend).lastCurveWriteAt = Date.now() - 30_000; // long stalled
+      mockReadFile.mockImplementation(() => Promise.resolve("82000"));
+      const writes = captureTeeWrites();
+
+      await internals(backend).safetyWatchdogTick();
+
+      expect(writes.length).toBeGreaterThan(0);
       expect(internals(backend).safetyEngaged).toBe(true);
     });
 
@@ -1691,7 +1720,7 @@ describe("FanControlBackend", () => {
       expect(internals(backend).manualModeRequested).toBeNull();
 
       persisted = { globalMode: { kind: "preset", name: "turbo" } };
-      internals(backend).restoredGlobalMode = false;
+      internals(backend).restoredVia = "none";
       await internals(backend).restoreGlobalMode();
       expect(internals(backend).activePreset).toBeNull();
     });
@@ -1828,6 +1857,134 @@ describe("FanControlBackend", () => {
       expect(internals(backend).curveInterval).toBeUndefined();
       // ...and the user's global choice is untouched on disk.
       expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+    });
+
+    it("a queued curve tick cannot write over the mode that replaced it", async () => {
+      // The tick reads the flags synchronously at *enqueue* time, then waits
+      // for the lock. clearInterval can't recall a tick already queued, so it
+      // used to run afterwards and write the old curve's duty over the new
+      // mode — with no loop left running to correct it.
+      await backend.applyPreset("silent");
+      const b = internals(backend);
+      const gen = b.curveGen;
+
+      // Order matters: the user's op takes the lock first, and the tick —
+      // enqueued by a timer that fired while the preset was still active —
+      // queues behind it. Enqueue the tick first and FIFO alone would give
+      // the right answer, hiding the bug.
+      // Captured at the hardware boundary: the curve tick writes through
+      // setFanSpeedInternal, which doesn't touch lastUserSpeedPwm, so
+      // in-memory state can't see a stale write at all.
+      const writes: { path: string; valuePromise: Promise<string> }[] = [];
+      spawnSpy.mockImplementation(
+        ((cmd: SpawnArgv, opts: { stdin?: ReadableStream<Uint8Array> }) => {
+          if (cmd[0] === "tee") {
+            const valuePromise = (async () => {
+              if (!opts?.stdin) return "";
+              const reader = opts.stdin.getReader();
+              let out = "";
+              for (;;) {
+                const { value, done } = await reader.read();
+                if (done) break;
+                if (value) out += new TextDecoder().decode(value);
+              }
+              return out;
+            })();
+            writes.push({ path: cmd[1] ?? "", valuePromise });
+          }
+          return asSpawned({
+            stdout: new ReadableStream({ start(c) { c.close(); } }),
+            stderr: new ReadableStream({ start(c) { c.close(); } }),
+            stdin: null,
+            exited: Promise.resolve(0),
+          });
+        }) as typeof Bun.spawn,
+      );
+
+      const speed = backend.setFanSpeed(20);
+      const queued = b._serialize(() => b.runCurveTick(gen, FAN_CURVES.silent));
+      await Promise.all([speed, queued]);
+
+      // The tick stood down instead of writing the preset's duty over the
+      // manual one — and nothing else would have corrected it, since the
+      // loop is stopped. 20% of 255 = 51.
+      const duties = await Promise.all(
+        writes.filter((w) => w.path.endsWith("/pwm1")).map((w) => w.valuePromise),
+      );
+      expect(duties.length).toBeGreaterThan(0);
+      expect(duties[duties.length - 1]).toBe("51");
+      expect(internals(backend).activePreset).toBeNull();
+    });
+
+    it("applies the saved mode to hwmon when the driver appears after ectool", async () => {
+      // scanHardware reports "found" only for a hwmon write path, so on a
+      // host whose driver loads late we restore through ectool first. That
+      // used to latch, and the hwmon device — the one that ends up owning the
+      // fan — never received the saved mode. For manual/auto nothing else
+      // would ever write it.
+      persisted = { globalMode: { kind: "manual", percent: 45 } };
+      const fresh = new FanControlBackend();
+      const fi = internals(fresh);
+      try {
+        // First pass: ectool only, no hwmon device.
+        fi.useEctool = true;
+        fi.activeFanDevice = null;
+        await fi.restoreGlobalMode();
+        expect(fi.restoredVia).toBe("ectool");
+
+        // The driver shows up; the scanner's onFound restores again.
+        fi.activeFanDevice = {
+          dir: "/sys/class/hwmon/hwmon0",
+          chipName: "test",
+          fans: [
+            {
+              index: 1,
+              inputPath: "/sys/class/hwmon/hwmon0/fan1_input",
+              pwmPath: "/sys/class/hwmon/hwmon0/pwm1",
+              pwmEnablePath: "/sys/class/hwmon/hwmon0/pwm1_enable",
+            },
+          ],
+          hasPwmControl: true,
+        };
+        await fi.restoreGlobalMode();
+
+        expect(fi.restoredVia).toBe("hwmon");
+        expect(fi.manualModeRequested).toBe("manual");
+      } finally {
+        clearInterval(fi.interval);
+        clearInterval(fi.curveInterval);
+      }
+    });
+
+    it("tells the UI whether fans[].percent is a real reading", async () => {
+      // On an RPM-target device (the Deck) there is no pwm to read back, so
+      // percent stays 0. A UI syncing a slider from it would snap to 0% every
+      // tick while the fan is plainly spinning — so getFanInfo says which it
+      // is, and what it last commanded.
+      await backend.setFanSpeed(40);
+
+      const withPwm = await backend.getFanInfo();
+      expect(withPwm.reportsDuty).toBe(true);
+      expect(withPwm.commandedPercent).toBe(40);
+
+      internals(backend).activeFanDevice = {
+        dir: "/sys/class/hwmon/hwmon0",
+        chipName: "steamdeck_hwmon",
+        fans: [
+          {
+            index: 1,
+            inputPath: "/sys/class/hwmon/hwmon0/fan1_input",
+            pwmPath: null,
+            pwmEnablePath: null,
+          },
+        ],
+        hasPwmControl: false,
+        hasRpmTargetControl: true,
+      };
+      const rpmTarget = await backend.getFanInfo();
+      expect(rpmTarget.reportsDuty).toBe(false);
+      expect(rpmTarget.fans[0]?.percent).toBe(0);
+      expect(rpmTarget.commandedPercent).toBe(40);
     });
 
     it("never leaves a preset flagged active without a curve loop", async () => {
@@ -1994,6 +2151,12 @@ describe("FanControlBackend", () => {
       // It exists for a session that hasn't expressed a choice yet, so a mode
       // the user picked in the meantime must stand.
       persisted = { globalMode: { kind: "preset", name: "silent" } };
+      // Storage is frozen for this test: the user's own tap would otherwise
+      // overwrite the stored value, leaving nothing for the restore to
+      // disagree with — and the test would pass with the guard deleted.
+      writeStorageSpy.mockImplementation(
+        (() => Promise.resolve()) as typeof storage.writePluginStorage,
+      );
       await backend.setFanMode("auto");
 
       await internals(backend).restoreGlobalMode();

--- a/plugins/fan-control/backend.test.ts
+++ b/plugins/fan-control/backend.test.ts
@@ -68,6 +68,13 @@ type FanBackendInternals = {
   setFanSpeedInternal(percent: number): Promise<{ success: boolean; error?: string }>;
   safetyWatchdogTick(): Promise<void>;
   getCpuTempCOrNull(): Promise<number | null>;
+  restoreGlobalMode(): Promise<void>;
+  restoredGlobalMode: boolean;
+  lastUserSpeedPwm: number | null;
+  lastUserRequestedPercent: number | null;
+  fanIntentEpoch: number;
+  applyGlobalMode(mode: unknown): Promise<void>;
+  profileEngine: { getActiveAppId(): number | null };
 };
 const internals = (b: FanControlBackend): FanBackendInternals =>
   b as unknown as FanBackendInternals;
@@ -1523,4 +1530,497 @@ describe("FanControlBackend", () => {
       expect(temps[0].tempC).toBe(0);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Issue #265: the global mode (preset / custom / manual / auto) has to
+  // survive a reboot or a `loadout.service` restart. Before this, applyPreset
+  // only set in-memory state, so the curve loop never restarted and the UI
+  // fell back to whatever pwm1_enable said — manual, on drivers like oxp_ec.
+  // ---------------------------------------------------------------------------
+
+  describe("global mode persistence (#265)", () => {
+    let readStorageSpy: ReturnType<typeof spyOn>;
+    let writeStorageSpy: ReturnType<typeof spyOn>;
+    let persisted: Record<string, unknown>;
+
+    beforeEach(() => {
+      persisted = {};
+      readStorageSpy = spyOn(storage, "readPluginStorage").mockImplementation(
+        (() => Promise.resolve(persisted)) as typeof storage.readPluginStorage,
+      );
+      writeStorageSpy = spyOn(storage, "writePluginStorage").mockImplementation(
+        ((_id: string, data: Record<string, unknown>) => {
+          persisted = data;
+          return Promise.resolve();
+        }) as typeof storage.writePluginStorage,
+      );
+      internals(backend).activeFanDevice = {
+        dir: "/sys/class/hwmon/hwmon0",
+        chipName: "test",
+        fans: [
+          {
+            index: 1,
+            inputPath: "/sys/class/hwmon/hwmon0/fan1_input",
+            pwmPath: "/sys/class/hwmon/hwmon0/pwm1",
+            pwmEnablePath: "/sys/class/hwmon/hwmon0/pwm1_enable",
+          },
+        ],
+        hasPwmControl: true,
+      };
+      spawnSpy.mockImplementation(
+        (() =>
+          asSpawned({
+            stdout: new ReadableStream({ start(c) { c.close(); } }),
+            stderr: new ReadableStream({ start(c) { c.close(); } }),
+            stdin: null,
+            exited: Promise.resolve(0),
+          })) as typeof Bun.spawn,
+      );
+      // A real sensor, so the floor is driven by the temperature below and
+      // not by getCpuTempCOrNull() returning null — which silently sent
+      // every setFanSpeed in this block down the "temperature unavailable,
+      // failsafe to MAX" path and made the 95 C case pass for the wrong
+      // reason.
+      internals(backend).tempSensors = [
+        {
+          inputPath: "/sys/class/hwmon/hwmon0/temp1_input",
+          label: "Tctl",
+          zone: "cpu",
+          chipName: "k10temp",
+        },
+      ];
+      // Cool enough that the safety floor never rewrites the value.
+      mockReadFile.mockImplementation(() => Promise.resolve("45000"));
+    });
+
+    /** The duty last written to hardware, as a percent. */
+    const writtenPercent = () => {
+      const pwm = internals(backend).lastUserSpeedPwm;
+      return pwm === null ? null : Math.round((pwm / 255) * 100);
+    };
+
+    afterEach(() => {
+      readStorageSpy.mockRestore();
+      writeStorageSpy.mockRestore();
+    });
+
+    it("persists a preset selection", async () => {
+      await backend.applyPreset("silent");
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+    });
+
+    it("persists the custom curve and each manual/auto choice", async () => {
+      await backend.applyCustomCurve();
+      expect(persisted.globalMode).toEqual({ kind: "custom" });
+
+      await backend.setFanSpeed(70);
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 70 });
+
+      await backend.setFanMode("auto");
+      expect(persisted.globalMode).toEqual({ kind: "auto" });
+    });
+
+    it("saves the requested speed, not a safety-raised one", async () => {
+      // 95 °C forces the safety floor well above the user's 20%. Persisting
+      // the floor would have the user reboot into fans they never chose.
+      mockReadFile.mockImplementation(() => Promise.resolve("95000"));
+      await backend.setFanSpeed(20);
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 20 });
+    });
+
+    it("restores a saved preset once fan hardware is found", async () => {
+      persisted = { globalMode: { kind: "preset", name: "performance" } };
+      await internals(backend).restoreGlobalMode();
+
+      expect(internals(backend).activePreset).toBe("performance");
+      expect(internals(backend).curveInterval).toBeDefined();
+    });
+
+    it.each([
+      [
+        "a manual duty, at that duty",
+        { kind: "manual", percent: 65 },
+        (b: FanControlBackend) => {
+          expect(internals(b).manualModeRequested).toBe("manual");
+          expect(writtenPercent()).toBe(65);
+        },
+      ],
+      [
+        "the custom curve, as a running curve",
+        { kind: "custom" },
+        (b: FanControlBackend) => {
+          expect(internals(b).customCurveActive).toBe(true);
+          expect(internals(b).curveInterval).toBeDefined();
+        },
+      ],
+      [
+        // Worth restoring rather than assuming: several drivers come up in
+        // manual, so "auto" has to be re-asserted.
+        "auto mode",
+        { kind: "auto" },
+        (b: FanControlBackend) => {
+          expect(internals(b).manualModeRequested).toBe("auto");
+          expect(internals(b).curveInterval).toBeUndefined();
+        },
+      ],
+    ])("restores %s", async (_label, globalMode, check) => {
+      persisted = { globalMode, customCurve: [{ tempC: 40, percent: 10 }] };
+      await internals(backend).restoreGlobalMode();
+      check(backend);
+      expect(internals(backend).activePreset).toBeNull();
+    });
+
+    it("restores nothing when no mode was ever saved", async () => {
+      persisted = {};
+      await internals(backend).restoreGlobalMode();
+
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).curveInterval).toBeUndefined();
+      // And doesn't write a mode back out just for having looked.
+      expect(persisted.globalMode).toBeUndefined();
+    });
+
+    it("ignores a malformed saved mode instead of throwing during load", async () => {
+      // An unknown preset name is caught by the sanitiser. Asserting only
+      // activePreset would also pass without it, since applyPreset bails on
+      // the FAN_CURVES lookup — so pin a shape that WOULD reach hardware if
+      // the value were used raw.
+      persisted = { globalMode: { kind: "manual", percent: "80" } };
+      await internals(backend).restoreGlobalMode();
+      expect(writtenPercent()).toBeNull();
+      expect(internals(backend).manualModeRequested).toBeNull();
+
+      persisted = { globalMode: { kind: "preset", name: "turbo" } };
+      internals(backend).restoredGlobalMode = false;
+      await internals(backend).restoreGlobalMode();
+      expect(internals(backend).activePreset).toBeNull();
+    });
+
+    it("restores only once, however often the hardware scanner re-fires", async () => {
+      persisted = { globalMode: { kind: "preset", name: "silent" } };
+      await internals(backend).restoreGlobalMode();
+      internals(backend).activePreset = null;
+      await internals(backend).restoreGlobalMode();
+      // Second call is a no-op: a rescan must not stomp a selection the user
+      // has changed since the first one.
+      expect(internals(backend).activePreset).toBeNull();
+    });
+
+    it("does not let a per-game profile overwrite the user's global choice", async () => {
+      // The crux of the persist:false wiring, driven through the real
+      // PerGameEngine rather than by passing the flag by hand: a game
+      // applying its own fan profile must not promote that setting to the
+      // system default, or the next boot would restore the game's fans.
+      await backend.applyPreset("silent");
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(730, "Test Game", {
+        mode: "manual",
+        speed: 90,
+      });
+      await backend.handleGameLaunch(730, "Test Game");
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+
+      // Exiting restores the pre-game snapshot — also not a user choice.
+      await backend.handleGameExit(730);
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+    });
+
+    it("puts the user back on their curve when a game with a profile exits", async () => {
+      // Found on-device: the restore worked, then a per-game profile applied
+      // a second later and the snapshot could only put back a *duty*, so the
+      // user sat at a fixed speed until the next backend restart.
+      await backend.applyPreset("silent");
+      expect(internals(backend).activePreset).toBe("silent");
+
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(730, "Test Game", {
+        mode: "manual",
+        speed: 90,
+      });
+
+      await backend.handleGameLaunch(730, "Test Game");
+      // The game's manual profile owns the fan while it runs.
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).manualModeRequested).toBe("manual");
+
+      await backend.handleGameExit(730);
+      // ...and the curve is running again afterwards, not a static duty.
+      expect(internals(backend).activePreset).toBe("silent");
+      expect(internals(backend).curveInterval).toBeDefined();
+      // Still the user's choice on disk — the round trip wrote nothing.
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+    });
+
+    it("restores from onLoad, not just when called directly", async () => {
+      // The #265 fix itself: the wiring from plugin load to restore. Every
+      // other restore test calls the private method by hand, so deleting
+      // `await this.restoreGlobalMode()` from the scanner's onFound left
+      // the whole suite green.
+      persisted = { globalMode: { kind: "preset", name: "performance" } };
+      const fresh = new FanControlBackend();
+      const internalsFresh = internals(fresh);
+      // Hardware the scanner will find on its first pass.
+      internalsFresh.scanHardware = () => {
+        internalsFresh.activeFanDevice = {
+          dir: "/sys/class/hwmon/hwmon0",
+          chipName: "test",
+          fans: [
+            {
+              index: 1,
+              inputPath: "/sys/class/hwmon/hwmon0/fan1_input",
+              pwmPath: "/sys/class/hwmon/hwmon0/pwm1",
+              pwmEnablePath: "/sys/class/hwmon/hwmon0/pwm1_enable",
+            },
+          ],
+          hasPwmControl: true,
+        };
+        return Promise.resolve(true);
+      };
+      try {
+        await fresh.onLoad();
+        expect(internalsFresh.activePreset).toBe("performance");
+        expect(internalsFresh.curveInterval).toBeDefined();
+      } finally {
+        clearInterval(internalsFresh.interval);
+        clearInterval(internalsFresh.curveInterval);
+        await fresh.onUnload();
+      }
+    });
+
+    it("serializes concurrent fan intents so the last caller wins", async () => {
+      // Fan intents used to interleave across their `tee` spawns, letting an
+      // older one stop the newer one's curve loop (or start a loop the newer
+      // one had stopped). They now queue, so the end state is simply the
+      // last caller's — here, manual with no curve running.
+      const preset = backend.applyPreset("silent");
+      const manual = backend.setFanSpeed(48);
+      await Promise.all([preset, manual]);
+
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).customCurveActive).toBe(false);
+      expect(internals(backend).curveInterval).toBeUndefined();
+      expect(writtenPercent()).toBe(48);
+    });
+
+    it("survives a game switch — the on-device repro", async () => {
+      // handleGameExit and handleGameLaunch are independent fire-and-forget
+      // chains from the injector's fan-out. Interleaved, the exit-restore's
+      // curve loop outlived the next profile's apply: the curve drove the fan
+      // while the profile was supposed to own it, and the UI showed a preset
+      // that wasn't in charge.
+      await backend.applyPreset("silent");
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(730, "Game A", { mode: "manual", speed: 30 });
+      await backend.setGameProfile(731, "Game B", { mode: "manual", speed: 48 });
+      await backend.handleGameLaunch(730, "Game A");
+
+      // Switch: A exits and B launches without waiting for each other.
+      await Promise.all([
+        backend.handleGameExit(730),
+        backend.handleGameLaunch(731, "Game B"),
+      ]);
+
+      // B's profile owns the fan, with no curve running behind it.
+      expect(writtenPercent()).toBe(48);
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).curveInterval).toBeUndefined();
+      // ...and the user's global choice is untouched on disk.
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+    });
+
+    it("never leaves a preset flagged active without a curve loop", async () => {
+      // The safety watchdog skips its own write whenever activePreset or
+      // customCurveActive is set, trusting the curve loop to write instead
+      // (safetyWatchdogTick). If a superseded or failed apply leaves the
+      // flag set with no loop, nothing writes at all while the SoC is hot.
+      const superseded = backend.applyPreset("silent", { persist: false });
+      await backend.setFanMode("manual", { persist: false });
+      await superseded;
+
+      const flagged =
+        internals(backend).activePreset !== null ||
+        internals(backend).customCurveActive;
+      const looping = internals(backend).curveInterval !== undefined;
+      expect(flagged).toBe(looping);
+    });
+
+    it("leaves no preset flagged when the mode write fails", async () => {
+      // Same invariant, via the failure path: applyPreset used to set
+      // activePreset before the hardware write and never roll it back.
+      spawnSpy.mockImplementation(
+        (() =>
+          asSpawned({
+            stdout: new ReadableStream({ start(c) { c.close(); } }),
+            stderr: new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("denied")); c.close(); } }),
+            stdin: null,
+            exited: Promise.resolve(1),
+          })) as typeof Bun.spawn,
+      );
+      await backend.applyPreset("silent");
+
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).curveInterval).toBeUndefined();
+    });
+
+    it("does not launder a per-game duty into the saved manual speed", async () => {
+      // setFanMode("manual") used to persist from lastUserSpeedPwm, which
+      // carries whatever was last *written* — including a profile's duty and
+      // the safety floor. Tapping Manual mid-game then saved the game's 90%
+      // as the user's global preference.
+      await backend.setFanSpeed(40);
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 40 });
+
+      // A per-game profile applies its own duty, through the engine.
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(730, "Test Game", { mode: "manual", speed: 90 });
+      await backend.handleGameLaunch(730, "Test Game");
+      await backend.setFanMode("manual");
+
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 40 });
+    });
+
+    it("does not launder a safety-raised duty into the saved manual speed", async () => {
+      await backend.setFanSpeed(20);
+      // Now run hot enough for the floor to raise the applied duty to 100.
+      mockReadFile.mockImplementation(() => Promise.resolve("95000"));
+      await internals(backend).applyUserFanSpeed(20);
+      expect(writtenPercent()).toBe(100); // the floor really did fire
+
+      await backend.setFanMode("manual");
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 20 });
+    });
+
+    it("still returns to the saved mode when a profile was bound at restore time", async () => {
+      // The bound-profile skip used to latch "already restored", so on a
+      // late-driver host the saved preset was cancelled for the whole
+      // session — #265 reintroduced by the guard meant to protect it.
+      persisted = { globalMode: { kind: "preset", name: "silent" } };
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(730, "Test Game", { mode: "manual", speed: 90 });
+      await backend.handleGameLaunch(730, "Test Game");
+
+      // Driver shows up late; a profile already owns the fan.
+      await internals(backend).restoreGlobalMode();
+      expect(internals(backend).activePreset).toBeNull();
+
+      await backend.handleGameExit(730);
+      expect(internals(backend).activePreset).toBe("silent");
+      expect(internals(backend).curveInterval).toBeDefined();
+    });
+
+    it("keeps a restored manual duty across a game", async () => {
+      // The restore wrote the duty but never recorded it as the user's
+      // requested percent, so the first launch snapshotted {manual, null}
+      // and exiting left the fan on the game's duty.
+      persisted = { globalMode: { kind: "manual", percent: 60 } };
+      await internals(backend).restoreGlobalMode();
+      expect(writtenPercent()).toBe(60);
+
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(730, "Test Game", { mode: "manual", speed: 90 });
+      await backend.handleGameLaunch(730, "Test Game");
+      expect(writtenPercent()).toBe(90);
+
+      await backend.handleGameExit(730);
+      expect(writtenPercent()).toBe(60);
+    });
+
+    it("treats a restored duty as the user's own for a later Manual tap", async () => {
+      // The restore records the duty as the user's requested percent.
+      // Without that, tapping Manual after a restart persisted
+      // {manual, null} — which restores nothing on the boot after.
+      persisted = { globalMode: { kind: "manual", percent: 60 } };
+      await internals(backend).restoreGlobalMode();
+
+      await backend.setFanMode("manual");
+      expect(persisted.globalMode).toEqual({ kind: "manual", percent: 60 });
+    });
+
+    it("tapping Manual while a preset runs ends the preset, not just storage", async () => {
+      // setFanMode("manual") persisted {manual, …} but left the curve loop
+      // running and the preset flagged, so the UI kept showing Silent while
+      // storage said otherwise — and the next boot restored neither.
+      await backend.applyPreset("silent");
+      expect(internals(backend).curveInterval).toBeDefined();
+
+      await backend.setFanMode("manual");
+
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).curveInterval).toBeUndefined();
+    });
+
+    it("merges into storage rather than clobbering the other keys", async () => {
+      // persistGlobalMode uses mutatePluginStorage precisely so a concurrent
+      // custom-curve or per-game save can't be lost. A bare write would
+      // pass every other test in this block.
+      persisted = {
+        customCurve: [{ tempC: 50, percent: 20 }],
+        profiles: [{ appId: 1, gameName: "G", payload: { mode: "auto" } }],
+        perGameEnabled: true,
+      };
+      await backend.applyPreset("silent");
+
+      expect(persisted.globalMode).toEqual({ kind: "preset", name: "silent" });
+      expect(persisted.customCurve).toEqual([{ tempC: 50, percent: 20 }]);
+      expect(persisted.profiles).toHaveLength(1);
+      expect(persisted.perGameEnabled).toBe(true);
+    });
+
+    it("restores on an ectool-only host, which the hardware scanner never reports", async () => {
+      // scanHardware() returns false when ectool is the only write path, so
+      // the scanner's onFound — and the restore hanging off it — never fire.
+      persisted = { globalMode: { kind: "preset", name: "silent" } };
+      const fresh = new FanControlBackend();
+      const fi = internals(fresh);
+      fi.scanHardware = () => {
+        fi.useEctool = true;
+        fi.activeFanDevice = null;
+        return Promise.resolve(false);
+      };
+      try {
+        await fresh.onLoad();
+        expect(fi.activePreset).toBe("silent");
+      } finally {
+        clearInterval(fi.interval);
+        clearInterval(fi.curveInterval);
+        await fresh.onUnload();
+      }
+    });
+
+    it("does not revert a choice the user already made this session", async () => {
+      // The restore can land up to 30s in (late driver), with RPCs long live.
+      // It exists for a session that hasn't expressed a choice yet, so a mode
+      // the user picked in the meantime must stand.
+      persisted = { globalMode: { kind: "preset", name: "silent" } };
+      await backend.setFanMode("auto");
+
+      await internals(backend).restoreGlobalMode();
+
+      expect(internals(backend).activePreset).toBeNull();
+      expect(internals(backend).manualModeRequested).toBe("auto");
+    });
+
+    it("falls back to the mode+speed snapshot when nothing global was active", async () => {
+      // No preset, no custom curve, no manual choice — currentGlobalMode()
+      // is null, so the snapshot's mode/speed is all there is to put back.
+      // This path must behave exactly as it did before the globalMode field
+      // existed.
+      expect(internals(backend).manualModeRequested).toBeNull();
+
+      await backend.setPerGameEnabled(true);
+      await backend.setGameProfile(731, "Other Game", {
+        mode: "manual",
+        speed: 80,
+      });
+      await backend.handleGameLaunch(731, "Other Game");
+      await backend.handleGameExit(731);
+
+      expect(internals(backend).activePreset).toBeNull();
+      // Nothing global was ever chosen, so nothing was written for it.
+      expect(persisted.globalMode).toBeUndefined();
+    });
+  });
+
 });

--- a/plugins/fan-control/backend.ts
+++ b/plugins/fan-control/backend.ts
@@ -83,6 +83,10 @@ interface TempSensor {
   chipName: string;
 }
 
+/** How long the curve loop may go without completing a write before the
+ *  safety watchdog stops deferring to it. Two missed 2s ticks. */
+const CURVE_STALE_MS = 5000;
+
 const PLUGIN_ID = "fan-control";
 
 /** The bit of a profile that varies per app — see GameProfile<FanProfilePayload>. */
@@ -271,6 +275,24 @@ export default class FanControlBackend implements PluginBackend {
   private curveTickBusy = false;
 
   /**
+   * Bumped whenever the curve loop starts or stops. A tick checks its flags
+   * synchronously at *enqueue* time, then waits for the lock — by the time it
+   * runs, the mode may have been replaced and its loop stopped, but
+   * clearInterval cannot recall a tick that is already queued. It would then
+   * write the old curve's duty over the new mode's, with no loop left running
+   * to correct it. The generation it captured tells it to stand down.
+   */
+  private curveGen = 0;
+
+  /**
+   * When the curve loop last completed a write. The safety watchdog defers to
+   * the curve loop while a curve is driving — but that write now goes through
+   * the op lock, so a stalled operation would silence both. If the loop looks
+   * stalled, the watchdog stops deferring and writes itself.
+   */
+  private lastCurveWriteAt = 0;
+
+  /**
    * The user's global choice as we last knew it — read from storage at load,
    * or recorded by the last persist. Kept explicitly rather than inferred
    * from activePreset/customCurveActive/manualModeRequested, because those
@@ -281,11 +303,20 @@ export default class FanControlBackend implements PluginBackend {
    */
   private globalModeIntent: GlobalFanMode | null = null;
 
-  // Issue #265. The user's persisted global choice, restored once fan
-  // hardware is detected. The scanner latches and fires onFound at most
-  // once, so the guard is not for it: it is for the two independent
-  // callers — that onFound, and the ectool path in onLoad.
-  private restoredGlobalMode = false;
+  /**
+   * Which write path the saved mode has been applied to. Not a boolean:
+   * ectool is the fallback used when no hwmon control exists *yet*, and on a
+   * host with a late-loading driver the scanner finds one 30s later. A latch
+   * would mean that device — the one that ends up owning the fan — never
+   * receives the saved mode, and for manual/auto there is no periodic writer
+   * to correct it. So an ectool restore is provisional: a hwmon device
+   * appearing afterwards gets its own.
+   */
+  private restoredVia: "none" | "ectool" | "hwmon" = "none";
+
+  /** Whether the user has expressed a choice this session, as opposed to one
+   *  we restored. A user choice always wins over the stored value. */
+  private userChoseThisSession = false;
 
   // Per-game state. The engine owns the {profiles, perGameEnabled, snapshot,
   // boundAppId} state machine — we just wire in the apply/snapshot/restore
@@ -526,6 +557,7 @@ export default class FanControlBackend implements PluginBackend {
    */
   private async persistGlobalMode(mode: GlobalFanMode): Promise<void> {
     this.globalModeIntent = mode;
+    this.userChoseThisSession = true;
     try {
       await mutatePluginStorage<Record<string, unknown>>(PLUGIN_ID, (existing) => ({
         ...existing,
@@ -551,21 +583,23 @@ export default class FanControlBackend implements PluginBackend {
   }
 
   private async restoreGlobalModeLocked(): Promise<void> {
-    if (this.restoredGlobalMode) return;
-    // Set before the first await: two callers (the hardware scanner's
-    // onFound and the ectool path in onLoad) can both reach here.
-    this.restoredGlobalMode = true;
+    // A choice the user made this session always wins over the stored one:
+    // the restore exists for a session that hasn't expressed one yet. (No
+    // RPC can land during the await below — every writer of globalModeIntent
+    // runs under this same lock — so this is read once, up front.)
+    if (this.userChoseThisSession) return;
 
-    // A choice the user already made this session wins over the stored one:
-    // the restore exists for a session that hasn't expressed one yet. Read
-    // before the storage read is applied, since that await is a window in
-    // which an RPC can land.
-    const chosenAlready = this.globalModeIntent !== null;
+    const via: "ectool" | "hwmon" =
+      this.activeFanDevice?.hasPwmControl || this.activeFanDevice?.hasRpmTargetControl
+        ? "hwmon"
+        : "ectool";
+    // hwmon is final; a second ectool pass has nothing new to say.
+    if (this.restoredVia === "hwmon" || this.restoredVia === via) return;
+    this.restoredVia = via;
 
     const stored = await readPluginStorage<{ globalMode?: unknown }>(PLUGIN_ID);
     const mode = sanitiseGlobalMode(stored.globalMode);
     if (!mode) return;
-    if (chosenAlready || this.globalModeIntent !== null) return;
 
     // Record the intent before any decision not to apply it now. Skipping
     // the apply must not lose the choice: it is what a per-game profile
@@ -1210,6 +1244,8 @@ export default class FanControlBackend implements PluginBackend {
   /** Starts the curve evaluation loop (every 2 seconds). */
   private startCurveLoop(curve: FanCurvePoint[]): void {
     this.stopCurveLoop();
+    const gen = ++this.curveGen;
+    this.lastCurveWriteAt = Date.now();
     this.curveInterval = setInterval(() => {
       // Synchronous bail first: by the time a queued tick runs, the mode may
       // have changed and this curve is no longer the one driving the fan.
@@ -1217,14 +1253,25 @@ export default class FanControlBackend implements PluginBackend {
       // Ticks slower than the interval skip rather than pile up.
       if (this.curveTickBusy) return;
       this.curveTickBusy = true;
-      void this._serialize(() => this.applyCurve(curve)).finally(() => {
+      void this._serialize(() => this.runCurveTick(gen, curve)).finally(() => {
         this.curveTickBusy = false;
       });
     }, 2000);
   }
 
   /** Stops the curve evaluation loop. */
+  /** One curve tick. Runs under the op lock, so `gen` is re-checked here
+   *  rather than at enqueue time — see {@link curveGen}. */
+  private async runCurveTick(gen: number, curve: FanCurvePoint[]): Promise<void> {
+    if (gen !== this.curveGen) return;
+    await this.applyCurve(curve);
+    this.lastCurveWriteAt = Date.now();
+  }
+
   private stopCurveLoop(): void {
+    // Bumped even when no interval is armed: a tick queued by a previous loop
+    // may still be waiting on the lock, and this is what tells it to stand down.
+    this.curveGen++;
     if (this.curveInterval) {
       clearInterval(this.curveInterval);
       this.curveInterval = undefined;
@@ -1393,7 +1440,18 @@ export default class FanControlBackend implements PluginBackend {
     // flag engaged and let the curve loop do the write. (customCurveActive
     // matters because applyCustomCurve sets activePreset=null while still
     // running startCurveLoop.)
-    if (this.activePreset !== null || this.customCurveActive) return;
+    //
+    // Only while the loop is demonstrably still writing, though. Its write
+    // goes through the op lock, so a stalled operation — a `tee` blocked on a
+    // wedged EC, `systemctl stop` waiting out a unit timeout — silences it,
+    // and deferring unconditionally would silence the safety floor with it.
+    // This watchdog is deliberately outside the lock; that is worth nothing
+    // if it hands its job to something that is inside.
+    const curveWriting =
+      Date.now() - this.lastCurveWriteAt < CURVE_STALE_MS;
+    if ((this.activePreset !== null || this.customCurveActive) && curveWriting) {
+      return;
+    }
 
     // Manual mode (or pure-auto with no user intent): the watchdog is
     // the only periodic writer, so it owns the write here. Pass the

--- a/plugins/fan-control/backend.ts
+++ b/plugins/fan-control/backend.ts
@@ -83,9 +83,24 @@ interface TempSensor {
   chipName: string;
 }
 
-/** How long the curve loop may go without completing a write before the
- *  safety watchdog stops deferring to it. Two missed 2s ticks. */
+/**
+ * How long the curve loop may go without completing a write before the safety
+ * watchdog stops deferring to it and writes itself.
+ *
+ * Ticks that overrun skip rather than queue (see `curveTickBusy`), so the gap
+ * between completed writes quantises to 4s, 6s, 8s… — this trips on the first
+ * gap of 6s, i.e. one tick that ran long enough to miss the next two.
+ *
+ * The backstop, not the fix: a write that hangs is bounded by
+ * WRITE_TIMEOUT_MS, so the loop recovers on its own. This covers a loop that
+ * is merely slow, at the cost of the watchdog briefly writing the same node —
+ * a fan that flaps beats a fan that stops at 85 °C.
+ */
 const CURVE_STALE_MS = 5000;
+
+/** Ceiling on a single sysfs fan write. Generous — these normally take
+ *  microseconds; this is only to stop a wedged EC holding the lock forever. */
+const WRITE_TIMEOUT_MS = 5000;
 
 const PLUGIN_ID = "fan-control";
 
@@ -155,9 +170,10 @@ interface FanInfoResult {
    */
   reportsDuty: boolean;
   /**
-   * The duty we last *told* the fan to run at, as a percent — including a
-   * per-game profile's and the safety floor's writes, since those are as
-   * real as the user's. Null before anything has been commanded.
+   * The duty we last *told* the fan to run at, as a percent — including the
+   * curve loop's, a per-game profile's and the safety floor's writes, since
+   * those are as real as the user's. Null before anything has been
+   * commanded, and cleared when the fan is handed back to auto.
    */
   commandedPercent: number | null;
 }
@@ -240,6 +256,16 @@ export default class FanControlBackend implements PluginBackend {
   // — without it the release silently drops the user from Manual at X%
   // back to Auto.
   private lastUserSpeedPwm: number | null = null;
+
+  /**
+   * The duty last written to the fan by *anyone* — the user, the curve loop,
+   * a per-game profile, the safety floor. Distinct from lastUserSpeedPwm,
+   * which the watchdog reads as "what the user asked for" and
+   * restoreOriginalModes rewrites; reusing that one would have both meanings
+   * fighting over one field. This is what hardware that can't report its own
+   * duty shows in the UI.
+   */
+  private lastCommandedPwm: number | null = null;
   // Paths we've already warned about for missing pwm_enable. Without
   // this the watchdog tick spams the journal every 2 s on the rare
   // legacy hwmon driver that exposes pwm but not pwm_enable.
@@ -439,8 +465,18 @@ export default class FanControlBackend implements PluginBackend {
 
   async onUnload(): Promise<void> {
     clearInterval(this.interval);
-    clearInterval(this.curveInterval);
+    // stopCurveLoop, not a bare clearInterval: a tick already queued on the
+    // op lock survives clearInterval, and would otherwise pass its generation
+    // check and write pwm_enable=1 plus a duty *after* restoreOriginalModes
+    // had handed the fan back — leaving it pinned in manual with no loop.
+    this.stopCurveLoop();
+    this.activePreset = null;
+    this.customCurveActive = false;
     this.hardwareScanner?.stop();
+
+    // Drain: anything mid-flight finishes before we restore, so the teardown
+    // is the last writer rather than racing one.
+    await this._serialize(async () => {});
 
     // Safety: restore auto mode on unload
     await this.restoreOriginalModes();
@@ -583,12 +619,6 @@ export default class FanControlBackend implements PluginBackend {
   }
 
   private async restoreGlobalModeLocked(): Promise<void> {
-    // A choice the user made this session always wins over the stored one:
-    // the restore exists for a session that hasn't expressed one yet. (No
-    // RPC can land during the await below — every writer of globalModeIntent
-    // runs under this same lock — so this is read once, up front.)
-    if (this.userChoseThisSession) return;
-
     const via: "ectool" | "hwmon" =
       this.activeFanDevice?.hasPwmControl || this.activeFanDevice?.hasRpmTargetControl
         ? "hwmon"
@@ -597,14 +627,21 @@ export default class FanControlBackend implements PluginBackend {
     if (this.restoredVia === "hwmon" || this.restoredVia === via) return;
     this.restoredVia = via;
 
-    const stored = await readPluginStorage<{ globalMode?: unknown }>(PLUGIN_ID);
-    const mode = sanitiseGlobalMode(stored.globalMode);
+    // A choice the user made this session outranks the stored one — but it
+    // still has to be applied to a device that appeared afterwards. Bailing
+    // outright here re-opened the very hole this method's tri-state closes:
+    // the user taps Manual during the ectool window, the hwmon driver loads
+    // 30s later, and nothing ever writes their duty to the device that ends
+    // up owning the fan.
+    let mode: GlobalFanMode | null;
+    if (this.userChoseThisSession) {
+      mode = this.globalModeIntent;
+    } else {
+      const stored = await readPluginStorage<{ globalMode?: unknown }>(PLUGIN_ID);
+      mode = sanitiseGlobalMode(stored.globalMode);
+      if (mode) this.globalModeIntent = mode;
+    }
     if (!mode) return;
-
-    // Record the intent before any decision not to apply it now. Skipping
-    // the apply must not lose the choice: it is what a per-game profile
-    // hands back to when its game exits.
-    this.globalModeIntent = mode;
 
     // A game whose profile is already bound owns the fan. Restoring over it
     // would hand the fan back to the global curve mid-game; the intent
@@ -797,7 +834,7 @@ export default class FanControlBackend implements PluginBackend {
   /** The duty last written to the fan, as a percent — the only duty figure
    *  available on hardware that can't report its own. */
   private commandedPercent(): number | null {
-    return this.lastUserSpeedPwm === null ? null : pwmToPercent(this.lastUserSpeedPwm);
+    return this.lastCommandedPwm === null ? null : pwmToPercent(this.lastCommandedPwm);
   }
 
   /** Returns all detected temperature sensors with current readings. */
@@ -854,6 +891,9 @@ export default class FanControlBackend implements PluginBackend {
     // Setting a specific speed implies manual mode.
     this.manualModeRequested = "manual";
     this.lastUserSpeedPwm = pwmValue;
+    // Also the last commanded duty — this path writes the fan directly
+    // rather than going through setFanSpeedInternal.
+    this.lastCommandedPwm = pwmValue;
 
     // RPM-target path (steamdeck_hwmon): stop Valve's jupiter-fan-control
     // daemon first so our write isn't overwritten by its PID loop within
@@ -946,6 +986,9 @@ export default class FanControlBackend implements PluginBackend {
     this.activePreset = null;
     this.customCurveActive = false;
     this.manualModeRequested = mode;
+    // In auto the EC owns the duty; a stale figure here would have the UI
+    // showing a fabricated value for a fan we are no longer driving.
+    if (mode === "auto") this.lastCommandedPwm = null;
 
     // RPM-target path: no pwm_enable to flip — "manual" means we own
     // fan1_target, "auto" means hand it back to Valve's daemon.
@@ -1407,7 +1450,18 @@ export default class FanControlBackend implements PluginBackend {
    * to manual before writing pwm.
    */
   private async safetyWatchdogTick(): Promise<void> {
-    if (!this.activeFanDevice?.hasPwmControl && !this.useEctool) return;
+    // RPM-target hardware (steamdeck_hwmon) is covered too: persisting a
+    // manual mode means the fan can now come up unattended at boot with
+    // jupiter-fan-control stopped, where before this plugin only held manual
+    // while the user was in the UI. setFanSpeedInternal already routes to
+    // setFanSpeedViaRpmTarget, so the floor reaches that hardware unchanged.
+    if (
+      !this.activeFanDevice?.hasPwmControl &&
+      !this.activeFanDevice?.hasRpmTargetControl &&
+      !this.useEctool
+    ) {
+      return;
+    }
 
     const tempC = await this.getCpuTempCOrNull();
     if (tempC === null) {
@@ -1582,6 +1636,8 @@ export default class FanControlBackend implements PluginBackend {
    * mode or running a preset curve.
    */
   private async setFanSpeedInternal(percent: number): Promise<{ success: boolean; error?: string }> {
+    // Recorded for every writer, not just the user's — see lastCommandedPwm.
+    this.lastCommandedPwm = percentToPwm(clampPercent(percent));
     const clamped = clampPercent(percent);
     const pwmValue = percentToPwm(clamped);
 
@@ -1817,8 +1873,13 @@ export default class FanControlBackend implements PluginBackend {
   /** Writes a value to a hwmon sysfs file via tee. The backend runs as
    *  root (system service), so no sudo/pkexec is needed. */
   private async writeHwmon(path: string, value: string): Promise<void> {
+    // Bounded: a sysfs write to a wedged EC can block in the kernel, and this
+    // runs under the op lock — an unbounded one would stall every fan
+    // operation behind it for the life of the process, including the curve
+    // loop the safety watchdog defers to.
     const { stderr, exitCode } = await runFull(["tee", path], {
       stdin: value,
+      timeoutMs: WRITE_TIMEOUT_MS,
     });
     if (exitCode !== 0) {
       throw new Error(`Failed to write "${value}" to ${path}: ${stderr.trim()}`);

--- a/plugins/fan-control/backend.ts
+++ b/plugins/fan-control/backend.ts
@@ -23,6 +23,7 @@ import {
   type PresetName,
 } from "./lib/fan-curves";
 import { DEFAULT_CUSTOM_CURVE, sanitiseCurve } from "./lib/custom-curve";
+import { sanitiseGlobalMode, type GlobalFanMode } from "./lib/global-mode";
 import { readPluginStorage, mutatePluginStorage } from "@loadout/plugin-storage";
 import {
   classifyTempZone,
@@ -232,6 +233,47 @@ export default class FanControlBackend implements PluginBackend {
   // stay hidden.
   private manualModeRequested: "auto" | "manual" | null = null;
 
+  /**
+   * Tail of the fan-operation queue. Everything that expresses a fan intent
+   * runs its critical section through {@link _serialize}, so no two can
+   * interleave.
+   *
+   * They otherwise do: `handleGameLaunch`/`handleGameExit` are fire-and-forget
+   * chains from the injector's fan-out, RPC calls aren't serialized per
+   * plugin, and each intent awaits several `tee` spawns. On device that let a
+   * game *switch* interleave the exit-restore with the next profile's apply —
+   * the restore's `startCurveLoop` landing after the profile had stopped it,
+   * so the curve drove the fan while the profile was supposed to own it.
+   *
+   * The rule: **public entry points serialize, private methods assume the
+   * lock is held.** An internal caller that goes through a public method
+   * instead deadlocks on re-entry.
+   *
+   * Same pattern (and reasoning) as plugins/disable-controller-input.
+   */
+  private opLock: Promise<void> = Promise.resolve();
+
+  /** True while the curve tick is running, so ticks slower than the 2s
+   *  interval skip rather than queue up behind each other. */
+  private curveTickBusy = false;
+
+  /**
+   * The user's global choice as we last knew it — read from storage at load,
+   * or recorded by the last persist. Kept explicitly rather than inferred
+   * from activePreset/customCurveActive/manualModeRequested, because those
+   * describe *what is driving the fan right now*, which is a different
+   * question: during an apply they still describe the previous mode, and
+   * while a per-game profile is bound they describe the game's setting.
+   * Inferring from them made the per-game snapshot capture the wrong mode.
+   */
+  private globalModeIntent: GlobalFanMode | null = null;
+
+  // Issue #265. The user's persisted global choice, restored once fan
+  // hardware is detected. The scanner latches and fires onFound at most
+  // once, so the guard is not for it: it is for the two independent
+  // callers — that onFound, and the ectool path in onLoad.
+  private restoredGlobalMode = false;
+
   // Per-game state. The engine owns the {profiles, perGameEnabled, snapshot,
   // boundAppId} state machine — we just wire in the apply/snapshot/restore
   // operations and delegate the RPC surface.
@@ -245,10 +287,13 @@ export default class FanControlBackend implements PluginBackend {
     guard: () => Boolean(this.activeFanDevice?.hasPwmControl) || this.useEctool,
     onSnapshot: () => this.captureModeSnapshot(),
     onApply: async (payload, ctx) => {
+      // The private, unlocked forms: this is the *game's* profile, not the
+      // user's choice, so nothing is recorded — and the public methods would
+      // deadlock, since handleGameLaunch already holds the lock.
       if (payload.mode === "manual" && typeof payload.speed === "number") {
-        await this.setFanSpeed(payload.speed);
+        await this.applyUserFanSpeed(payload.speed);
       } else {
-        await this.setFanMode(payload.mode);
+        await this.applyUserFanMode(payload.mode);
       }
       console.log(
         `[fan-control] Applied per-game profile for ${ctx.gameName || `App ${ctx.appId}`}: ${payload.mode}` +
@@ -258,10 +303,19 @@ export default class FanControlBackend implements PluginBackend {
       );
     },
     onRestore: async (snap) => {
+      // Re-apply the user's *current* global choice, not a copy taken at
+      // launch: a preset or custom curve has to come back as a running curve,
+      // which a mode+speed snapshot can't express — and reading the live
+      // intent means a mode changed mid-game survives the game exiting.
+      // Not a user choice, so nothing is written to storage.
+      if (this.globalModeIntent) {
+        await this.applyGlobalMode(this.globalModeIntent);
+        return;
+      }
       if (snap.mode === "manual" && typeof snap.speed === "number") {
-        await this.setFanSpeed(snap.speed);
+        await this.applyUserFanSpeed(snap.speed);
       } else {
-        await this.setFanMode("auto");
+        await this.applyUserFanMode("auto");
       }
     },
   });
@@ -302,10 +356,20 @@ export default class FanControlBackend implements PluginBackend {
       scan: () => this.scanHardware(),
       intervalMs: 30_000,
       onFound: async () => {
+        // Restore before the first emit so the UI's opening state already
+        // reflects the saved mode rather than the driver's power-on default.
+        await this.restoreGlobalMode();
         this.emit?.({ event: "fan-update", data: await this.getFanInfo() });
       },
     });
     await this.hardwareScanner.start();
+
+    // scanHardware() reports "found" only for a hwmon PWM or RPM-target
+    // device — deliberately not for ectool (see its comment). So on a host
+    // where ectool is the only write path, onFound never fires and the
+    // restore above never runs, while every user choice still persists.
+    // restoreGlobalMode's own guard makes the double call a no-op.
+    if (this.useEctool) await this.restoreGlobalMode();
 
     // Emit fan status updates every 2 seconds. Also runs the safety
     // watchdog on the same cadence — independent of the curve loop and
@@ -439,6 +503,144 @@ export default class FanControlBackend implements PluginBackend {
   }
 
   /** Returns comprehensive fan status. */
+  /**
+   * Record the user's global choice. Best-effort: a storage failure must not
+   * fail the fan operation the user actually asked for, so it logs and
+   * continues. mutatePluginStorage is used (not a bare write) so a concurrent
+   * custom-curve save into the same file can't lost-update it.
+   */
+  private async persistGlobalMode(mode: GlobalFanMode): Promise<void> {
+    this.globalModeIntent = mode;
+    try {
+      await mutatePluginStorage<Record<string, unknown>>(PLUGIN_ID, (existing) => ({
+        ...existing,
+        globalMode: mode,
+      }));
+    } catch (err) {
+      console.error("[fan-control] Failed to persist fan mode:", err);
+    }
+  }
+
+  /**
+   * Re-apply the persisted global choice. Called from the hardware
+   * scanner's onFound, not from onLoad directly: a preset means writing
+   * PWM, and on hosts where the driver module (oxpec and friends) lands
+   * after our service starts there is nothing to write to yet.
+   *
+   * Deliberately does nothing when no mode was saved — an install that has
+   * never chosen one keeps the pre-#265 behaviour of leaving the fans to
+   * whatever the firmware set.
+   */
+  private async restoreGlobalMode(): Promise<void> {
+    return this._serialize(() => this.restoreGlobalModeLocked());
+  }
+
+  private async restoreGlobalModeLocked(): Promise<void> {
+    if (this.restoredGlobalMode) return;
+    // Set before the first await: two callers (the hardware scanner's
+    // onFound and the ectool path in onLoad) can both reach here.
+    this.restoredGlobalMode = true;
+
+    // A choice the user already made this session wins over the stored one:
+    // the restore exists for a session that hasn't expressed one yet. Read
+    // before the storage read is applied, since that await is a window in
+    // which an RPC can land.
+    const chosenAlready = this.globalModeIntent !== null;
+
+    const stored = await readPluginStorage<{ globalMode?: unknown }>(PLUGIN_ID);
+    const mode = sanitiseGlobalMode(stored.globalMode);
+    if (!mode) return;
+    if (chosenAlready || this.globalModeIntent !== null) return;
+
+    // Record the intent before any decision not to apply it now. Skipping
+    // the apply must not lose the choice: it is what a per-game profile
+    // hands back to when its game exits.
+    this.globalModeIntent = mode;
+
+    // A game whose profile is already bound owns the fan. Restoring over it
+    // would hand the fan back to the global curve mid-game; the intent
+    // recorded above is what puts the user back on it at exit.
+    if (this.profileEngine.getActiveAppId() !== null) {
+      console.log(
+        "[fan-control] Deferring saved-mode restore — a per-game profile is active",
+      );
+      return;
+    }
+
+    if (mode.kind === "manual" && mode.percent === null) {
+      // "Manual" with no duty. Asserting it would stop Valve's
+      // jupiter-fan-control on the RPM-target path without writing a target
+      // to replace it — and that hardware has no safety watchdog either
+      // (see safetyWatchdogTick's guard), so nothing would own the fan.
+      // There is no duty worth restoring, so leave the firmware's default.
+      console.log(
+        "[fan-control] Saved mode is manual with no speed — leaving the fan as the firmware set it",
+      );
+      return;
+    }
+
+    await this.applyGlobalMode(mode);
+  }
+
+  /**
+   * Re-assert a global mode without recording it — shared by the on-load
+   * restore and by the per-game engine's onRestore when a game exits.
+   *
+   * Records nothing: neither caller is a fresh user choice, and writing here
+   * would let a game exit overwrite what the user picked. Assumes the op
+   * lock is held.
+   */
+  private async applyGlobalMode(mode: GlobalFanMode): Promise<void> {
+    try {
+      switch (mode.kind) {
+        case "preset":
+          console.log(`[fan-control] Restoring saved preset: ${mode.name}`);
+          await this.applyPresetLocked(mode.name);
+          break;
+        case "custom":
+          console.log("[fan-control] Restoring saved custom curve");
+          await this.applyCustomCurveLocked();
+          break;
+        case "manual":
+          console.log(
+            `[fan-control] Restoring manual mode${mode.percent !== null ? ` at ${mode.percent}%` : ""}`,
+          );
+          if (mode.percent !== null) {
+            await this.applyUserFanSpeed(mode.percent);
+          } else {
+            await this.applyUserFanMode("manual");
+          }
+          break;
+        case "auto":
+          console.log("[fan-control] Restoring auto mode");
+          await this.applyUserFanMode("auto");
+          break;
+      }
+    } catch (err) {
+      console.error("[fan-control] Failed to apply fan mode:", err);
+    }
+  }
+
+  /**
+   * Run `fn` as the sole holder of the fan-operation lock. The next caller
+   * waits on the promise we publish to `opLock`. We swap `opLock` before
+   * awaiting the previous tail so the queue chains correctly even if several
+   * callers arrive synchronously.
+   */
+  private async _serialize<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = this.opLock;
+    let release: () => void = () => {};
+    this.opLock = new Promise<void>((r) => (release = r));
+    await prev;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  /** The global mode implied by current in-memory state, for snapshotting
+   *  before a per-game profile takes over. */
   async getFanInfo(): Promise<FanInfoResult> {
     if (!this.activeFanDevice && !this.useEctool) {
       return this.unavailableFanInfo();
@@ -557,7 +759,28 @@ export default class FanControlBackend implements PluginBackend {
   }
 
   /** Sets fan speed as a percentage (0-100). Enforces safety limits. */
+  /**
+   * Set a manual fan duty. `persist` is false for writes we make on the
+   * user's behalf (per-game profiles, restoring a saved mode) so they can't
+   * be mistaken for a new global choice — see {@link persistGlobalMode}.
+   */
   async setFanSpeed(percent: number): Promise<{ success: boolean; error?: string }> {
+    return this._serialize(async () => {
+      // The *requested* percent, not the safety-floor-raised one applied in
+      // applyUserFanSpeed: baking a hot-moment override into the saved
+      // preference would have the user come back to fans they never asked for.
+      await this.persistGlobalMode({
+        kind: "manual",
+        percent: clampPercent(percent),
+      });
+      return this.applyUserFanSpeed(percent);
+    });
+  }
+
+  /** The user-facing write: safety floor, curve-loop teardown, mode flip.
+   *  Distinct from setFanSpeedInternal below, which is the bare duty write
+   *  the safety watchdog and curve loop use. */
+  private async applyUserFanSpeed(percent: number): Promise<{ success: boolean; error?: string }> {
     // Safety override (issue #97): user's value first, then the floor
     // can only RAISE it. Fails safe to 100% on any temp-read error.
     const safePercent = await this.applySafetyFloor(percent);
@@ -628,13 +851,40 @@ export default class FanControlBackend implements PluginBackend {
     }
   }
 
-  /** Sets fan mode: "auto" (kernel-controlled) or "manual" (user-controlled). */
+  /** Sets fan mode: "auto" (kernel-controlled) or "manual" (user-controlled).
+   *  See {@link setFanSpeed} for what `persist` is doing here. */
   async setFanMode(mode: "auto" | "manual"): Promise<{ success: boolean; error?: string }> {
-    if (mode === "auto") {
-      this.stopCurveLoop();
-      this.activePreset = null;
-      this.customCurveActive = false;
-    }
+    return this._serialize(async () => {
+      await this.persistGlobalMode(
+        mode === "auto"
+          ? { kind: "auto" }
+          : {
+              kind: "manual",
+              // Flipping to manual without naming a speed carries the duty
+              // the *user* last asked for. Read from the recorded intent,
+              // never from what was last written to hardware — that includes
+              // a per-game profile's duty and the safety floor.
+              percent:
+                this.globalModeIntent?.kind === "manual"
+                  ? this.globalModeIntent.percent
+                  : null,
+            },
+      );
+      return this.applyUserFanMode(mode);
+    });
+  }
+
+  private async applyUserFanMode(
+    mode: "auto" | "manual",
+  ): Promise<{ success: boolean; error?: string }> {
+    // Both directions end curve control: "auto" hands the fan to the
+    // kernel/EC, "manual" hands it to the user's own duty. Leaving the loop
+    // running under "manual" meant tapping Manual while a preset was active
+    // rewrote storage to {manual, ...} while the preset kept driving the fan
+    // and the UI kept showing it selected.
+    this.stopCurveLoop();
+    this.activePreset = null;
+    this.customCurveActive = false;
     this.manualModeRequested = mode;
 
     // RPM-target path: no pwm_enable to flip — "manual" means we own
@@ -680,24 +930,39 @@ export default class FanControlBackend implements PluginBackend {
   }
 
   /** Applies a fan curve preset. Starts a loop that adjusts speed based on temperature. */
-  async applyPreset(
+  async applyPreset(name: PresetName): Promise<{ success: boolean; error?: string }> {
+    if (!FAN_CURVES[name]) {
+      return { success: false, error: `Unknown preset: ${name}` };
+    }
+    return this._serialize(async () => {
+      // Persist before applying: the record is of what the user chose, which
+      // stands whether or not the hardware write then succeeds.
+      await this.persistGlobalMode({ kind: "preset", name });
+      return this.applyPresetLocked(name);
+    });
+  }
+
+  /** Apply a preset without recording it. Assumes the op lock is held. */
+  private async applyPresetLocked(
     name: PresetName,
   ): Promise<{ success: boolean; error?: string }> {
     const curve = FAN_CURVES[name];
-    if (!curve) {
-      return { success: false, error: `Unknown preset: ${name}` };
-    }
-
-    this.activePreset = name;
-    this.customCurveActive = false;
+    if (!curve) return { success: false, error: `Unknown preset: ${name}` };
     console.log(`[fan-control] Applying preset: ${name}`);
 
     // Set to manual mode first
     const modeResult = await this.setFanModeInternal("manual");
     if (!modeResult.success) return modeResult;
 
-    // Apply curve immediately, then start a loop
     await this.applyCurve(curve);
+
+    // Flags and the loop are set together, in one synchronous block with no
+    // await between them. The safety watchdog skips its own write whenever
+    // either flag is set, on the understanding that the curve loop owns the
+    // fan — and it runs on a timer outside this lock, so a flag set with no
+    // loop running would mute the safety floor entirely.
+    this.activePreset = name;
+    this.customCurveActive = false;
     this.startCurveLoop(curve);
 
     return { success: true };
@@ -719,6 +984,12 @@ export default class FanControlBackend implements PluginBackend {
    * mode, the curve loop is restarted so edits take effect immediately.
    */
   async setCustomCurve(
+    points: unknown,
+  ): Promise<{ success: boolean; error?: string; curve: FanCurvePoint[] }> {
+    return this._serialize(() => this.setCustomCurveLocked(points));
+  }
+
+  private async setCustomCurveLocked(
     points: unknown,
   ): Promise<{ success: boolean; error?: string; curve: FanCurvePoint[] }> {
     const curve = sanitiseCurve(points);
@@ -748,18 +1019,25 @@ export default class FanControlBackend implements PluginBackend {
    * applyPreset — switch to manual, apply once, then run the curve loop.
    */
   async applyCustomCurve(): Promise<{ success: boolean; error?: string }> {
+    return this._serialize(async () => {
+      await this.persistGlobalMode({ kind: "custom" });
+      return this.applyCustomCurveLocked();
+    });
+  }
+
+  /** Apply the saved custom curve without recording it. Lock must be held. */
+  private async applyCustomCurveLocked(): Promise<{ success: boolean; error?: string }> {
     const curve = this.customCurve;
-    this.activePreset = null;
-    this.customCurveActive = true;
     console.log("[fan-control] Applying custom fan curve");
 
     const modeResult = await this.setFanModeInternal("manual");
-    if (!modeResult.success) {
-      this.customCurveActive = false;
-      return modeResult;
-    }
+    if (!modeResult.success) return modeResult;
 
     await this.applyCurve(curve);
+
+    // Same commit ordering as applyPresetLocked, for the same reason.
+    this.activePreset = null;
+    this.customCurveActive = true;
     this.startCurveLoop(curve);
 
     return { success: true };
@@ -906,7 +1184,17 @@ export default class FanControlBackend implements PluginBackend {
   /** Starts the curve evaluation loop (every 2 seconds). */
   private startCurveLoop(curve: FanCurvePoint[]): void {
     this.stopCurveLoop();
-    this.curveInterval = setInterval(() => this.applyCurve(curve), 2000);
+    this.curveInterval = setInterval(() => {
+      // Synchronous bail first: by the time a queued tick runs, the mode may
+      // have changed and this curve is no longer the one driving the fan.
+      if (!this.activePreset && !this.customCurveActive) return;
+      // Ticks slower than the interval skip rather than pile up.
+      if (this.curveTickBusy) return;
+      this.curveTickBusy = true;
+      void this._serialize(() => this.applyCurve(curve)).finally(() => {
+        this.curveTickBusy = false;
+      });
+    }, 2000);
   }
 
   /** Stops the curve evaluation loop. */
@@ -1517,12 +1805,16 @@ export default class FanControlBackend implements PluginBackend {
   // Game lifecycle — invoked by the loader's __broadcast fan-out from the
   // injector. Delegates to the engine; the apply/snapshot/restore wiring
   // is on the engine instance (see private profileEngine above).
+  // Serialized here rather than inside PerGameEngine so the engine's
+  // snapshot-then-apply is atomic against a user tap, and so a game *switch*
+  // (exit of one, launch of the next — independent fire-and-forget chains
+  // from the injector) can't interleave.
   async handleGameLaunch(appId: number, gameName: string): Promise<void> {
-    await this.profileEngine.handleGameLaunch(appId, gameName);
+    await this._serialize(() => this.profileEngine.handleGameLaunch(appId, gameName));
   }
 
   async handleGameExit(appId: number): Promise<void> {
-    await this.profileEngine.handleGameExit(appId);
+    await this._serialize(() => this.profileEngine.handleGameExit(appId));
   }
 
   private async captureModeSnapshot(): Promise<FanModeSnapshot> {

--- a/plugins/fan-control/backend.ts
+++ b/plugins/fan-control/backend.ts
@@ -143,6 +143,19 @@ interface FanInfoResult {
    *  Sticky: stays true through the WARM_C → release-hysteresis band so
    *  the UI banner doesn't flicker as temp wobbles around 75 °C. */
   safetyEngaged: boolean;
+  /**
+   * Whether `fans[].percent` is a real reading. False on hardware that has
+   * no PWM to read back — ectool, and the Deck's RPM-target path, where the
+   * field is hard 0. A UI showing duty must use {@link commandedPercent}
+   * there instead, or it reads out 0% while the fan is plainly spinning.
+   */
+  reportsDuty: boolean;
+  /**
+   * The duty we last *told* the fan to run at, as a percent — including a
+   * per-game profile's and the safety floor's writes, since those are as
+   * real as the user's. Null before anything has been commanded.
+   */
+  commandedPercent: number | null;
 }
 
 interface TempResult {
@@ -497,6 +510,8 @@ export default class FanControlBackend implements PluginBackend {
       activePreset: this.activePreset,
       customCurveActive: this.customCurveActive,
       usingEctool: false,
+      reportsDuty: false,
+      commandedPercent: null,
       warning: null,
       safetyEngaged: false,
     };
@@ -639,8 +654,6 @@ export default class FanControlBackend implements PluginBackend {
     }
   }
 
-  /** The global mode implied by current in-memory state, for snapshotting
-   *  before a per-game profile takes over. */
   async getFanInfo(): Promise<FanInfoResult> {
     if (!this.activeFanDevice && !this.useEctool) {
       return this.unavailableFanInfo();
@@ -681,6 +694,9 @@ export default class FanControlBackend implements PluginBackend {
         activePreset: this.activePreset,
         customCurveActive: this.customCurveActive,
         usingEctool: true,
+        // ectool gives us RPM only; percent above is a placeholder.
+        reportsDuty: false,
+        commandedPercent: this.commandedPercent(),
         warning,
         safetyEngaged: this.safetyEngaged,
       };
@@ -735,9 +751,19 @@ export default class FanControlBackend implements PluginBackend {
       activePreset: this.activePreset,
       customCurveActive: this.customCurveActive,
       usingEctool: false,
+      // Only a device with a pwm path reads its duty back; an RPM-target
+      // device (steamdeck_hwmon) leaves percent at 0.
+      reportsDuty: device.hasPwmControl === true,
+      commandedPercent: this.commandedPercent(),
       warning,
       safetyEngaged: this.safetyEngaged,
     };
+  }
+
+  /** The duty last written to the fan, as a percent — the only duty figure
+   *  available on hardware that can't report its own. */
+  private commandedPercent(): number | null {
+    return this.lastUserSpeedPwm === null ? null : pwmToPercent(this.lastUserSpeedPwm);
   }
 
   /** Returns all detected temperature sensors with current readings. */

--- a/plugins/fan-control/lib/global-mode.test.ts
+++ b/plugins/fan-control/lib/global-mode.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "bun:test";
+import { sanitiseGlobalMode } from "./global-mode";
+import { FAN_CURVES } from "./fan-curves";
+
+describe("sanitiseGlobalMode", () => {
+  it("accepts every preset the curve table defines", () => {
+    // Derived, not hand-listed: PRESET_NAMES used to be a copy of these
+    // keys, so adding a fourth preset silently made it non-restorable —
+    // rejected here before applyPreset ever saw it.
+    for (const name of Object.keys(FAN_CURVES)) {
+      expect(sanitiseGlobalMode({ kind: "preset", name })).toEqual({
+        kind: "preset",
+        name: name as never,
+      });
+    }
+  });
+
+  it("round-trips each mode the backend persists", () => {
+    expect(sanitiseGlobalMode({ kind: "preset", name: "silent" })).toEqual({
+      kind: "preset",
+      name: "silent",
+    });
+    expect(sanitiseGlobalMode({ kind: "custom" })).toEqual({ kind: "custom" });
+    expect(sanitiseGlobalMode({ kind: "auto" })).toEqual({ kind: "auto" });
+    expect(sanitiseGlobalMode({ kind: "manual", percent: 42 })).toEqual({
+      kind: "manual",
+      percent: 42,
+    });
+  });
+
+  it("rejects an unknown preset name rather than restoring a bogus curve", () => {
+    expect(sanitiseGlobalMode({ kind: "preset", name: "turbo" })).toBeNull();
+    expect(sanitiseGlobalMode({ kind: "preset" })).toBeNull();
+    expect(sanitiseGlobalMode({ kind: "preset", name: 3 })).toBeNull();
+  });
+
+  it("keeps manual intent when the percent is missing or unusable", () => {
+    // The auto-vs-manual choice still stands even with no duty to write —
+    // the backend re-asserts the mode and skips the speed.
+    expect(sanitiseGlobalMode({ kind: "manual" })).toEqual({
+      kind: "manual",
+      percent: null,
+    });
+    expect(sanitiseGlobalMode({ kind: "manual", percent: "80" })).toEqual({
+      kind: "manual",
+      percent: null,
+    });
+    expect(sanitiseGlobalMode({ kind: "manual", percent: NaN })).toEqual({
+      kind: "manual",
+      percent: null,
+    });
+  });
+
+  it("clamps and rounds an out-of-range percent", () => {
+    // Storage is user-editable JSON, so a hand-typed 900 must not reach the
+    // PWM write path.
+    expect(sanitiseGlobalMode({ kind: "manual", percent: 900 })).toEqual({
+      kind: "manual",
+      percent: 100,
+    });
+    expect(sanitiseGlobalMode({ kind: "manual", percent: -20 })).toEqual({
+      kind: "manual",
+      percent: 0,
+    });
+    expect(sanitiseGlobalMode({ kind: "manual", percent: 55.6 })).toEqual({
+      kind: "manual",
+      percent: 56,
+    });
+  });
+
+  it("returns null for absent or malformed values", () => {
+    expect(sanitiseGlobalMode(undefined)).toBeNull();
+    expect(sanitiseGlobalMode(null)).toBeNull();
+    expect(sanitiseGlobalMode("silent")).toBeNull();
+    expect(sanitiseGlobalMode(42)).toBeNull();
+    expect(sanitiseGlobalMode([])).toBeNull();
+    expect(sanitiseGlobalMode({})).toBeNull();
+    expect(sanitiseGlobalMode({ kind: "nonsense" })).toBeNull();
+  });
+});

--- a/plugins/fan-control/lib/global-mode.ts
+++ b/plugins/fan-control/lib/global-mode.ts
@@ -1,0 +1,72 @@
+/**
+ * The user's global fan-control choice, persisted across restarts.
+ *
+ * Issue #265: `applyPreset` only ever set `activePreset` in memory, so a
+ * reboot (or a `loadout.service` restart) dropped the selection. Nothing
+ * restarted the curve loop, and `getFanInfo` fell back to reading
+ * `pwm1_enable` — which drivers like `oxp_ec` initialise to 1 (manual) —
+ * so a user who had picked "Silent" came back to a fixed manual duty.
+ *
+ * "Global" is the operative word: this is what the user chose for the
+ * system, distinct from the per-game profiles the PerGameEngine owns. A
+ * per-game profile applying on launch must NOT overwrite it, or exiting
+ * the game (or rebooting after playing one) would silently promote that
+ * game's fan setting to the user's default.
+ */
+
+import { FAN_CURVES, type PresetName } from "./fan-curves";
+
+/** Derived, not hand-listed: a hand-copied list silently made any newly
+ *  added preset non-restorable — rejected here before applyPreset ever
+ *  saw it. */
+const PRESET_NAMES: readonly string[] = Object.keys(FAN_CURVES);
+
+export type GlobalFanMode =
+  /** One of the built-in curves. */
+  | { kind: "preset"; name: PresetName }
+  /** The user's own curve, whose points persist separately as `customCurve`. */
+  | { kind: "custom" }
+  /**
+   * Manual duty. `percent` is null when the user flipped to manual without
+   * naming a speed — restoring then only re-asserts the mode, since we have
+   * no duty to write.
+   */
+  | { kind: "manual"; percent: number | null }
+  /** Kernel/EC-controlled. Worth persisting: several drivers come up in
+   *  manual, so "auto" has to be re-asserted rather than assumed. */
+  | { kind: "auto" };
+
+/**
+ * Parse a persisted value back into a {@link GlobalFanMode}, or null when it
+ * is absent or malformed.
+ *
+ * Plugin storage is user-editable JSON, so this trusts nothing — same
+ * posture as `sanitiseCurve`. A bad value restores nothing rather than
+ * throwing during `onLoad` and taking the whole plugin down with it.
+ */
+export function sanitiseGlobalMode(input: unknown): GlobalFanMode | null {
+  if (typeof input !== "object" || input === null) return null;
+  const raw = input as Record<string, unknown>;
+
+  switch (raw.kind) {
+    case "preset":
+      return typeof raw.name === "string" && PRESET_NAMES.includes(raw.name)
+        ? { kind: "preset", name: raw.name as PresetName }
+        : null;
+    case "custom":
+      return { kind: "custom" };
+    case "auto":
+      return { kind: "auto" };
+    case "manual": {
+      // Absent/!finite percent degrades to "manual, no duty" rather than
+      // discarding the mode — the user's auto-vs-manual intent still stands.
+      const pct = raw.percent;
+      if (typeof pct !== "number" || !Number.isFinite(pct)) {
+        return { kind: "manual", percent: null };
+      }
+      return { kind: "manual", percent: Math.max(0, Math.min(100, Math.round(pct))) };
+    }
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Fixes #265. Replaces #266 — same feature, rebuilt as a single commit after that branch grew to six commits of accreted concurrency machinery. #266's review history is worth keeping as the record of *why* the guards below exist; every one of them was found by review or on-device testing, not invented.

## The bug

Pick "Silent", reboot or restart `loadout.service`, and the fan is back on a fixed manual duty. `applyPreset` only set in-memory state, and `onLoad` restored per-game profiles and the custom curve's *points* but never the mode. `getFanInfo` then fell back to reading `pwm1_enable` — which drivers like `oxp_ec` initialise to `1` — so the UI showed a static manual speed.

The reporter's root-cause analysis was exact; I verified each part before writing anything.

## The design

The user's global choice persists as a tagged union (`preset` / `custom` / `manual` / `auto`), sanitised on read like the custom curve is, and re-applied once fan hardware is detected. Three things needed care beyond persist-and-restore:

**Per-game profiles must not become the global default.** `PerGameEngine` drives the same entry points as the user. Public RPC methods record the choice then call private apply methods; the engine and the restore path call those privates directly, so nothing they do reads as a user choice. On game exit the user's *current* intent is re-applied — as a running curve where that's what they chose, which a `{mode, speed}` snapshot can't express.

**Fan intents are serialized.** `handleGameLaunch`/`handleGameExit` are fire-and-forget chains from the injector's fan-out (`apps/loadout/src/injector/injector.ts:482-495`), RPCs aren't serialized per plugin (`apps/loadout/src/loader/rpc-handler.ts:103-113`), and each intent awaits several `tee` spawns. A game *switch* therefore interleaved the exit-restore with the next profile's apply, and the restore's curve loop outlived it — observed on device, with the curve driving the fan while the profile was meant to own it:

```
15:53:13  Restoring saved preset: silent
15:53:14  Applied per-game profile for Konsole: manual 48%
          → pwm1 writes every 2s at the *curve's* duty, not the profile's
```

Every entry point now runs through an operation lock — the same pattern and rationale as `plugins/disable-controller-input/backend.ts:437-450`. The rule is one line: **public entry points serialize, private methods assume the lock is held.** An internal caller going through a public method would deadlock on re-entry, which is why the split above is structural rather than a flag.

**The safety watchdog deliberately does not take that lock.** A hung sysfs write inside a user operation must not starve the safety writer. Its one requirement is that `activePreset`/`customCurveActive` set implies a running curve loop — it defers its own write when either is set, so a flag set with no loop mutes the safety floor entirely. That invariant is held by statement ordering: flags and `startCurveLoop` are set in the same synchronous block, never with an `await` between.

## UI

A preset puts the *hardware* in manual mode, so both the panel and the home widget showed the user's last manual value while the curve rewrote the duty every 2s — a live "Fan speed" row sitting above a slider that disagreed with it. Both now track the live percent whenever a curve is driving. Dragging the slider still cancels the preset and takes manual control.

## Testing

3283 backend tests, typecheck and lint clean. 161 lines of new backend code (the rest of the diff is comments and tests).

Mutation-checked — each of these reverts fails at least one test: restore unwired from the scanner's `onFound`; the sanitiser bypassed; `setFanMode` persisting from the last-written duty rather than the recorded intent; flags set on entry instead of at the commit point; the lock removed from `handleGameLaunch`; `onRestore` no longer intent-first; a per-game apply routed through the persisting public setter.

**Not yet verified on device in this form.** It is plugin-only, so it deploys via `prepare-plugins.sh` with no binary rebuild. Worth checking: preset survives a restart; a manual duty set before a game isn't replaced by the game's; exiting a game returns you to your curve; and writes continue above 75 °C under load (the watchdog bug this design guards against showed up precisely as writes stopping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bknnb7AaRitj1mMh6rjUoZ