### PR TITLE
feat(input-plumber): supply a device config when InputPlumber has none

### DIFF
--- a/plugins/input-plumber/README.md
+++ b/plugins/input-plumber/README.md
@@ -4,6 +4,37 @@
 
 Installs the InputPlumber input-routing daemon that other controller features rely on, and quietly does nothing if it's already present. Mostly a one-time setup helper so the rest 'just works'.
 
+## Device configs
+
+InputPlumber only builds a `CompositeDevice` for hardware one of its configs
+matches, and matching is on the exact `/sys/class/dmi/id/product_name`. On a
+handheld it has no config for there is no composite device at all — so the
+wake-button picker lists nothing and overlay input intercept has nothing to
+act on. Every InputPlumber-dependent feature is inert on hardware that is
+otherwise completely conventional.
+
+For devices we can describe, this plugin offers to drop a config into
+`/etc/inputplumber/devices.d`. That directory is searched *before*
+`/usr/share/inputplumber/devices`, with ties broken by basename — so these
+files deliberately use the name upstream would use, and *shadow* a future
+upstream config rather than loading alongside it and matching the same
+machine twice. When upstream does ship one, the UI says so and suggests
+removing ours, since theirs is tested on the hardware.
+
+The card only appears when we have a config for this exact machine **and**
+InputPlumber has genuinely produced no composite devices. A device that
+already works is never offered one.
+
+Currently shipped:
+
+| Device | DMI `product_name` | Notes |
+| --- | --- | --- |
+| OneXPlayer X2 Mini Pro | `ONEXPLAYER X2Mini PRO` | Not in InputPlumber 0.78.1. Gamepad + MCU only. |
+
+Each config is deliberately minimal — enough to make a composite device
+exist, and no more. See the docblock in `lib/device-config.ts` for what is
+left out and why (the system keyboard, and the back-paddle capability map).
+
 ## Screenshots
 
 ![InputPlumber](./assets/screenshot.png)

--- a/plugins/input-plumber/README.md
+++ b/plugins/input-plumber/README.md
@@ -15,21 +15,33 @@ otherwise completely conventional.
 
 For devices we can describe, this plugin offers to drop a config into
 `/etc/inputplumber/devices.d`. That directory is searched *before*
-`/usr/share/inputplumber/devices`, with ties broken by basename — so these
-files deliberately use the name upstream would use, and *shadow* a future
-upstream config rather than loading alongside it and matching the same
-machine twice. When upstream does ship one, the UI says so and suggests
-removing ours, since theirs is tested on the hardware.
+`/usr/share/inputplumber/devices`, with ties broken by basename, and the
+first config matching a given source device wins — so these files use the
+name upstream would use, and a same-name upstream config is shadowed rather
+than loading alongside ours and matching the same machine twice.
 
-The card only appears when we have a config for this exact machine **and**
-InputPlumber has genuinely produced no composite devices. A device that
-already works is never offered one.
+That only holds for an *identical* basename, though, and upstream may well
+pick a different one (their family runs `50-onexplayer_apex.yaml`,
+`50-onexplayer_x1.yaml`, `50-onexplayer_mini_pro.yaml`). So "has upstream
+caught up" is decided by reading the DMI pairs their configs claim, not by
+comparing filenames — otherwise the UI would report "not superseded" in
+exactly the case where both configs load and the user most needs telling.
+
+The card only appears when InputPlumber is actually running, we have a
+config for this exact machine, and it has genuinely produced no composite
+devices. A device that already works is never offered one.
 
 Currently shipped:
 
 | Device | DMI `product_name` | Notes |
 | --- | --- | --- |
 | OneXPlayer X2 Mini Pro | `ONEXPLAYER X2Mini PRO` | Not in InputPlumber 0.78.1. Gamepad + MCU only. |
+
+Note the MCU exposes two evdev nodes under one name, so its source entry
+needs `unique: false` or InputPlumber forks a second CompositeDevice off the
+same config — duplicate virtual pads. Upstream's Apex and X1 configs avoid
+this by pinning `phys_path`; without that board's topology, joining is the
+portable equivalent.
 
 Each config is deliberately minimal — enough to make a composite device
 exist, and no more. See the docblock in `lib/device-config.ts` for what is

--- a/plugins/input-plumber/app.spec.tsx
+++ b/plugins/input-plumber/app.spec.tsx
@@ -411,9 +411,9 @@ const applicableConfig = {
   superseded: false,
 };
 
-function rpcWithDeviceConfig(deviceConfig: unknown) {
+function rpcWithDeviceConfig(deviceConfig: unknown, install = installedActiveStatus) {
   callMock.mockImplementation((method: string) => {
-    if (method === "getStatus") return Promise.resolve(installedActiveStatus);
+    if (method === "getStatus") return Promise.resolve(install);
     if (method === "isInstallRunning") return Promise.resolve({ running: false });
     if (method === "getDeviceConfigStatus") return Promise.resolve(deviceConfig);
     if (method === "installDeviceConfig" || method === "removeDeviceConfig") {
@@ -426,14 +426,19 @@ function rpcWithDeviceConfig(deviceConfig: unknown) {
   });
 }
 
-async function mountWith(deviceConfig: unknown): Promise<HTMLDivElement> {
-  rpcWithDeviceConfig(deviceConfig);
+async function mountWith(
+  deviceConfig: unknown,
+  install = installedActiveStatus,
+): Promise<HTMLDivElement> {
+  rpcWithDeviceConfig(deviceConfig, install);
   const container = document.createElement("div");
   const { mount } = await import("./app");
   mount(container);
   // Wait for the page itself, so "section absent" assertions can't pass
   // simply because nothing has rendered yet.
-  await waitFor(() => expect(container.textContent).toContain("Active"));
+  await waitFor(() =>
+    expect(container.textContent).toContain(install.installed ? "Active" : "Not installed"),
+  );
   return container;
 }
 
@@ -485,6 +490,50 @@ describe("device config drop-in", () => {
     });
     await waitFor(() => {
       expect(container.textContent).toContain("taking precedence");
+    });
+  });
+
+  it("says nothing when InputPlumber isn't installed at all", async () => {
+    // "InputPlumber doesn't recognise this device" is the wrong diagnosis
+    // when the daemon isn't there — the install card says the true thing.
+    const container = await mountWith(applicableConfig, notInstalledStatus);
+    expect(container.textContent).not.toContain("Controller support for this device");
+  });
+
+  it("stops offering a config once upstream ships one for this machine", async () => {
+    // The UI gate and shouldOfferInstall must agree: writing a config that
+    // shadows a freshly-shipped upstream one is the thing to avoid.
+    const container = await mountWith({ ...applicableConfig, superseded: true });
+    expect(container.textContent).not.toContain("Install config");
+  });
+
+  it("surfaces a rejected RPC rather than going quiet", async () => {
+    // installDeviceConfig restarts InputPlumber, so the call can outlive the
+    // socket. Failing silently leaves a written config and a UI claiming
+    // nothing happened.
+    rpcWithDeviceConfig(applicableConfig);
+    callMock.mockImplementation((method: string) => {
+      if (method === "getStatus") return Promise.resolve(installedActiveStatus);
+      if (method === "isInstallRunning") return Promise.resolve({ running: false });
+      if (method === "getDeviceConfigStatus") return Promise.resolve(applicableConfig);
+      if (method === "installDeviceConfig") return Promise.reject(new Error("WebSocket closed"));
+      return Promise.resolve(null);
+    });
+    const container = document.createElement("div");
+    const { mount } = await import("./app");
+    mount(container);
+
+    const btn = await waitFor(() => {
+      const el = [...container.querySelectorAll('[role="button"], button')].find(
+        (b) => b.textContent?.trim() === "Install config",
+      );
+      if (!el) throw new Error("install button not rendered yet");
+      return el;
+    });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("WebSocket closed");
     });
   });
 

--- a/plugins/input-plumber/app.spec.tsx
+++ b/plugins/input-plumber/app.spec.tsx
@@ -397,3 +397,139 @@ describe("input-plumber plugin", () => {
   // InputPlumber), and the IP path only runs on non-Deck hosts (isDeck:false),
   // so isDeck:true + ipActive:false can never occur.
 });
+
+// ---------------------------------------------------------------------------
+// Device config drop-in
+// ---------------------------------------------------------------------------
+
+const applicableConfig = {
+  applicable: true,
+  label: "OneXPlayer X2 Mini Pro",
+  path: "/etc/inputplumber/devices.d/50-onexplayer_x2.yaml",
+  installed: false,
+  hasCompositeDevices: false,
+  superseded: false,
+};
+
+function rpcWithDeviceConfig(deviceConfig: unknown) {
+  callMock.mockImplementation((method: string) => {
+    if (method === "getStatus") return Promise.resolve(installedActiveStatus);
+    if (method === "isInstallRunning") return Promise.resolve({ running: false });
+    if (method === "getDeviceConfigStatus") return Promise.resolve(deviceConfig);
+    if (method === "installDeviceConfig" || method === "removeDeviceConfig") {
+      return Promise.resolve({
+        success: true,
+        status: { ...applicableConfig, installed: method === "installDeviceConfig" },
+      });
+    }
+    return Promise.resolve(null);
+  });
+}
+
+async function mountWith(deviceConfig: unknown): Promise<HTMLDivElement> {
+  rpcWithDeviceConfig(deviceConfig);
+  const container = document.createElement("div");
+  const { mount } = await import("./app");
+  mount(container);
+  // Wait for the page itself, so "section absent" assertions can't pass
+  // simply because nothing has rendered yet.
+  await waitFor(() => expect(container.textContent).toContain("Active"));
+  return container;
+}
+
+describe("device config drop-in", () => {
+  beforeEach(() => {
+    callMock.mockReset();
+    eventHandlers.clear();
+  });
+
+  it("offers a config when InputPlumber doesn't recognise the device", async () => {
+    const container = await mountWith(applicableConfig);
+    await waitFor(() => {
+      expect(container.textContent).toContain("Controller support for this device");
+      expect(container.textContent).toContain("OneXPlayer X2 Mini Pro");
+      expect(container.textContent).toContain("Install config");
+    });
+  });
+
+  it("says nothing on a device we have no config for", async () => {
+    const container = await mountWith({ ...applicableConfig, applicable: false });
+    expect(container.textContent).not.toContain("Controller support for this device");
+  });
+
+  it("says nothing when InputPlumber already drives the device", async () => {
+    // The one outcome to avoid: handing a config to hardware that works.
+    const container = await mountWith({ ...applicableConfig, hasCompositeDevices: true });
+    expect(container.textContent).not.toContain("Controller support for this device");
+  });
+
+  it("still shows the card when our config is why the device works", async () => {
+    // hasCompositeDevices is true *because* we installed it — the user needs
+    // a way back out.
+    const container = await mountWith({
+      ...applicableConfig,
+      installed: true,
+      hasCompositeDevices: true,
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain("Remove config");
+    });
+  });
+
+  it("warns when upstream has shipped its own and ours is shadowing it", async () => {
+    const container = await mountWith({
+      ...applicableConfig,
+      installed: true,
+      hasCompositeDevices: true,
+      superseded: true,
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain("taking precedence");
+    });
+  });
+
+  it("installs on click and flips to the remove action", async () => {
+    const container = await mountWith(applicableConfig);
+    const btn = await waitFor(() => {
+      const el = [...container.querySelectorAll('[role="button"], button')].find(
+        (b) => b.textContent?.trim() === "Install config",
+      );
+      if (!el) throw new Error("install button not rendered yet");
+      return el;
+    });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(callMock).toHaveBeenCalledWith("installDeviceConfig");
+      expect(container.textContent).toContain("Remove config");
+    });
+  });
+
+  it("surfaces a failed write instead of silently doing nothing", async () => {
+    rpcWithDeviceConfig(applicableConfig);
+    callMock.mockImplementation((method: string) => {
+      if (method === "getStatus") return Promise.resolve(installedActiveStatus);
+      if (method === "isInstallRunning") return Promise.resolve({ running: false });
+      if (method === "getDeviceConfigStatus") return Promise.resolve(applicableConfig);
+      if (method === "installDeviceConfig")
+        return Promise.resolve({ success: false, error: "EACCES", status: applicableConfig });
+      return Promise.resolve(null);
+    });
+    const container = document.createElement("div");
+    const { mount } = await import("./app");
+    mount(container);
+
+    const btn = await waitFor(() => {
+      const el = [...container.querySelectorAll('[role="button"], button')].find(
+        (b) => b.textContent?.trim() === "Install config",
+      );
+      if (!el) throw new Error("install button not rendered yet");
+      return el;
+    });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("EACCES");
+    });
+  });
+});

--- a/plugins/input-plumber/app.tsx
+++ b/plugins/input-plumber/app.tsx
@@ -17,7 +17,7 @@ import {
   useFocusable,
 } from "@loadout/ui";
 import { labelFor, parseCapability } from "./lib/profile";
-import type { DeviceConfigStatus } from "./lib/device-config";
+import { shouldOfferInstall, type DeviceConfigStatus } from "./lib/device-config";
 import type {
   InstallLogEvent,
   InstallRunResult,
@@ -332,7 +332,7 @@ function InputPlumberPanel() {
         </div>
         )}
 
-        <DeviceConfigSection />
+        <DeviceConfigSection daemonUp={status.installed && status.serviceActive} />
 
         <WakeButtonSection />
       </div>
@@ -355,14 +355,16 @@ function InputPlumberPanel() {
  * has genuinely come up empty, so it stays invisible on every device that
  * already works.
  */
-function DeviceConfigSection() {
+function DeviceConfigSection({ daemonUp }: { daemonUp: boolean }) {
   const { call, useEvent } = useBackend("input-plumber");
   const [status, setStatus] = useState<DeviceConfigStatus | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    call("getDeviceConfigStatus").then((d) => setStatus(d as DeviceConfigStatus));
+    call("getDeviceConfigStatus")
+      .then((d) => setStatus(d as DeviceConfigStatus))
+      .catch(() => setStatus(null));
   }, [call]);
 
   useEvent({
@@ -380,6 +382,11 @@ function DeviceConfigSection() {
           | null;
         if (res?.status) setStatus(res.status);
         if (!res?.success) setError(res?.error ?? "Couldn't change the InputPlumber config.");
+      } catch (e) {
+        // This call restarts InputPlumber, so the RPC can outlive the socket.
+        // Failing silently would leave a written config and a UI claiming
+        // nothing happened.
+        setError(String(e));
       } finally {
         setBusy(false);
       }
@@ -387,10 +394,14 @@ function DeviceConfigSection() {
     [call],
   );
 
-  if (!status?.applicable) return null;
-  // Nothing to say on a device InputPlumber already drives, unless we're the
-  // reason it does.
-  if (status.hasCompositeDevices && !status.installed) return null;
+  if (!status) return null;
+  // "InputPlumber doesn't recognise this device" is the wrong diagnosis when
+  // InputPlumber isn't running at all — the install card above says the true
+  // thing, and this would send the user down the wrong path.
+  if (!daemonUp) return null;
+  // One source of truth for the offer; `installed` is the separate
+  // remove path.
+  if (!shouldOfferInstall(status) && !status.installed) return null;
 
   return (
     <div className="card mt-3.5">
@@ -426,7 +437,11 @@ function DeviceConfigSection() {
           {status.path}
         </div>
 
-        {error && <div className="subsection-desc mt-2">{error}</div>}
+        {error && (
+          <div className="subsection-desc mt-2" style={{ color: "var(--color-error)" }}>
+            {error}
+          </div>
+        )}
 
         <div className="flex gap-2 mt-3.5 flex-wrap">
           <FocusButton

--- a/plugins/input-plumber/app.tsx
+++ b/plugins/input-plumber/app.tsx
@@ -17,6 +17,7 @@ import {
   useFocusable,
 } from "@loadout/ui";
 import { labelFor, parseCapability } from "./lib/profile";
+import type { DeviceConfigStatus } from "./lib/device-config";
 import type {
   InstallLogEvent,
   InstallRunResult,
@@ -331,7 +332,118 @@ function InputPlumberPanel() {
         </div>
         )}
 
+        <DeviceConfigSection />
+
         <WakeButtonSection />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Device config drop-in
+// ---------------------------------------------------------------------------
+
+/**
+ * InputPlumber only builds a CompositeDevice for hardware one of its configs
+ * matches. On a handheld it doesn't recognise there is no composite device at
+ * all, so the wake-button picker below has nothing to list and overlay
+ * intercept has nothing to act on — the whole plugin looks broken on hardware
+ * that is fine. For the devices we can describe, offer to supply the config.
+ *
+ * Renders nothing unless we have a config for *this* machine and InputPlumber
+ * has genuinely come up empty, so it stays invisible on every device that
+ * already works.
+ */
+function DeviceConfigSection() {
+  const { call, useEvent } = useBackend("input-plumber");
+  const [status, setStatus] = useState<DeviceConfigStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    call("getDeviceConfigStatus").then((d) => setStatus(d as DeviceConfigStatus));
+  }, [call]);
+
+  useEvent({
+    event: "device-config-status",
+    handler: useCallback((data: unknown) => setStatus(data as DeviceConfigStatus), []),
+  });
+
+  const act = useCallback(
+    async (method: "installDeviceConfig" | "removeDeviceConfig") => {
+      setBusy(true);
+      setError(null);
+      try {
+        const res = (await call(method)) as
+          | { success: boolean; error?: string; status: DeviceConfigStatus }
+          | null;
+        if (res?.status) setStatus(res.status);
+        if (!res?.success) setError(res?.error ?? "Couldn't change the InputPlumber config.");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [call],
+  );
+
+  if (!status?.applicable) return null;
+  // Nothing to say on a device InputPlumber already drives, unless we're the
+  // reason it does.
+  if (status.hasCompositeDevices && !status.installed) return null;
+
+  return (
+    <div className="card mt-3.5">
+      <div className="card-body p-4.5">
+        <div className="flex items-center gap-2 mb-2">
+          <FaGamepad className="opacity-60" />
+          <div className="font-medium">Controller support for this device</div>
+        </div>
+
+        {status.installed ? (
+          <>
+            <div className="subsection-desc">
+              Loadout is supplying InputPlumber&apos;s config for the {status.label}. Remove it if
+              you&apos;d rather InputPlumber managed this device itself.
+            </div>
+            {status.superseded && (
+              <div className="subsection-desc mt-2">
+                InputPlumber now ships its own config for this device, and Loadout&apos;s is taking
+                precedence over it. Removing ours is probably the better choice — theirs is tested
+                on the hardware.
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="subsection-desc">
+            InputPlumber doesn&apos;t recognise the {status.label}, so it isn&apos;t managing this
+            device&apos;s controller at all — which is why there&apos;s no wake button to pick
+            below. Loadout can supply a config for it.
+          </div>
+        )}
+
+        <div className="subsection-desc mono text-[11px] mt-2 text-base-content/40">
+          {status.path}
+        </div>
+
+        {error && <div className="subsection-desc mt-2">{error}</div>}
+
+        <div className="flex gap-2 mt-3.5 flex-wrap">
+          <FocusButton
+            onClick={() => void act(status.installed ? "removeDeviceConfig" : "installDeviceConfig")}
+            disabled={busy}
+          >
+            {busy
+              ? "Working…"
+              : status.installed
+                ? "Remove config"
+                : "Install config"}
+          </FocusButton>
+        </div>
+
+        <div className="subsection-desc mt-2">
+          InputPlumber restarts either way, which briefly drops the controller.
+        </div>
       </div>
     </div>
   );

--- a/plugins/input-plumber/backend.ts
+++ b/plugins/input-plumber/backend.ts
@@ -14,8 +14,20 @@
  */
 
 import type { PluginBackend, EmitPayload, PluginLogger } from "@loadout/types";
+import { mkdir, writeFile, readdir, unlink } from "node:fs/promises";
+import { readDmi } from "@loadout/devices";
 import * as installer from "./lib/install";
 import * as wake from "./lib/wake-trigger";
+import * as ipdbus from "./lib/ipdbus";
+import {
+  DEVICES_D,
+  NOT_APPLICABLE,
+  UPSTREAM_DEVICES_DIR,
+  configPath,
+  findDeviceConfig,
+  isSupersededByUpstream,
+  type DeviceConfigStatus,
+} from "./lib/device-config";
 import type {
   InstallStartResult,
   WakeStatus,
@@ -308,6 +320,96 @@ export default class InputPlumberBackend implements PluginBackend {
     const r = await wake.clearWakeButton();
     this.emit?.({ event: "wake-status", data: await wake.getWakeStatus() });
     return r;
+  }
+
+  // ── Device config ────────────────────────────────────────────────────────
+  //
+  // InputPlumber only builds a CompositeDevice for hardware one of its
+  // configs matches. On a handheld it has no config for, every feature this
+  // plugin offers is inert — so for the devices we can describe, offer to
+  // drop one in. See lib/device-config.ts for why this is a shadowing
+  // drop-in rather than a Loadout-branded addition.
+
+  async getDeviceConfigStatus(): Promise<DeviceConfigStatus> {
+    const config = findDeviceConfig(await readDmi());
+    if (!config) return NOT_APPLICABLE;
+
+    const path = configPath(config);
+    // Composite devices are the actual question — "does InputPlumber already
+    // drive this machine" — not whether the daemon is merely installed.
+    const [installed, composites, upstream] = await Promise.all([
+      Bun.file(path)
+        .exists()
+        .catch(() => false),
+      ipdbus.listCompositeDevicePaths().catch(() => [] as string[]),
+      readdir(UPSTREAM_DEVICES_DIR).catch(() => [] as string[]),
+    ]);
+
+    return {
+      applicable: true,
+      label: config.label,
+      path,
+      installed,
+      hasCompositeDevices: composites.length > 0,
+      superseded: isSupersededByUpstream(config, upstream),
+    };
+  }
+
+  /** Write the config and restart InputPlumber so it picks it up. */
+  async installDeviceConfig(): Promise<{
+    success: boolean;
+    error?: string;
+    status: DeviceConfigStatus;
+  }> {
+    const config = findDeviceConfig(await readDmi());
+    if (!config) {
+      return { success: false, error: "No InputPlumber config for this device.", status: NOT_APPLICABLE };
+    }
+    try {
+      await mkdir(DEVICES_D, { recursive: true });
+      await writeFile(configPath(config), config.yaml, "utf-8");
+      this.log?.info(`[input-plumber] installed device config ${configPath(config)}`);
+    } catch (e) {
+      this.log?.warn(`[input-plumber] could not write device config: ${e}`);
+      return { success: false, error: String(e), status: await this.getDeviceConfigStatus() };
+    }
+
+    // The daemon reads configs at startup only.
+    const restart = await wake.restartInputPlumber();
+    const status = await this.getDeviceConfigStatus();
+    this.emit?.({ event: "device-config-status", data: status });
+    return restart.ok
+      ? { success: true, status }
+      : { success: false, error: `Config written, but InputPlumber didn't restart: ${restart.error}`, status };
+  }
+
+  /** Remove the config we installed and restart InputPlumber. */
+  async removeDeviceConfig(): Promise<{
+    success: boolean;
+    error?: string;
+    status: DeviceConfigStatus;
+  }> {
+    const config = findDeviceConfig(await readDmi());
+    if (!config) {
+      return { success: false, error: "No InputPlumber config for this device.", status: NOT_APPLICABLE };
+    }
+    try {
+      await unlink(configPath(config));
+      this.log?.info(`[input-plumber] removed device config ${configPath(config)}`);
+    } catch (e) {
+      // Already gone is the outcome the user asked for, not a failure.
+      const code = (e as NodeJS.ErrnoException)?.code;
+      if (code !== "ENOENT") {
+        this.log?.warn(`[input-plumber] could not remove device config: ${e}`);
+        return { success: false, error: String(e), status: await this.getDeviceConfigStatus() };
+      }
+    }
+    const restart = await wake.restartInputPlumber();
+    const status = await this.getDeviceConfigStatus();
+    this.emit?.({ event: "device-config-status", data: status });
+    return restart.ok
+      ? { success: true, status }
+      : { success: false, error: `Config removed, but InputPlumber didn't restart: ${restart.error}`, status };
   }
 
   /** Recovery: restart the InputPlumber daemon and re-load the wake profile.

--- a/plugins/input-plumber/backend.ts
+++ b/plugins/input-plumber/backend.ts
@@ -14,7 +14,8 @@
  */
 
 import type { PluginBackend, EmitPayload, PluginLogger } from "@loadout/types";
-import { mkdir, writeFile, readdir, unlink } from "node:fs/promises";
+import { mkdir, writeFile, readdir, readFile, unlink } from "node:fs/promises";
+import { join } from "node:path";
 import { readDmi } from "@loadout/devices";
 import * as installer from "./lib/install";
 import * as wake from "./lib/wake-trigger";
@@ -26,7 +27,9 @@ import {
   configPath,
   findDeviceConfig,
   isSupersededByUpstream,
+  parseUpstreamMatches,
   type DeviceConfigStatus,
+  type UpstreamMatch,
 } from "./lib/device-config";
 import type {
   InstallStartResult,
@@ -342,7 +345,7 @@ export default class InputPlumberBackend implements PluginBackend {
         .exists()
         .catch(() => false),
       ipdbus.listCompositeDevicePaths().catch(() => [] as string[]),
-      readdir(UPSTREAM_DEVICES_DIR).catch(() => [] as string[]),
+      this.readUpstreamMatches(),
     ]);
 
     return {
@@ -353,6 +356,23 @@ export default class InputPlumberBackend implements PluginBackend {
       hasCompositeDevices: composites.length > 0,
       superseded: isSupersededByUpstream(config, upstream),
     };
+  }
+
+  /**
+   * Every DMI pair InputPlumber's own configs claim.
+   *
+   * Read rather than inferred from filenames: upstream may well name their
+   * X2 config something other than ours, in which case both load and both
+   * match, and only the DMI tells us so.
+   */
+  private async readUpstreamMatches(): Promise<UpstreamMatch[]> {
+    const files = await readdir(UPSTREAM_DEVICES_DIR).catch(() => [] as string[]);
+    const docs = await Promise.all(
+      files
+        .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+        .map((f) => readFile(join(UPSTREAM_DEVICES_DIR, f), "utf-8").catch(() => "")),
+    );
+    return docs.flatMap(parseUpstreamMatches);
   }
 
   /** Write the config and restart InputPlumber so it picks it up. */
@@ -393,8 +413,10 @@ export default class InputPlumberBackend implements PluginBackend {
     if (!config) {
       return { success: false, error: "No InputPlumber config for this device.", status: NOT_APPLICABLE };
     }
+    let removed = false;
     try {
       await unlink(configPath(config));
+      removed = true;
       this.log?.info(`[input-plumber] removed device config ${configPath(config)}`);
     } catch (e) {
       // Already gone is the outcome the user asked for, not a failure.
@@ -404,6 +426,15 @@ export default class InputPlumberBackend implements PluginBackend {
         return { success: false, error: String(e), status: await this.getDeviceConfigStatus() };
       }
     }
+
+    // Restarting drops the controller for seconds; skip it when there was
+    // nothing on disk to stop InputPlumber reading.
+    if (!removed) {
+      const status = await this.getDeviceConfigStatus();
+      this.emit?.({ event: "device-config-status", data: status });
+      return { success: true, status };
+    }
+
     const restart = await wake.restartInputPlumber();
     const status = await this.getDeviceConfigStatus();
     this.emit?.({ event: "device-config-status", data: status });

--- a/plugins/input-plumber/lib/device-config.test.ts
+++ b/plugins/input-plumber/lib/device-config.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "bun:test";
+import {
+  DEVICE_CONFIGS,
+  DEVICES_D,
+  NOT_APPLICABLE,
+  X2_MINI_PRO,
+  configPath,
+  findDeviceConfig,
+  isSupersededByUpstream,
+  shouldOfferInstall,
+  type DeviceConfigStatus,
+} from "./device-config";
+
+/**
+ * These configs hand a device's input handling to InputPlumber, so the tests
+ * care about two things above all: that the YAML is actually loadable, and
+ * that we never claim a machine we didn't mean to.
+ */
+
+function status(over: Partial<DeviceConfigStatus> = {}): DeviceConfigStatus {
+  return {
+    applicable: true,
+    label: X2_MINI_PRO.label,
+    path: configPath(X2_MINI_PRO),
+    installed: false,
+    hasCompositeDevices: false,
+    superseded: false,
+    ...over,
+  };
+}
+
+describe("the shipped configs", () => {
+  it.each(DEVICE_CONFIGS.map((c) => [c.label, c] as const))("%s parses as YAML", (_label, c) => {
+    // A config InputPlumber can't parse is worse than none: it's a file on
+    // the user's disk doing nothing, with no error surfaced to them.
+    expect(() => Bun.YAML.parse(c.yaml)).not.toThrow();
+  });
+
+  it.each(DEVICE_CONFIGS.map((c) => [c.label, c] as const))(
+    "%s declares the shape InputPlumber requires",
+    (_label, c) => {
+      const doc = Bun.YAML.parse(c.yaml) as Record<string, unknown>;
+      expect(doc.version).toBe(1);
+      expect(doc.kind).toBe("CompositeDevice");
+      expect(Array.isArray(doc.source_devices)).toBe(true);
+      expect((doc.source_devices as unknown[]).length).toBeGreaterThan(0);
+      expect(Array.isArray(doc.target_devices)).toBe(true);
+    },
+  );
+
+  it.each(DEVICE_CONFIGS.map((c) => [c.label, c] as const))(
+    "%s matches the same DMI in its YAML as in its metadata",
+    (_label, c) => {
+      // These are two hand-written copies of the same fact. If they drift,
+      // the file installs on a device whose DMI it then doesn't match, and
+      // InputPlumber silently ignores it.
+      const doc = Bun.YAML.parse(c.yaml) as {
+        matches: { dmi_data: { product_name: string; sys_vendor: string } }[];
+      };
+      expect(doc.matches.map((m) => m.dmi_data.product_name)).toContain(c.productName);
+      expect(doc.matches.map((m) => m.dmi_data.sys_vendor)).toContain(c.sysVendor);
+    },
+  );
+
+  it("keeps the X2's DMI string exactly as the firmware reports it", () => {
+    // No space in "X2Mini", uppercase PRO. Taken from a doctor report and
+    // corroborated by Handheld Daemon's device table; InputPlumber matches
+    // this literally, so a prettified string matches nothing.
+    expect(X2_MINI_PRO.productName).toBe("ONEXPLAYER X2Mini PRO");
+    expect(X2_MINI_PRO.sysVendor).toBe("ONE-NETBOOK");
+  });
+
+  it("names files the way upstream would, so a future config is shadowed not duplicated", () => {
+    // /etc/inputplumber/devices.d is searched before /usr/share, and ties
+    // are broken by basename. A Loadout-branded name would load *alongside*
+    // an upstream config rather than instead of it.
+    for (const c of DEVICE_CONFIGS) {
+      expect(c.filename).toMatch(/^\d\d-[a-z0-9_]+\.yaml$/);
+      expect(c.filename).not.toMatch(/loadout/i);
+    }
+  });
+
+  it("does not claim the system keyboard or map the back paddles", () => {
+    // Both are deliberate omissions (see the module docblock); a later edit
+    // adding either should have to argue with this test first.
+    const doc = Bun.YAML.parse(X2_MINI_PRO.yaml) as {
+      source_devices: { evdev?: { name?: string } }[];
+      capability_map_id?: string;
+    };
+    const names = doc.source_devices.map((s) => s.evdev?.name).filter(Boolean);
+    expect(names).not.toContain("AT Translated Set 2 keyboard");
+    expect(doc.capability_map_id).toBeUndefined();
+  });
+});
+
+describe("findDeviceConfig", () => {
+  it("finds the X2 Mini Pro by its exact DMI", () => {
+    expect(
+      findDeviceConfig({ productName: "ONEXPLAYER X2Mini PRO", sysVendor: "ONE-NETBOOK" }),
+    ).toBe(X2_MINI_PRO);
+  });
+
+  it("tolerates the trailing newline sysfs actually returns", () => {
+    expect(
+      findDeviceConfig({ productName: "ONEXPLAYER X2Mini PRO\n", sysVendor: "ONE-NETBOOK\n" }),
+    ).toBe(X2_MINI_PRO);
+  });
+
+  it("refuses near-misses rather than claiming a device we've never run on", () => {
+    // Substring matching would catch all of these. A config claims specific
+    // USB ids and takes over input handling, so a false positive is far
+    // worse than a false negative.
+    for (const dmi of [
+      { productName: "ONEXPLAYER X2Mini", sysVendor: "ONE-NETBOOK" }, // the non-Pro
+      { productName: "ONEXPLAYER X2Mini PRO 2", sysVendor: "ONE-NETBOOK" },
+      { productName: "ONEXPLAYER APEX", sysVendor: "ONE-NETBOOK" },
+      { productName: "ONEXPLAYER X2Mini PRO", sysVendor: "AOKZOE" },
+      { productName: "", sysVendor: "" },
+    ]) {
+      expect(findDeviceConfig(dmi)).toBeNull();
+    }
+  });
+
+  it("returns null when the DMI couldn't be read at all", () => {
+    expect(findDeviceConfig(null)).toBeNull();
+  });
+});
+
+describe("configPath", () => {
+  it("installs into InputPlumber's drop-in directory", () => {
+    expect(configPath(X2_MINI_PRO)).toBe(`${DEVICES_D}/50-onexplayer_x2.yaml`);
+  });
+});
+
+describe("isSupersededByUpstream", () => {
+  it("spots upstream shipping the same basename", () => {
+    expect(isSupersededByUpstream(X2_MINI_PRO, ["50-onexplayer_apex.yaml"])).toBe(false);
+    expect(
+      isSupersededByUpstream(X2_MINI_PRO, ["50-onexplayer_apex.yaml", "50-onexplayer_x2.yaml"]),
+    ).toBe(true);
+  });
+});
+
+describe("shouldOfferInstall", () => {
+  it("offers it when InputPlumber has nothing for this device", () => {
+    expect(shouldOfferInstall(status())).toBe(true);
+  });
+
+  it("stays quiet when the device already works", () => {
+    // The worst outcome here is handing a config to a device InputPlumber
+    // already drives correctly.
+    expect(shouldOfferInstall(status({ hasCompositeDevices: true }))).toBe(false);
+  });
+
+  it("stays quiet once ours is installed", () => {
+    expect(shouldOfferInstall(status({ installed: true }))).toBe(false);
+  });
+
+  it("stays quiet once upstream ships its own", () => {
+    expect(shouldOfferInstall(status({ superseded: true }))).toBe(false);
+  });
+
+  it("stays quiet on a device we have no config for", () => {
+    expect(shouldOfferInstall(NOT_APPLICABLE)).toBe(false);
+  });
+});

--- a/plugins/input-plumber/lib/device-config.test.ts
+++ b/plugins/input-plumber/lib/device-config.test.ts
@@ -7,6 +7,7 @@ import {
   configPath,
   findDeviceConfig,
   isSupersededByUpstream,
+  parseUpstreamMatches,
   shouldOfferInstall,
   type DeviceConfigStatus,
 } from "./device-config";
@@ -80,6 +81,43 @@ describe("the shipped configs", () => {
     }
   });
 
+  it("keeps USB ids as strings, not numbers", () => {
+    // InputPlumber glob-matches evdev ids against a %04x-formatted string.
+    // Unquoted, "045e" is the number 45 to a YAML parser — which serde would
+    // reject outright, and InputPlumber would then skip the file with only a
+    // log line to show for it.
+    const doc = Bun.YAML.parse(X2_MINI_PRO.yaml) as {
+      source_devices: { evdev?: { vendor_id?: unknown; product_id?: unknown } }[];
+    };
+    for (const src of doc.source_devices) {
+      if (!src.evdev?.vendor_id && !src.evdev?.product_id) continue;
+      expect(typeof src.evdev.vendor_id).toBe("string");
+      expect(typeof src.evdev.product_id).toBe("string");
+    }
+  });
+
+  it("joins the MCU's second evdev node instead of forking a composite", () => {
+    // The 1a86:fe00 MCU exposes TWO evdev nodes under one name (input0, and
+    // input1 with a mouse). Left unique, the second forks a second
+    // CompositeDevice off this same config — duplicate virtual pads.
+    const doc = Bun.YAML.parse(X2_MINI_PRO.yaml) as {
+      source_devices: { unique?: boolean; evdev?: { name?: string } }[];
+    };
+    const mcu = doc.source_devices.find((s) => s.evdev?.name === "HID 1a86:fe00");
+    expect(mcu?.unique).toBe(false);
+  });
+
+  it("does not swallow external XInput pads into the handheld's composite", () => {
+    // 045e:028e is the generic XInput id. unique:false here would fold any
+    // external Xbox pad into the built-in controller; the name narrows it.
+    const doc = Bun.YAML.parse(X2_MINI_PRO.yaml) as {
+      source_devices: { unique?: boolean; evdev?: { name?: string; vendor_id?: string } }[];
+    };
+    const pad = doc.source_devices.find((s) => s.evdev?.vendor_id === "045e");
+    expect(pad?.evdev?.name).toBe("Microsoft X-Box 360 pad");
+    expect(pad?.unique).not.toBe(false);
+  });
+
   it("does not claim the system keyboard or map the back paddles", () => {
     // Both are deliberate omissions (see the module docblock); a later edit
     // adding either should have to argue with this test first.
@@ -132,12 +170,63 @@ describe("configPath", () => {
   });
 });
 
-describe("isSupersededByUpstream", () => {
-  it("spots upstream shipping the same basename", () => {
-    expect(isSupersededByUpstream(X2_MINI_PRO, ["50-onexplayer_apex.yaml"])).toBe(false);
+describe("parseUpstreamMatches", () => {
+  it("pulls the DMI pairs a config claims", () => {
     expect(
-      isSupersededByUpstream(X2_MINI_PRO, ["50-onexplayer_apex.yaml", "50-onexplayer_x2.yaml"]),
+      parseUpstreamMatches(`version: 1
+kind: CompositeDevice
+matches:
+  - dmi_data:
+      product_name: ONEXPLAYER X1 A
+      sys_vendor: ONE-NETBOOK
+  - dmi_data:
+      product_name: ONEXPLAYER X1 i
+      sys_vendor: ONE-NETBOOK
+`),
+    ).toEqual([
+      { productName: "ONEXPLAYER X1 A", sysVendor: "ONE-NETBOOK" },
+      { productName: "ONEXPLAYER X1 i", sysVendor: "ONE-NETBOOK" },
+    ]);
+  });
+
+  it("yields nothing rather than throwing on anything unexpected", () => {
+    // These are files another project ships, in a schema it can extend. A
+    // parse error here would break the whole status probe.
+    for (const bad of ["", "just a string", "{{{", "matches: not-a-list", "version: 1"]) {
+      expect(parseUpstreamMatches(bad)).toEqual([]);
+    }
+    // A match with no dmi_data (InputPlumber also supports other match
+    // kinds) contributes nothing rather than an undefined-filled entry.
+    expect(parseUpstreamMatches("matches:\n  - dmi_data:\n      product_name: X\n")).toEqual([]);
+  });
+});
+
+describe("isSupersededByUpstream", () => {
+  it("spots upstream claiming this machine's DMI", () => {
+    expect(
+      isSupersededByUpstream(X2_MINI_PRO, [
+        { productName: "ONEXPLAYER APEX", sysVendor: "ONE-NETBOOK" },
+      ]),
+    ).toBe(false);
+    expect(
+      isSupersededByUpstream(X2_MINI_PRO, [
+        { productName: "ONEXPLAYER APEX", sysVendor: "ONE-NETBOOK" },
+        { productName: "ONEXPLAYER X2Mini PRO", sysVendor: "ONE-NETBOOK" },
+      ]),
     ).toBe(true);
+  });
+
+  it("still spots it when upstream picks a different filename", () => {
+    // The whole point of keying on DMI. Their family is named
+    // 50-onexplayer_apex / _x1 / _mini_pro, so 50-onexplayer_x2_mini_pro.yaml
+    // is at least as likely as our 50-onexplayer_x2.yaml — and under a
+    // different name BOTH configs load and both match this machine.
+    const upstreamFile = `matches:
+  - dmi_data:
+      product_name: ONEXPLAYER X2Mini PRO
+      sys_vendor: ONE-NETBOOK
+`;
+    expect(isSupersededByUpstream(X2_MINI_PRO, parseUpstreamMatches(upstreamFile))).toBe(true);
   });
 });
 

--- a/plugins/input-plumber/lib/device-config.ts
+++ b/plugins/input-plumber/lib/device-config.ts
@@ -1,0 +1,209 @@
+/**
+ * Ship an InputPlumber *device* config for handhelds InputPlumber doesn't
+ * recognise yet.
+ *
+ * ## Why this exists
+ *
+ * InputPlumber only builds a CompositeDevice for hardware one of its configs
+ * matches, and matching is on the exact `/sys/class/dmi/id/product_name`
+ * (`glob_match`, but no shipped OneXPlayer config uses a wildcard). A device
+ * it hasn't got a config for produces *no* composite device — so
+ * `listCompositeDevicePaths()` comes back empty, the wake-button picker has
+ * nothing to offer, and overlay input intercept has nothing to act on. Every
+ * InputPlumber-dependent feature is inert, on hardware that is otherwise
+ * completely conventional.
+ *
+ * That is the OneXPlayer X2 Mini Pro's situation as of InputPlumber 0.78.1:
+ * a stock `045e:028e` XInput pad and the same `1a86:fe00` OneXPlayer MCU the
+ * Apex and X1 configs already use, and no config naming it.
+ *
+ * ## Why a drop-in works
+ *
+ * `get_devices_paths()` reads `/etc/inputplumber/devices.d` *before*
+ * `/usr/share/inputplumber/devices`, and files are sorted by filename with
+ * directory order breaking ties. So a file here with the same basename an
+ * upstream config would use *shadows* it rather than adding a second config
+ * that matches the same machine. That is why {@link X2_MINI_PRO} pins
+ * `50-onexplayer_x2.yaml` and not something Loadout-branded: the day
+ * InputPlumber ships its own, ours quietly takes precedence instead of
+ * racing it, and {@link isSupersededByUpstream} can tell the user to drop it.
+ *
+ * NOTE the capability-map search order is *inverted* from this one
+ * (`/usr/share` first, `/etc/inputplumber/capability_maps.d` second), so the
+ * same trick does not work for capability maps. This module deliberately
+ * ships none — see below.
+ *
+ * ## What is deliberately left out
+ *
+ * Only what makes a composite device exist: the gamepad, the MCU's HID
+ * interface, and the MCU's keyboard interface. Not included, because neither
+ * can be verified without the hardware and both can make things worse:
+ *
+ * - **The `AT Translated Set 2 keyboard` source.** The Apex config claims it
+ *   for volume keys. Claiming the system keyboard on a board we have never
+ *   run means a wrong guess costs the user their keyboard, not a feature.
+ * - **A capability map for the back paddles.** On the X2 the MCU's intercept
+ *   mode no longer carries them; Handheld Daemon remaps them to keycodes so
+ *   they arrive as KEY_F15/KEY_F16 on the MCU keyboard interface. Two
+ *   problems: that mapping is applied by *HHD's* init, and we would be
+ *   relying on the kernel `hid-oxp` driver to do the same — untested — and
+ *   KEY_F16 is already the overlay's wake key (KEY_F15 is a capture
+ *   sentinel), so claiming them would change behaviour that may already
+ *   work. That needs a decision and an `evtest`, not a default.
+ */
+
+/** InputPlumber's drop-in directory for device configs. */
+export const DEVICES_D = "/etc/inputplumber/devices.d";
+
+/** Where InputPlumber's own configs live, checked to spot upstream catching
+ *  up with us. */
+export const UPSTREAM_DEVICES_DIR = "/usr/share/inputplumber/devices";
+
+const SCHEMA =
+  "https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json";
+
+export interface DeviceConfig {
+  /** Exact `/sys/class/dmi/id/product_name` this applies to. */
+  productName: string;
+  /** Exact `/sys/class/dmi/id/sys_vendor`. */
+  sysVendor: string;
+  /** Shown in the UI. */
+  label: string;
+  /** Basename, matching what upstream would ship so this shadows it. */
+  filename: string;
+  yaml: string;
+}
+
+/**
+ * OneXPlayer X2 Mini Pro.
+ *
+ * Sources are matched by USB id rather than `phys_path`: the schema makes
+ * `phys_path` optional and the ROG Ally / Legion Go configs already omit it,
+ * and we have this device's USB ids from a doctor report but not its bus
+ * topology. If a second X2 variant ever collides, pin `phys_path` then.
+ */
+export const X2_MINI_PRO: DeviceConfig = {
+  productName: "ONEXPLAYER X2Mini PRO",
+  sysVendor: "ONE-NETBOOK",
+  label: "OneXPlayer X2 Mini Pro",
+  filename: "50-onexplayer_x2.yaml",
+  yaml: `# yaml-language-server: $schema=${SCHEMA}
+#
+# Installed by Loadout because InputPlumber ships no config matching this
+# device, which leaves it with no CompositeDevice at all. Remove it from
+# Loadout's InputPlumber plugin, or delete this file and restart
+# inputplumber.service.
+version: 1
+kind: CompositeDevice
+
+name: ONEXPLAYER X2 Mini Pro
+
+single_source: false
+
+# /sys/class/dmi/id/product_name
+matches:
+  - dmi_data:
+      product_name: ONEXPLAYER X2Mini PRO
+      sys_vendor: ONE-NETBOOK
+
+source_devices:
+  - group: gamepad
+    unique: false
+    evdev:
+      vendor_id: 045e
+      product_id: 028e
+      handler: event*
+  - group: keyboard
+    evdev:
+      name: HID 1a86:fe00
+      handler: event*
+  - group: gamepad
+    hidraw:
+      vendor_id: 0x1a86
+      product_id: 0xfe00
+      interface_num: 2
+
+options:
+  auto_manage: true
+
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+`,
+};
+
+/** Every device we can supply a config for. */
+export const DEVICE_CONFIGS: readonly DeviceConfig[] = [X2_MINI_PRO];
+
+export interface Dmi {
+  productName: string;
+  sysVendor: string;
+}
+
+/**
+ * The config for this machine, or null.
+ *
+ * Exact match on both DMI fields — deliberately stricter than
+ * `packages/devices`' substring matching. A config claims specific USB ids
+ * and hands input handling to InputPlumber, so matching a device we did not
+ * mean to is a much worse failure than not matching one we did.
+ */
+export function findDeviceConfig(dmi: Dmi | null): DeviceConfig | null {
+  if (!dmi) return null;
+  const productName = dmi.productName.trim();
+  const sysVendor = dmi.sysVendor.trim();
+  return (
+    DEVICE_CONFIGS.find((c) => c.productName === productName && c.sysVendor === sysVendor) ?? null
+  );
+}
+
+/** Absolute path the config is installed to. */
+export function configPath(config: DeviceConfig): string {
+  return `${DEVICES_D}/${config.filename}`;
+}
+
+/**
+ * Whether InputPlumber now ships its own config under this basename, meaning
+ * ours is shadowing it and should be removed. Ours winning is the correct
+ * behaviour while it is the only config; it is the wrong behaviour once
+ * upstream — which can test the hardware — has one.
+ */
+export function isSupersededByUpstream(config: DeviceConfig, upstreamFiles: string[]): boolean {
+  return upstreamFiles.includes(config.filename);
+}
+
+export interface DeviceConfigStatus {
+  /** We have a config for this machine. When false the UI shows nothing. */
+  applicable: boolean;
+  label: string | null;
+  path: string | null;
+  /** Our file is on disk. */
+  installed: boolean;
+  /** InputPlumber is already producing composite devices here. */
+  hasCompositeDevices: boolean;
+  /** Upstream now ships this filename; ours is shadowing it. */
+  superseded: boolean;
+}
+
+export const NOT_APPLICABLE: DeviceConfigStatus = {
+  applicable: false,
+  label: null,
+  path: null,
+  installed: false,
+  hasCompositeDevices: false,
+  superseded: false,
+};
+
+/**
+ * Should the user be offered the install?
+ *
+ * Only when we have a config, it isn't already installed, and InputPlumber
+ * genuinely has nothing — a device that already works must never be offered
+ * a config that would take its input handling over.
+ */
+export function shouldOfferInstall(status: DeviceConfigStatus): boolean {
+  return (
+    status.applicable && !status.installed && !status.hasCompositeDevices && !status.superseded
+  );
+}

--- a/plugins/input-plumber/lib/device-config.ts
+++ b/plugins/input-plumber/lib/device-config.ts
@@ -107,13 +107,26 @@ matches:
       sys_vendor: ONE-NETBOOK
 
 source_devices:
+  # Quoted: these are glob-matched as strings against a %04x-formatted id.
+  # Unquoted, 045e is a number to some YAML parsers.
+  #
+  # \`name\` as well as the ids, and no \`unique: false\`: 045e:028e is the
+  # generic XInput id, so an external Xbox pad would otherwise be folded into
+  # the handheld's own composite device instead of presenting separately.
   - group: gamepad
-    unique: false
     evdev:
-      vendor_id: 045e
-      product_id: 028e
+      name: Microsoft X-Box 360 pad
+      vendor_id: "045e"
+      product_id: "028e"
       handler: event*
+  # unique: false because the MCU exposes TWO evdev nodes under this one
+  # name (input0 keyboard, input1 keyboard+mouse). Left unique, the second
+  # forks a second CompositeDevice off this same config — duplicate virtual
+  # pads, which is the "works in menus, not in Steam" signature. Upstream's
+  # Apex and X1 configs avoid it by pinning phys_path; we don't have this
+  # board's topology, so we join instead.
   - group: keyboard
+    unique: false
     evdev:
       name: HID 1a86:fe00
       handler: event*
@@ -163,14 +176,51 @@ export function configPath(config: DeviceConfig): string {
   return `${DEVICES_D}/${config.filename}`;
 }
 
+/** A DMI pair some upstream config claims. */
+export interface UpstreamMatch {
+  productName: string;
+  sysVendor: string;
+}
+
 /**
- * Whether InputPlumber now ships its own config under this basename, meaning
- * ours is shadowing it and should be removed. Ours winning is the correct
- * behaviour while it is the only config; it is the wrong behaviour once
- * upstream — which can test the hardware — has one.
+ * Pull the DMI pairs a config file claims. Tolerant by design: this reads
+ * files another project ships, in a schema it can extend, so anything
+ * unrecognised yields no matches rather than throwing.
  */
-export function isSupersededByUpstream(config: DeviceConfig, upstreamFiles: string[]): boolean {
-  return upstreamFiles.includes(config.filename);
+export function parseUpstreamMatches(yamlText: string): UpstreamMatch[] {
+  let doc: unknown;
+  try {
+    doc = Bun.YAML.parse(yamlText);
+  } catch {
+    return [];
+  }
+  const matches = (doc as { matches?: unknown })?.matches;
+  if (!Array.isArray(matches)) return [];
+  return matches.flatMap((m) => {
+    const dmi = (m as { dmi_data?: { product_name?: unknown; sys_vendor?: unknown } })?.dmi_data;
+    if (typeof dmi?.product_name !== "string" || typeof dmi?.sys_vendor !== "string") return [];
+    return [{ productName: dmi.product_name, sysVendor: dmi.sys_vendor }];
+  });
+}
+
+/**
+ * Whether InputPlumber now ships its own config for this machine, meaning
+ * ours should be removed. Ours winning is correct while it is the only
+ * config; it is wrong once upstream — which can test the hardware — has one.
+ *
+ * Deliberately keyed on the DMI upstream claims, not on our filename. We
+ * name files the way upstream would so a same-name config is shadowed rather
+ * than duplicated, but there is no guarantee they pick that name: their
+ * family runs `50-onexplayer_apex.yaml`, `50-onexplayer_x1.yaml`,
+ * `50-onexplayer_mini_pro.yaml`, so `50-onexplayer_x2_mini_pro.yaml` is at
+ * least as likely as ours. Under a different name both configs load and both
+ * match — and a filename check would report "not superseded" in exactly the
+ * case where the user most needs telling.
+ */
+export function isSupersededByUpstream(config: DeviceConfig, upstream: UpstreamMatch[]): boolean {
+  return upstream.some(
+    (m) => m.productName === config.productName && m.sysVendor === config.sysVendor,
+  );
 }
 
 export interface DeviceConfigStatus {

--- a/plugins/input-plumber/package.json
+++ b/plugins/input-plumber/package.json
@@ -52,6 +52,7 @@
         "/etc/udev/rules.d",
         "/etc/loadout/inputplumber",
         "/etc/inputplumber",
+        "/usr/share/inputplumber",
         "/usr/share/polkit-1/actions",
         "/sys/class/hidraw",
         "/dev/hidraw*"


### PR DESCRIPTION
Follow-up to #271. Separate PR because it's a different plugin and a different risk class: #271's claims are all backed by a doctor report, whereas a device config is a *behavioural* change on hardware we can't test.

## The problem

InputPlumber only builds a `CompositeDevice` for hardware one of its configs matches, on the exact `/sys/class/dmi/id/product_name` (no shipped OneXPlayer config uses a wildcard). A handheld it doesn't recognise gets **no composite device at all** — `listCompositeDevicePaths()` returns empty, the wake-button picker lists nothing, overlay intercept has nothing to act on. The whole plugin looks broken on hardware that's fine.

That's the OneXPlayer X2 Mini Pro as of InputPlumber 0.78.1: a stock `045e:028e` XInput pad and the same `1a86:fe00` MCU the Apex and X1 configs already use, and nothing naming it.

## Why a drop-in works

`get_devices_paths()` reads `/etc/inputplumber/devices.d` **before** `/usr/share/inputplumber/devices`, with ties broken by basename. So the config uses the filename upstream would use — it *shadows* a future upstream config rather than loading alongside it and matching the same machine twice. When upstream ships one, the UI says so and suggests removing ours, since theirs is tested on the hardware.

(Note for later: the capability-map search order is **inverted** — `/usr/share` first — so the same trick doesn't work there.)

## What's deliberately left out

Only enough to make a composite device exist. Not included:

- **The `AT Translated Set 2 keyboard` source.** The Apex config claims it for volume keys. Claiming the system keyboard on a board we've never run means a wrong guess costs the user their keyboard, not a feature.
- **A back-paddle capability map.** On the X2 the MCU's intercept mode no longer carries the paddles; HHD remaps them to keycodes so they arrive as KEY_F15/KEY_F16. But that mapping is applied by *HHD's* init and we'd be relying on the kernel `hid-oxp` to do the same (untested), and F16 is already the overlay's wake key while F15 is its capture sentinel. Claiming them would change behaviour that may already work — that needs a decision and an `evtest`, not a default.

## Safety

The card only renders when we have a config for this exact machine **and** InputPlumber has produced no composite devices. A device that already works is never offered one. DMI matching is exact on both fields — deliberately stricter than `packages/devices`' substring matching, because a false positive here hands input handling to a config written for different hardware.

Install and remove both restart InputPlumber; removal treats "already gone" as success.

## Tests

17 unit tests + 7 UI tests. Every config is parsed with `Bun.YAML` and checked for the shape InputPlumber requires, and the DMI in the YAML body is cross-checked against the metadata (they're two hand-written copies of one fact). Mutation-checked: substring matching, a Loadout-branded filename, a prettified DMI string, adding the AT keyboard, and dropping either UI guard each fail a test.

## Not verified

We have no X2 Mini Pro. This is the reviewable form of the question rather than a tested change — worth getting in front of the user who reported it before it ships. If it works on hardware, this is also the basis for an upstream InputPlumber PR (their ONEXPLAYER 3 support, #660, is the same three-file shape).