### PR TITLE
docs(doctor): point at the file redirect instead of "paste this"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,13 @@ restarts — so it is always safe to ask for:
 curl -fsSL https://raw.githubusercontent.com/srsholmes/loadout/main/scripts/loadout-doctor.sh | sh
 ```
 
+It prints ~500 lines, which is past what a chat client will accept as a
+paste — so for Discord reports ask for it as a file instead:
+
+```
+curl -fsSL … /loadout-doctor.sh | sh > ~/Desktop/loadout-doctor.txt 2>&1
+```
+
 It covers distro/kernel, the required tools + dlopen'd sonames, the
 install layout with the on-disk `--version`, both units, a `/up` probe,
 session/gamescope detection, both journals, and a "smoking guns" section

--- a/scripts/loadout-doctor.sh
+++ b/scripts/loadout-doctor.sh
@@ -385,5 +385,12 @@ journalctl -u loadout -b --no-pager 2>/dev/null \
     | tail -20 | sed 's/^/  /' || true
 
 section "End of report"
-echo "  Paste this whole output into the issue / thread."
+# ~500 lines — past what a chat client will take as a paste, so point at the
+# redirect rather than telling people to paste it and watch them truncate the
+# half that matters.
+echo "  Send this whole report, not an excerpt — the useful part is usually"
+echo "  a section nobody thought to include."
+echo ""
+echo "  To save it to a file you can attach:"
+echo "    curl -fsSL https://raw.githubusercontent.com/srsholmes/loadout/main/scripts/loadout-doctor.sh | sh > ~/Desktop/loadout-doctor.txt 2>&1"
 echo ""


### PR DESCRIPTION
Section 10 (#270) took the doctor report to **~500 lines / 45 KB**. That's past what Discord and most chat clients accept as a paste, so the closing line — "Paste this whole output into the issue / thread" — now reliably produces a *truncated* report, and the part that gets cut is usually the part that matters.

It now prints the redirect instead:

```
  Send this whole report, not an excerpt — the useful part is usually
  a section nobody thought to include.

  To save it to a file you can attach:
    curl -fsSL …/loadout-doctor.sh | sh > ~/Desktop/loadout-doctor.txt 2>&1
```

`~/Desktop` exists on SteamOS, so it lands somewhere a user can drag into a thread. `CLAUDE.md`'s triage section says the same, since that's where the command usually gets copied from.

No behaviour change — the script still writes only to stdout, which keeps it composable and correct for `curl | sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bknnb7AaRitj1mMh6rjUoZ