### PR TITLE
feat(doctor): report device hardware, so "does my handheld work" is answerable

### DIFF
--- a/scripts/loadout-doctor.sh
+++ b/scripts/loadout-doctor.sh
@@ -331,6 +331,45 @@ done
 [ "$found_hid" -eq 1 ] || echo "  no HID device exposes rumble/gamepad-mode attributes"
 
 echo ""
+echo "  --- USB devices ---"
+# The full table, not just a probe for ids we already know: on unfamiliar
+# hardware the useful question is what this device's internal gamepad and
+# fingerprint reader enumerate AS, which is what would let us extend the
+# id lists the OneXPlayer plugin matches on.
+if command -v lsusb >/dev/null 2>&1; then
+    lsusb 2>/dev/null | sed 's/^/  /'
+    echo ""
+    echo "  known ids the OneXPlayer plugin looks for:"
+    for pair in "1a86:fe00 gamepad HID MCU" "045e:028e gamepad (X360-compatible)" "2808:c652 fingerprint reader"; do
+        id=${pair%% *}
+        label=${pair#* }
+        if lsusb -d "$id" >/dev/null 2>&1; then
+            printf "    %-12s %-32s present\n" "$id" "$label"
+        else
+            printf "    %-12s %-32s ABSENT\n" "$id" "$label"
+        fi
+    done
+else
+    echo "  lsusb not installed — cannot check the gamepad or fingerprint reader"
+fi
+
+echo ""
+echo "  --- xHCI controllers ---"
+# The gamepad-recovery fix rebinds one of these. Which one is normally read
+# out of the kernel log; the bound list is what it would act on.
+if [ -d /sys/bus/pci/drivers/xhci_hcd ]; then
+    for l in /sys/bus/pci/drivers/xhci_hcd/0000:*; do
+        [ -e "$l" ] || continue
+        echo "  bound: $(basename "$l")"
+    done
+else
+    echo "  no xhci_hcd driver directory"
+fi
+echo "  --- controller died in this boot's log? ---"
+dmesg 2>/dev/null | grep -iE "xhci_hcd .*(HC died|assume dead)" | tail -5 | sed 's/^/  /' \
+    || echo "  (nothing, or dmesg needs root)"
+
+echo ""
 echo "  --- temperatures now ---"
 for d in /sys/class/hwmon/hwmon*; do
     [ -r "$d/temp1_input" ] || continue

--- a/scripts/loadout-doctor.sh
+++ b/scripts/loadout-doctor.sh
@@ -251,6 +251,100 @@ journalctl --user -u loadout-overlay -b --no-pager 2>/dev/null \
     | grep -iE "start-limit|Scheduled restart|too often recently|Failed with result" \
     | tail -10 | sed 's/^/  /' || true
 
+# ---------------------------------------------------------------
+section "10. Device hardware"
+# ---------------------------------------------------------------
+# Everything a "does my handheld work" report needs, in one paste.
+#
+# The recurring failure is a board whose kernel driver never bound: no
+# oxpec/ayn-platform/etc. means no hwmon node, which means fan control has
+# nothing to write to and its safety floor is inert. That is invisible in
+# the sections above, and indistinguishable from a Loadout bug without it.
+#
+# DMI first: the exact product_name is what decides whether a driver's DMI
+# table matches, which TDP profile is picked, and what an upstream patch
+# would need to add.
+echo "  --- DMI ---"
+for f in sys_vendor product_name product_version board_name bios_version; do
+    v=$(cat "/sys/class/dmi/id/$f" 2>/dev/null)
+    printf "  %-16s %s\n" "$f:" "${v:-<unreadable>}"
+done
+
+echo ""
+echo "  --- hwmon (fan control needs fanN_input + pwmN + pwmN_enable, or a writable fanN_target) ---"
+found_hwmon=0
+for d in /sys/class/hwmon/hwmon*; do
+    [ -d "$d" ] || continue
+    found_hwmon=1
+    name=$(cat "$d/name" 2>/dev/null)
+    attrs=""
+    for a in fan1_input pwm1 pwm1_enable fan1_target temp1_input; do
+        [ -e "$d/$a" ] && attrs="$attrs $a"
+    done
+    printf "  %-28s %s\n" "$(basename "$d") ${name:-?}" "${attrs:- (no fan/temp attrs)}"
+done
+[ "$found_hwmon" -eq 1 ] || echo "  no /sys/class/hwmon entries at all"
+
+echo ""
+echo "  --- platform / HID drivers ---"
+if [ -r /proc/modules ]; then
+    mods=$(grep -iE '^(oxpec|oxp_platform|oxp_sensors|hid_oxp|ayn_platform|ayaneo_platform|gpdfan|asus_wmi) ' /proc/modules | awk '{print $1}' | tr '\n' ' ')
+    echo "  loaded: ${mods:-<none of the known handheld platform drivers>}"
+else
+    echo "  /proc/modules unreadable"
+fi
+if [ -f /etc/modprobe.d/hid-oxp.conf ]; then
+    echo "  NOTE: /etc/modprobe.d/hid-oxp.conf present — hid-oxp is blacklisted."
+    echo "        That disables rumble/gamepad-mode/button remapping. Remove it in the"
+    echo "        OneXPlayer plugin; Loadout no longer recommends it."
+fi
+
+echo ""
+echo "  --- ectool ---"
+# `command -v ectool` is not enough: the binary exists on hardware where the
+# handshake fails (no ChromeOS-style EC behind it), which is exactly the
+# fallback fan-control probes with `ectool hello`.
+if command -v ectool >/dev/null 2>&1; then
+    if ectool hello >/dev/null 2>&1; then
+        echo "  ectool hello: OK (usable fan fallback)"
+    else
+        echo "  ectool hello: FAILED (binary present but no usable EC — normal on OneXPlayer)"
+    fi
+else
+    echo "  ectool: not installed"
+fi
+
+echo ""
+echo "  --- HID device attributes ---"
+found_hid=0
+for d in /sys/bus/hid/devices/*; do
+    [ -d "$d" ] || continue
+    attrs=""
+    for a in rumble_intensity rumble_intensity_range gamepad_mode; do
+        [ -e "$d/$a" ] && attrs="$attrs $a=$(cat "$d/$a" 2>/dev/null | tr -d '\n')"
+    done
+    if [ -n "$attrs" ]; then
+        found_hid=1
+        printf "  %-30s %s\n" "$(basename "$d")" "$attrs"
+    fi
+done
+[ "$found_hid" -eq 1 ] || echo "  no HID device exposes rumble/gamepad-mode attributes"
+
+echo ""
+echo "  --- temperatures now ---"
+for d in /sys/class/hwmon/hwmon*; do
+    [ -r "$d/temp1_input" ] || continue
+    t=$(cat "$d/temp1_input" 2>/dev/null)
+    [ -n "$t" ] || continue
+    printf "  %-16s %s C\n" "$(cat "$d/name" 2>/dev/null)" "$((t / 1000))"
+done
+
+echo ""
+echo "  --- backend plugin lines (hardware detection) ---"
+journalctl -u loadout -b --no-pager 2>/dev/null \
+    | grep -iE "\[fan-control\]|\[tdp-control\]|\[vibration\]|\[apex\]" \
+    | tail -20 | sed 's/^/  /' || true
+
 section "End of report"
 echo "  Paste this whole output into the issue / thread."
 echo ""


### PR DESCRIPTION
Prompted by a **OneXPlayer X2 Mini Pro** report: fan control says "no hardware", and the SoC reached 84 °C at 80 W before the user shut the device down.

## Why

`loadout-doctor.sh` reads no DMI, no hwmon, and no module list. So for the most common new-device report — "fan control finds nothing" — its output cannot distinguish a Loadout bug from a kernel driver that never bound, which is almost always the real cause.

For that user specifically: `oxpec` provides the `oxp_ec` hwmon node and binds by DMI alias. It ships 34 aliases — `ONEXPLAYERAPEX`, `ONEXPLAYERX1MiniPro`, `ONEXPLAYERG1A` … — and **no X2 entry**. No binding, no `fan1_input`, nothing to write to. The current doctor output would never have shown that.

## What section 10 adds

- **DMI** — `sys_vendor`, `product_name`, `product_version`, `board_name`, `bios_version`. The exact `product_name` decides whether a driver's DMI table matches, which TDP profile `matchDevice()` picks, and what an upstream patch would need to add.
- **Every hwmon node** with which of `fanN_input` / `pwmN` / `pwmN_enable` / `fanN_target` it carries — the same predicates `scanHwmonDevices()` uses, so the output says directly whether fan control *could* work.
- **Loaded handheld platform/HID drivers**, plus whether `/etc/modprobe.d/hid-oxp.conf` is still on disk (it disables rumble, gamepad mode and button remapping — see #268).
- **`ectool hello`**, not `command -v ectool`. The binary exists on hardware where the handshake fails, so the current optional-tools "yes" is misleading; `hello` is what fan control actually probes with.
- **HID rumble / gamepad-mode attributes**, current temperatures, and the backend's own plugin detection lines (section 9 greps the overlay journal only).

## Output on a working device

Run on an Apex — the healthy case, for contrast with what the X2 will show:

```
  --- DMI ---
  sys_vendor:      ONE-NETBOOK
  product_name:    ONEXPLAYER APEX

  --- hwmon (fan control needs fanN_input + pwmN + pwmN_enable, or a writable fanN_target) ---
  hwmon5 k10temp                temp1_input
  hwmon6 oxp_ec                 fan1_input pwm1 pwm1_enable
  hwmon9 amdgpu                 temp1_input

  --- platform / HID drivers ---
  loaded: hid_oxp oxpec

  --- ectool ---
  ectool: not installed

  --- HID device attributes ---
  0003:1A86:FE00.0005    rumble_intensity=5 rumble_intensity_range=0-5 gamepad_mode=xinput
```

On the X2 Mini Pro the `oxp_ec` line and the `oxpec` module will both be absent — diagnosis in one paste.

## Notes

POSIX `sh`, read-only, no sudo, matching the existing sections' style — the script is safe to ask any user to pipe from `curl`. `sh -n` clean, and run end to end on an Apex.

Shipping this before any device-support code deliberately: it turns future reports into evidence rather than hearsay, which is the habit `CLAUDE.md`'s triage section already argues for — and it's what would have caught the #232 misdiagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bknnb7AaRitj1mMh6rjUoZ