### PR TITLE
fix(apex): the wake block counts as applied on distros we don't stage a karg on

### DIFF
--- a/plugins/apex/lib/fingerprint.test.ts
+++ b/plugins/apex/lib/fingerprint.test.ts
@@ -597,3 +597,71 @@ describe("shouldHeal", () => {
     );
   });
 });
+
+describe("an Apex on a distro whose bootloader we don't edit", () => {
+  /**
+   * CachyOS/Bazzite: the board is measured (so we know the pin) but we never
+   * stage the karg there. Counting it toward `applied` anyway left the toggle
+   * springing back to off with PME genuinely blocking the wake — and made the
+   * startup self-heal re-apply and toast "restored after a system update" on
+   * every boot, forever.
+   */
+  const pmeApplied = {
+    [UDEV_RULE_PATH]: "(rule)",
+    [`/sys/bus/pci/devices/${CTRL}/power/wakeup`]: "disabled",
+  };
+
+  it.each([["cachyos"], ["bazzite"], ["arch"]])(
+    "%s: PME blocking alone counts as applied",
+    async (distro) => {
+      const { deps } = makeFpDeps({
+        files: { ...pmeApplied },
+        cmdline: "BOOT_IMAGE=x quiet",
+        distro,
+      });
+      const s = await getStatus(deps, true); // known board
+      expect(s.kargActive).toBe(false);
+      expect(s.applied).toBe(true);
+    },
+  );
+
+  it("so the startup heal leaves it alone instead of firing every boot", async () => {
+    const { deps } = makeFpDeps({
+      files: { ...pmeApplied },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "cachyos",
+    });
+    const status = await getStatus(deps, true);
+    expect(shouldHeal({ wanted: true, status })).toBe(false);
+  });
+
+  it("still heals there when the block genuinely goes missing", async () => {
+    const { deps } = makeFpDeps({
+      files: {},
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "cachyos",
+    });
+    const status = await getStatus(deps, true);
+    expect(status.applied).toBe(false);
+    expect(shouldHeal({ wanted: true, status })).toBe(true);
+  });
+
+  it("on SteamOS the karg is still required for applied", async () => {
+    // Where we DO stage it, a missing karg still means half-applied.
+    const { deps } = makeFpDeps({
+      files: { ...pmeApplied, "/etc/default/grub-steamos": GRUB_SAMPLE },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "steamos",
+    });
+    expect((await getStatus(deps, true)).applied).toBe(false);
+  });
+
+  it("an unmeasured board is unaffected — PME is the whole fix there", async () => {
+    const { deps } = makeFpDeps({
+      files: { ...pmeApplied, "/etc/default/grub-steamos": GRUB_SAMPLE },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "steamos",
+    });
+    expect((await getStatus(deps, false)).applied).toBe(true);
+  });
+});

--- a/plugins/apex/lib/fingerprint.ts
+++ b/plugins/apex/lib/fingerprint.ts
@@ -171,6 +171,9 @@ export async function getStatus(
   // they do not have. Saying nothing beats saying something false.
   const bootloaderKnown = distro === "steamos";
   const kargLiveOnly = bootloaderKnown && kargActive && !kargStaged;
+  // Distinct from kargApplicable, which means "we know this board's pin" and
+  // still drives the manual hint we show off SteamOS.
+  const kargAutomatic = kargApplicable && bootloaderKnown;
   return {
     supported: controller !== null,
     controller,
@@ -179,12 +182,18 @@ export async function getStatus(
     kargActive,
     kargStaged,
     kargApplicable,
-    // On a board whose pin we haven't confirmed the karg is never staged, so
-    // requiring kargActive left `applied` permanently false: the user flipped
-    // the switch on, PME *was* blocked, and the control sprang back to off.
-    // The natural response is to flip it again — which calls revert() and
-    // undoes the one path that had worked.
-    applied: path2Closed && (kargActive || !kargApplicable),
+    // The karg only counts toward "applied" where we can actually put it
+    // there: a confirmed board AND a bootloader we edit. Requiring kargActive
+    // anywhere else left `applied` permanently false — the user flipped the
+    // switch on, PME *was* blocked, and the control sprang back to off. The
+    // natural response is to flip it again, which calls revert() and undoes
+    // the one path that had worked.
+    //
+    // That held for unmeasured boards, and — until this — for an Apex on
+    // CachyOS or Bazzite too, where we deliberately never stage the karg. It
+    // also made the startup self-heal fire on every single boot there,
+    // re-applying and announcing "restored after a system update" forever.
+    applied: path2Closed && (kargActive || !kargAutomatic),
     // Staged but not yet live → a reboot applies it. Live but not staged
     // *and* the block was reverted → a reboot finishes removing it.
     rebootPending: (kargStaged && !kargActive) || (kargLiveOnly && !udevRuleInstalled),


### PR DESCRIPTION
On an **Apex running CachyOS or Bazzite**, `applied` was permanently false even though the PME layer was genuinely blocking the wake:

```
cachyos: applied=false  kargActive=false  kargApplicable=true
bazzite: applied=false  kargActive=false  kargApplicable=true
steamos: applied=true
```

`kargApplicable` conflated *"we know this board's GPIO pin"* with *"we can actually put the karg there"*. Off SteamOS we deliberately never edit the bootloader, so `kargActive` could only become true if the user added it by hand.

## Why it matters more now

- **The toggle springs back to off.** The user enables the block, PME *is* applied, and the control flips back — whose natural response is to flip it again, calling `revert()` and undoing the one path that worked. This is the same defect fixed in #274 for *unmeasured* boards; measured boards on a non-SteamOS distro were still exposed.
- **The self-heal fires every boot.** `shouldHeal` keys on `!applied`, so on those distros it would re-apply and toast *"restored after a system update"* on every single boot, forever. That ships in #274, so this wants to land before any release carrying it.

## Fix

`kargAutomatic` — a confirmed board **and** a bootloader we edit — now drives `applied`. `kargApplicable` keeps its meaning (the pin is known) and still gates the manual hint shown off SteamOS.

So per distro, for a measured board:

| | PME layer | GPIO karg | `applied` |
| --- | --- | --- | --- |
| SteamOS | automatic | automatic | needs both |
| CachyOS / Bazzite / Arch | automatic | manual hint only | PME alone |
| Unmeasured board, any distro | automatic | withheld | PME alone |

## Tests

Six new, covering all three distro classes plus the unmeasured board, and asserting the heal stays quiet where PME alone is the whole fix while still firing when the block genuinely goes missing. Mutation-checked: reverting to `kargApplicable`, and forcing `kargAutomatic` to either constant, each fail multiple tests.

Found by checking whether the fix actually worked on CachyOS and Bazzite rather than assuming. Two adversarial review passes missed it because every existing test pinned `distro: "steamos"`.