### PR TITLE
feat(apex): stage the GPIO kernel arg on Bazzite too, and tell everyone else

### DIFF
--- a/plugins/apex/README.md
+++ b/plugins/apex/README.md
@@ -15,24 +15,31 @@ close** — closing one leaves the device wakeable:
   `gpiolib_acpi.ignore_wake=AMDI0030:00@58`. Boot-time, so it needs a reboot,
   and it names a pin that is board wiring rather than a family constant.
 
-Because the karg is the only way to close path 1, "which bootloader is this"
-decides whether we can deliver a complete block:
+Because the karg is the only way to close path 1, whether we can deliver a
+complete block depends on the boot mechanism:
 
-| Distro | Kernel arg | Result |
+| System | Kernel arg | Result |
 | --- | --- | --- |
 | SteamOS | `/etc/default/grub-steamos`, behind `steamos-readonly` | automatic |
 | Bazzite and other rpm-ostree images | `rpm-ostree kargs` | automatic |
-| CachyOS / Arch / Fedora | `/etc/default/grub` + `grub-mkconfig` | automatic, verified against the generated `grub.cfg` |
-| Anything else | — | we print the arg; you add it |
+| **Everything else, CachyOS and Arch included** | — | we print the arg; you add it |
 | A board whose pin we haven't measured | — | withheld: the wrong pin is worse than none |
 
-GRUB is *assumed* on the Arch/Fedora family. CachyOS also ships systemd-boot
-and limine, where `/etc/default/grub` exists but nothing reads it — so after
-writing we check the karg actually reached `grub.cfg` and roll back with an
-error if it didn't, rather than reporting a block the device doesn't have.
+**We do not edit GRUB.** An earlier attempt did, and it was wrong in ways that
+could leave a machine unbootable: `/etc/default/grub` is *sourced*, so a value
+that isn't double-quoted (common on encrypted or hibernating systems) got a
+second assignment appended and the user's real `cryptdevice=`/`resume=` args
+were discarded. Fedora needs `grub2-mkconfig` and BLS entries rather than that
+file at all, and CachyOS may boot via systemd-boot or limine, where the file
+exists and nothing reads it. None of that is verifiable before a reboot, so
+GRUB systems get an instruction instead of an edit.
 
-Where we can't stage it, the UI says one wake path is still open. It does not
-claim the block is complete.
+Detection is by mechanism, not distro name — `/run/ostree-booted` rather than
+a list of IDs, because Silverblue and Kinoite both report `ID=fedora`.
+
+Where we can't stage it, the UI says one wake path is still open and names the
+systems we do automate, so it's clear why the step is manual. It never claims
+the block is complete.
 
 ### Healing itself
 

--- a/plugins/apex/README.md
+++ b/plugins/apex/README.md
@@ -69,8 +69,10 @@ look.
 
 Uninstalling Loadout removes the udev rule and re-enables the controller, so
 the block doesn't outlive the app. The kernel arg is deliberately left alone —
-editing a bootloader during an uninstall is a worse failure than a stale arg,
-which is inert once the rule is gone.
+editing a bootloader during an uninstall is a worse failure than a stale arg.
+It is **not** inert, though: the two paths are independent, so the arg keeps
+the GPIO wake line disarmed on its own. The uninstaller prints it and how to
+remove it rather than pretending it doesn't matter.
 
 ## Vibration
 

--- a/plugins/apex/README.md
+++ b/plugins/apex/README.md
@@ -5,37 +5,65 @@
 ## Fingerprint wake block, and why it heals itself
 
 The power button's fingerprint reader wakes the device from sleep on a light
-touch. The block closes two paths:
+touch. The touch reaches the SoC by **two independent paths, and both must
+close** — closing one leaves the device wakeable:
 
 - **Controller PME** — `power/wakeup=disabled` on the xHCI controller hosting
-  the reader, plus a udev rule to persist it. This is the layer that actually
-  stops the wake, it's derived from your hardware at runtime, and it takes
-  effect immediately.
-- **GPIO kernel arg** — `gpiolib_acpi.ignore_wake=...`, belt-and-braces, and
-  only live after a reboot. It names a specific pin, which is board wiring,
-  so it is only staged on boards we have measured.
+  the reader, plus a udev rule to persist it. Derived from your hardware at
+  runtime; takes effect immediately, no reboot.
+- **GPIO wake line** — disarmed only by a kernel argument,
+  `gpiolib_acpi.ignore_wake=AMDI0030:00@58`. Boot-time, so it needs a reboot,
+  and it names a pin that is board wiring rather than a family constant.
 
-Both live in `/etc`, and a SteamOS A/B update regenerates that tree — so an
-update silently removes the block and the device quietly starts waking on a
+Because the karg is the only way to close path 1, "which bootloader is this"
+decides whether we can deliver a complete block:
+
+| Distro | Kernel arg | Result |
+| --- | --- | --- |
+| SteamOS | `/etc/default/grub-steamos`, behind `steamos-readonly` | automatic |
+| Bazzite and other rpm-ostree images | `rpm-ostree kargs` | automatic |
+| CachyOS / Arch / Fedora | `/etc/default/grub` + `grub-mkconfig` | automatic, verified against the generated `grub.cfg` |
+| Anything else | — | we print the arg; you add it |
+| A board whose pin we haven't measured | — | withheld: the wrong pin is worse than none |
+
+GRUB is *assumed* on the Arch/Fedora family. CachyOS also ships systemd-boot
+and limine, where `/etc/default/grub` exists but nothing reads it — so after
+writing we check the karg actually reached `grub.cfg` and roll back with an
+error if it didn't, rather than reporting a block the device doesn't have.
+
+Where we can't stage it, the UI says one wake path is still open. It does not
+claim the block is complete.
+
+### Healing itself
+
+Both paths live in `/etc`, and a SteamOS A/B update regenerates that tree — so
+an update silently removes the block and the device quietly starts waking on a
 touch again, with nothing to tell you.
 
 So the plugin checks at startup and puts it back. The user's choice is stored
 in plugin storage under `$HOME` (`fingerprintBlock`), not inferred from
 `/etc`: every signal in the live status is derived from the files an update
-deletes, so after one they cannot distinguish "never wanted it" from "wanted
+deletes, so afterwards they cannot distinguish "never wanted it" from "wanted
 it and the OS ate it". Healing off those would enable the block on machines
 whose owner deliberately never turned it on.
 
-The re-apply runs fire-and-forget from `onLoad`. The loader awaits each
-plugin's `onLoad` in turn with no timeout and the HTTP server does not start
-until that loop finishes, so blocking on `update-grub` here would stall the
-whole backend boot.
+The re-apply runs fire-and-forget from `onLoad` — the loader awaits each
+plugin's `onLoad` in turn with no timeout and the HTTP server doesn't start
+until that loop finishes, so blocking on `update-grub` would stall the whole
+backend boot.
 
 You are told it happened via a toast at overlay startup — the plugin declares
 `loadOnStartup` and exports `init()`, which pulls the outcome and waits for
 the window to actually be on screen before notifying (the overlay boots
 hidden, so a toast fired at boot is consumed by nobody). The same notice
-renders as an alert on the plugin page if you get there first.
+renders as an alert on the plugin page — reading it doesn't consume it, so
+both surfaces can show it and it isn't lost if the webview reloads before you
+look.
+
+Uninstalling Loadout removes the udev rule and re-enables the controller, so
+the block doesn't outlive the app. The kernel arg is deliberately left alone —
+editing a bootloader during an uninstall is a worse failure than a stale arg,
+which is inert once the rule is gone.
 
 ## Vibration
 

--- a/plugins/apex/app.spec.tsx
+++ b/plugins/apex/app.spec.tsx
@@ -697,3 +697,77 @@ describe("reboot button", () => {
     expect(container.textContent).not.toContain("finish applying");
   });
 });
+
+describe("fingerprint block: what the UI claims", () => {
+  beforeEach(() => {
+    callMock.mockReset();
+    notifyMock.mockReset();
+    eventHandlers.clear();
+  });
+
+  const fp = (over: Record<string, unknown> = {}) => ({
+    ...healthyStatus,
+    fingerprintBlockWanted: false,
+    fingerprint: {
+      supported: true,
+      applied: false,
+      rebootPending: false,
+      kargUnpersisted: false,
+      kargApplicable: true,
+      kargAutomatic: false,
+      kargMode: "manual",
+      kargActive: false,
+      udevRuleInstalled: false,
+      distro: "cachyos",
+      controller: "0000:67:00.0",
+      ...over,
+    },
+  });
+
+  async function mountWith(status: unknown) {
+    callMock.mockImplementation((method: string) =>
+      method === "getStatus" ? Promise.resolve(status) : Promise.resolve(null),
+    );
+    const container = document.createElement("div");
+    const { mount } = await import("./app");
+    mount(container);
+    await waitFor(() => expect(container.textContent).toContain("Fingerprint"));
+    return container;
+  }
+
+  it("keeps the switch on what the user chose, not on a derived state", async () => {
+    // Binding `checked` to `applied` made the toggle spring back off whenever
+    // the second wake path wasn't closed — and flipping it again called
+    // revert(), undoing the path that had worked.
+    const container = await mountWith({ ...fp(), fingerprintBlockWanted: true });
+    const toggles = [...container.querySelectorAll('input[type="checkbox"]')];
+    expect(toggles.some((t) => (t as HTMLInputElement).checked)).toBe(true);
+  });
+
+  it("does not claim the controller is blocked when the block is off", async () => {
+    // Both "one wake path is still open" alerts opened by asserting the USB
+    // controller *is* blocked — rendered next to a toggle sitting at OFF.
+    const container = await mountWith(fp({ kargMode: "none", applied: false }));
+    expect(container.textContent).not.toContain("is blocked at its USB controller");
+  });
+
+  it("says a wake path is still open once the block IS on but the karg isn't", async () => {
+    const container = await mountWith({
+      ...fp({ kargMode: "none", applied: true, udevRuleInstalled: true }),
+      fingerprintBlockWanted: true,
+    });
+    await waitFor(() => expect(container.textContent).toContain("One wake path is still open"));
+  });
+
+  it("names the distros we automate, so a CachyOS user knows why they're doing it by hand", async () => {
+    const container = await mountWith({
+      ...fp({ kargMode: "manual", applied: true, udevRuleInstalled: true }),
+      fingerprintBlockWanted: true,
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain("SteamOS");
+      expect(container.textContent).toContain("Bazzite");
+      expect(container.textContent).toContain("CachyOS");
+    });
+  });
+});

--- a/plugins/apex/app.spec.tsx
+++ b/plugins/apex/app.spec.tsx
@@ -715,6 +715,7 @@ describe("fingerprint block: what the UI claims", () => {
       kargUnpersisted: false,
       kargApplicable: true,
       kargAutomatic: false,
+      kargStagedUnknown: false,
       kargMode: "manual",
       kargActive: false,
       udevRuleInstalled: false,
@@ -739,9 +740,33 @@ describe("fingerprint block: what the UI claims", () => {
     // Binding `checked` to `applied` made the toggle spring back off whenever
     // the second wake path wasn't closed — and flipping it again called
     // revert(), undoing the path that had worked.
-    const container = await mountWith({ ...fp(), fingerprintBlockWanted: true });
-    const toggles = [...container.querySelectorAll('input[type="checkbox"]')];
-    expect(toggles.some((t) => (t as HTMLInputElement).checked)).toBe(true);
+    //
+    // autoRecoverOnWake is deliberately ON here: asserting "some checkbox is
+    // checked" passed via that one even with the fingerprint toggle bound
+    // back to `applied`.
+    const container = await mountWith({
+      ...fp(),
+      autoRecoverOnWake: true,
+      fingerprintBlockWanted: true,
+    });
+    const toggle = [...container.querySelectorAll('input[type="checkbox"]')].at(-1);
+    expect((toggle as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("says so when the switch is on but nothing is in effect", async () => {
+    // The switch reflects intent, so it can sit ON after a failed apply —
+    // and no alert was keyed on that, leaving a control in the on position
+    // with nothing anywhere saying it wasn't working.
+    const container = await mountWith({
+      ...fp({ applied: false, rebootPending: false }),
+      fingerprintBlockWanted: true,
+    });
+    await waitFor(() => expect(container.textContent).toContain("Asked for, but not in effect"));
+  });
+
+  it("does not nag when the switch is off and nothing is applied", async () => {
+    const container = await mountWith({ ...fp({ applied: false }), fingerprintBlockWanted: false });
+    expect(container.textContent).not.toContain("Asked for, but not in effect");
   });
 
   it("does not claim the controller is blocked when the block is off", async () => {

--- a/plugins/apex/app.tsx
+++ b/plugins/apex/app.tsx
@@ -25,6 +25,7 @@ function rumbleLevels(min: number, max: number): number[] {
 interface FingerprintHealNotice {
   restored: boolean;
   rebootRequired: boolean;
+  manualKarg?: string;
   error?: string;
 }
 
@@ -53,6 +54,10 @@ interface FingerprintStatus {
   /** False when this board's GPIO pin is unconfirmed, so the karg path is
    *  unavailable and PME blocking is the whole of the fix. */
   kargApplicable: boolean;
+  /** How the kernel arg gets staged here: steamos | ostree | grub | manual | none. */
+  kargMode: string;
+  /** We stage the kernel arg ourselves on this machine. */
+  kargAutomatic: boolean;
   /** Our udev rule is on disk — the marker for "the block is meant to be on",
    *  which is what tells a pending apply from a pending revert. */
   udevRuleInstalled: boolean;
@@ -564,8 +569,10 @@ function Apex() {
                     Block fingerprint wake
                   </span>
                   <span className="text-xs text-base-content/55 leading-relaxed">
-                    Disables the sensor's USB-controller wake and adds a kernel parameter for the
-                    GPIO wake line.
+                    Disables the sensor&apos;s USB-controller wake
+                    {data.fingerprint.kargAutomatic
+                      ? " and adds a kernel parameter for the GPIO wake line."
+                      : "; the GPIO wake line needs a kernel parameter we can't add here."}
                   </span>
                 </div>
                 <Toggle
@@ -620,9 +627,11 @@ function Apex() {
                 >
                   The wake block had been removed — system updates regenerate the files it lives
                   in. It has been re-applied automatically
-                  {healed.rebootRequired
-                    ? ", though the kernel-argument layer needs a reboot to come back."
-                    : ", and is in effect now."}
+                  {healed.manualKarg
+                    ? ", but the GPIO layer needs a kernel argument this distro's bootloader isn't one we manage — see below."
+                    : healed.rebootRequired
+                      ? ", though the kernel-argument layer needs a reboot to come back."
+                      : ", and is in effect now."}
                 </Alert>
               )}
 
@@ -638,24 +647,41 @@ function Apex() {
                 </Alert>
               )}
 
-              {!data.fingerprint.kargActive &&
-                data.fingerprint.kargApplicable &&
-                data.fingerprint.distro !== "steamos" && (
-                  <div className="text-xs text-base-content/55 leading-relaxed">
-                    On {data.fingerprint.distro || "this distro"} the GPIO kernel arg can&apos;t be
-                    applied automatically yet. Add{" "}
-                    <span className="mono">gpiolib_acpi.ignore_wake=AMDI0030:00@58</span> to your
-                    kernel command line and reboot to fully block the touch wake.
+              {/* The touch has two independent wake paths and this one closes
+                  only with a kernel arg, so these are genuinely incomplete
+                  blocks — not niceties. */}
+              {!data.fingerprint.kargActive && data.fingerprint.kargMode === "manual" && (
+                <Alert
+                  variant="warning"
+                  icon={<FaTriangleExclamation size={14} />}
+                  title="One wake path is still open"
+                >
+                  <div className="flex flex-col gap-2">
+                    <div className="leading-relaxed">
+                      The reader&apos;s USB controller is blocked, but the GPIO wake line needs a
+                      kernel argument and {data.fingerprint.distro || "this distro"}&apos;s
+                      bootloader isn&apos;t one we manage. Until you add it, a touch can still wake
+                      the device. Add:
+                    </div>
+                    <div className="mono text-[11px]">
+                      gpiolib_acpi.ignore_wake=AMDI0030:00@58
+                    </div>
+                    <div className="leading-relaxed">to your kernel command line, then reboot.</div>
                   </div>
-                )}
+                </Alert>
+              )}
 
-              {!data.fingerprint.kargApplicable && (
-                <div className="text-xs text-base-content/55 leading-relaxed">
+              {data.fingerprint.kargMode === "none" && (
+                <Alert
+                  variant="warning"
+                  icon={<FaTriangleExclamation size={14} />}
+                  title="One wake path is still open"
+                >
                   Wake from the reader is blocked at its USB controller, which is derived from your
-                  hardware. There&apos;s a second, belt-and-braces kernel argument we apply on the
-                  Apex, but it names a specific GPIO pin on that board — we don&apos;t know this
-                  model&apos;s, and the wrong pin is worse than none.
-                </div>
+                  hardware. The second path needs a kernel argument naming a specific GPIO pin — we
+                  know the Apex&apos;s, but not this model&apos;s, and the wrong pin is worse than
+                  none. A touch may still wake the device.
+                </Alert>
               )}
             </div>
           </div>
@@ -718,9 +744,11 @@ export async function init(api: {
   void visible.promise.then(async () => {
     if (shown.restored) {
       notify(
-        shown.rebootRequired
-          ? "Fingerprint wake block was restored after a system update. Reboot to finish re-applying it."
-          : "Fingerprint wake block was restored after a system update.",
+        shown.manualKarg
+          ? "Fingerprint wake block was partly restored after a system update — open the plugin to finish it."
+          : shown.rebootRequired
+            ? "Fingerprint wake block was restored after a system update. Reboot to finish re-applying it."
+            : "Fingerprint wake block was restored after a system update.",
         { kind: "success", id: "apex-fp-healed", duration: 8000 },
       );
     } else {

--- a/plugins/apex/app.tsx
+++ b/plugins/apex/app.tsx
@@ -71,6 +71,7 @@ interface StatusResult {
   fingerprint?: FingerprintStatus;
   autoRecoverOnWake?: boolean;
   listenerRunning?: boolean;
+  fingerprintBlockWanted?: boolean;
 }
 
 interface FingerprintResult {
@@ -572,11 +573,11 @@ function Apex() {
                     Disables the sensor&apos;s USB-controller wake
                     {data.fingerprint.kargAutomatic
                       ? " and adds a kernel parameter for the GPIO wake line."
-                      : "; the GPIO wake line needs a kernel parameter we can't add here."}
+                      : "; the GPIO wake line needs a kernel parameter this distro won't let us add."}
                   </span>
                 </div>
                 <Toggle
-                  checked={!!data.fingerprint.applied}
+                  checked={!!data.fingerprintBlockWanted}
                   disabled={fpBusy}
                   onChange={handleToggleFingerprint}
                 />
@@ -628,7 +629,7 @@ function Apex() {
                   The wake block had been removed — system updates regenerate the files it lives
                   in. It has been re-applied automatically
                   {healed.manualKarg
-                    ? ", but the GPIO layer needs a kernel argument this distro's bootloader isn't one we manage — see below."
+                    ? ", but the GPIO layer still needs a kernel argument this distro won't let us add — see below."
                     : healed.rebootRequired
                       ? ", though the kernel-argument layer needs a reboot to come back."
                       : ", and is in effect now."}
@@ -641,8 +642,8 @@ function Apex() {
                   icon={<FaCircleInfo size={14} />}
                   title="Active, but not saved to your bootloader"
                 >
-                  The kernel argument is live on this boot but missing from the bootloader config —
-                  a SteamOS update regenerates that file and drops it. The block still works right
+                  The kernel argument is live on this boot but missing from the boot configuration
+                  — a system update can regenerate that and drop it. The block still works right
                   now; switch it off and on again to write it back, so it survives the next reboot.
                 </Alert>
               )}
@@ -650,7 +651,9 @@ function Apex() {
               {/* The touch has two independent wake paths and this one closes
                   only with a kernel arg, so these are genuinely incomplete
                   blocks — not niceties. */}
-              {!data.fingerprint.kargActive && data.fingerprint.kargMode === "manual" && (
+              {data.fingerprint.applied &&
+                !data.fingerprint.kargActive &&
+                data.fingerprint.kargMode === "manual" && (
                 <Alert
                   variant="warning"
                   icon={<FaTriangleExclamation size={14} />}
@@ -667,11 +670,16 @@ function Apex() {
                       gpiolib_acpi.ignore_wake=AMDI0030:00@58
                     </div>
                     <div className="leading-relaxed">to your kernel command line, then reboot.</div>
+                    <div className="leading-relaxed text-base-content/45">
+                      We do this automatically on SteamOS and on Bazzite (and other rpm-ostree
+                      images). Elsewhere — CachyOS and Arch included — the bootloader isn&apos;t one
+                      we edit, so this step is yours.
+                    </div>
                   </div>
                 </Alert>
               )}
 
-              {data.fingerprint.kargMode === "none" && (
+              {data.fingerprint.applied && data.fingerprint.kargMode === "none" && (
                 <Alert
                   variant="warning"
                   icon={<FaTriangleExclamation size={14} />}

--- a/plugins/apex/app.tsx
+++ b/plugins/apex/app.tsx
@@ -53,11 +53,11 @@ interface FingerprintStatus {
   kargActive: boolean;
   /** False when this board's GPIO pin is unconfirmed, so the karg path is
    *  unavailable and PME blocking is the whole of the fix. */
-  kargApplicable: boolean;
-  /** How the kernel arg gets staged here: steamos | ostree | grub | manual | none. */
+  /** How the kernel arg gets staged here: steamos | ostree | manual | unknown | none. */
   kargMode: string;
   /** We stage the kernel arg ourselves on this machine. */
   kargAutomatic: boolean;
+  kargStagedUnknown: boolean;
   /** Our udev rule is on disk — the marker for "the block is meant to be on",
    *  which is what tells a pending apply from a pending revert. */
   udevRuleInstalled: boolean;
@@ -158,7 +158,14 @@ function Apex() {
   const [healed, setHealed] = useState<FingerprintHealNotice | null>(null);
 
   const refresh = useCallback(async () => {
-    setData((await call("getStatus")) as StatusResult);
+    // A rejected getStatus (RPC timeout while rpm-ostree is busy, backend
+    // restarting) used to leave `data` null forever with the page on its
+    // spinner, plus an unhandled rejection.
+    try {
+      setData((await call("getStatus")) as StatusResult);
+    } catch (e) {
+      notify(`Couldn't read device status: ${e}`, { kind: "error", id: "apex-status" });
+    }
   }, [call]);
 
   useEvent({ event: "statusChanged", handler: () => refresh() });
@@ -292,7 +299,9 @@ function Apex() {
           notify(res.error ?? "Couldn't update the fingerprint setting.", { kind: "error" });
         } else if (res.manualKarg) {
           notify(
-            `Controller wake ${next ? "blocked" : "restored"}. Your distro needs a manual kernel arg — see the panel.`,
+            next
+              ? "Controller wake blocked. One wake path still needs a kernel argument — see the panel."
+              : "Controller wake restored. The kernel argument is still live — see the panel.",
             { kind: "success" },
           );
         } else if (res.rebootRequired) {
@@ -302,6 +311,10 @@ function Apex() {
         } else {
           notify(next ? "Fingerprint wake blocked." : "Fingerprint wake restored.", { kind: "success" });
         }
+      } catch (e) {
+        // setFingerprintBlock can outlive the RPC cap (rpm-ostree staging a
+        // deployment). Without this the user got no feedback at all.
+        notify(String(e), { kind: "error" });
       } finally {
         setFpBusy(false);
         await refresh();
@@ -573,7 +586,9 @@ function Apex() {
                     Disables the sensor&apos;s USB-controller wake
                     {data.fingerprint.kargAutomatic
                       ? " and adds a kernel parameter for the GPIO wake line."
-                      : "; the GPIO wake line needs a kernel parameter this distro won't let us add."}
+                      : data.fingerprint.kargMode === "none"
+                        ? "; the GPIO wake line needs a kernel parameter naming a pin we haven't measured on this model."
+                        : "; the GPIO wake line needs a kernel parameter we can't add automatically on this system."}
                   </span>
                 </div>
                 <Toggle
@@ -582,6 +597,26 @@ function Apex() {
                   onChange={handleToggleFingerprint}
                 />
               </div>
+
+              {/* The switch reflects the user's choice, so it can sit ON while
+                  nothing is in effect — a failed apply, or a staged read we
+                  couldn't make. Without this the panel showed a control in
+                  the on position and no indication anywhere that it wasn't. */}
+              {data.fingerprintBlockWanted &&
+                !data.fingerprint.applied &&
+                !data.fingerprint.rebootPending && (
+                  <Alert
+                    variant="warning"
+                    icon={<FaTriangleExclamation size={14} />}
+                    title="Asked for, but not in effect"
+                  >
+                    The wake block is switched on but isn&apos;t currently applied. Switch it off
+                    and on again to retry
+                    {data.fingerprint.kargStagedUnknown
+                      ? " — we also couldn't read what your next boot will carry."
+                      : "."}
+                  </Alert>
+                )}
 
               {data.fingerprint.rebootPending && (
                 <>
@@ -615,8 +650,11 @@ function Apex() {
                   title="Couldn't restore the wake block"
                 >
                   A system update removed the wake block and re-applying it failed
-                  {healed.error ? `: ${healed.error}` : "."} Switching it off and on again should
-                  put it back.
+                  {healed.error ? `: ${healed.error}` : "."}{" "}
+                  {healed.manualKarg
+                    ? "Add this to your kernel command line and reboot instead: "
+                    : "Switching it off and on again should put it back."}
+                  {healed.manualKarg && <span className="mono">{healed.manualKarg}</span>}
                 </Alert>
               )}
 
@@ -676,6 +714,19 @@ function Apex() {
                       we edit, so this step is yours.
                     </div>
                   </div>
+                </Alert>
+              )}
+
+              {data.fingerprint.applied && data.fingerprint.kargMode === "unknown" && (
+                <Alert
+                  variant="warning"
+                  icon={<FaTriangleExclamation size={14} />}
+                  title="One wake path is still open"
+                >
+                  The reader&apos;s USB controller is blocked, but we couldn&apos;t identify this
+                  system well enough to add the kernel argument the GPIO wake line needs. Add{" "}
+                  <span className="mono">gpiolib_acpi.ignore_wake=AMDI0030:00@58</span> to your
+                  kernel command line and reboot.
                 </Alert>
               )}
 

--- a/plugins/apex/backend.ts
+++ b/plugins/apex/backend.ts
@@ -407,6 +407,10 @@ export default class ApexBackend implements PluginBackend {
     fingerprint?: FingerprintStatus;
     autoRecoverOnWake?: boolean;
     listenerRunning?: boolean;
+    /** The user's stored choice. The toggle reflects THIS, not `applied` —
+     *  binding a switch to a derived hardware state made it spring back
+     *  whenever the second wake path wasn't closed yet. */
+    fingerprintBlockWanted?: boolean;
   }> {
     if (this.unsupported) return { unsupported: true };
     const [status, hidOxp, fingerprint, settings] = await Promise.all([
@@ -422,6 +426,7 @@ export default class ApexBackend implements PluginBackend {
       fingerprint,
       autoRecoverOnWake: !!settings.autoRecoverOnWake,
       listenerRunning: this.wakeStop !== null,
+      fingerprintBlockWanted: settings.fingerprintBlock ?? fingerprint.applied,
     };
   }
 

--- a/plugins/apex/backend.ts
+++ b/plugins/apex/backend.ts
@@ -55,6 +55,13 @@ export interface FingerprintHealNotice {
   restored: boolean;
   /** A reboot is still needed to bring the GPIO karg layer up. */
   rebootRequired: boolean;
+  /**
+   * The kernel arg the user has to add by hand, on a distro whose bootloader
+   * we don't manage. Previously dropped on the floor — the notice reported
+   * "reboot to finish re-applying it" when nothing had been staged and a
+   * reboot could never help, discarding the one actionable thing we had.
+   */
+  manualKarg?: string;
   /** Set when the re-apply itself failed. */
   error?: string;
 }
@@ -353,6 +360,7 @@ export default class ApexBackend implements PluginBackend {
       this.healNotice = {
         restored: res.success,
         rebootRequired: !!res.rebootRequired,
+        manualKarg: res.manualKarg,
         error: res.success ? undefined : (res.error ?? "Re-applying the block failed."),
       };
       this.log?.info(
@@ -453,7 +461,7 @@ export default class ApexBackend implements PluginBackend {
     const result = await this.serialiseFingerprint(() =>
       enabled
         ? applyFingerprint(this.fpDeps, { autoKarg: this.isKnownBoard })
-        : revertFingerprint(this.fpDeps),
+        : revertFingerprint(this.fpDeps, { autoKarg: this.isKnownBoard }),
     );
 
     // Record the intent even when the apply partly failed: the user asked for

--- a/plugins/apex/lib/fingerprint.test.ts
+++ b/plugins/apex/lib/fingerprint.test.ts
@@ -51,8 +51,9 @@ interface FakeOpts {
   /** argv[0]s that should THROW — a missing binary or a denied command
    *  policy raises, it does not return a non-zero exit code. */
   throwCommands?: string[];
-  /** Let a test model a command's side effect on the fake filesystem —
-   *  e.g. grub-mkconfig propagating /etc/default/grub into grub.cfg. */
+  /** Make `command -v` report the tool as absent. */
+  noCommandV?: boolean;
+  /** Let a test model a command's side effect on the fake filesystem. */
   onCommand?: (cmd: string[], files: Record<string, string>) => void;
 }
 
@@ -65,6 +66,9 @@ function makeFpDeps(o: FakeOpts = {}): { deps: FingerprintDeps; files: Record<st
   const deps: FingerprintDeps = {
     run: async (cmd) => {
       commands.push(cmd.join(" "));
+      if (cmd[0] === "sh" && cmd[1] === "-c" && String(cmd[2]).startsWith("command -v")) {
+        return o.noCommandV ? fail() : ok("/usr/bin/rpm-ostree\n");
+      }
       if (cmd[0] === "lsusb") return fpPresent ? ok("Bus 003 Device 004: ID 2808:c652") : fail();
       if (cmd[0] === "sh") return fpPresent ? ok(`${controller}\n`) : ok("");
       if (cmd[0] === "tee") {
@@ -236,7 +240,9 @@ describe("getStatus", () => {
       },
       cmdline: `BOOT_IMAGE=x ${KARG} quiet`,
     });
-    const s = await getStatus(deps);
+    // kargApplicable: true, so this exercises the karg logic it is named for
+    // rather than passing via the !kargAutomatic shortcut.
+    const s = await getStatus(deps, true);
     expect(s.supported).toBe(true);
     expect(s.controllerWakeDisabled).toBe(true);
     expect(s.udevRuleInstalled).toBe(true);
@@ -639,10 +645,12 @@ describe("kargMode", () => {
     expect(kargMode("ubuntu", true)).toBe("manual");
   });
 
-  it("treats an unreadable /etc/os-release as unknown, not unmanaged", () => {
-    // "" fell into the manual case, silently downgrading a real SteamOS Apex
-    // to PME-only with nothing saying so.
-    expect(kargMode("", true)).toBe("none");
+  it("distinguishes an unidentifiable SYSTEM from an unmeasured BOARD", () => {
+    // "" fell into the manual case, silently downgrading a real SteamOS Apex.
+    // Collapsing it into "none" was also wrong: the UI then told that Apex
+    // owner we didn't know their model's pin, which is false.
+    expect(kargMode("", true)).toBe("unknown");
+    expect(kargMode("steamos", false)).toBe("none");
   });
 
   it("says nothing at all when the board's pin is unknown", () => {
@@ -777,5 +785,112 @@ describe("the SteamOS window between staging and rebooting", () => {
     const s = await getStatus(deps, false); // unmeasured board
     expect(s.kargMode).toBe("none");
     expect(s.rebootPending).toBe(false);
+  });
+});
+
+describe("a staged karg waiting on a reboot is pending, not lost", () => {
+  it("does not heal, and does not announce that an update removed it", async () => {
+    // The heal keys on !applied, and applied excludes a staged-not-live karg.
+    // So every backend restart before the reboot re-ran apply(), changed
+    // nothing, and toasted "a system update removed the wake block".
+    const { deps } = makeFpDeps({
+      files: {
+        [UDEV_RULE_PATH]: "(rule)",
+        [`/sys/bus/pci/devices/${CTRL}/power/wakeup`]: "disabled",
+        "/etc/default/grub-steamos": addKargToGrubSteamos(GRUB_SAMPLE),
+      },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "steamos",
+    });
+    const status = await getStatus(deps, true);
+    expect(status.applied).toBe(false);
+    expect(status.kargStaged).toBe(true);
+    expect(status.rebootPending).toBe(true);
+    expect(shouldHeal({ wanted: true, status })).toBe(false);
+  });
+
+  it("still heals once the staged karg has genuinely gone", async () => {
+    const { deps } = makeFpDeps({
+      files: {
+        [UDEV_RULE_PATH]: "(rule)",
+        [`/sys/bus/pci/devices/${CTRL}/power/wakeup`]: "disabled",
+        "/etc/default/grub-steamos": GRUB_SAMPLE,
+      },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "steamos",
+    });
+    expect(shouldHeal({ wanted: true, status: await getStatus(deps, true) })).toBe(true);
+  });
+});
+
+describe("an unreadable staged-state is not 'not staged'", () => {
+  const busy = (over: Record<string, string> = {}) =>
+    makeFpDeps({
+      files: {
+        "/run/ostree-booted": "",
+        [UDEV_RULE_PATH]: "(rule)",
+        [`/sys/bus/pci/devices/${CTRL}/power/wakeup`]: "disabled",
+        ...over,
+      },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "bazzite",
+      failCommands: ["rpm-ostree"],
+    });
+
+  it("keeps the reboot prompt rather than silently dropping it", async () => {
+    // rebootPending used `kargStaged`, which folds undefined into false — so
+    // a machine with the karg genuinely staged lost its prompt and the karg
+    // would never be activated.
+    const { deps } = busy();
+    const s = await getStatus(deps, true);
+    expect(s.kargStagedUnknown).toBe(true);
+    expect(s.rebootPending).toBe(false);
+    // ...and the UI is told, rather than shown nothing.
+    expect(s.applied).toBe(false);
+  });
+});
+
+describe("ostree needs the tool, not just the marker", () => {
+  it("falls back to a workable instruction when rpm-ostree isn't there", async () => {
+    // /run/ostree-booted exists on bootc images where rpm-ostree may not.
+    // Claiming "automatic" there loops forever instead of telling the user
+    // what to add.
+    const { deps } = makeFpDeps({
+      files: { "/run/ostree-booted": "" },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "bazzite",
+      throwCommands: ["rpm-ostree"],
+      noCommandV: true,
+    });
+    const s = await getStatus(deps, true);
+    expect(s.kargMode).toBe("manual");
+    expect(s.kargAutomatic).toBe(false);
+  });
+});
+
+describe("a system we can't identify still gets the arg", () => {
+  it("hands over the karg instead of withholding it like an unknown board", async () => {
+    // "" meant we don't know the SYSTEM; withholding the pin there was wrong,
+    // because the pin is a board fact and the board is known.
+    const { deps } = makeFpDeps({ cmdline: "BOOT_IMAGE=x quiet", distro: "" });
+    const r = await apply(deps, { autoKarg: true });
+    expect(r.success).toBe(true);
+    expect(r.manualKarg).toBe(KARG);
+  });
+
+  it("tells them how to remove it again on revert", async () => {
+    // revert only offered manualKarg for mode === "manual", so on an
+    // unidentifiable system the user was told to add the arg and then never
+    // told how to take it out.
+    const { deps } = makeFpDeps({ cmdline: `BOOT_IMAGE=x quiet ${KARG}`, distro: "" });
+    const r = await revert(deps, { autoKarg: true });
+    expect(r.manualKarg).toBe(KARG);
+    expect(r.steps).toContain("karg-manual-removal-required");
+  });
+
+  it("still withholds it on a board we haven't measured", async () => {
+    const { deps } = makeFpDeps({ cmdline: `BOOT_IMAGE=x quiet ${KARG}`, distro: "" });
+    const r = await revert(deps, { autoKarg: false });
+    expect(r.manualKarg).toBeUndefined();
   });
 });

--- a/plugins/apex/lib/fingerprint.test.ts
+++ b/plugins/apex/lib/fingerprint.test.ts
@@ -7,6 +7,9 @@ import {
   addKargToGrubSteamos,
   removeKargFromGrubSteamos,
   KARG,
+  kargMode,
+  addKargToGrubDefault,
+  removeKargFromGrubDefault,
   shouldHeal,
   UDEV_RULE_PATH,
   FP_PRODUCTS,
@@ -45,6 +48,11 @@ interface FakeOpts {
   commands?: string[];
   /** Force update-grub to fail, to exercise the rollback path. */
   updateGrubFails?: boolean;
+  /** argv[0]s that should exit non-zero. */
+  failCommands?: string[];
+  /** Let a test model a command's side effect on the fake filesystem —
+   *  e.g. grub-mkconfig propagating /etc/default/grub into grub.cfg. */
+  onCommand?: (cmd: string[], files: Record<string, string>) => void;
 }
 
 function makeFpDeps(o: FakeOpts = {}): { deps: FingerprintDeps; files: Record<string, string>; commands: string[] } {
@@ -64,6 +72,19 @@ function makeFpDeps(o: FakeOpts = {}): { deps: FingerprintDeps; files: Record<st
         return ok();
       }
       if (cmd[0] === "update-grub") return o.updateGrubFails ? fail() : ok();
+      if (o.failCommands?.includes(cmd[0]!)) return fail();
+      // `tee` above writes a literal, so it never models stdin; this hook is
+      // how a test says what a command does to the fake filesystem.
+      o.onCommand?.(cmd, files);
+      if (cmd[0] === "rpm-ostree" && cmd[1] === "kargs" && cmd.length === 2) {
+        // Bare `rpm-ostree kargs` reports the current set.
+        return ok(files["__ostree_kargs__"] ?? "");
+      }
+      if (cmd[0] === "rpm-ostree" && cmd[1] === "kargs") {
+        const arg = cmd[2] ?? "";
+        if (arg.startsWith("--append-if-missing=")) files["__ostree_kargs__"] = arg.split("=").slice(1).join("=");
+        if (arg.startsWith("--delete-if-present=")) delete files["__ostree_kargs__"];
+      }
       return ok();
     },
     pathExists: async (p) => p in files,
@@ -357,16 +378,18 @@ describe("apply — board whose GPIO pin we haven't measured", () => {
   });
 });
 
-describe("apply (non-SteamOS)", () => {
+describe("apply (a distro we don't know the bootloader for)", () => {
   it("closes path 2 but surfaces a manual karg for the GPIO path", async () => {
     const { deps, files } = makeFpDeps({
       cmdline: "BOOT_IMAGE=x quiet",
-      distro: "cachyos",
+      distro: "ubuntu",
     });
     const r = await apply(deps);
     expect(r.success).toBe(true);
     expect(r.manualKarg).toBe(KARG);
-    expect(r.rebootRequired).toBe(true);
+    // Nothing was staged, so a reboot achieves nothing — claiming otherwise
+    // sent the user to reboot and threw away the one thing they can act on.
+    expect(r.rebootRequired).toBe(false);
     expect(files[UDEV_RULE_PATH]).toContain(CTRL); // path 2 still applied
   });
 });
@@ -497,7 +520,7 @@ describe("re-staging a karg that is live but lost from the bootloader", () => {
   });
 });
 
-describe("distros whose bootloader we don't edit", () => {
+describe("distros we don't know the bootloader for", () => {
   /**
    * kargStaged can only be read on SteamOS. Without gating on that, an
    * Arch/Bazzite user who followed our own manual-karg hint and rebooted got
@@ -512,7 +535,7 @@ describe("distros whose bootloader we don't edit", () => {
   };
 
   it("does not claim the karg is missing from a bootloader we never wrote", async () => {
-    const { deps } = makeFpDeps({ ...liveNotStaged, distro: "arch" });
+    const { deps } = makeFpDeps({ ...liveNotStaged, distro: "ubuntu" });
     const s = await getStatus(deps, true);
     expect(s.kargActive).toBe(true);
     expect(s.kargUnpersisted).toBe(false);
@@ -523,7 +546,7 @@ describe("distros whose bootloader we don't edit", () => {
     const { deps } = makeFpDeps({
       files: {},
       cmdline: `BOOT_IMAGE=x quiet ${KARG}`,
-      distro: "bazzite",
+      distro: "opensuse",
     });
     expect((await getStatus(deps, true)).rebootPending).toBe(false);
   });
@@ -595,5 +618,156 @@ describe("shouldHeal", () => {
     expect(shouldHeal({ wanted: true, status: { ...ok, supported: false, applied: false } })).toBe(
       false,
     );
+  });
+});
+
+describe("kargMode", () => {
+  // "we know the pin" and "we can put it there" are different questions;
+  // conflating them is what had the UI reporting a half-applied block as on.
+  it("routes each distro to the mechanism it actually uses", () => {
+    expect(kargMode("steamos", true)).toBe("steamos");
+    expect(kargMode("bazzite", true)).toBe("ostree");
+    expect(kargMode("cachyos", true)).toBe("grub");
+    expect(kargMode("arch", true)).toBe("grub");
+    expect(kargMode("ubuntu", true)).toBe("manual");
+  });
+
+  it("says nothing at all when the board's pin is unknown", () => {
+    // We never hand over the Apex's wiring for a board we haven't measured,
+    // on any distro — printing it is the same act as staging it.
+    for (const distro of ["steamos", "bazzite", "cachyos", "ubuntu"]) {
+      expect(kargMode(distro, false)).toBe("none");
+    }
+  });
+});
+
+describe("Bazzite (rpm-ostree)", () => {
+  const bazzite = (over: Record<string, unknown> = {}) =>
+    makeFpDeps({ cmdline: "BOOT_IMAGE=x quiet", distro: "bazzite", ...over });
+
+  it("stages the karg with rpm-ostree rather than editing a file", async () => {
+    const { deps, commands, files } = bazzite();
+    const r = await apply(deps, { autoKarg: true });
+    expect(r.success).toBe(true);
+    expect(r.steps).toContain("karg-staged");
+    expect(commands.some((c) => c.includes("rpm-ostree kargs --append-if-missing"))).toBe(true);
+    expect(r.rebootRequired).toBe(true);
+    // No bootloader file touched — the deployment is the record.
+    expect(Object.keys(files)).not.toContain("/etc/default/grub");
+  });
+
+  it("removes it again on revert", async () => {
+    const { deps, commands } = bazzite();
+    await revert(deps, { autoKarg: true });
+    expect(commands.some((c) => c.includes("rpm-ostree kargs --delete-if-present"))).toBe(true);
+  });
+
+  it("surfaces a failure instead of reporting a block it didn't apply", async () => {
+    const { deps } = bazzite({ failCommands: ["rpm-ostree"] });
+    const r = await apply(deps, { autoKarg: true });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("Path 1");
+  });
+});
+
+describe("CachyOS / Arch (GRUB)", () => {
+  const GRUB = 'GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"\n';
+
+  it("edits /etc/default/grub and regenerates the config", async () => {
+    const { deps, files, commands } = makeFpDeps({
+      files: { "/etc/default/grub": GRUB, "/boot/grub/grub.cfg": "" },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "cachyos",
+      // grub-mkconfig writes the karg through to the generated config.
+      onCommand: (cmd: string[], f: Record<string, string>) => {
+        if (cmd[0] === "grub-mkconfig") f["/boot/grub/grub.cfg"] = f["/etc/default/grub"] ?? "";
+      },
+    });
+    const r = await apply(deps, { autoKarg: true });
+    expect(r.success).toBe(true);
+    expect(files["/etc/default/grub"]).toContain(KARG);
+    expect(commands.some((c) => c.startsWith("grub-mkconfig"))).toBe(true);
+    expect(files["/etc/default/grub.loadout.bak"]).toBe(GRUB);
+  });
+
+  it("rolls back and reports when the karg never reaches grub.cfg", async () => {
+    // systemd-boot or limine: the file is written, grub-mkconfig "succeeds",
+    // and nothing that boots the machine ever reads it. Silently reporting
+    // success there would claim protection the device does not have.
+    const { deps, files } = makeFpDeps({
+      files: { "/etc/default/grub": GRUB, "/boot/grub/grub.cfg": "" },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "cachyos",
+    });
+    const r = await apply(deps, { autoKarg: true });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("may not boot with GRUB");
+    expect(files["/etc/default/grub"]).toBe(GRUB); // restored
+  });
+});
+
+describe("GRUB_CMDLINE_LINUX_DEFAULT editing", () => {
+  it("appends to an existing line without disturbing it", () => {
+    const out = addKargToGrubDefault('GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"\n');
+    expect(out).toContain(`quiet splash ${KARG}`);
+  });
+
+  it("is idempotent", () => {
+    const once = addKargToGrubDefault('GRUB_CMDLINE_LINUX_DEFAULT="quiet"\n');
+    expect(addKargToGrubDefault(once)).toBe(once);
+  });
+
+  it("handles an empty cmdline", () => {
+    expect(addKargToGrubDefault('GRUB_CMDLINE_LINUX_DEFAULT=""\n')).toContain(
+      `GRUB_CMDLINE_LINUX_DEFAULT="${KARG}"`,
+    );
+  });
+
+  it("adds the line when the file has none, rather than doing nothing", () => {
+    expect(addKargToGrubDefault("GRUB_TIMEOUT=5\n")).toContain(
+      `GRUB_CMDLINE_LINUX_DEFAULT="${KARG}"`,
+    );
+  });
+
+  it("round-trips", () => {
+    const before = 'GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"\n';
+    expect(removeKargFromGrubDefault(addKargToGrubDefault(before)).trim()).toBe(before.trim());
+  });
+});
+
+describe("the SteamOS window between staging and rebooting", () => {
+  it("counts a staged karg as applied, so the toggle doesn't fight the user", async () => {
+    // Staged, not yet live. Treating this as not-applied made the toggle
+    // spring back OFF right beside the alert saying a change was staged —
+    // and made the startup heal fire on every restart until the reboot.
+    const { deps } = makeFpDeps({
+      files: {
+        [UDEV_RULE_PATH]: "(rule)",
+        [`/sys/bus/pci/devices/${CTRL}/power/wakeup`]: "disabled",
+        "/etc/default/grub-steamos": addKargToGrubSteamos(GRUB_SAMPLE),
+      },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "steamos",
+    });
+    const s = await getStatus(deps, true);
+    expect(s.kargStaged).toBe(true);
+    expect(s.kargActive).toBe(false);
+    expect(s.applied).toBe(true);
+    // ...while still telling them it isn't live yet.
+    expect(s.rebootPending).toBe(true);
+    expect(shouldHeal({ wanted: true, status: s })).toBe(false);
+  });
+
+  it("is still not applied when the karg is neither staged nor live", async () => {
+    const { deps } = makeFpDeps({
+      files: {
+        [UDEV_RULE_PATH]: "(rule)",
+        [`/sys/bus/pci/devices/${CTRL}/power/wakeup`]: "disabled",
+        "/etc/default/grub-steamos": GRUB_SAMPLE,
+      },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "steamos",
+    });
+    expect((await getStatus(deps, true)).applied).toBe(false);
   });
 });

--- a/plugins/apex/lib/fingerprint.test.ts
+++ b/plugins/apex/lib/fingerprint.test.ts
@@ -8,8 +8,6 @@ import {
   removeKargFromGrubSteamos,
   KARG,
   kargMode,
-  addKargToGrubDefault,
-  removeKargFromGrubDefault,
   shouldHeal,
   UDEV_RULE_PATH,
   FP_PRODUCTS,
@@ -50,6 +48,9 @@ interface FakeOpts {
   updateGrubFails?: boolean;
   /** argv[0]s that should exit non-zero. */
   failCommands?: string[];
+  /** argv[0]s that should THROW — a missing binary or a denied command
+   *  policy raises, it does not return a non-zero exit code. */
+  throwCommands?: string[];
   /** Let a test model a command's side effect on the fake filesystem —
    *  e.g. grub-mkconfig propagating /etc/default/grub into grub.cfg. */
   onCommand?: (cmd: string[], files: Record<string, string>) => void;
@@ -72,6 +73,7 @@ function makeFpDeps(o: FakeOpts = {}): { deps: FingerprintDeps; files: Record<st
         return ok();
       }
       if (cmd[0] === "update-grub") return o.updateGrubFails ? fail() : ok();
+      if (o.throwCommands?.includes(cmd[0]!)) throw new Error(`spawn ${cmd[0]}: ENOENT`);
       if (o.failCommands?.includes(cmd[0]!)) return fail();
       // `tee` above writes a literal, so it never models stdin; this hook is
       // how a test says what a command does to the fake filesystem.
@@ -248,7 +250,9 @@ describe("getStatus", () => {
       files: { "/etc/default/grub-steamos": addKargToGrubSteamos(GRUB_SAMPLE) },
       cmdline: "BOOT_IMAGE=x quiet", // karg not active yet
     });
-    const s = await getStatus(deps);
+    // kargApplicable: true — on an unmeasured board there is no reboot to
+    // offer, which the sibling test below pins.
+    const s = await getStatus(deps, true);
     expect(s.kargStaged).toBe(true);
     expect(s.kargActive).toBe(false);
     expect(s.rebootPending).toBe(true);
@@ -624,12 +628,21 @@ describe("shouldHeal", () => {
 describe("kargMode", () => {
   // "we know the pin" and "we can put it there" are different questions;
   // conflating them is what had the UI reporting a half-applied block as on.
-  it("routes each distro to the mechanism it actually uses", () => {
+  it("routes by mechanism, not distro name", () => {
+    // Silverblue and Kinoite both report ID=fedora, so a name table routed
+    // them to the wrong backend entirely. /run/ostree-booted is the fact.
     expect(kargMode("steamos", true)).toBe("steamos");
-    expect(kargMode("bazzite", true)).toBe("ostree");
-    expect(kargMode("cachyos", true)).toBe("grub");
-    expect(kargMode("arch", true)).toBe("grub");
+    expect(kargMode("bazzite", true, true)).toBe("ostree");
+    expect(kargMode("fedora", true, true)).toBe("ostree");
+    expect(kargMode("cachyos", true)).toBe("manual");
+    expect(kargMode("arch", true)).toBe("manual");
     expect(kargMode("ubuntu", true)).toBe("manual");
+  });
+
+  it("treats an unreadable /etc/os-release as unknown, not unmanaged", () => {
+    // "" fell into the manual case, silently downgrading a real SteamOS Apex
+    // to PME-only with nothing saying so.
+    expect(kargMode("", true)).toBe("none");
   });
 
   it("says nothing at all when the board's pin is unknown", () => {
@@ -642,8 +655,14 @@ describe("kargMode", () => {
 });
 
 describe("Bazzite (rpm-ostree)", () => {
-  const bazzite = (over: Record<string, unknown> = {}) =>
-    makeFpDeps({ cmdline: "BOOT_IMAGE=x quiet", distro: "bazzite", ...over });
+  const bazzite = (over: { files?: Record<string, string>; failCommands?: string[] } = {}) =>
+    makeFpDeps({
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "bazzite",
+      ...over,
+      // Detection is by mechanism: this marker is what makes it ostree.
+      files: { "/run/ostree-booted": "", ...(over.files ?? {}) },
+    });
 
   it("stages the karg with rpm-ostree rather than editing a file", async () => {
     const { deps, commands, files } = bazzite();
@@ -656,10 +675,61 @@ describe("Bazzite (rpm-ostree)", () => {
     expect(Object.keys(files)).not.toContain("/etc/default/grub");
   });
 
-  it("removes it again on revert", async () => {
-    const { deps, commands } = bazzite();
-    await revert(deps, { autoKarg: true });
+  it("removes it again on revert, and says a reboot is needed", async () => {
+    const { deps, commands } = bazzite({ files: { __ostree_kargs__: KARG } });
+    const r = await revert(deps, { autoKarg: true });
     expect(commands.some((c) => c.includes("rpm-ostree kargs --delete-if-present"))).toBe(true);
+    expect(r.rebootRequired).toBe(true);
+    expect(r.steps).toContain("karg-unstaged");
+  });
+
+  it("does not send the user to reboot when there was nothing staged", async () => {
+    // These helpers returned true unconditionally, so toggling the block off
+    // when it was never on produced "Reboot required" — contradicting the
+    // panel, which correctly showed nothing pending.
+    const { deps, commands } = bazzite();
+    const r = await revert(deps, { autoKarg: true });
+    expect(r.rebootRequired).toBe(false);
+    expect(r.steps).toContain("karg-not-present");
+    expect(commands.some((c) => c.includes("--delete-if-present"))).toBe(false);
+  });
+
+  it("treats an unreadable rpm-ostree as unknown, not as drift", async () => {
+    // rpm-ostree exits non-zero mid-transaction, and Bazzite's auto-update
+    // timer fires around boot — exactly when the heal runs. Reading that as
+    // "not staged" produced a false alert and a heal loop.
+    // A fully protected machine: both paths closed, karg live from the last
+    // boot. Only the read of what the NEXT boot carries is failing.
+    const { deps } = makeFpDeps({
+      files: {
+        "/run/ostree-booted": "",
+        [UDEV_RULE_PATH]: "(rule)",
+        [`/sys/bus/pci/devices/${CTRL}/power/wakeup`]: "disabled",
+      },
+      cmdline: `BOOT_IMAGE=x quiet ${KARG}`,
+      distro: "bazzite",
+      failCommands: ["rpm-ostree"],
+    });
+    const s = await getStatus(deps, true);
+    expect(s.applied).toBe(true);
+    // Reading `false` here would have called it drift, alerted, and re-run
+    // the heal on every boot.
+    expect(s.kargUnpersisted).toBe(false);
+    expect(shouldHeal({ wanted: true, status: s })).toBe(false);
+  });
+
+  it("keeps getStatus alive when rpm-ostree can't be run at all", async () => {
+    // An uncaught throw here rejected the whole getStatus RPC, so the entire
+    // OneXPlayer page never left its loading state on Bazzite.
+    const { deps } = makeFpDeps({
+      files: { "/run/ostree-booted": "" },
+      cmdline: "BOOT_IMAGE=x quiet",
+      distro: "bazzite",
+      throwCommands: ["rpm-ostree"],
+    });
+    const s = await getStatus(deps, true);
+    expect(s.kargStaged).toBe(false);
+    expect(s.supported).toBe(true);
   });
 
   it("surfaces a failure instead of reporting a block it didn't apply", async () => {
@@ -670,76 +740,11 @@ describe("Bazzite (rpm-ostree)", () => {
   });
 });
 
-describe("CachyOS / Arch (GRUB)", () => {
-  const GRUB = 'GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"\n';
-
-  it("edits /etc/default/grub and regenerates the config", async () => {
-    const { deps, files, commands } = makeFpDeps({
-      files: { "/etc/default/grub": GRUB, "/boot/grub/grub.cfg": "" },
-      cmdline: "BOOT_IMAGE=x quiet",
-      distro: "cachyos",
-      // grub-mkconfig writes the karg through to the generated config.
-      onCommand: (cmd: string[], f: Record<string, string>) => {
-        if (cmd[0] === "grub-mkconfig") f["/boot/grub/grub.cfg"] = f["/etc/default/grub"] ?? "";
-      },
-    });
-    const r = await apply(deps, { autoKarg: true });
-    expect(r.success).toBe(true);
-    expect(files["/etc/default/grub"]).toContain(KARG);
-    expect(commands.some((c) => c.startsWith("grub-mkconfig"))).toBe(true);
-    expect(files["/etc/default/grub.loadout.bak"]).toBe(GRUB);
-  });
-
-  it("rolls back and reports when the karg never reaches grub.cfg", async () => {
-    // systemd-boot or limine: the file is written, grub-mkconfig "succeeds",
-    // and nothing that boots the machine ever reads it. Silently reporting
-    // success there would claim protection the device does not have.
-    const { deps, files } = makeFpDeps({
-      files: { "/etc/default/grub": GRUB, "/boot/grub/grub.cfg": "" },
-      cmdline: "BOOT_IMAGE=x quiet",
-      distro: "cachyos",
-    });
-    const r = await apply(deps, { autoKarg: true });
-    expect(r.success).toBe(false);
-    expect(r.error).toContain("may not boot with GRUB");
-    expect(files["/etc/default/grub"]).toBe(GRUB); // restored
-  });
-});
-
-describe("GRUB_CMDLINE_LINUX_DEFAULT editing", () => {
-  it("appends to an existing line without disturbing it", () => {
-    const out = addKargToGrubDefault('GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"\n');
-    expect(out).toContain(`quiet splash ${KARG}`);
-  });
-
-  it("is idempotent", () => {
-    const once = addKargToGrubDefault('GRUB_CMDLINE_LINUX_DEFAULT="quiet"\n');
-    expect(addKargToGrubDefault(once)).toBe(once);
-  });
-
-  it("handles an empty cmdline", () => {
-    expect(addKargToGrubDefault('GRUB_CMDLINE_LINUX_DEFAULT=""\n')).toContain(
-      `GRUB_CMDLINE_LINUX_DEFAULT="${KARG}"`,
-    );
-  });
-
-  it("adds the line when the file has none, rather than doing nothing", () => {
-    expect(addKargToGrubDefault("GRUB_TIMEOUT=5\n")).toContain(
-      `GRUB_CMDLINE_LINUX_DEFAULT="${KARG}"`,
-    );
-  });
-
-  it("round-trips", () => {
-    const before = 'GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"\n';
-    expect(removeKargFromGrubDefault(addKargToGrubDefault(before)).trim()).toBe(before.trim());
-  });
-});
-
 describe("the SteamOS window between staging and rebooting", () => {
-  it("counts a staged karg as applied, so the toggle doesn't fight the user", async () => {
-    // Staged, not yet live. Treating this as not-applied made the toggle
-    // spring back OFF right beside the alert saying a change was staged —
-    // and made the startup heal fire on every restart until the reboot.
+  it("is NOT applied yet — the GPIO path is open until the reboot", async () => {
+    // Counting a staged karg as applied was unbounded: where staging succeeds
+    // but can never take effect, `applied` stayed true forever with path 1
+    // open. The toggle no longer keys on this, so being strict costs nothing.
     const { deps } = makeFpDeps({
       files: {
         [UDEV_RULE_PATH]: "(rule)",
@@ -752,22 +757,25 @@ describe("the SteamOS window between staging and rebooting", () => {
     const s = await getStatus(deps, true);
     expect(s.kargStaged).toBe(true);
     expect(s.kargActive).toBe(false);
-    expect(s.applied).toBe(true);
-    // ...while still telling them it isn't live yet.
+    expect(s.applied).toBe(false);
     expect(s.rebootPending).toBe(true);
-    expect(shouldHeal({ wanted: true, status: s })).toBe(false);
   });
 
-  it("is still not applied when the karg is neither staged nor live", async () => {
+  it("does not offer a reboot on a board whose pin we don't know", async () => {
+    // rebootPending ungated by kargAutomatic put a reboot button under the
+    // text saying we don't know this model's pin — and pressing it would
+    // activate that foreign pin.
     const { deps } = makeFpDeps({
       files: {
         [UDEV_RULE_PATH]: "(rule)",
         [`/sys/bus/pci/devices/${CTRL}/power/wakeup`]: "disabled",
-        "/etc/default/grub-steamos": GRUB_SAMPLE,
+        "/etc/default/grub-steamos": addKargToGrubSteamos(GRUB_SAMPLE),
       },
       cmdline: "BOOT_IMAGE=x quiet",
       distro: "steamos",
     });
-    expect((await getStatus(deps, true)).applied).toBe(false);
+    const s = await getStatus(deps, false); // unmeasured board
+    expect(s.kargMode).toBe("none");
+    expect(s.rebootPending).toBe(false);
   });
 });

--- a/plugins/apex/lib/fingerprint.ts
+++ b/plugins/apex/lib/fingerprint.ts
@@ -53,27 +53,42 @@ const GRUB_STEAMOS = "/etc/default/grub-steamos";
  *
  *   "steamos" — /etc/default/grub-steamos, behind steamos-readonly
  *   "ostree"  — rpm-ostree kargs (Bazzite and other rpm-ostree images)
- *   "grub"    — /etc/default/grub + grub-mkconfig (CachyOS/Arch/Fedora)
- *   "manual"  — we know the pin but not this bootloader; tell the user
+ *   "manual"  — we know the pin but not this bootloader (CachyOS, Arch, …);
+ *               print the arg and say the block is incomplete
+ *   "unknown" — we couldn't identify the system at all
  *   "none"    — unmeasured board: we don't know the pin, so say nothing
+ *
+ * There is deliberately no GRUB mode. Editing /etc/default/grub was tried and
+ * removed: the file is sourced, so a value that isn't double-quoted got a
+ * second assignment appended and the user's real cryptdevice=/resume= args
+ * were discarded — and none of it is verifiable before a reboot.
  */
-export type KargMode = "steamos" | "ostree" | "manual" | "none";
+export type KargMode = "steamos" | "ostree" | "manual" | "unknown" | "none";
 
 export function kargMode(
   distro: string,
   pinKnown: boolean,
-  /** `/run/ostree-booted` exists. Detected by mechanism rather than distro
-   *  name: Silverblue and Kinoite both report `ID=fedora`, so a name table
-   *  silently routed them to the wrong backend. */
+  /** `/run/ostree-booted` exists AND `rpm-ostree` is usable. Detected by
+   *  mechanism rather than distro name (Silverblue and Kinoite both report
+   *  `ID=fedora`), and the tool is required as well as the marker — the
+   *  marker is present on bootc images where rpm-ostree may be absent, and
+   *  claiming "automatic" there loops forever instead of falling back to a
+   *  workable instruction. */
   ostreeBooted = false,
 ): KargMode {
   if (!pinKnown) return "none";
-  // An unreadable /etc/os-release must not look like a distro we've decided
-  // we don't manage — that silently downgraded a SteamOS Apex to PME-only.
-  if (!distro) return "none";
+  // Distinct from "none": an unreadable /etc/os-release means we don't know
+  // the SYSTEM, not that we don't know the BOARD. Collapsing them made the UI
+  // tell a real Apex owner "we don't know this model's pin", which is false.
+  if (!distro) return "unknown";
   if (ostreeBooted) return "ostree";
   if (distro === "steamos") return "steamos";
   return "manual";
+}
+
+/** Modes where we know the pin but cannot stage it — the user can. */
+export function isKargManual(mode: KargMode): boolean {
+  return mode === "manual" || mode === "unknown";
 }
 
 /** Modes where we put the karg there ourselves. */
@@ -112,6 +127,9 @@ export interface FingerprintStatus {
   kargMode: KargMode;
   /** We stage the karg ourselves here — so it counts toward `applied`. */
   kargAutomatic: boolean;
+  /** We manage the bootloader here, but couldn't read what the next boot
+   *  will carry — distinct from knowing it isn't staged. */
+  kargStagedUnknown: boolean;
   /**
    * Whether the karg path is usable on this board at all. False when we
    * haven't confirmed the board's GPIO pin, in which case PME blocking is
@@ -191,14 +209,17 @@ export async function getStatus(
     controllerWakeDisabled = wake.trim() === "disabled";
   }
   const udevRuleInstalled = await deps.pathExists(UDEV_RULE_PATH);
-  const ostreeBooted = await deps.pathExists("/run/ostree-booted");
+  // Marker AND tool: /run/ostree-booted is present on bootc images where
+  // rpm-ostree may not be, and "automatic" without the tool is a heal loop.
+  const ostreeBooted =
+    (await deps.pathExists("/run/ostree-booted")) && (await ostreeUsable(deps));
   const mode = kargMode(distro, kargApplicable, ostreeBooted);
   const kargAutomatic = isKargAutomatic(mode);
-  // Read the bootloader this distro uses regardless of whether we would stage
-  // here: whether the karg is in the boot config is a fact about the machine,
-  // not a function of what we're willing to write. A user who added it by
-  // hand on an unmeasured board should still see it reported.
-  const stagedRead = await readKargStaged(deps, kargMode(distro, true, ostreeBooted));
+  // Only where we actually manage the bootloader. Forcing `pinKnown: true`
+  // here spent an rpm-ostree DBus round-trip on every status refresh for a
+  // value nothing reads: kargStaged isn't surfaced to the UI, and its one
+  // internal consumer (rebootPending) is gated on kargAutomatic anyway.
+  const stagedRead = controller === null ? undefined : await readKargStaged(deps, mode);
   const kargStaged = stagedRead === true;
 
   const path2Closed = controllerWakeDisabled && udevRuleInstalled;
@@ -242,8 +263,14 @@ export async function getStatus(
     // a karg in its boot config from anywhere rendered "Reboot to finish
     // applying" — with a reboot button — directly beneath the text saying we
     // don't know this model's pin. Pressing it activated that foreign pin.
+    // `stagedRead === true`, not `kargStaged`: an unknown read must not read
+    // as "not staged" here, or a machine with the karg genuinely staged loses
+    // its reboot prompt and the karg is never activated.
     rebootPending:
-      kargAutomatic && ((kargStaged && !kargActive) || (kargLiveOnly && !udevRuleInstalled)),
+      kargAutomatic &&
+      ((stagedRead === true && !kargActive) || (kargLiveOnly && !udevRuleInstalled)),
+    /** We manage the bootloader here but couldn't read what it will carry. */
+    kargStagedUnknown: kargAutomatic && stagedRead === undefined,
     kargUnpersisted: kargLiveOnly && udevRuleInstalled,
     distro,
   };
@@ -271,11 +298,19 @@ export async function getStatus(
 export function shouldHeal(input: {
   /** The user's stored choice. `undefined` = never chose. */
   wanted: boolean | undefined;
-  status: Pick<FingerprintStatus, "supported" | "applied" | "kargUnpersisted">;
+  status: Pick<
+    FingerprintStatus,
+    "supported" | "applied" | "kargUnpersisted" | "kargStaged" | "kargActive" | "kargAutomatic"
+  >;
 }): boolean {
   if (input.wanted !== true) return false;
   // No reader on this machine — nothing to re-apply, and apply() would fail.
   if (!input.status.supported) return false;
+  // Staged and waiting for a reboot is PENDING, not LOST. Healing here did
+  // nothing and then announced "a system update removed the wake block" —
+  // on every backend restart until the user rebooted.
+  const { kargAutomatic, kargStaged, kargActive } = input.status;
+  if (kargAutomatic && kargStaged && !kargActive) return false;
   return !input.status.applied || input.status.kargUnpersisted;
 }
 
@@ -343,20 +378,30 @@ async function addKargSteamos(deps: FingerprintDeps, steps: string[]): Promise<b
     return false;
   }
   await deps.run(["steamos-readonly", "disable"], { timeoutMs: 30_000 });
-  await deps.writeFile(`${GRUB_STEAMOS}.loadout.bak`, current);
-  await deps.writeFile(GRUB_STEAMOS, addKargToGrubSteamos(current));
-  const gen = await deps.run(["update-grub"], { timeoutMs: 120_000 });
-  await deps.run(["steamos-readonly", "enable"], { timeoutMs: 30_000 });
-  if (gen.exitCode !== 0) {
+  // try/finally, not an exit-code branch alone: `update-grub` can THROW
+  // (missing binary, denied command policy) rather than exit non-zero, and a
+  // throw used to escape between the write and `steamos-readonly enable` —
+  // leaving a modified grub source, no regeneration, and the rootfs writable.
+  let staged = false;
+  try {
+    await deps.writeFile(`${GRUB_STEAMOS}.loadout.bak`, current);
+    await deps.writeFile(GRUB_STEAMOS, addKargToGrubSteamos(current));
+    const gen = await deps.run(["update-grub"], { timeoutMs: 120_000 });
+    if (gen.exitCode !== 0) {
+      throw new Error(`update-grub failed: ${gen.stderr.trim() || gen.exitCode}`);
+    }
+    staged = true;
+  } catch (e) {
     // Roll back the source file so a bad generation can't strand boot config.
-    await deps.run(["steamos-readonly", "disable"], { timeoutMs: 30_000 });
-    await deps.writeFile(GRUB_STEAMOS, current);
-    await deps.run(["update-grub"], { timeoutMs: 120_000 });
-    await deps.run(["steamos-readonly", "enable"], { timeoutMs: 30_000 });
-    throw new Error(`update-grub failed: ${gen.stderr.trim() || gen.exitCode}`);
+    await deps.writeFile(GRUB_STEAMOS, current).catch(() => {});
+    await deps.run(["update-grub"], { timeoutMs: 120_000 }).catch(() => {});
+    throw e;
+  } finally {
+    // Always re-seal the rootfs, on every path out of here.
+    await deps.run(["steamos-readonly", "enable"], { timeoutMs: 30_000 }).catch(() => {});
   }
   steps.push("karg-staged");
-  return true;
+  return staged;
 }
 
 /** Whether a bootloader config currently carries the karg. */
@@ -416,8 +461,18 @@ async function removeKargOstree(deps: FingerprintDeps, steps: string[]): Promise
  * downstream decision, and an uncaught throw took the whole getStatus RPC
  * down with it — leaving the plugin page stuck loading.
  */
+/** Whether `rpm-ostree` can actually be run here. */
+async function ostreeUsable(deps: FingerprintDeps): Promise<boolean> {
+  const r = await deps.run(["sh", "-c", "command -v rpm-ostree"], { timeoutMs: 5_000 }).catch(
+    () => null,
+  );
+  return !!r && r.exitCode === 0 && r.stdout.trim() !== "";
+}
+
 async function ostreeKargStaged(deps: FingerprintDeps): Promise<boolean | undefined> {
-  const r = await deps.run(["rpm-ostree", "kargs"], { timeoutMs: 30_000 }).catch(() => null);
+  // Well under the overlay's 30s RPC cap: this runs inside getStatus, and a
+  // read that outlasts the cap leaves the plugin page spinning forever.
+  const r = await deps.run(["rpm-ostree", "kargs"], { timeoutMs: 8_000 }).catch(() => null);
   if (!r || r.exitCode !== 0) return undefined;
   return r.stdout.includes(KARG);
 }
@@ -578,7 +633,7 @@ export async function revert(
     } catch (e) {
       return { success: false, rebootRequired: false, steps, error: `Karg removal failed: ${e}` };
     }
-  } else if (mode === "manual" && (await deps.readCmdline()).includes(KARG)) {
+  } else if (isKargManual(mode) && (await deps.readCmdline()).includes(KARG)) {
     // Only where we know the pin: on an unmeasured board we never told them
     // to add it, so we don't tell them to remove it either.
     steps.push("karg-manual-removal-required");

--- a/plugins/apex/lib/fingerprint.ts
+++ b/plugins/apex/lib/fingerprint.ts
@@ -41,11 +41,6 @@ export const FP_PRODUCTS: readonly string[] = ["c652", "5952"];
 
 export const UDEV_RULE_PATH = "/etc/udev/rules.d/90-loadout-fingerprint-no-wake.rules";
 const GRUB_STEAMOS = "/etc/default/grub-steamos";
-/** Arch/CachyOS/Fedora GRUB. Assumed on those — CachyOS also offers
- *  systemd-boot and limine, where this file exists but nothing reads it. */
-const GRUB_DEFAULT = "/etc/default/grub";
-const GRUB_CFG = "/boot/grub/grub.cfg";
-
 /**
  * How the GPIO kernel arg gets onto the command line here.
  *
@@ -62,38 +57,28 @@ const GRUB_CFG = "/boot/grub/grub.cfg";
  *   "manual"  — we know the pin but not this bootloader; tell the user
  *   "none"    — unmeasured board: we don't know the pin, so say nothing
  */
-export type KargMode = "steamos" | "ostree" | "grub" | "manual" | "none";
+export type KargMode = "steamos" | "ostree" | "manual" | "none";
 
-export function kargMode(distro: string, pinKnown: boolean): KargMode {
+export function kargMode(
+  distro: string,
+  pinKnown: boolean,
+  /** `/run/ostree-booted` exists. Detected by mechanism rather than distro
+   *  name: Silverblue and Kinoite both report `ID=fedora`, so a name table
+   *  silently routed them to the wrong backend. */
+  ostreeBooted = false,
+): KargMode {
   if (!pinKnown) return "none";
-  switch (distro) {
-    case "steamos":
-      return "steamos";
-    // Bazzite and friends. rpm-ostree kargs is idempotent, reversible and the
-    // supported API — no file editing, no bootloader guessing.
-    case "bazzite":
-    case "silverblue":
-    case "kinoite":
-    case "bluefin":
-    case "aurora":
-      return "ostree";
-    // GRUB is assumed on these. CachyOS also ships systemd-boot and limine,
-    // where /etc/default/grub exists but nothing reads it — we verify the
-    // generated grub.cfg afterwards rather than trusting the write.
-    case "cachyos":
-    case "arch":
-    case "endeavouros":
-    case "fedora":
-    case "nobara":
-      return "grub";
-    default:
-      return "manual";
-  }
+  // An unreadable /etc/os-release must not look like a distro we've decided
+  // we don't manage — that silently downgraded a SteamOS Apex to PME-only.
+  if (!distro) return "none";
+  if (ostreeBooted) return "ostree";
+  if (distro === "steamos") return "steamos";
+  return "manual";
 }
 
 /** Modes where we put the karg there ourselves. */
 export function isKargAutomatic(mode: KargMode): boolean {
-  return mode === "steamos" || mode === "ostree" || mode === "grub";
+  return mode === "steamos" || mode === "ostree";
 }
 
 export interface FingerprintDeps {
@@ -206,13 +191,15 @@ export async function getStatus(
     controllerWakeDisabled = wake.trim() === "disabled";
   }
   const udevRuleInstalled = await deps.pathExists(UDEV_RULE_PATH);
-  const mode = kargMode(distro, kargApplicable);
+  const ostreeBooted = await deps.pathExists("/run/ostree-booted");
+  const mode = kargMode(distro, kargApplicable, ostreeBooted);
   const kargAutomatic = isKargAutomatic(mode);
   // Read the bootloader this distro uses regardless of whether we would stage
   // here: whether the karg is in the boot config is a fact about the machine,
   // not a function of what we're willing to write. A user who added it by
   // hand on an unmeasured board should still see it reported.
-  const kargStaged = await readKargStaged(deps, kargMode(distro, true));
+  const stagedRead = await readKargStaged(deps, kargMode(distro, true, ostreeBooted));
+  const kargStaged = stagedRead === true;
 
   const path2Closed = controllerWakeDisabled && udevRuleInstalled;
 
@@ -230,7 +217,10 @@ export async function getStatus(
   // it by hand, "live but not staged" is simply how that looks — reporting it
   // as drift gave them an alert describing a bootloader file they may not
   // even have, and a remedy that could never run.
-  const kargLiveOnly = kargAutomatic && kargActive && !kargStaged;
+  // `stagedRead === false` and not merely `!kargStaged`: an unknown read must
+  // never look like drift, or a transient rpm-ostree failure produces a false
+  // alert and a heal that runs on every boot.
+  const kargLiveOnly = kargAutomatic && kargActive && stagedRead === false;
   return {
     supported: controller !== null,
     controller,
@@ -241,21 +231,19 @@ export async function getStatus(
     kargApplicable,
     kargMode: mode,
     kargAutomatic,
-    // Both wake paths must close, so where we CAN stage the karg it is
-    // required. `kargStaged` counts alongside `kargActive`: between enabling
-    // the block and rebooting, the karg is staged but not yet live, and
-    // treating that as "not applied" made the toggle spring back OFF right
-    // beside the alert saying a change was staged — and made the startup heal
-    // fire on every restart in that window. rebootPending is what tells the
-    // user it is not live yet.
-    //
-    // Where we cannot stage it (unmeasured board), PME is all we can offer
-    // and `applied` reflects that; the UI says so rather than claiming the
-    // GPIO path is closed.
-    applied: path2Closed && (kargActive || kargStaged || !kargAutomatic),
-    // Staged but not yet live → a reboot applies it. Live but not staged
-    // *and* the block was reverted → a reboot finishes removing it.
-    rebootPending: (kargStaged && !kargActive) || (kargLiveOnly && !udevRuleInstalled),
+    // Both wake paths must close, so where we CAN stage the karg, the karg
+    // has to be LIVE — staged-but-not-yet-live means path 1 is open right
+    // now. Counting `kargStaged` here was a lie whenever staging succeeded
+    // but could never take effect, and nothing bounded it to a pre-reboot
+    // window. The toggle no longer keys on this at all; it reflects the
+    // user's stored choice, so being strict here costs nothing.
+    applied: path2Closed && (kargActive || !kargAutomatic),
+    // Gated on kargAutomatic throughout. Without it, an unmeasured board with
+    // a karg in its boot config from anywhere rendered "Reboot to finish
+    // applying" — with a reboot button — directly beneath the text saying we
+    // don't know this model's pin. Pressing it activated that foreign pin.
+    rebootPending:
+      kargAutomatic && ((kargStaged && !kargActive) || (kargLiveOnly && !udevRuleInstalled)),
     kargUnpersisted: kargLiveOnly && udevRuleInstalled,
     distro,
   };
@@ -387,6 +375,12 @@ async function readsKarg(deps: FingerprintDeps, path: string): Promise<boolean> 
  * rollback.
  */
 async function addKargOstree(deps: FingerprintDeps, steps: string[]): Promise<boolean> {
+  // Report whether this changed anything, like the SteamOS backend does —
+  // returning true unconditionally sent users to reboot for a no-op.
+  if ((await ostreeKargStaged(deps)) === true) {
+    steps.push("karg-already-staged");
+    return false;
+  }
   const r = await deps.run(["rpm-ostree", "kargs", `--append-if-missing=${KARG}`], {
     timeoutMs: 180_000,
   });
@@ -398,6 +392,10 @@ async function addKargOstree(deps: FingerprintDeps, steps: string[]): Promise<bo
 }
 
 async function removeKargOstree(deps: FingerprintDeps, steps: string[]): Promise<boolean> {
+  if ((await ostreeKargStaged(deps)) === false) {
+    steps.push("karg-not-present");
+    return false;
+  }
   const r = await deps.run(["rpm-ostree", "kargs", `--delete-if-present=${KARG}`], {
     timeoutMs: 180_000,
   });
@@ -408,80 +406,20 @@ async function removeKargOstree(deps: FingerprintDeps, steps: string[]): Promise
   return true;
 }
 
-/** What the next boot will use, per rpm-ostree itself. */
-async function ostreeKargStaged(deps: FingerprintDeps): Promise<boolean> {
-  const r = await deps.run(["rpm-ostree", "kargs"], { timeoutMs: 30_000 });
-  return r.exitCode === 0 && r.stdout.includes(KARG);
-}
-
-// --- karg backends: GRUB (CachyOS / Arch / Fedora) ---------------------------
-
 /**
- * Assumes GRUB, per an explicit product decision. CachyOS also offers
- * systemd-boot and limine, where /etc/default/grub exists but nothing reads
- * it — so rather than trust the write, we check the karg actually landed in
- * the generated grub.cfg and report failure if it didn't. That turns a silent
- * "protected but isn't" into a visible error.
+ * What the next boot will use, per rpm-ostree itself.
+ *
+ * Never throws and never guesses: an exception (the command policy, a missing
+ * binary) or a non-zero exit (a transaction in progress — Bazzite's
+ * auto-update timer fires around boot, exactly when the heal runs) yields
+ * `undefined`. Returning `false` there put an unread deployment into every
+ * downstream decision, and an uncaught throw took the whole getStatus RPC
+ * down with it — leaving the plugin page stuck loading.
  */
-async function addKargGrub(deps: FingerprintDeps, steps: string[]): Promise<boolean> {
-  const current = await deps.readFile(GRUB_DEFAULT).catch(() => "");
-  if (!current) throw new Error(`${GRUB_DEFAULT} not readable — is this a GRUB system?`);
-  if (current.includes(KARG)) {
-    steps.push("karg-already-staged");
-    return false;
-  }
-  await deps.writeFile(`${GRUB_DEFAULT}.loadout.bak`, current);
-  await deps.writeFile(GRUB_DEFAULT, addKargToGrubDefault(current));
-
-  const gen = await deps.run(["grub-mkconfig", "-o", GRUB_CFG], { timeoutMs: 180_000 });
-  if (gen.exitCode !== 0) {
-    await deps.writeFile(GRUB_DEFAULT, current);
-    throw new Error(`grub-mkconfig failed: ${gen.stderr.trim() || gen.exitCode}`);
-  }
-  if (!(await readsKarg(deps, GRUB_CFG))) {
-    // The file was written and grub-mkconfig succeeded, but the karg is not
-    // in the generated config — this bootloader isn't the one in use.
-    await deps.writeFile(GRUB_DEFAULT, current);
-    await deps.run(["grub-mkconfig", "-o", GRUB_CFG], { timeoutMs: 180_000 });
-    throw new Error("The kernel arg didn't reach grub.cfg — this system may not boot with GRUB.");
-  }
-  steps.push("karg-staged");
-  return true;
-}
-
-async function removeKargGrub(deps: FingerprintDeps, steps: string[]): Promise<boolean> {
-  const current = await deps.readFile(GRUB_DEFAULT).catch(() => "");
-  if (!current.includes(KARG)) {
-    steps.push("karg-not-present");
-    return false;
-  }
-  await deps.writeFile(`${GRUB_DEFAULT}.loadout.bak`, current);
-  await deps.writeFile(GRUB_DEFAULT, removeKargFromGrubDefault(current));
-  await deps.run(["grub-mkconfig", "-o", GRUB_CFG], { timeoutMs: 180_000 });
-  steps.push("karg-unstaged");
-  return true;
-}
-
-/** Append the karg to GRUB_CMDLINE_LINUX_DEFAULT="…". */
-export function addKargToGrubDefault(content: string): string {
-  if (content.includes(KARG)) return content;
-  const re = /^(GRUB_CMDLINE_LINUX_DEFAULT=")([^"]*)(")/m;
-  if (!re.test(content)) {
-    // No such line — append one rather than silently doing nothing.
-    return `${content.replace(/\n*$/, "")}\nGRUB_CMDLINE_LINUX_DEFAULT="${KARG}"\n`;
-  }
-  return content.replace(re, (_m, open: string, inner: string, close: string) => {
-    const next = inner.trim() ? `${inner.trim()} ${KARG}` : KARG;
-    return `${open}${next}${close}`;
-  });
-}
-
-export function removeKargFromGrubDefault(content: string): string {
-  return content.replace(
-    /^(GRUB_CMDLINE_LINUX_DEFAULT=")([^"]*)(")/m,
-    (_m, open: string, inner: string, close: string) =>
-      `${open}${inner.split(/\s+/).filter((t) => t && t !== KARG).join(" ")}${close}`,
-  );
+async function ostreeKargStaged(deps: FingerprintDeps): Promise<boolean | undefined> {
+  const r = await deps.run(["rpm-ostree", "kargs"], { timeoutMs: 30_000 }).catch(() => null);
+  if (!r || r.exitCode !== 0) return undefined;
+  return r.stdout.includes(KARG);
 }
 
 async function removeKargSteamos(deps: FingerprintDeps, steps: string[]): Promise<boolean> {
@@ -501,15 +439,21 @@ async function removeKargSteamos(deps: FingerprintDeps, steps: string[]): Promis
 
 // --- karg dispatch -----------------------------------------------------------
 
-/** What the NEXT boot will carry, per whichever bootloader we manage here. */
-async function readKargStaged(deps: FingerprintDeps, mode: KargMode): Promise<boolean> {
+/**
+ * What the NEXT boot will carry, per whichever bootloader we manage here.
+ * `undefined` means we could not find out — distinct from "not staged", which
+ * would otherwise drive a false drift alert and a heal loop every time
+ * rpm-ostree happened to be mid-transaction.
+ */
+async function readKargStaged(
+  deps: FingerprintDeps,
+  mode: KargMode,
+): Promise<boolean | undefined> {
   switch (mode) {
     case "steamos":
       return readsKarg(deps, GRUB_STEAMOS);
     case "ostree":
       return ostreeKargStaged(deps);
-    case "grub":
-      return readsKarg(deps, GRUB_DEFAULT);
     default:
       // Not ours to read; a hand-added karg shows up as kargActive instead.
       return false;
@@ -522,8 +466,6 @@ async function stageKarg(deps: FingerprintDeps, mode: KargMode, steps: string[])
       return addKargSteamos(deps, steps);
     case "ostree":
       return addKargOstree(deps, steps);
-    case "grub":
-      return addKargGrub(deps, steps);
     default:
       return false;
   }
@@ -539,8 +481,6 @@ async function unstageKarg(
       return removeKargSteamos(deps, steps);
     case "ostree":
       return removeKargOstree(deps, steps);
-    case "grub":
-      return removeKargGrub(deps, steps);
     default:
       return false;
   }
@@ -574,10 +514,10 @@ export async function apply(
   // Path 1 — karg. SteamOS automated; other distros get a manual hint so we
   // never edit a bootloader we haven't validated.
   const distro = await deps.distroId();
-  const mode = kargMode(distro, autoKarg);
+  const mode = kargMode(distro, autoKarg, await deps.pathExists("/run/ostree-booted"));
   const canStage = isKargAutomatic(mode);
   const alreadyActive = (await deps.readCmdline()).includes(KARG);
-  const alreadyStaged = canStage ? await readKargStaged(deps, mode) : false;
+  const alreadyStaged = canStage ? (await readKargStaged(deps, mode)) === true : false;
 
   // Only skip the bootloader edit when the karg is live AND already staged —
   // or when we would not be editing the bootloader anyway.
@@ -630,7 +570,7 @@ export async function revert(
   await enablePme(deps, controller, steps);
 
   const distro = await deps.distroId();
-  const mode = kargMode(distro, autoKarg);
+  const mode = kargMode(distro, autoKarg, await deps.pathExists("/run/ostree-booted"));
   let rebootRequired = false;
   if (isKargAutomatic(mode)) {
     try {

--- a/plugins/apex/lib/fingerprint.ts
+++ b/plugins/apex/lib/fingerprint.ts
@@ -41,6 +41,60 @@ export const FP_PRODUCTS: readonly string[] = ["c652", "5952"];
 
 export const UDEV_RULE_PATH = "/etc/udev/rules.d/90-loadout-fingerprint-no-wake.rules";
 const GRUB_STEAMOS = "/etc/default/grub-steamos";
+/** Arch/CachyOS/Fedora GRUB. Assumed on those — CachyOS also offers
+ *  systemd-boot and limine, where this file exists but nothing reads it. */
+const GRUB_DEFAULT = "/etc/default/grub";
+const GRUB_CFG = "/boot/grub/grub.cfg";
+
+/**
+ * How the GPIO kernel arg gets onto the command line here.
+ *
+ * The touch has TWO independent wake paths and both must close (see the file
+ * header); path 1 is disarmed *only* by this karg, so a distro we can't stage
+ * on is a distro where the block is genuinely incomplete. That is why this
+ * returns a mode rather than a boolean — "we know the pin" and "we can put it
+ * there" are different questions, and conflating them is what previously had
+ * the UI reporting a half-applied block as fully on.
+ *
+ *   "steamos" — /etc/default/grub-steamos, behind steamos-readonly
+ *   "ostree"  — rpm-ostree kargs (Bazzite and other rpm-ostree images)
+ *   "grub"    — /etc/default/grub + grub-mkconfig (CachyOS/Arch/Fedora)
+ *   "manual"  — we know the pin but not this bootloader; tell the user
+ *   "none"    — unmeasured board: we don't know the pin, so say nothing
+ */
+export type KargMode = "steamos" | "ostree" | "grub" | "manual" | "none";
+
+export function kargMode(distro: string, pinKnown: boolean): KargMode {
+  if (!pinKnown) return "none";
+  switch (distro) {
+    case "steamos":
+      return "steamos";
+    // Bazzite and friends. rpm-ostree kargs is idempotent, reversible and the
+    // supported API — no file editing, no bootloader guessing.
+    case "bazzite":
+    case "silverblue":
+    case "kinoite":
+    case "bluefin":
+    case "aurora":
+      return "ostree";
+    // GRUB is assumed on these. CachyOS also ships systemd-boot and limine,
+    // where /etc/default/grub exists but nothing reads it — we verify the
+    // generated grub.cfg afterwards rather than trusting the write.
+    case "cachyos":
+    case "arch":
+    case "endeavouros":
+    case "fedora":
+    case "nobara":
+      return "grub";
+    default:
+      return "manual";
+  }
+}
+
+/** Modes where we put the karg there ourselves. */
+export function isKargAutomatic(mode: KargMode): boolean {
+  return mode === "steamos" || mode === "ostree" || mode === "grub";
+}
 
 export interface FingerprintDeps {
   /** Run a subprocess (wired to `@loadout/exec` runFull in prod). */
@@ -69,6 +123,10 @@ export interface FingerprintStatus {
   kargActive: boolean;
   /** Karg staged in the bootloader config but not yet booted. */
   kargStaged: boolean;
+  /** How (or whether) the karg gets staged on this machine. */
+  kargMode: KargMode;
+  /** We stage the karg ourselves here — so it counts toward `applied`. */
+  kargAutomatic: boolean;
   /**
    * Whether the karg path is usable on this board at all. False when we
    * haven't confirmed the board's GPIO pin, in which case PME blocking is
@@ -148,9 +206,13 @@ export async function getStatus(
     controllerWakeDisabled = wake.trim() === "disabled";
   }
   const udevRuleInstalled = await deps.pathExists(UDEV_RULE_PATH);
-  const kargStaged = distro === "steamos"
-    ? await deps.readFile(GRUB_STEAMOS).then((c) => c.includes(KARG)).catch(() => false)
-    : false;
+  const mode = kargMode(distro, kargApplicable);
+  const kargAutomatic = isKargAutomatic(mode);
+  // Read the bootloader this distro uses regardless of whether we would stage
+  // here: whether the karg is in the boot config is a fact about the machine,
+  // not a function of what we're willing to write. A user who added it by
+  // hand on an unmeasured board should still see it reported.
+  const kargStaged = await readKargStaged(deps, kargMode(distro, true));
 
   const path2Closed = controllerWakeDisabled && udevRuleInstalled;
 
@@ -164,13 +226,11 @@ export async function getStatus(
   //
   // The udev rule is our marker for "the block is meant to be on", which is
   // what separates that case from a revert still waiting on a reboot.
-  // `kargStaged` can only ever be read on SteamOS — everywhere else we do not
-  // touch the bootloader, so it is hardcoded false. Without this gate, any
-  // Arch/Bazzite user who followed our own manual-karg hint and rebooted got
-  // kargLiveOnly forever, and an alert confidently describing a grub file
-  // they do not have. Saying nothing beats saying something false.
-  const bootloaderKnown = distro === "steamos";
-  const kargLiveOnly = bootloaderKnown && kargActive && !kargStaged;
+  // Only meaningful where we stage the karg ourselves. Where the user added
+  // it by hand, "live but not staged" is simply how that looks — reporting it
+  // as drift gave them an alert describing a bootloader file they may not
+  // even have, and a remedy that could never run.
+  const kargLiveOnly = kargAutomatic && kargActive && !kargStaged;
   return {
     supported: controller !== null,
     controller,
@@ -179,12 +239,20 @@ export async function getStatus(
     kargActive,
     kargStaged,
     kargApplicable,
-    // On a board whose pin we haven't confirmed the karg is never staged, so
-    // requiring kargActive left `applied` permanently false: the user flipped
-    // the switch on, PME *was* blocked, and the control sprang back to off.
-    // The natural response is to flip it again — which calls revert() and
-    // undoes the one path that had worked.
-    applied: path2Closed && (kargActive || !kargApplicable),
+    kargMode: mode,
+    kargAutomatic,
+    // Both wake paths must close, so where we CAN stage the karg it is
+    // required. `kargStaged` counts alongside `kargActive`: between enabling
+    // the block and rebooting, the karg is staged but not yet live, and
+    // treating that as "not applied" made the toggle spring back OFF right
+    // beside the alert saying a change was staged — and made the startup heal
+    // fire on every restart in that window. rebootPending is what tells the
+    // user it is not live yet.
+    //
+    // Where we cannot stage it (unmeasured board), PME is all we can offer
+    // and `applied` reflects that; the UI says so rather than claiming the
+    // GPIO path is closed.
+    applied: path2Closed && (kargActive || kargStaged || !kargAutomatic),
     // Staged but not yet live → a reboot applies it. Live but not staged
     // *and* the block was reverted → a reboot finishes removing it.
     rebootPending: (kargStaged && !kargActive) || (kargLiveOnly && !udevRuleInstalled),
@@ -311,6 +379,111 @@ async function readsKarg(deps: FingerprintDeps, path: string): Promise<boolean> 
     .catch(() => false);
 }
 
+// --- karg backends: rpm-ostree (Bazzite) ------------------------------------
+
+/**
+ * `rpm-ostree kargs` is idempotent both ways, so these are plain calls with
+ * no read-modify-write and no backup file — the deployment itself is the
+ * rollback.
+ */
+async function addKargOstree(deps: FingerprintDeps, steps: string[]): Promise<boolean> {
+  const r = await deps.run(["rpm-ostree", "kargs", `--append-if-missing=${KARG}`], {
+    timeoutMs: 180_000,
+  });
+  if (r.exitCode !== 0) {
+    throw new Error(`rpm-ostree kargs failed: ${r.stderr.trim() || r.exitCode}`);
+  }
+  steps.push("karg-staged");
+  return true;
+}
+
+async function removeKargOstree(deps: FingerprintDeps, steps: string[]): Promise<boolean> {
+  const r = await deps.run(["rpm-ostree", "kargs", `--delete-if-present=${KARG}`], {
+    timeoutMs: 180_000,
+  });
+  if (r.exitCode !== 0) {
+    throw new Error(`rpm-ostree kargs failed: ${r.stderr.trim() || r.exitCode}`);
+  }
+  steps.push("karg-unstaged");
+  return true;
+}
+
+/** What the next boot will use, per rpm-ostree itself. */
+async function ostreeKargStaged(deps: FingerprintDeps): Promise<boolean> {
+  const r = await deps.run(["rpm-ostree", "kargs"], { timeoutMs: 30_000 });
+  return r.exitCode === 0 && r.stdout.includes(KARG);
+}
+
+// --- karg backends: GRUB (CachyOS / Arch / Fedora) ---------------------------
+
+/**
+ * Assumes GRUB, per an explicit product decision. CachyOS also offers
+ * systemd-boot and limine, where /etc/default/grub exists but nothing reads
+ * it — so rather than trust the write, we check the karg actually landed in
+ * the generated grub.cfg and report failure if it didn't. That turns a silent
+ * "protected but isn't" into a visible error.
+ */
+async function addKargGrub(deps: FingerprintDeps, steps: string[]): Promise<boolean> {
+  const current = await deps.readFile(GRUB_DEFAULT).catch(() => "");
+  if (!current) throw new Error(`${GRUB_DEFAULT} not readable — is this a GRUB system?`);
+  if (current.includes(KARG)) {
+    steps.push("karg-already-staged");
+    return false;
+  }
+  await deps.writeFile(`${GRUB_DEFAULT}.loadout.bak`, current);
+  await deps.writeFile(GRUB_DEFAULT, addKargToGrubDefault(current));
+
+  const gen = await deps.run(["grub-mkconfig", "-o", GRUB_CFG], { timeoutMs: 180_000 });
+  if (gen.exitCode !== 0) {
+    await deps.writeFile(GRUB_DEFAULT, current);
+    throw new Error(`grub-mkconfig failed: ${gen.stderr.trim() || gen.exitCode}`);
+  }
+  if (!(await readsKarg(deps, GRUB_CFG))) {
+    // The file was written and grub-mkconfig succeeded, but the karg is not
+    // in the generated config — this bootloader isn't the one in use.
+    await deps.writeFile(GRUB_DEFAULT, current);
+    await deps.run(["grub-mkconfig", "-o", GRUB_CFG], { timeoutMs: 180_000 });
+    throw new Error("The kernel arg didn't reach grub.cfg — this system may not boot with GRUB.");
+  }
+  steps.push("karg-staged");
+  return true;
+}
+
+async function removeKargGrub(deps: FingerprintDeps, steps: string[]): Promise<boolean> {
+  const current = await deps.readFile(GRUB_DEFAULT).catch(() => "");
+  if (!current.includes(KARG)) {
+    steps.push("karg-not-present");
+    return false;
+  }
+  await deps.writeFile(`${GRUB_DEFAULT}.loadout.bak`, current);
+  await deps.writeFile(GRUB_DEFAULT, removeKargFromGrubDefault(current));
+  await deps.run(["grub-mkconfig", "-o", GRUB_CFG], { timeoutMs: 180_000 });
+  steps.push("karg-unstaged");
+  return true;
+}
+
+/** Append the karg to GRUB_CMDLINE_LINUX_DEFAULT="…". */
+export function addKargToGrubDefault(content: string): string {
+  if (content.includes(KARG)) return content;
+  const re = /^(GRUB_CMDLINE_LINUX_DEFAULT=")([^"]*)(")/m;
+  if (!re.test(content)) {
+    // No such line — append one rather than silently doing nothing.
+    return `${content.replace(/\n*$/, "")}\nGRUB_CMDLINE_LINUX_DEFAULT="${KARG}"\n`;
+  }
+  return content.replace(re, (_m, open: string, inner: string, close: string) => {
+    const next = inner.trim() ? `${inner.trim()} ${KARG}` : KARG;
+    return `${open}${next}${close}`;
+  });
+}
+
+export function removeKargFromGrubDefault(content: string): string {
+  return content.replace(
+    /^(GRUB_CMDLINE_LINUX_DEFAULT=")([^"]*)(")/m,
+    (_m, open: string, inner: string, close: string) =>
+      `${open}${inner.split(/\s+/).filter((t) => t && t !== KARG).join(" ")}${close}`,
+  );
+}
+
 async function removeKargSteamos(deps: FingerprintDeps, steps: string[]): Promise<boolean> {
   const current = await deps.readFile(GRUB_STEAMOS).catch(() => "");
   if (!current.includes(KARG)) {
@@ -324,6 +497,53 @@ async function removeKargSteamos(deps: FingerprintDeps, steps: string[]): Promis
   await deps.run(["steamos-readonly", "enable"], { timeoutMs: 30_000 });
   steps.push("karg-unstaged");
   return true;
+}
+
+// --- karg dispatch -----------------------------------------------------------
+
+/** What the NEXT boot will carry, per whichever bootloader we manage here. */
+async function readKargStaged(deps: FingerprintDeps, mode: KargMode): Promise<boolean> {
+  switch (mode) {
+    case "steamos":
+      return readsKarg(deps, GRUB_STEAMOS);
+    case "ostree":
+      return ostreeKargStaged(deps);
+    case "grub":
+      return readsKarg(deps, GRUB_DEFAULT);
+    default:
+      // Not ours to read; a hand-added karg shows up as kargActive instead.
+      return false;
+  }
+}
+
+async function stageKarg(deps: FingerprintDeps, mode: KargMode, steps: string[]): Promise<boolean> {
+  switch (mode) {
+    case "steamos":
+      return addKargSteamos(deps, steps);
+    case "ostree":
+      return addKargOstree(deps, steps);
+    case "grub":
+      return addKargGrub(deps, steps);
+    default:
+      return false;
+  }
+}
+
+async function unstageKarg(
+  deps: FingerprintDeps,
+  mode: KargMode,
+  steps: string[],
+): Promise<boolean> {
+  switch (mode) {
+    case "steamos":
+      return removeKargSteamos(deps, steps);
+    case "ostree":
+      return removeKargOstree(deps, steps);
+    case "grub":
+      return removeKargGrub(deps, steps);
+    default:
+      return false;
+  }
 }
 
 // --- apply / revert ----------------------------------------------------------
@@ -354,9 +574,10 @@ export async function apply(
   // Path 1 — karg. SteamOS automated; other distros get a manual hint so we
   // never edit a bootloader we haven't validated.
   const distro = await deps.distroId();
+  const mode = kargMode(distro, autoKarg);
+  const canStage = isKargAutomatic(mode);
   const alreadyActive = (await deps.readCmdline()).includes(KARG);
-  const canStage = distro === "steamos" && autoKarg;
-  const alreadyStaged = canStage ? await readsKarg(deps, GRUB_STEAMOS) : false;
+  const alreadyStaged = canStage ? await readKargStaged(deps, mode) : false;
 
   // Only skip the bootloader edit when the karg is live AND already staged —
   // or when we would not be editing the bootloader anyway.
@@ -372,7 +593,7 @@ export async function apply(
   }
   if (canStage) {
     try {
-      await addKargSteamos(deps, steps);
+      await stageKarg(deps, mode, steps);
       // Nothing to wait for when the running kernel already has it; this
       // call only re-persisted it for the next boot.
       return { success: true, rebootRequired: !alreadyActive, steps };
@@ -385,31 +606,41 @@ export async function apply(
   // the whole fix we can offer here — and we deliberately do NOT hand over
   // KARG, because AMDI0030:00@58 is the Apex's wiring. Printing it as an
   // instruction is the same act as staging it, just with extra steps.
-  if (!autoKarg) {
+  if (mode === "none") {
     steps.push("karg-not-applicable");
     return { success: true, rebootRequired: false, steps };
   }
 
   // Known board, distro whose bootloader we don't edit: we know the right
   // pin, so offer it as text for the user to apply.
+  // Nothing was staged, so a reboot changes nothing — saying otherwise sent
+  // the user to reboot and discarded the one actionable thing we have.
   steps.push("karg-manual-required");
-  return { success: true, rebootRequired: true, steps, manualKarg: KARG };
+  return { success: true, rebootRequired: false, steps, manualKarg: KARG };
 }
 
-export async function revert(deps: FingerprintDeps): Promise<FingerprintResult> {
+export async function revert(
+  deps: FingerprintDeps,
+  /** Symmetric with {@link apply}. Without it, revert handed the Apex's GPIO
+   *  pin to unmeasured boards that apply() deliberately withholds it from. */
+  { autoKarg = true }: { autoKarg?: boolean } = {},
+): Promise<FingerprintResult> {
   const steps: string[] = [];
   const controller = await detectController(deps);
   await enablePme(deps, controller, steps);
 
   const distro = await deps.distroId();
+  const mode = kargMode(distro, autoKarg);
   let rebootRequired = false;
-  if (distro === "steamos") {
+  if (isKargAutomatic(mode)) {
     try {
-      rebootRequired = await removeKargSteamos(deps, steps);
+      rebootRequired = await unstageKarg(deps, mode, steps);
     } catch (e) {
       return { success: false, rebootRequired: false, steps, error: `Karg removal failed: ${e}` };
     }
-  } else if ((await deps.readCmdline()).includes(KARG)) {
+  } else if (mode === "manual" && (await deps.readCmdline()).includes(KARG)) {
+    // Only where we know the pin: on an unmeasured board we never told them
+    // to add it, so we don't tell them to remove it either.
     steps.push("karg-manual-removal-required");
     return { success: true, rebootRequired: true, steps, manualKarg: KARG };
   }

--- a/plugins/apex/package.json
+++ b/plugins/apex/package.json
@@ -26,7 +26,8 @@
         "sh",
         "udevadm",
         "steamos-readonly",
-        "update-grub"
+        "update-grub",
+        "rpm-ostree"
       ],
       "filesystem": [
         "/sys/bus/hid/devices"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -46,6 +46,13 @@ IP_ETC_DIR="/etc/loadout/inputplumber"
 IP_ETC_PARENT="/etc/loadout"
 IP_UACCESS_RULE="/etc/udev/rules.d/71-loadout-inputplumber-uaccess.rules"
 IP_DECK_HIDRAW_RULE="/etc/udev/rules.d/72-loadout-deck-hidraw.rules"
+# The apex plugin's fingerprint wake block. Left behind, this udev rule keeps
+# re-disabling the reader's controller wakeup on every boot with no Loadout
+# installed to undo it — the user's fingerprint wake stays blocked forever and
+# nothing on the system explains why. The kernel arg is deliberately NOT
+# stripped here: editing a bootloader during an uninstall is a worse failure
+# mode than a stale arg, and it is inert once the udev rule is gone.
+FP_WAKE_RULE="/etc/udev/rules.d/90-loadout-fingerprint-no-wake.rules"
 # Written only by Loadout versions predating #87 (when the Deck moved to a
 # native hidraw watcher). Left in place it keeps InputPlumber claiming the
 # Deck's built-in controller away from Steam Input, so it's worth removing —
@@ -253,6 +260,20 @@ revert_inputplumber() {
     fi
     if [ "$ip_removed_input_rule" -eq 1 ] || [ "$ip_removed_hidraw_rule" -eq 1 ]; then
         as_root udevadm control --reload 2>/dev/null || true
+    fi
+    # Undo the fingerprint wake block, and re-enable the controller now rather
+    # than leaving it disabled until the next boot.
+    if [ -f "$FP_WAKE_RULE" ]; then
+        fp_ctrl="$(sed -n 's/.*KERNEL=="\([0-9a-f:.]*\)".*/\1/p' "$FP_WAKE_RULE" 2>/dev/null | head -1)"
+        if as_root rm -f "$FP_WAKE_RULE"; then
+            info "Removed the fingerprint wake block ($FP_WAKE_RULE)"
+            as_root udevadm control --reload 2>/dev/null || true
+            if [ -n "$fp_ctrl" ] && [ -e "/sys/bus/pci/devices/$fp_ctrl/power/wakeup" ]; then
+                printf 'enabled' | as_root tee "/sys/bus/pci/devices/$fp_ctrl/power/wakeup" >/dev/null 2>&1 || true
+            fi
+        else
+            warn "Could not remove $FP_WAKE_RULE — fingerprint wake will stay blocked"
+        fi
     fi
     if [ "$ip_removed_input_rule" -eq 1 ]; then
         as_root udevadm trigger --subsystem-match=input 2>/dev/null || true

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -50,8 +50,9 @@ IP_DECK_HIDRAW_RULE="/etc/udev/rules.d/72-loadout-deck-hidraw.rules"
 # re-disabling the reader's controller wakeup on every boot with no Loadout
 # installed to undo it — the user's fingerprint wake stays blocked forever and
 # nothing on the system explains why. The kernel arg is deliberately NOT
-# stripped here: editing a bootloader during an uninstall is a worse failure
-# mode than a stale arg, and it is inert once the udev rule is gone.
+# stripped (editing a bootloader during an uninstall is a worse failure than a
+# stale arg) — but it is NOT inert either: the two wake paths are independent,
+# so the arg keeps the GPIO line disarmed on its own. We print it instead.
 FP_WAKE_RULE="/etc/udev/rules.d/90-loadout-fingerprint-no-wake.rules"
 # Written only by Loadout versions predating #87 (when the Deck moved to a
 # native hidraw watcher). Left in place it keeps InputPlumber claiming the
@@ -173,6 +174,39 @@ remove_tree() {
 # Everything here is best-effort: a failure leaves the user with a working
 # system and printed instructions, and must not abort the rest of the
 # uninstall (hence the `|| warn` on each privileged step).
+# Undo the fingerprint wake block. Its own function called from main(), NOT
+# part of revert_inputplumber(): that returns early for anyone with no
+# InputPlumber artefacts on disk, which is most people who used this feature —
+# so the removal never ran for exactly the users it was written for.
+revert_fingerprint_block() {
+    [ -f "$FP_WAKE_RULE" ] || return 0
+
+    info "Reverting the fingerprint wake block..."
+    # The rule names the controller it disables; re-enable it now rather than
+    # leaving wake off until the next boot.
+    fp_ctrl="$(sed -n 's/.*KERNEL=="\([0-9a-f:.]*\)".*/\1/p' "$FP_WAKE_RULE" 2>/dev/null | head -1)"
+    if as_root rm -f "$FP_WAKE_RULE"; then
+        as_root udevadm control --reload 2>/dev/null || true
+        if [ -n "$fp_ctrl" ] && [ -e "/sys/bus/pci/devices/$fp_ctrl/power/wakeup" ]; then
+            printf 'enabled' | as_root tee "/sys/bus/pci/devices/$fp_ctrl/power/wakeup" >/dev/null 2>&1 || true
+        fi
+        success "Fingerprint wake restored."
+    else
+        warn "Could not remove $FP_WAKE_RULE — fingerprint wake will stay blocked."
+    fi
+
+    # The kernel arg is deliberately left alone: editing a bootloader during an
+    # uninstall is a worse failure than a stale arg. But it is NOT inert — it
+    # independently suppresses the GPIO wake line — so say so rather than
+    # leaving the user to wonder why a touch still doesn't wake the device.
+    if grep -q "gpiolib_acpi.ignore_wake=" /proc/cmdline 2>/dev/null; then
+        warn "A kernel argument from Loadout is still on your command line:"
+        warn "  gpiolib_acpi.ignore_wake=AMDI0030:00@58"
+        warn "  It keeps the power button's GPIO wake line disarmed. Remove it"
+        warn "  from your bootloader config and reboot to fully restore wake."
+    fi
+}
+
 revert_inputplumber() {
     ip_found=0
     # Whether any of what we found actually involves InputPlumber. The Deck
@@ -260,20 +294,6 @@ revert_inputplumber() {
     fi
     if [ "$ip_removed_input_rule" -eq 1 ] || [ "$ip_removed_hidraw_rule" -eq 1 ]; then
         as_root udevadm control --reload 2>/dev/null || true
-    fi
-    # Undo the fingerprint wake block, and re-enable the controller now rather
-    # than leaving it disabled until the next boot.
-    if [ -f "$FP_WAKE_RULE" ]; then
-        fp_ctrl="$(sed -n 's/.*KERNEL=="\([0-9a-f:.]*\)".*/\1/p' "$FP_WAKE_RULE" 2>/dev/null | head -1)"
-        if as_root rm -f "$FP_WAKE_RULE"; then
-            info "Removed the fingerprint wake block ($FP_WAKE_RULE)"
-            as_root udevadm control --reload 2>/dev/null || true
-            if [ -n "$fp_ctrl" ] && [ -e "/sys/bus/pci/devices/$fp_ctrl/power/wakeup" ]; then
-                printf 'enabled' | as_root tee "/sys/bus/pci/devices/$fp_ctrl/power/wakeup" >/dev/null 2>&1 || true
-            fi
-        else
-            warn "Could not remove $FP_WAKE_RULE — fingerprint wake will stay blocked"
-        fi
     fi
     if [ "$ip_removed_input_rule" -eq 1 ]; then
         as_root udevadm trigger --subsystem-match=input 2>/dev/null || true
@@ -371,6 +391,7 @@ main() {
     # After the services are stopped, so the backend can't re-apply the
     # profile between our delete and the InputPlumber restart.
     revert_inputplumber
+    revert_fingerprint_block
 
     # --- Remove .desktop file ---
     if [ -f "$DESKTOP_FILE" ]; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -54,6 +54,9 @@ IP_DECK_HIDRAW_RULE="/etc/udev/rules.d/72-loadout-deck-hidraw.rules"
 # stale arg) — but it is NOT inert either: the two wake paths are independent,
 # so the arg keeps the GPIO line disarmed on its own. We print it instead.
 FP_WAKE_RULE="/etc/udev/rules.d/90-loadout-fingerprint-no-wake.rules"
+# The exact arg the plugin adds. Matched literally so a user's own
+# gpiolib_acpi.ignore_wake for a different device is never attributed to us.
+FP_KARG="gpiolib_acpi.ignore_wake=AMDI0030:00@58"
 # Written only by Loadout versions predating #87 (when the Deck moved to a
 # native hidraw watcher). Left in place it keeps InputPlumber claiming the
 # Deck's built-in controller away from Steam Input, so it's worth removing —
@@ -161,6 +164,82 @@ remove_tree() {
     return 0
 }
 
+# Undo the fingerprint wake block. Its own function called from main(), NOT
+# part of revert_inputplumber(): that returns early for anyone with no
+# InputPlumber artefacts on disk, which is most people who used this feature —
+# so the removal never ran for exactly the users it was written for.
+revert_fingerprint_block() {
+    # NOT gated on the rule existing: a system update that regenerated /etc
+    # removes the rule but leaves the karg staged, which is precisely the
+    # state this feature exists for — and the state where the user most needs
+    # telling that something is still disarming their power button.
+    if [ ! -f "$FP_WAKE_RULE" ]; then
+        warn_leftover_karg
+        return 0
+    fi
+
+    info "Reverting the fingerprint wake block..."
+    # The rule names the controller it disables; re-enable it now rather than
+    # leaving wake off until the next boot.
+    fp_ctrl="$(sed -n 's/.*KERNEL=="\([0-9a-f:.]*\)".*/\1/p' "$FP_WAKE_RULE" 2>/dev/null | head -1)"
+    if as_root rm -f "$FP_WAKE_RULE"; then
+        as_root udevadm control --reload 2>/dev/null || true
+        fp_restored=0
+        if [ -n "$fp_ctrl" ] && [ -e "/sys/bus/pci/devices/$fp_ctrl/power/wakeup" ]; then
+            if printf 'enabled' | as_root tee "/sys/bus/pci/devices/$fp_ctrl/power/wakeup" >/dev/null 2>&1; then
+                fp_restored=1
+            fi
+        fi
+        # Only claim what actually happened: the sysfs write is skipped when
+        # the rule was hand-edited (no parsable controller) or the PCI device
+        # is gone, and in those cases wake returns at the next boot, not now.
+        if [ "$fp_restored" -eq 1 ]; then
+            success "Fingerprint wake restored."
+        else
+            success "Fingerprint wake block removed — wake returns after a reboot."
+        fi
+    else
+        warn "Could not remove $FP_WAKE_RULE — fingerprint wake will stay blocked."
+    fi
+
+    # The kernel arg is deliberately left alone: editing a bootloader during an
+    # uninstall is a worse failure than a stale arg. But it is NOT inert — it
+    # independently suppresses the GPIO wake line — so say so rather than
+    # leaving the user to wonder why a touch still doesn't wake the device.
+    warn_leftover_karg
+}
+
+# The kernel arg is deliberately not stripped — editing a bootloader during an
+# uninstall is a worse failure than a stale arg. But it is NOT inert: the two
+# wake paths are independent, so it keeps the GPIO line disarmed on its own.
+# Say so, and say it for a staged-but-not-yet-live arg too.
+warn_leftover_karg() {
+    _fp_live="$(tr ' ' '\n' < /proc/cmdline 2>/dev/null | grep -F "$FP_KARG" | head -1)"
+    _fp_staged=""
+    if [ -z "$_fp_live" ]; then
+        # Applied but not yet rebooted: still on its way in.
+        if grep -qF "$FP_KARG" /etc/default/grub-steamos 2>/dev/null; then
+            _fp_staged="/etc/default/grub-steamos"
+        elif command -v rpm-ostree >/dev/null 2>&1 && rpm-ostree kargs 2>/dev/null | grep -qF "$FP_KARG"; then
+            _fp_staged="your rpm-ostree deployment"
+        fi
+    fi
+    [ -n "$_fp_live" ] || [ -n "$_fp_staged" ] || return 0
+
+    # Match the exact arg we add, not any ignore_wake — a user's own entry for
+    # some other device must not be attributed to us.
+    warn "Loadout's kernel argument is still ${_fp_live:+on your command line}${_fp_staged:+staged in $_fp_staged}:"
+    warn "  $FP_KARG"
+    warn "  It disarms the power button's GPIO wake line independently of the"
+    warn "  udev rule, so wake stays partly blocked until you remove it."
+    if command -v rpm-ostree >/dev/null 2>&1; then
+        warn "  Remove it with:  sudo rpm-ostree kargs --delete-if-present='$FP_KARG'"
+    else
+        warn "  Remove it from your bootloader config and reboot."
+    fi
+}
+
+
 # Reverse the input-plumber plugin's system-level changes: remove the wake
 # profile and udev rules we wrote, then restart InputPlumber so the button
 # mapping is dropped from its *running* state too.
@@ -174,39 +253,6 @@ remove_tree() {
 # Everything here is best-effort: a failure leaves the user with a working
 # system and printed instructions, and must not abort the rest of the
 # uninstall (hence the `|| warn` on each privileged step).
-# Undo the fingerprint wake block. Its own function called from main(), NOT
-# part of revert_inputplumber(): that returns early for anyone with no
-# InputPlumber artefacts on disk, which is most people who used this feature —
-# so the removal never ran for exactly the users it was written for.
-revert_fingerprint_block() {
-    [ -f "$FP_WAKE_RULE" ] || return 0
-
-    info "Reverting the fingerprint wake block..."
-    # The rule names the controller it disables; re-enable it now rather than
-    # leaving wake off until the next boot.
-    fp_ctrl="$(sed -n 's/.*KERNEL=="\([0-9a-f:.]*\)".*/\1/p' "$FP_WAKE_RULE" 2>/dev/null | head -1)"
-    if as_root rm -f "$FP_WAKE_RULE"; then
-        as_root udevadm control --reload 2>/dev/null || true
-        if [ -n "$fp_ctrl" ] && [ -e "/sys/bus/pci/devices/$fp_ctrl/power/wakeup" ]; then
-            printf 'enabled' | as_root tee "/sys/bus/pci/devices/$fp_ctrl/power/wakeup" >/dev/null 2>&1 || true
-        fi
-        success "Fingerprint wake restored."
-    else
-        warn "Could not remove $FP_WAKE_RULE — fingerprint wake will stay blocked."
-    fi
-
-    # The kernel arg is deliberately left alone: editing a bootloader during an
-    # uninstall is a worse failure than a stale arg. But it is NOT inert — it
-    # independently suppresses the GPIO wake line — so say so rather than
-    # leaving the user to wonder why a touch still doesn't wake the device.
-    if grep -q "gpiolib_acpi.ignore_wake=" /proc/cmdline 2>/dev/null; then
-        warn "A kernel argument from Loadout is still on your command line:"
-        warn "  gpiolib_acpi.ignore_wake=AMDI0030:00@58"
-        warn "  It keeps the power button's GPIO wake line disarmed. Remove it"
-        warn "  from your bootloader config and reboot to fully restore wake."
-    fi
-}
-
 revert_inputplumber() {
     ip_found=0
     # Whether any of what we found actually involves InputPlumber. The Deck


### PR DESCRIPTION
The fingerprint touch reaches the SoC by **two independent wake paths, and both must close**. Path 1 is disarmed only by a kernel argument, which we staged on SteamOS alone — so on every other distro the block was silently incomplete while the UI gave no sense anything was missing.

This automates **Bazzite** (and other rpm-ostree images), and makes the gap explicit and actionable everywhere else.

| System | Kernel arg | Result |
| --- | --- | --- |
| SteamOS | `/etc/default/grub-steamos` behind `steamos-readonly` | automatic |
| Bazzite / rpm-ostree | `rpm-ostree kargs` | automatic |
| **CachyOS, Arch, everything else** | — | we print the arg and say a wake path is still open |
| System we can't identify | — | same — we know the pin, we just can't stage it |
| Board we haven't measured | — | withheld; the wrong pin is worse than none |

Detection is by **mechanism, not distro name**: `/run/ostree-booted` *and* a usable `rpm-ostree`, since Silverblue and Kinoite both report `ID=fedora`, and the marker exists on bootc images where the tool may not.

## Why there is no GRUB backend

An earlier revision edited `/etc/default/grub`. Review found it unsafe in ways that could leave a machine unbootable, so it's gone:

- The file is **sourced**, and the helper only matched double-quoted values. On the single-quoted form — common on encrypted or hibernating systems — it appended a **second** assignment, and last-wins discarded the user's `cryptdevice=`/`resume=` args. Revert then matched its own appended line and left `GRUB_CMDLINE_LINUX_DEFAULT=""` permanently.
- Fedora needs `grub2-mkconfig` and BLS entries, not that file.
- CachyOS may boot via systemd-boot or limine, where the file exists and nothing reads it.
- The `grub.cfg` verification meant to catch that couldn't: `grub-mkconfig` succeeds wherever it's installed regardless of what the firmware boots.

`rpm-ostree kargs` has none of that shape — no file editing, idempotent both ways, the supported API, and a failed call now degrades to *"unknown"* rather than to a false claim.

## Honesty of the status

- `applied` requires **both** paths closed wherever we can close them. It never counts a staged-but-not-live karg — that state is real but path 1 is open right now, and nothing bounded it to a pre-reboot window.
- The **toggle reflects the user's stored choice**, not `applied`, so it can't spring back and undo a working path when the second one isn't up yet.
- Because those can diverge, there's an explicit alert for *"asked for, but not in effect"* — previously that state rendered a switch in the on position and no indication anywhere.
- A staged karg waiting on a reboot is **pending, not lost**, so the self-heal leaves it alone instead of re-running every restart and announcing that an update removed it.
- An unreadable staged-state is surfaced as unknown rather than folded into "not staged".

## Uninstall

Removes the udev rule and re-enables the controller, in its own function called unconditionally from `main()` — it previously sat below an early return and never ran for anyone without InputPlumber artifacts. It reports what actually happened rather than claiming "wake restored" on the strength of the `rm`, and it warns about a leftover kernel arg — live **or** merely staged, and including when an update already removed the rule. The arg is deliberately not stripped (editing a bootloader during an uninstall is a worse failure) but it is **not inert**: the paths are independent, so it disarms the GPIO line on its own.

## Review

Three adversarial passes plus a regression audit of all prior findings. 22 mutations across the rounds, all caught. Notable fixes beyond the above: `rpm-ostree` was missing from `permissions.commands` (every call would have thrown); the ostree read threw out of `getStatus` and then, once caught, could still outlast the overlay's RPC cap and hang the page; a failed heal dropped the manual karg; and the SteamOS staging rollback was an exit-code branch while the real failure is a throw, which left the rootfs writable.

## Verified

SteamOS only. The rpm-ostree path runs against injected fakes — nobody here has a Bazzite handheld — and the fake cannot prove that bare `rpm-ostree kargs` reports the *pending* deployment, which is the assumption "staged" rests on. That's the thing to confirm first if a Bazzite user turns up.