### PR TITLE
refactor(apex): make the hid-oxp blacklist removal-only

### DIFF
--- a/plugins/apex/README.md
+++ b/plugins/apex/README.md
@@ -22,6 +22,22 @@ That drops the built-in gamepad (`1a86:fe00` HID MCU + `045e:028e` Xbox 360 pad)
 
 The same logic is also available as a standalone shell script for use outside Loadout: [`scripts/fix-controller-resume.sh`](../../scripts/fix-controller-resume.sh).
 
+## The hid-oxp blacklist (removal only)
+
+Loadout once recommended blacklisting the OneXPlayer HID driver, because it
+looked implicated in the xHCI controller dying on resume. **We no longer offer
+to apply it, and shouldn't again.** It disabled the driver instead of fixing
+the wake bug — that's what **Recover gamepad** above is for — and `hid-oxp` is
+where OneXPlayer's device controls live: rumble intensity, gamepad mode and
+button remapping all disappear with it, on a machine that has no way to know
+why.
+
+What remains is a **Driver blacklist** card that appears only if the drop-in
+is still on disk, offering to remove it. There is deliberately no path to
+write it, in the UI or in [`lib/hid-oxp.ts`](lib/hid-oxp.ts) — a unit test
+asserts the module exports no `set`/`apply`/`enable` function. If the wake bug
+resurfaces, the fix belongs in [`lib/xhci.ts`](lib/xhci.ts).
+
 ## Fingerprint wake
 
 The power button's fingerprint sensor wakes the Apex from sleep on a light touch — annoying in a bag. The **Block fingerprint wake** toggle disables it as a wake source (controller PME at runtime + a GPIO kernel argument); a deliberate power-button press still wakes the device. The kernel-arg change needs a reboot, and on non-SteamOS distros the GPIO arg may need to be added manually (the panel shows the exact arg).

--- a/plugins/apex/app.spec.tsx
+++ b/plugins/apex/app.spec.tsx
@@ -220,7 +220,7 @@ describe("apex plugin", () => {
     ) as HTMLButtonElement;
     fireEvent.click(removeBtn);
     await waitFor(() => {
-      expect(callMock).toHaveBeenCalledWith("setHidOxpBlacklist", false);
+      expect(callMock).toHaveBeenCalledWith("removeHidOxpBlacklist");
     });
   });
 

--- a/plugins/apex/app.tsx
+++ b/plugins/apex/app.tsx
@@ -117,7 +117,7 @@ function Apex() {
   const handleRemoveBlacklist = useCallback(async () => {
     setBlacklistBusy(true);
     try {
-      const res = (await call("setHidOxpBlacklist", false)) as {
+      const res = (await call("removeHidOxpBlacklist")) as {
         success: boolean;
         error?: string;
         hidOxp?: HidOxpStatus;
@@ -273,7 +273,9 @@ function Apex() {
                 The OneXPlayer <span className="mono">hid-oxp</span> driver is currently blacklisted
                 on this device — an older workaround for the built-in gamepad dropping out on wake.
                 <span className="font-medium"> Recover automatically on wake</span> (above) is the
-                preferred fix now, so you can safely remove the blacklist and restore the driver.
+                fix now, so you can safely remove the blacklist and restore the driver. Doing so
+                also restores the controls that live in this driver — rumble intensity, gamepad
+                mode and button remapping.
               </div>
 
               {hidOxp.rebootRequired && (

--- a/plugins/apex/backend.test.ts
+++ b/plugins/apex/backend.test.ts
@@ -32,8 +32,8 @@ const hidOxpStatusImpl = mock(async () => ({
   moduleLoaded: true,
   rebootRequired: false,
 }));
-const setHidOxpImpl = mock(async () => ({
-  blacklisted: true,
+const removeHidOxpImpl = mock(async () => ({
+  blacklisted: false,
   moduleLoaded: true,
   rebootRequired: true,
 }));
@@ -56,7 +56,7 @@ mock.module("./lib/xhci", () => ({
 }));
 mock.module("./lib/hid-oxp", () => ({
   getHidOxpStatus: hidOxpStatusImpl,
-  setHidOxpBlacklist: setHidOxpImpl,
+  removeHidOxpBlacklist: removeHidOxpImpl,
 }));
 mock.module("./lib/fingerprint", () => ({
   getStatus: fingerprintStatusImpl,
@@ -101,7 +101,7 @@ describe("Apex backend", () => {
     recoverImpl.mockClear();
     getStatusImpl.mockClear();
     hidOxpStatusImpl.mockClear();
-    setHidOxpImpl.mockClear();
+    removeHidOxpImpl.mockClear();
     fingerprintStatusImpl.mockClear();
     applyFingerprintImpl.mockClear();
     revertFingerprintImpl.mockClear();
@@ -138,27 +138,29 @@ describe("Apex backend", () => {
     expect(hidOxpStatusImpl).toHaveBeenCalledTimes(1);
   });
 
-  it("toggles the hid-oxp blacklist and emits statusChanged", async () => {
+  it("removes the hid-oxp blacklist and emits statusChanged", async () => {
     const { backend, events } = makeBackend();
     await backend.onLoad();
 
-    const res = await backend.setHidOxpBlacklist(true);
+    const res = await backend.removeHidOxpBlacklist();
     expect(res.success).toBe(true);
     expect(res.hidOxp?.rebootRequired).toBe(true);
-    expect(setHidOxpImpl).toHaveBeenCalledTimes(1);
-    expect(setHidOxpImpl).toHaveBeenCalledWith(expect.anything(), true);
+    expect(removeHidOxpImpl).toHaveBeenCalledTimes(1);
+    // No second argument — removal is the only operation; there is
+    // deliberately no way to apply the blacklist.
+    expect(removeHidOxpImpl).toHaveBeenCalledWith(expect.anything());
     expect(events).toEqual([{ event: "statusChanged", data: undefined }]);
   });
 
-  it("refuses to toggle the hid-oxp blacklist on non-Apex hardware", async () => {
+  it("refuses to remove the hid-oxp blacklist on non-Apex hardware", async () => {
     isApexResult = false;
     const { backend } = makeBackend();
     await backend.onLoad();
 
-    const res = await backend.setHidOxpBlacklist(true);
+    const res = await backend.removeHidOxpBlacklist();
     expect(res.unsupported).toBe(true);
     expect(res.success).toBe(false);
-    expect(setHidOxpImpl).not.toHaveBeenCalled();
+    expect(removeHidOxpImpl).not.toHaveBeenCalled();
   });
 
   it("refuses to recover on non-Apex hardware", async () => {

--- a/plugins/apex/backend.ts
+++ b/plugins/apex/backend.ts
@@ -12,7 +12,7 @@ import {
 } from "./lib/xhci";
 import {
   getHidOxpStatus,
-  setHidOxpBlacklist,
+  removeHidOxpBlacklist,
   type HidOxpDeps,
   type HidOxpStatus,
 } from "./lib/hid-oxp";
@@ -122,9 +122,9 @@ export default class ApexBackend implements PluginBackend {
       : { ok: false, error: res.stderr || `systemctl exited ${res.exitCode}` };
   }
 
-  // IO dependencies for the hid-oxp blacklist. The backend runs as root, so
-  // it writes /etc/modprobe.d directly; readFile/removeFile swallow ENOENT so
-  // "absent" is a normal, non-throwing state.
+  // IO for clearing the old hid-oxp blacklist. The backend runs as root, so
+  // it touches /etc/modprobe.d directly; readFile/removeFile swallow ENOENT
+  // so "absent" is a normal, non-throwing state.
   private get hidOxpDeps(): HidOxpDeps {
     return {
       readFile: async (path) => {
@@ -134,7 +134,6 @@ export default class ApexBackend implements PluginBackend {
           return null;
         }
       },
-      writeFile: (path, content) => writeFile(path, content, "utf8"),
       removeFile: async (path) => {
         try {
           await rm(path);
@@ -240,23 +239,26 @@ export default class ApexBackend implements PluginBackend {
   }
 
   /**
-   * Enable/disable the hid-oxp driver blacklist — the OneXPlayer HID driver
-   * implicated in the xHCI controller dying on wake. Writes/removes a
-   * modprobe.d drop-in; takes effect on the next reboot (the returned status
-   * flags `rebootRequired` while the change is staged). See ./lib/hid-oxp.ts.
+   * Remove the old hid-oxp driver blacklist. Removal only — there is
+   * deliberately no way to apply it, here or in the UI: it disabled the
+   * driver instead of fixing the wake bug (that's "Recover gamepad"), and it
+   * takes every control hid-oxp exposes with it. See ./lib/hid-oxp.ts.
    */
-  async setHidOxpBlacklist(
-    enabled: boolean,
-  ): Promise<{ success: boolean; unsupported?: boolean; error?: string; hidOxp?: HidOxpStatus }> {
+  async removeHidOxpBlacklist(): Promise<{
+    success: boolean;
+    unsupported?: boolean;
+    error?: string;
+    hidOxp?: HidOxpStatus;
+  }> {
     if (this.unsupported) {
       return { success: false, unsupported: true, error: "Not running on Apex hardware." };
     }
     try {
-      const hidOxp = await setHidOxpBlacklist(this.hidOxpDeps, !!enabled);
+      const hidOxp = await removeHidOxpBlacklist(this.hidOxpDeps);
       this.emit?.({ event: "statusChanged", data: undefined });
       return { success: true, hidOxp };
     } catch (e) {
-      this.log?.warn(`[apex] setHidOxpBlacklist failed: ${e}`);
+      this.log?.warn(`[apex] removeHidOxpBlacklist failed: ${e}`);
       return { success: false, error: String(e) };
     }
   }

--- a/plugins/apex/lib/hid-oxp.test.ts
+++ b/plugins/apex/lib/hid-oxp.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import {
   getHidOxpStatus,
-  setHidOxpBlacklist,
+  removeHidOxpBlacklist,
   HID_OXP_CONF,
   BLACKLIST_LINE,
   type HidOxpDeps,
@@ -70,28 +70,29 @@ describe("getHidOxpStatus", () => {
   });
 });
 
-describe("setHidOxpBlacklist", () => {
-  it("writes the drop-in when enabling", async () => {
-    const { deps, files } = makeDeps({ [PROC_MODULES]: loadedModules });
-    const s = await setHidOxpBlacklist(deps, true);
-    expect(files.get(HID_OXP_CONF)).toBe(`${BLACKLIST_LINE}\n`);
-    expect(s).toEqual({ blacklisted: true, moduleLoaded: true, rebootRequired: true });
-  });
-
-  it("removes the drop-in when disabling", async () => {
+describe("removeHidOxpBlacklist", () => {
+  it("removes the drop-in", async () => {
     const { deps, files } = makeDeps({
       [PROC_MODULES]: loadedModules,
       [HID_OXP_CONF]: `${BLACKLIST_LINE}\n`,
     });
-    const s = await setHidOxpBlacklist(deps, false);
+    const s = await removeHidOxpBlacklist(deps);
     expect(files.has(HID_OXP_CONF)).toBe(false);
     expect(s.blacklisted).toBe(false);
   });
 
-  it("disabling when already absent is a no-op (idempotent)", async () => {
+  it("is idempotent when the drop-in is already absent", async () => {
     const { deps, files } = makeDeps({ [PROC_MODULES]: loadedModules });
-    const s = await setHidOxpBlacklist(deps, false);
+    const s = await removeHidOxpBlacklist(deps);
     expect(files.has(HID_OXP_CONF)).toBe(false);
     expect(s.blacklisted).toBe(false);
+  });
+
+  it("exposes no way to apply the blacklist", async () => {
+    // Deliberate: it disabled the driver instead of fixing the wake bug, and
+    // takes rumble/gamepad-mode/button-mapping with it. If this assertion is
+    // ever in the way, the answer is in ./xhci.ts, not here.
+    const mod = (await import("./hid-oxp")) as Record<string, unknown>;
+    expect(Object.keys(mod).some((k) => /^set|apply|enable/i.test(k))).toBe(false);
   });
 });

--- a/plugins/apex/lib/hid-oxp.ts
+++ b/plugins/apex/lib/hid-oxp.ts
@@ -1,25 +1,32 @@
 /**
- * hid-oxp driver blacklist — the OneXPlayer-specific HID kernel driver.
+ * The old `hid-oxp` driver blacklist — **removal only**.
  *
- * On the Apex, the `hid-oxp` driver appears to be implicated in the xHCI
- * USB controller dying on resume from sleep. Blacklisting it (so the kernel
- * doesn't bind it to the gamepad's HID MCU) makes the controller survive
- * wake far more reliably in field testing — a cleaner, root-cause-adjacent
- * mitigation than rebinding the dead controller after the fact (see
- * ./xhci.ts for that recovery path).
+ * ## Do not add an enable path to this file
  *
- * The blacklist is just a one-line drop-in under /etc/modprobe.d. It only
- * takes effect on the next boot: an already-loaded module stays loaded
- * until reboot, so `getHidOxpStatus` reports `rebootRequired` when the
- * blacklist is in place but the module is still resident.
+ * Loadout once recommended blacklisting the OneXPlayer HID driver, because it
+ * looked implicated in the xHCI USB controller dying on resume. That was never
+ * a fix: it disabled the driver instead of addressing the wake bug, and the
+ * real mitigation ships in ./xhci.ts — unbind/rebind the controller so the bus
+ * re-enumerates, exposed as **Recover gamepad** and as
+ * `scripts/fix-controller-resume.sh`.
  *
- * All IO is injected (`HidOxpDeps`) so the logic is unit-testable without
- * root or a real /etc + /proc.
+ * The cost has since grown. `hid-oxp` is where OneXPlayer's device controls
+ * live — rumble intensity, gamepad mode, button remapping — so a machine
+ * carrying this drop-in silently loses all of them, with nothing on screen to
+ * explain why. A future plugin reading those attributes will find no hardware
+ * on exactly the machines that took our advice.
+ *
+ * So this module reads the state and takes the blacklist *off*. There is
+ * deliberately no way to put it back on, and the UI offers none. If the wake
+ * bug resurfaces, fix it in ./xhci.ts.
+ *
+ * All IO is injected (`HidOxpDeps`) so the logic is unit-testable without root
+ * or a real /etc + /proc.
  */
 
 /** modprobe.d drop-in that disables the driver. */
 export const HID_OXP_CONF = "/etc/modprobe.d/hid-oxp.conf";
-/** The exact directive we write / look for. */
+/** The directive we look for. Never written — see the note above. */
 export const BLACKLIST_LINE = "blacklist hid-oxp";
 /** Module name as it appears in /proc/modules (underscored). */
 const MODULE_NAME = "hid_oxp";
@@ -28,8 +35,6 @@ const PROC_MODULES = "/proc/modules";
 export interface HidOxpDeps {
   /** Read a file, or resolve null when it doesn't exist. */
   readFile: (path: string) => Promise<string | null>;
-  /** Write (create/overwrite) a file. */
-  writeFile: (path: string, content: string) => Promise<void>;
   /** Remove a file; must be a no-op when it's already absent. */
   removeFile: (path: string) => Promise<void>;
   /** Optional progress sink. */
@@ -37,14 +42,19 @@ export interface HidOxpDeps {
 }
 
 export interface HidOxpStatus {
-  /** The modprobe.d drop-in is present and contains the blacklist line. */
+  /** The modprobe.d drop-in is present and carries the blacklist line. */
   blacklisted: boolean;
   /** `hid_oxp` is currently loaded (still resident until the next boot). */
   moduleLoaded: boolean;
   /**
-   * The desired state is set but a reboot is needed to reach it: blacklisted
-   * yet still loaded. (Un-blacklisting also only frees the module at the next
-   * boot, but that's the harmless direction, so we don't flag it.)
+   * The blacklist is in place but the module is still resident, so it hasn't
+   * taken effect yet.
+   *
+   * Deliberately not extended to cover "removed but not yet loaded": on a
+   * machine where hid_oxp simply isn't loaded — a gen-1 device, or a kernel
+   * without the driver — that would flag a reboot nobody needs. The UI says
+   * "reboot to restore the driver" after a successful removal instead, where
+   * the context is unambiguous.
    */
   rebootRequired: boolean;
 }
@@ -73,20 +83,13 @@ export async function getHidOxpStatus(deps: HidOxpDeps): Promise<HidOxpStatus> {
 }
 
 /**
- * Enable or disable the blacklist by writing / removing the drop-in, then
- * return the fresh status. Idempotent: enabling when already blacklisted
- * just rewrites the same line; disabling when absent is a no-op.
+ * Remove the drop-in and report the fresh status. Idempotent: removing when
+ * it's already absent is a no-op, so this is safe to call unconditionally.
  */
-export async function setHidOxpBlacklist(
+export async function removeHidOxpBlacklist(
   deps: HidOxpDeps,
-  enabled: boolean,
 ): Promise<HidOxpStatus> {
-  if (enabled) {
-    await deps.writeFile(HID_OXP_CONF, `${BLACKLIST_LINE}\n`);
-    deps.log?.(`wrote ${HID_OXP_CONF} (blacklist hid-oxp)`);
-  } else {
-    await deps.removeFile(HID_OXP_CONF);
-    deps.log?.(`removed ${HID_OXP_CONF}`);
-  }
+  await deps.removeFile(HID_OXP_CONF);
+  deps.log?.(`removed ${HID_OXP_CONF}`);
   return getHidOxpStatus(deps);
 }


### PR DESCRIPTION
We used to offer to blacklist the OneXPlayer HID driver, because it looked implicated in the xHCI controller dying on resume. It was never a fix — it disabled the driver rather than addressing the wake bug, which is what **Recover gamepad** (`lib/xhci.ts`) actually does, and which also ships as `scripts/fix-controller-resume.sh`.

## Why now

`hid-oxp` is where OneXPlayer's device controls live. Kernel 7.2 adds `rumble_intensity` / `rumble_intensity_range` to it, alongside the existing `gamepad_mode` and the 19-attribute button-remap surface — and SteamOS already backports the driver, so those nodes are live on an Apex today.

A machine carrying our drop-in silently loses all of them, with nothing on screen explaining why. A rumble plugin (#260) would report "no hardware" on exactly the machines that took our advice.

## What changes

- `setHidOxpBlacklist(enabled)` → `removeHidOxpBlacklist()`. No argument, no enable path.
- `HidOxpDeps` loses its `writeFile` — the module has no way to create the file.
- The UI keeps only the **Driver blacklist** card that appears when the drop-in is present, offering to remove it. It was already removal-only in practice; this makes it so in the code.
- A unit test asserts the module exports no `set`/`apply`/`enable` function, so the enable path can't quietly return.
- `plugins/apex/README.md` records the decision and points future work at `lib/xhci.ts`.

Nothing removes the file automatically — the UI remains the only path. Per the maintainer's call, few users are likely to still have it, and silently editing `/etc/modprobe.d` on load is a bigger hammer than the situation needs.

Also corrects the UI copy: removing the blacklist restores rumble, gamepad mode and button remapping, which is the reason to do it beyond tidiness.

## Testing

3250 backend tests, 11 apex UI tests, typecheck and lint clean.

One behavioural note for review: I briefly redefined `rebootRequired` to also cover "blacklist removed, driver not yet loaded", and the existing tests correctly caught it — on a machine where `hid_oxp` simply isn't loaded (gen-1 device, or a kernel without the driver) that flags a reboot nobody needs. Reverted; the post-removal notification says "reboot to restore the driver" instead, where the context is unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bknnb7AaRitj1mMh6rjUoZ