### PR TITLE
fix(storage): never offer, rewrite or delete a partition that isn't ours

### DIFF
--- a/plugins/storage/README.md
+++ b/plugins/storage/README.md
@@ -2,6 +2,38 @@
 
 > Detect and mount a game-storage drive (e.g. a second SSD holding a Steam library) that the system stopped auto-mounting after an update, and optionally pin it in /etc/fstab so it survives future updates. Works on any device.
 
+## What it will not touch
+
+The plugin edits `/etc/fstab` as root, so its filters are deny-by-default and
+its ownership rules are explicit.
+
+**System partitions.** A partition is judged by _where it is mounted_, not by
+whether someone labelled it helpfully. Only `/run/media/`, `/media/` and
+`/mnt/` count as data mount roots; everything else is the OS's. Labels alone
+were never enough — SteamOS is the one distro that both labels its system
+partitions (`rootfs-A`, `var`) and refers to them in fstab by
+`/dev/disk/by-partsets/…` rather than `UUID=`. Fedora, Bazzite and Nobara
+label the root `fedora` and leave `/boot` unlabelled at exactly the 1 GiB size
+floor; Arch and Ubuntu label nothing. An unmounted system partition is caught
+by its fstab target instead.
+
+**Entries it didn't write.** Ownership is decided by the options field
+(`MANAGED_OPTIONS`), never by `UUID=` alone: one filesystem UUID legitimately
+has many fstab entries — that is how btrfs subvolumes are mounted. A line the
+user wrote is never rewritten and never removed, and the boot-mount toggle is
+disabled for a drive pinned that way (`externallyPinned`) rather than offering
+a switch we would refuse to honour.
+
+**Malformed writes.** Mount points are octal-escaped on the way in, so a drive
+labelled `My Passport` produces six fields rather than seven — an unescaped
+space shifts every field along, which silently drops `nofail` and turns the
+mount into a hard requirement of `local-fs.target`.
+
+**Interrupted writes.** `/etc/fstab` is replaced by write-to-temp plus
+`rename`, never truncated in place, and a read that _fails_ is never treated
+as an empty file. The backup at `/etc/fstab.loadout.bak` is only taken from
+content actually read, and is never overwritten with nothing.
+
 ## Screenshots
 
 ![Storage](./assets/screenshot.png)

--- a/plugins/storage/app.spec.tsx
+++ b/plugins/storage/app.spec.tsx
@@ -103,7 +103,11 @@ describe("storage plugin", () => {
     callMock.mockImplementation((method: string) => {
       if (method === "getStatus") return Promise.resolve({ drives: [unmountedDrive] });
       if (method === "mountDrive")
-        return Promise.resolve({ success: true, mountpoint: "/run/media/deck/Games", steamLibraryFound: true });
+        return Promise.resolve({
+          success: true,
+          mountpoint: "/run/media/deck/Games",
+          steamLibraryFound: true,
+        });
       return Promise.resolve({ success: true });
     });
     const container = document.createElement("div");
@@ -113,7 +117,9 @@ describe("storage plugin", () => {
     let mountBtn: HTMLButtonElement | undefined;
     await waitFor(() => {
       expect(container.textContent).toContain("Games");
-      const btn = [...container.querySelectorAll("button")].find((b) => b.textContent?.trim() === "Mount");
+      const btn = [...container.querySelectorAll("button")].find(
+        (b) => b.textContent?.trim() === "Mount",
+      );
       expect(btn).toBeTruthy();
       mountBtn = btn as HTMLButtonElement;
     });
@@ -154,5 +160,40 @@ describe("storage plugin", () => {
     await waitFor(() => {
       expect(callMock).toHaveBeenCalledWith("setDriveAutoMount", "GAME-1", false);
     });
+  });
+
+  it("disables the boot toggle for a drive pinned by someone else's fstab entry", async () => {
+    // Its entry carries options we can't reason about (subvol=, uid=), and
+    // switching the toggle off would mean deleting a line the user wrote.
+    // Offering a switch we would refuse to honour is worse than none.
+    callMock.mockImplementation((method: string) => {
+      if (method === "getStatus")
+        return Promise.resolve({
+          drives: [
+            {
+              ...unmountedDrive,
+              mounted: true,
+              mountpoint: "/mnt/games",
+              inFstab: true,
+              externallyPinned: true,
+            },
+          ],
+        });
+      return Promise.resolve({ success: true });
+    });
+    const container = document.createElement("div");
+    const { mount } = await import("./app");
+    mount(container);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Pinned in /etc/fstab");
+    });
+    const toggles = [...container.querySelectorAll('input[type="checkbox"]')];
+    const bootToggle = toggles[toggles.length - 1] as HTMLInputElement;
+    expect(bootToggle.disabled).toBe(true);
+
+    fireEvent.click(bootToggle);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(callMock).not.toHaveBeenCalledWith("setDriveAutoMount", "GAME-1", false);
   });
 });

--- a/plugins/storage/app.tsx
+++ b/plugins/storage/app.tsx
@@ -15,6 +15,8 @@ interface StorageDrive {
   suggestedMountpoint: string;
   steamLibraryFound: boolean;
   inFstab: boolean;
+  /** Pinned by an /etc/fstab entry Loadout didn't write — read-only to us. */
+  externallyPinned?: boolean;
 }
 
 interface StorageStatus {
@@ -134,8 +136,8 @@ function Storage() {
           <div className="card-body p-6">
             <div className="text-sm text-base-content/80 leading-relaxed">
               If a second internal SSD holding a Steam library stops showing up after a system or
-              Steam update, it's usually just no longer mounted. This finds unmounted data drives and
-              mounts them where Steam looks — and can pin the mount in{" "}
+              Steam update, it's usually just no longer mounted. This finds unmounted data drives
+              and mounts them where Steam looks — and can pin the mount in{" "}
               <span className="mono">/etc/fstab</span> so an update can't quietly drop it again. It
               only ever mounts an existing filesystem; it never formats or repairs anything.
             </div>
@@ -209,10 +211,15 @@ function Storage() {
                       )}
 
                       <div className="flex items-center gap-2 whitespace-nowrap">
-                        <span className="text-xs text-base-content/55">Mount on boot</span>
+                        <span className="text-xs text-base-content/55">
+                          {d.externallyPinned ? "Pinned in /etc/fstab" : "Mount on boot"}
+                        </span>
                         <Toggle
                           checked={d.inFstab}
-                          disabled={bootBusyUuid === d.uuid}
+                          // Its fstab entry is the user's, with options we
+                          // can't reason about. Showing a switch we would
+                          // refuse to honour is worse than showing none.
+                          disabled={bootBusyUuid === d.uuid || !!d.externallyPinned}
                           onChange={(next) => handleToggleAutoMount(d.uuid, next)}
                         />
                       </div>

--- a/plugins/storage/backend.ts
+++ b/plugins/storage/backend.ts
@@ -1,4 +1,4 @@
-import { access, readFile, writeFile, mkdir } from "node:fs/promises";
+import { access, readFile, writeFile, mkdir, rename } from "node:fs/promises";
 import { userInfo, homedir } from "node:os";
 import type { PluginBackend, EmitPayload, PluginLogger } from "@loadout/types";
 import { runFull } from "@loadout/exec";
@@ -58,6 +58,7 @@ export default class StorageBackend implements PluginBackend {
       run: (cmd, opts) => runFull(cmd, opts),
       readFile: (path) => readFile(path, "utf-8"),
       writeFile: (path, content) => writeFile(path, content),
+      renameFile: (from, to) => rename(from, to),
       pathExists: async (path) => {
         try {
           await access(path);
@@ -105,7 +106,12 @@ export default class StorageBackend implements PluginBackend {
    */
   async mountDrive(uuid: string): Promise<MountResult> {
     if (!uuid) {
-      return { success: false, mountpoint: "", steamLibraryFound: false, error: "No drive selected." };
+      return {
+        success: false,
+        mountpoint: "",
+        steamLibraryFound: false,
+        error: "No drive selected.",
+      };
     }
     const result = await mountCandidate(this.storageDeps, { uuid });
     this.emit?.({ event: "statusChanged", data: undefined });
@@ -131,7 +137,8 @@ export default class StorageBackend implements PluginBackend {
         if (!drive) return { success: false, error: `Drive ${uuid} not found.` };
         // Persist the live mount point if it's mounted, else the path we'd
         // mount it at — systemd's fstab generator creates the directory.
-        const mountpoint = drive.mounted && drive.mountpoint ? drive.mountpoint : drive.suggestedMountpoint;
+        const mountpoint =
+          drive.mounted && drive.mountpoint ? drive.mountpoint : drive.suggestedMountpoint;
         result = await persistFstab(this.storageDeps, { uuid, mountpoint, fstype: drive.fstype });
       }
       this.emit?.({ event: "statusChanged", data: undefined });

--- a/plugins/storage/lib/storage.test.ts
+++ b/plugins/storage/lib/storage.test.ts
@@ -6,6 +6,12 @@ import {
   isWhitelistedFs,
   isDataPartition,
   mountPointFor,
+  isSafeLabel,
+  isSystemMountpoint,
+  escapeFstabField,
+  unescapeFstabField,
+  isManagedFstabLine,
+  hasUnmanagedEntry,
   fstabEntryLine,
   fstabHasUuid,
   addFstabEntry,
@@ -45,10 +51,50 @@ const LSBLK = JSON.stringify({
       size: 512110190592,
       ro: false,
       children: [
-        { name: "nvme0n1p1", path: "/dev/nvme0n1p1", fstype: "vfat", label: "ESP", uuid: "ESP-1", mountpoint: "/boot/efi", type: "part", size: 268435456, ro: false },
-        { name: "nvme0n1p2", path: "/dev/nvme0n1p2", fstype: "ext4", label: "rootfs-A", uuid: "ROOT-A", mountpoint: "/", type: "part", size: 10 * GiB, ro: false },
-        { name: "nvme0n1p3", path: "/dev/nvme0n1p3", fstype: "ext4", label: "var-A", uuid: "VAR-A", mountpoint: null, type: "part", size: 5 * GiB, ro: false },
-        { name: "nvme0n1p4", path: "/dev/nvme0n1p4", fstype: "swap", label: "swap", uuid: "SWAP-1", mountpoint: "[SWAP]", type: "part", size: 8 * GiB, ro: false },
+        {
+          name: "nvme0n1p1",
+          path: "/dev/nvme0n1p1",
+          fstype: "vfat",
+          label: "ESP",
+          uuid: "ESP-1",
+          mountpoint: "/boot/efi",
+          type: "part",
+          size: 268435456,
+          ro: false,
+        },
+        {
+          name: "nvme0n1p2",
+          path: "/dev/nvme0n1p2",
+          fstype: "ext4",
+          label: "rootfs-A",
+          uuid: "ROOT-A",
+          mountpoint: "/",
+          type: "part",
+          size: 10 * GiB,
+          ro: false,
+        },
+        {
+          name: "nvme0n1p3",
+          path: "/dev/nvme0n1p3",
+          fstype: "ext4",
+          label: "var-A",
+          uuid: "VAR-A",
+          mountpoint: null,
+          type: "part",
+          size: 5 * GiB,
+          ro: false,
+        },
+        {
+          name: "nvme0n1p4",
+          path: "/dev/nvme0n1p4",
+          fstype: "swap",
+          label: "swap",
+          uuid: "SWAP-1",
+          mountpoint: "[SWAP]",
+          type: "part",
+          size: 8 * GiB,
+          ro: false,
+        },
       ],
     },
     {
@@ -58,10 +104,50 @@ const LSBLK = JSON.stringify({
       size: 1024209543168,
       ro: false,
       children: [
-        { name: "nvme1n1p1", path: "/dev/nvme1n1p1", fstype: "ext4", label: "Games", uuid: "GAME-1", mountpoint: null, type: "part", size: 1000 * GiB, ro: false },
-        { name: "nvme1n1p2", path: "/dev/nvme1n1p2", fstype: "ntfs", label: "Media", uuid: "MEDIA-1", mountpoint: "/run/media/deck/Media", type: "part", size: 500 * GiB, ro: false },
-        { name: "nvme1n1p3", path: "/dev/nvme1n1p3", fstype: "ext4", label: "tiny", uuid: "TINY-1", mountpoint: null, type: "part", size: 256 * 1024 * 1024, ro: false },
-        { name: "nvme1n1p4", path: "/dev/nvme1n1p4", fstype: "exfat", label: "ReadOnly", uuid: "RO-1", mountpoint: null, type: "part", size: 64 * GiB, ro: true },
+        {
+          name: "nvme1n1p1",
+          path: "/dev/nvme1n1p1",
+          fstype: "ext4",
+          label: "Games",
+          uuid: "GAME-1",
+          mountpoint: null,
+          type: "part",
+          size: 1000 * GiB,
+          ro: false,
+        },
+        {
+          name: "nvme1n1p2",
+          path: "/dev/nvme1n1p2",
+          fstype: "ntfs",
+          label: "Media",
+          uuid: "MEDIA-1",
+          mountpoint: "/run/media/deck/Media",
+          type: "part",
+          size: 500 * GiB,
+          ro: false,
+        },
+        {
+          name: "nvme1n1p3",
+          path: "/dev/nvme1n1p3",
+          fstype: "ext4",
+          label: "tiny",
+          uuid: "TINY-1",
+          mountpoint: null,
+          type: "part",
+          size: 256 * 1024 * 1024,
+          ro: false,
+        },
+        {
+          name: "nvme1n1p4",
+          path: "/dev/nvme1n1p4",
+          fstype: "exfat",
+          label: "ReadOnly",
+          uuid: "RO-1",
+          mountpoint: null,
+          type: "part",
+          size: 64 * GiB,
+          ro: true,
+        },
       ],
     },
   ],
@@ -89,7 +175,8 @@ function makeDeps(o: FakeOpts = {}): {
   const deps: StorageDeps = {
     run: async (cmd) => {
       commands.push(cmd.join(" "));
-      if (cmd[0] === "lsblk") return { stdout: o.lsblk ?? "{}", stderr: "", exitCode: o.lsblkExit ?? 0 };
+      if (cmd[0] === "lsblk")
+        return { stdout: o.lsblk ?? "{}", stderr: "", exitCode: o.lsblkExit ?? 0 };
       if (cmd[0] === "findmnt") {
         const uuid = (cmd[3] ?? "").replace(/^UUID=/, "");
         const target = mounted[uuid];
@@ -113,6 +200,11 @@ function makeDeps(o: FakeOpts = {}): {
     writeFile: async (p, c) => {
       files[p] = c;
     },
+    renameFile: async (from, to) => {
+      if (!(from in files)) throw new Error("ENOENT");
+      files[to] = files[from]!;
+      delete files[from];
+    },
     pathExists: async (p) => p in files,
     mkdirp: async (p) => {
       files[p] = files[p] ?? "(dir)";
@@ -127,7 +219,15 @@ describe("pure filters", () => {
     for (const fs of ["ext4", "BTRFS", "xfs", "exFAT", "ntfs", "vfat"]) {
       expect(isWhitelistedFs(fs)).toBe(true);
     }
-    for (const fs of ["swap", "linux_raid_member", "crypto_LUKS", "squashfs", "", null, undefined]) {
+    for (const fs of [
+      "swap",
+      "linux_raid_member",
+      "crypto_LUKS",
+      "squashfs",
+      "",
+      null,
+      undefined,
+    ]) {
       expect(isWhitelistedFs(fs)).toBe(false);
     }
   });
@@ -167,7 +267,13 @@ describe("parseLsblk", () => {
     const candidates = parseLsblk(LSBLK);
     expect(candidates.map((c) => c.uuid)).toEqual(["GAME-1"]);
     const c = candidates[0];
-    expect(c).toEqual({ path: "/dev/nvme1n1p1", label: "Games", uuid: "GAME-1", fstype: "ext4", size: 1000 * GiB });
+    expect(c).toEqual({
+      path: "/dev/nvme1n1p1",
+      label: "Games",
+      uuid: "GAME-1",
+      fstype: "ext4",
+      size: 1000 * GiB,
+    });
   });
 
   it("excludes mounted, swap, system-labelled, tiny, and read-only partitions", () => {
@@ -200,37 +306,62 @@ describe("parseLsblk", () => {
 
 describe("mountPointFor", () => {
   it("uses a clean label as the mount-point name", () => {
-    expect(mountPointFor({ user: "deck", label: "Games", uuid: "U1" })).toBe("/run/media/deck/Games");
+    expect(mountPointFor({ user: "deck", label: "Games", uuid: "U1" })).toBe(
+      "/run/media/deck/Games",
+    );
   });
 
   it("falls back to the UUID for a missing or unsafe label", () => {
     expect(mountPointFor({ user: "deck", label: null, uuid: "U1" })).toBe("/run/media/deck/U1");
-    expect(mountPointFor({ user: "ally", label: "My Games/../x", uuid: "U2" })).toBe("/run/media/ally/U2");
-    expect(mountPointFor({ user: "deck", label: "has space", uuid: "U3" })).toBe("/run/media/deck/U3");
+    expect(mountPointFor({ user: "ally", label: "My Games/../x", uuid: "U2" })).toBe(
+      "/run/media/ally/U2",
+    );
+    expect(mountPointFor({ user: "deck", label: "has space", uuid: "U3" })).toBe(
+      "/run/media/deck/U3",
+    );
   });
 });
 
 describe("fstab helpers", () => {
-  const line = "UUID=GAME-1 /run/media/deck/Games ext4 defaults,nofail,x-systemd.device-timeout=5s 0 2";
+  const line =
+    "UUID=GAME-1 /run/media/deck/Games ext4 defaults,nofail,x-systemd.device-timeout=5s 0 2";
 
   it("builds the canonical entry with nofail + device-timeout", () => {
-    expect(fstabEntryLine({ uuid: "GAME-1", mountpoint: "/run/media/deck/Games", fstype: "ext4" })).toBe(line);
+    expect(
+      fstabEntryLine({ uuid: "GAME-1", mountpoint: "/run/media/deck/Games", fstype: "ext4" }),
+    ).toBe(line);
   });
 
   it("addFstabEntry appends to an existing fstab and is idempotent", () => {
     const base = "# /etc/fstab\nUUID=ROOT / ext4 defaults 0 1\n";
-    const once = addFstabEntry(base, { uuid: "GAME-1", mountpoint: "/run/media/deck/Games", fstype: "ext4" });
+    const once = addFstabEntry(base, {
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
     expect(once).toContain(line);
     expect(once).toContain("UUID=ROOT / ext4 defaults 0 1");
     // Second add is a no-op — no duplicate line.
-    const twice = addFstabEntry(once, { uuid: "GAME-1", mountpoint: "/run/media/deck/Games", fstype: "ext4" });
+    const twice = addFstabEntry(once, {
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
     expect(twice).toBe(once);
     expect(twice.match(/UUID=GAME-1/g)?.length).toBe(1);
   });
 
   it("addFstabEntry replaces a stale entry for the same UUID (keyed on UUID)", () => {
-    const base = addFstabEntry("", { uuid: "GAME-1", mountpoint: "/run/media/deck/Old", fstype: "ext4" });
-    const updated = addFstabEntry(base, { uuid: "GAME-1", mountpoint: "/run/media/deck/Games", fstype: "ext4" });
+    const base = addFstabEntry("", {
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Old",
+      fstype: "ext4",
+    });
+    const updated = addFstabEntry(base, {
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
     expect(updated).toContain("/run/media/deck/Games");
     expect(updated).not.toContain("/run/media/deck/Old");
     expect(updated.match(/UUID=GAME-1/g)?.length).toBe(1);
@@ -257,7 +388,9 @@ describe("detectCandidates", () => {
     const { deps, commands } = makeDeps({ lsblk: LSBLK });
     const candidates = await detectCandidates(deps);
     expect(candidates.map((c) => c.uuid)).toEqual(["GAME-1"]);
-    expect(commands[0]).toContain("lsblk -J -b -o NAME,PATH,FSTYPE,LABEL,UUID,MOUNTPOINT,TYPE,SIZE,RO");
+    expect(commands[0]).toContain(
+      "lsblk -J -b -o NAME,PATH,FSTYPE,LABEL,UUID,MOUNTPOINT,TYPE,SIZE,RO",
+    );
   });
 
   it("returns [] when lsblk fails", async () => {
@@ -313,26 +446,43 @@ describe("persistFstab / unpersistFstab", () => {
   it("persists an entry and backs up the original fstab", async () => {
     const original = "# /etc/fstab\nUUID=ROOT / ext4 defaults 0 1\n";
     const { deps, files } = makeDeps({ files: { [FSTAB_PATH]: original } });
-    const res = await persistFstab(deps, { uuid: "GAME-1", mountpoint: "/run/media/deck/Games", fstype: "ext4" });
+    const res = await persistFstab(deps, {
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
     expect(res.success).toBe(true);
     expect(files[FSTAB_BACKUP]).toBe(original);
-    expect(files[FSTAB_PATH]).toContain("UUID=GAME-1 /run/media/deck/Games ext4 defaults,nofail,x-systemd.device-timeout=5s 0 2");
+    expect(files[FSTAB_PATH]).toContain(
+      "UUID=GAME-1 /run/media/deck/Games ext4 defaults,nofail,x-systemd.device-timeout=5s 0 2",
+    );
     expect(files[FSTAB_PATH]).toContain("UUID=ROOT / ext4 defaults 0 1");
   });
 
   it("persist is idempotent — re-running doesn't rewrite or duplicate", async () => {
-    const { deps, files } = makeDeps({ files: { [FSTAB_PATH]: "UUID=ROOT / ext4 defaults 0 1\n" } });
-    await persistFstab(deps, { uuid: "GAME-1", mountpoint: "/run/media/deck/Games", fstype: "ext4" });
+    const { deps, files } = makeDeps({
+      files: { [FSTAB_PATH]: "UUID=ROOT / ext4 defaults 0 1\n" },
+    });
+    await persistFstab(deps, {
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
     const after = files[FSTAB_PATH];
     delete files[FSTAB_BACKUP]; // prove a second run doesn't even back up again
-    const res = await persistFstab(deps, { uuid: "GAME-1", mountpoint: "/run/media/deck/Games", fstype: "ext4" });
+    const res = await persistFstab(deps, {
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
     expect(res.success).toBe(true);
     expect(files[FSTAB_PATH]).toBe(after);
     expect(files[FSTAB_BACKUP]).toBeUndefined();
   });
 
   it("unpersists an entry, backing up first", async () => {
-    const original = "UUID=ROOT / ext4 defaults 0 1\nUUID=GAME-1 /run/media/deck/Games ext4 defaults,nofail,x-systemd.device-timeout=5s 0 2\n";
+    const original =
+      "UUID=ROOT / ext4 defaults 0 1\nUUID=GAME-1 /run/media/deck/Games ext4 defaults,nofail,x-systemd.device-timeout=5s 0 2\n";
     const { deps, files } = makeDeps({ files: { [FSTAB_PATH]: original } });
     const res = await unpersistFstab(deps, { uuid: "GAME-1" });
     expect(res.success).toBe(true);
@@ -342,7 +492,9 @@ describe("persistFstab / unpersistFstab", () => {
   });
 
   it("unpersist is a no-op when the UUID isn't present", async () => {
-    const { deps, files } = makeDeps({ files: { [FSTAB_PATH]: "UUID=ROOT / ext4 defaults 0 1\n" } });
+    const { deps, files } = makeDeps({
+      files: { [FSTAB_PATH]: "UUID=ROOT / ext4 defaults 0 1\n" },
+    });
     const res = await unpersistFstab(deps, { uuid: "GAME-1" });
     expect(res.success).toBe(true);
     expect(files[FSTAB_BACKUP]).toBeUndefined();
@@ -351,7 +503,8 @@ describe("persistFstab / unpersistFstab", () => {
 
 describe("getStorageStatus", () => {
   it("reports mounted + unmounted data drives with fstab + steam-library flags", async () => {
-    const fstab = "UUID=GAME-1 /run/media/deck/Games ext4 defaults,nofail,x-systemd.device-timeout=5s 0 2\n";
+    const fstab =
+      "UUID=GAME-1 /run/media/deck/Games ext4 defaults,nofail,x-systemd.device-timeout=5s 0 2\n";
     const { deps } = makeDeps({
       lsblk: LSBLK,
       files: { [FSTAB_PATH]: fstab, "/run/media/deck/Media/steamapps": "(dir)" },
@@ -371,5 +524,278 @@ describe("getStorageStatus", () => {
     // System partitions never appear.
     expect(byUuid["ROOT-A"]).toBeUndefined();
     expect(byUuid["VAR-A"]).toBeUndefined();
+  });
+});
+/**
+ * These pin the guarantees that keep the plugin off a machine's system
+ * partitions. Every one of them is a scenario that was live on a non-SteamOS
+ * distro: the developer's Deck is the only layout where labelling alone is
+ * enough, because SteamOS both labels its system partitions AND refers to
+ * them in fstab as /dev/disk/by-partsets/… rather than UUID=.
+ */
+describe("never touch the operating system's partitions", () => {
+  const GiB2 = 1024 ** 3;
+
+  // Stock Fedora / Bazzite / Nobara: btrfs root labelled `fedora`, and a
+  // /boot with NO label at exactly the 1 GiB size floor.
+  const FEDORA = JSON.stringify({
+    blockdevices: [
+      {
+        name: "nvme0n1",
+        type: "disk",
+        children: [
+          {
+            name: "nvme0n1p1",
+            path: "/dev/nvme0n1p1",
+            fstype: "vfat",
+            label: null,
+            uuid: "EFI-1",
+            mountpoint: "/boot/efi",
+            type: "part",
+            size: 600 * 1024 * 1024,
+            ro: false,
+          },
+          {
+            name: "nvme0n1p2",
+            path: "/dev/nvme0n1p2",
+            fstype: "ext4",
+            label: null,
+            uuid: "BOOT-1",
+            mountpoint: "/boot",
+            type: "part",
+            size: GiB2,
+            ro: false,
+          },
+          {
+            name: "nvme0n1p3",
+            path: "/dev/nvme0n1p3",
+            fstype: "btrfs",
+            label: "fedora",
+            uuid: "ROOT-1",
+            mountpoint: "/",
+            type: "part",
+            size: 460 * GiB2,
+            ro: false,
+          },
+          {
+            name: "nvme0n1p4",
+            path: "/dev/nvme0n1p4",
+            fstype: "ext4",
+            label: "Games",
+            uuid: "GAME-1",
+            mountpoint: "/run/media/deck/Games",
+            type: "part",
+            size: 900 * GiB2,
+            ro: false,
+          },
+        ],
+      },
+    ],
+  });
+
+  const FEDORA_FSTAB =
+    [
+      "UUID=ROOT-1 / btrfs subvol=root,compress=zstd:1 0 0",
+      "UUID=ROOT-1 /home btrfs subvol=home,compress=zstd:1 0 0",
+      "UUID=BOOT-1 /boot ext4 defaults 1 2",
+      "UUID=EFI-1 /boot/efi vfat umask=0077,shortname=winnt 0 2",
+    ].join("\n") + "\n";
+
+  it("classifies by mount point, not by whether someone labelled it", () => {
+    expect(isSystemMountpoint("/")).toBe(true);
+    expect(isSystemMountpoint("/boot")).toBe(true);
+    expect(isSystemMountpoint("/home")).toBe(true);
+    expect(isSystemMountpoint("/var")).toBe(true);
+    expect(isSystemMountpoint("[SWAP]")).toBe(true);
+    expect(isSystemMountpoint("/run/media/deck/Games")).toBe(false);
+    expect(isSystemMountpoint("/mnt/games")).toBe(false);
+    expect(isSystemMountpoint("/media/usb")).toBe(false);
+    // Unmounted is judged by the label and fstab rules instead.
+    expect(isSystemMountpoint(null)).toBe(false);
+  });
+
+  it("keeps a Fedora root and /boot out of the drive list entirely", async () => {
+    const { deps } = makeDeps({ lsblk: FEDORA, files: { [FSTAB_PATH]: FEDORA_FSTAB } });
+    const { drives } = await getStorageStatus(deps);
+    expect(drives.map((d) => d.uuid)).toEqual(["GAME-1"]);
+  });
+
+  it("excludes an UNMOUNTED system partition using its fstab target", async () => {
+    // A dual-boot install's /boot, or a root that simply isn't mounted right
+    // now: no label, no mount point, nothing but the fstab entry to go on.
+    const unmounted = JSON.stringify({
+      blockdevices: [
+        {
+          name: "sda1",
+          path: "/dev/sda1",
+          fstype: "ext4",
+          label: null,
+          uuid: "BOOT-1",
+          mountpoint: null,
+          type: "part",
+          size: 2 * GiB2,
+          ro: false,
+        },
+      ],
+    });
+    const { deps } = makeDeps({ lsblk: unmounted, files: { [FSTAB_PATH]: FEDORA_FSTAB } });
+    expect((await getStorageStatus(deps)).drives).toEqual([]);
+  });
+
+  it("refuses to delete the user's fstab lines when a drive is switched off", async () => {
+    // The catastrophic path: one tap took out /, /home and /var, because a
+    // btrfs UUID legitimately has one entry per subvolume.
+    const { deps, files } = makeDeps({ lsblk: FEDORA, files: { [FSTAB_PATH]: FEDORA_FSTAB } });
+    const res = await unpersistFstab(deps, { uuid: "ROOT-1" });
+    expect(res.success).toBe(false);
+    expect(files[FSTAB_PATH]).toBe(FEDORA_FSTAB); // byte-for-byte
+  });
+
+  it("removes only our own line when a UUID has several entries", async () => {
+    const ours = fstabEntryLine({
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
+    const theirs = "UUID=GAME-1 /snapshots btrfs subvol=@snap 0 0";
+    const { deps, files } = makeDeps({
+      lsblk: FEDORA,
+      files: { [FSTAB_PATH]: `UUID=ROOT-1 / btrfs subvol=root 0 0\n${ours}\n${theirs}\n` },
+    });
+    const res = await unpersistFstab(deps, { uuid: "GAME-1" });
+    expect(res.success).toBe(true);
+    expect(files[FSTAB_PATH]).toContain(theirs);
+    expect(files[FSTAB_PATH]).not.toContain("device-timeout");
+  });
+
+  it("flags a hand-pinned drive so the UI can refuse to touch it", async () => {
+    const { deps } = makeDeps({
+      lsblk: FEDORA,
+      files: { [FSTAB_PATH]: `${FEDORA_FSTAB}UUID=GAME-1 /mnt/games btrfs subvol=@games 0 0\n` },
+    });
+    const games = (await getStorageStatus(deps)).drives.find((d) => d.uuid === "GAME-1");
+    expect(games?.inFstab).toBe(true);
+    expect(games?.externallyPinned).toBe(true);
+  });
+
+  it("does not flag a drive we pinned ourselves", async () => {
+    const ours = fstabEntryLine({
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
+    const { deps } = makeDeps({
+      lsblk: FEDORA,
+      files: { [FSTAB_PATH]: `${FEDORA_FSTAB}${ours}\n` },
+    });
+    const games = (await getStorageStatus(deps)).drives.find((d) => d.uuid === "GAME-1");
+    expect(games?.externallyPinned).toBe(false);
+  });
+});
+
+describe("fstab field escaping", () => {
+  it("escapes a space, so the line keeps its six fields", () => {
+    // udisks mounts at /run/media/<user>/<label> verbatim, and drives ship
+    // labelled "My Passport". Seven fields means systemd reads the fstype as
+    // "Passport" and the options as "exfat" — nofail gone, boot to emergency.
+    const line = fstabEntryLine({
+      uuid: "1111-2222",
+      mountpoint: "/run/media/deck/My Passport",
+      fstype: "exfat",
+    });
+    expect(line.split(/\s+/)).toHaveLength(6);
+    expect(line).toContain("/run/media/deck/My\\040Passport");
+    expect(isManagedFstabLine(line, "1111-2222")).toBe(true);
+  });
+
+  it("escapes tabs and backslashes too", () => {
+    expect(escapeFstabField("/mnt/a\tb")).toBe("/mnt/a\\011b");
+    expect(escapeFstabField("/mnt/a\\b")).toBe("/mnt/a\\134b");
+  });
+
+  it("round-trips through unescape", () => {
+    for (const path of ["/mnt/Game Drive", "/mnt/plain", "/mnt/a\tb", "/mnt/a\\b"]) {
+      expect(unescapeFstabField(escapeFstabField(path))).toBe(path);
+    }
+  });
+});
+
+describe("label safety", () => {
+  it("rejects a label that would escape the mount root", () => {
+    // `..` is a legal ext4/exFAT/NTFS label, and produced /run/media/<user>/..
+    // — i.e. /run/media itself, mounted over as root from any USB stick.
+    expect(isSafeLabel("..")).toBe(false);
+    expect(isSafeLabel(".")).toBe(false);
+    expect(isSafeLabel("...")).toBe(false);
+    expect(mountPointFor({ user: "deck", label: "..", uuid: "U1" })).toBe("/run/media/deck/U1");
+    expect(mountPointFor({ user: "deck", label: ".", uuid: "U1" })).toBe("/run/media/deck/U1");
+  });
+
+  it("still accepts ordinary labels, dots included", () => {
+    expect(isSafeLabel("Games")).toBe(true);
+    expect(isSafeLabel("my.games")).toBe(true);
+    expect(mountPointFor({ user: "deck", label: "my.games", uuid: "U1" })).toBe(
+      "/run/media/deck/my.games",
+    );
+  });
+});
+
+describe("/etc/fstab writes are safe to interrupt", () => {
+  const line = "UUID=ROOT / ext4 defaults 0 1\n";
+
+  it("never rebuilds fstab from a FAILED read", async () => {
+    // ENOENT and EIO both used to collapse to "", and the writer then
+    // replaced /etc/fstab with a single line — root, swap and /home gone.
+    const { deps, files } = makeDeps({ files: { [FSTAB_PATH]: line } });
+    deps.readFile = async () => {
+      throw Object.assign(new Error("EIO: i/o error"), { code: "EIO" });
+    };
+    const res = await persistFstab(deps, {
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
+    expect(res.success).toBe(false);
+    expect(files[FSTAB_PATH]).toBe(line); // untouched
+    expect(files[FSTAB_BACKUP]).toBeUndefined(); // and not clobbered
+  });
+
+  it("still treats a genuinely missing fstab as empty", async () => {
+    const { deps, files } = makeDeps({});
+    const res = await persistFstab(deps, {
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
+    expect(res.success).toBe(true);
+    expect(files[FSTAB_PATH]).toContain("UUID=GAME-1");
+  });
+
+  it("swaps the file in atomically via rename, never truncate-in-place", async () => {
+    const renames: [string, string][] = [];
+    const { deps } = makeDeps({ files: { [FSTAB_PATH]: line } });
+    const realRename = deps.renameFile;
+    deps.renameFile = async (from, to) => {
+      renames.push([from, to]);
+      await realRename(from, to);
+    };
+    await persistFstab(deps, {
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
+    expect(renames).toEqual([["/etc/fstab.loadout.tmp", FSTAB_PATH]]);
+  });
+
+  it("never overwrites the backup with nothing", async () => {
+    // The backup is the only recovery path; clobbering it with "" in exactly
+    // the case it is needed is worse than not having one.
+    const { deps, files } = makeDeps({ files: { [FSTAB_BACKUP]: line } });
+    await persistFstab(deps, {
+      uuid: "GAME-1",
+      mountpoint: "/run/media/deck/Games",
+      fstype: "ext4",
+    });
+    expect(files[FSTAB_BACKUP]).toBe(line);
   });
 });

--- a/plugins/storage/lib/storage.ts
+++ b/plugins/storage/lib/storage.ts
@@ -49,6 +49,8 @@ export interface StorageDeps {
   readFile: (path: string) => Promise<string>;
   /** Write a file (UTF-8), creating it if absent. */
   writeFile: (path: string, content: string) => Promise<void>;
+  /** Rename a file. Must be same-filesystem, so the swap is atomic. */
+  renameFile: (from: string, to: string) => Promise<void>;
   pathExists: (path: string) => Promise<boolean>;
   /** Create a directory and any missing parents (mkdir -p). */
   mkdirp: (path: string) => Promise<void>;
@@ -81,11 +83,69 @@ export const SYSTEM_LABEL_TOKENS = [
   "boot",
 ] as const;
 
+/**
+ * Where a removable or secondary data drive legitimately lives.
+ *
+ * Everything else is the operating system's. This is the primary system-
+ * partition guard; {@link SYSTEM_LABEL_TOKENS} is a fallback for the
+ * unmounted case, and on its own it is nowhere near enough — see
+ * {@link isSystemMountpoint}.
+ */
+export const DATA_MOUNT_ROOTS = ["/run/media/", "/media/", "/mnt/"] as const;
+
+/**
+ * Is this partition mounted somewhere that belongs to the OS?
+ *
+ * Judging "is this a system partition" by LABEL alone is safe on exactly one
+ * distro. SteamOS labels its system partitions `rootfs-A`/`var`/`home`/`esp`
+ * and refers to them in fstab as `/dev/disk/by-partsets/…` rather than
+ * `UUID=`, so neither the label filter nor the fstab matcher can be fooled
+ * there. Nowhere else is like that:
+ *
+ *   - Fedora, Bazzite and Nobara label the btrfs root `fedora`, and leave
+ *     `/boot` with NO LABEL AT ALL. Both are `part`, both carry a UUID, both
+ *     use a whitelisted filesystem, and `/boot` is exactly 1 GiB — the size
+ *     floor is `>=`, so it passes that too.
+ *   - Arch, Ubuntu and most manual installs label nothing.
+ *
+ * So on every non-SteamOS machine `/` and `/boot` were being offered in the
+ * UI as game drives with a "Mount on boot" toggle. Turning one off deleted
+ * every fstab line carrying that UUID — on btrfs, where one filesystem UUID
+ * legitimately has many subvolume entries, that is `/`, `/home` and `/var` in
+ * a single click, and an emergency shell on the next boot.
+ *
+ * An unmounted partition returns false here and is judged by the label and
+ * fstab-target rules instead; there is no way to tell an unmounted data drive
+ * from an unmounted system partition by inspection alone.
+ */
+export function isSystemMountpoint(mountpoint: string | null | undefined): boolean {
+  if (!mountpoint) return false; // unmounted — other rules decide
+  const m = mountpoint.trim();
+  if (!m) return false;
+  if (m === "[SWAP]") return true;
+  return !DATA_MOUNT_ROOTS.some((root) => m.startsWith(root));
+}
+
 /** Skip anything smaller than this — real game libraries are never this small. */
 export const MIN_SIZE_BYTES = 1024 ** 3; // 1 GiB
 
-/** Mount-point name must be a single clean path segment to be Steam-visible. */
+/**
+ * Mount-point name must be a single clean path segment to be Steam-visible.
+ *
+ * `.` and `..` are explicitly excluded despite matching the character class:
+ * a partition labelled `..` (legal on ext4, exFAT and NTFS) produced the
+ * mount point `/run/media/<user>/..`, i.e. `/run/media` itself — mounted over
+ * as root, hiding every other mounted drive, and written into /etc/fstab so
+ * it recurred every boot. Reachable from any attached USB stick.
+ */
 const SAFE_LABEL = /^[A-Za-z0-9._-]+$/;
+const DOTS_ONLY = /^\.+$/;
+
+/** True if a label is safe to use as a single mount-point path segment. */
+export function isSafeLabel(label: string | null | undefined): label is string {
+  if (!label) return false;
+  return SAFE_LABEL.test(label) && !DOTS_ONLY.test(label);
+}
 
 // --- types -------------------------------------------------------------------
 
@@ -142,6 +202,14 @@ export interface StorageDrive {
   steamLibraryFound: boolean;
   /** A persistent /etc/fstab entry for this UUID exists. */
   inFstab: boolean;
+  /**
+   * That entry (or one of them) is not one Loadout wrote.
+   *
+   * The UI disables the boot-mount toggle in this state: the drive shows as
+   * pinned, but switching it off would mean deleting a line the user wrote
+   * with options we can't reason about, and we won't do that.
+   */
+  externallyPinned: boolean;
 }
 
 export interface StorageStatus {
@@ -202,6 +270,9 @@ export function isDataPartition(node: LsblkNode): boolean {
   if (!node.uuid) return false;
   if (!isWhitelistedFs(node.fstype)) return false;
   if (isSystemLabel(node.label)) return false;
+  // Where it is mounted beats what it is called: a label filter alone cannot
+  // see an unlabelled /boot or a root labelled `fedora`.
+  if (isSystemMountpoint(nodeMountpoint(node))) return false;
   return true;
 }
 
@@ -259,8 +330,34 @@ export function mountPointFor({
   label: string | null;
   uuid: string;
 }): string {
-  const name = label && SAFE_LABEL.test(label) ? label : uuid;
+  const name = isSafeLabel(label) ? label : uuid;
   return `/run/media/${user}/${name}`;
+}
+
+/**
+ * Escape a path for an fstab field, the way systemd expects.
+ *
+ * fstab is whitespace-delimited, so an unescaped space splits one field into
+ * two and shifts every field after it. udisks — which mounts removable drives
+ * on KDE and GNOME, and SD cards on SteamOS — mounts at
+ * `/run/media/<user>/<label>` with the label VERBATIM, and drives ship
+ * labelled `My Passport`, `New Volume`, `Seagate Expansion Drive`. Persisting
+ * that live mount point produced a seven-field line:
+ *
+ *   UUID=… /run/media/deck/My Passport exfat defaults,nofail,… 0 2
+ *
+ * which systemd reads as target `/run/media/deck/My`, fstype `Passport`,
+ * options `exfat` — `nofail` GONE, so the generated unit became a hard
+ * requirement of local-fs.target, failed, and dropped the machine to an
+ * emergency shell.
+ */
+export function escapeFstabField(field: string): string {
+  return field.replace(/[\\\s]/g, (c) => `\\${c.charCodeAt(0).toString(8).padStart(3, "0")}`);
+}
+
+/** Decode systemd's octal escaping (`\040` space, `\011` tab, `\134` backslash). */
+export function unescapeFstabField(field: string): string {
+  return field.replace(/\\([0-7]{3})/g, (_m, oct: string) => String.fromCharCode(parseInt(oct, 8)));
 }
 
 /** The canonical fstab line for a managed mount. */
@@ -273,7 +370,53 @@ export function fstabEntryLine({
   mountpoint: string;
   fstype: string;
 }): string {
-  return `UUID=${uuid} ${mountpoint} ${fstype} defaults,nofail,x-systemd.device-timeout=5s 0 2`;
+  return `UUID=${uuid} ${escapeFstabField(mountpoint)} ${fstype} defaults,nofail,x-systemd.device-timeout=5s 0 2`;
+}
+
+/**
+ * Every option string Loadout has written for a managed mount.
+ *
+ * This is the ONLY thing that identifies an entry as ours. Keying on
+ * `UUID=<uuid>` alone does not: the user may have written that line by hand,
+ * long before installing Loadout, with options that matter enormously —
+ * `subvol=@games` on btrfs, `uid=`/`umask=` on ntfs and exfat, `noauto` on a
+ * dual-booter's Windows partition. Deleting or rewriting one of those is not
+ * ours to do.
+ */
+export const MANAGED_OPTIONS = ["defaults,nofail,x-systemd.device-timeout=5s"] as const;
+
+/** Split a non-comment fstab line into fields, or null if it isn't one. */
+function fstabFields(line: string): string[] | null {
+  const t = line.trim();
+  if (!t || t.startsWith("#")) return null;
+  return t.split(/\s+/);
+}
+
+/**
+ * Did Loadout write this line? The options field is the whole discriminator;
+ * mount point and fstype are deliberately not checked, so a drive relabelled
+ * or reformatted since we pinned it is still recognised as ours.
+ */
+export function isManagedFstabLine(line: string | null | undefined, uuid: string): boolean {
+  if (!line) return false;
+  const fields = fstabFields(line);
+  if (!fields || fields.length < 6) return false;
+  if ((fields[0] ?? "").toLowerCase() !== `uuid=${uuid.toLowerCase()}`) return false;
+  if (!(MANAGED_OPTIONS as readonly string[]).includes(fields[3] ?? "")) return false;
+  return fields[4] === "0" && fields[5] === "2";
+}
+
+/** The mount point an existing fstab entry uses for this UUID, unescaped. */
+export function fstabMountpointFor(content: string, uuid: string): string | null {
+  const marker = `uuid=${uuid.toLowerCase()}`;
+  for (const line of content.replace(/\r\n/g, "\n").split("\n")) {
+    const fields = fstabFields(line);
+    if (!fields) continue;
+    if ((fields[0] ?? "").toLowerCase() !== marker) continue;
+    const target = fields[1];
+    if (target) return unescapeFstabField(target);
+  }
+  return null;
 }
 
 /** True if a non-comment fstab line already mounts this UUID. */
@@ -294,7 +437,11 @@ export function fstabHasUuid(content: string, uuid: string): boolean {
  * the fs_spec field so it only ever drops our own `UUID=…` line, never a
  * device-path or label entry that happens to mention the UUID in a comment.
  */
-export function removeFstabEntry(content: string, uuid: string): string {
+export function removeFstabEntry(
+  content: string,
+  uuid: string,
+  { onlyManaged = true }: { onlyManaged?: boolean } = {},
+): string {
   const marker = `uuid=${uuid.toLowerCase()}`;
   return content
     .replace(/\r\n/g, "\n")
@@ -302,9 +449,29 @@ export function removeFstabEntry(content: string, uuid: string): string {
     .filter((line) => {
       const t = line.trim();
       if (!t || t.startsWith("#")) return true;
-      return (t.split(/\s+/)[0] ?? "").toLowerCase() !== marker; // t non-empty ⇒ [0] present
+      if ((t.split(/\s+/)[0] ?? "").toLowerCase() !== marker) return true; // t non-empty ⇒ [0] present
+      // One filesystem UUID legitimately has MANY fstab entries — that is how
+      // btrfs subvolumes are mounted (`subvol=@games`, `subvol=@snapshots`).
+      // Dropping every line for a UUID therefore deletes mounts we never
+      // wrote and were never asked to remove; on a root filesystem that is
+      // `/`, `/home` and `/var` at once. Keep anything that isn't ours.
+      return onlyManaged && !isManagedFstabLine(t, uuid);
     })
     .join("\n");
+}
+
+/** True if any entry for this UUID is one the user wrote rather than us. */
+export function hasUnmanagedEntry(content: string, uuid: string): boolean {
+  const marker = `uuid=${uuid.toLowerCase()}`;
+  return content
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .some((line) => {
+      const t = line.trim();
+      if (!t || t.startsWith("#")) return false;
+      if ((t.split(/\s+/)[0] ?? "").toLowerCase() !== marker) return false;
+      return !isManagedFstabLine(t, uuid);
+    });
 }
 
 /**
@@ -319,13 +486,21 @@ export function addFstabEntry(
   const line = fstabEntryLine(opts);
   const normalized = content.replace(/\r\n/g, "\n");
   if (normalized.split("\n").some((l) => l.trim() === line)) return content;
+  // Replaces a stale line of OURS; a user-written entry for the same UUID is
+  // preserved (see removeFstabEntry) rather than silently swapped out.
   const without = removeFstabEntry(content, opts.uuid).replace(/\s*$/, "");
   return without.length ? `${without}\n${line}\n` : `${line}\n`;
 }
 
 // --- impure orchestration ----------------------------------------------------
 
-const LSBLK_ARGS = ["lsblk", "-J", "-b", "-o", "NAME,PATH,FSTYPE,LABEL,UUID,MOUNTPOINT,TYPE,SIZE,RO"];
+const LSBLK_ARGS = [
+  "lsblk",
+  "-J",
+  "-b",
+  "-o",
+  "NAME,PATH,FSTYPE,LABEL,UUID,MOUNTPOINT,TYPE,SIZE,RO",
+];
 
 /** Enumerate unmounted, mountable data partitions. */
 export async function detectCandidates(deps: StorageDeps): Promise<Candidate[]> {
@@ -422,8 +597,59 @@ export async function mountCandidate(
   }
 
   const steamLibraryFound = await steamLibraryAt(deps, verified);
-  deps.log?.(`mounted ${candidate.uuid} (${candidate.fstype}) at ${verified}; steamLibrary=${steamLibraryFound}`);
+  deps.log?.(
+    `mounted ${candidate.uuid} (${candidate.fstype}) at ${verified}; steamLibrary=${steamLibraryFound}`,
+  );
   return { success: true, mountpoint: verified, steamLibraryFound };
+}
+
+/** Temp file for the atomic /etc/fstab swap. Same directory, so rename works. */
+const FSTAB_TMP = "/etc/fstab.loadout.tmp";
+
+/** True if a thrown error means "no such file" rather than "couldn't read it". */
+function isNotFound(e: unknown): boolean {
+  const code = (e as { code?: unknown } | null)?.code;
+  if (typeof code === "string") return code === "ENOENT";
+  return /ENOENT|no such file/i.test(String(e));
+}
+
+/**
+ * Read /etc/fstab, distinguishing "the file isn't there" from "the read
+ * failed" — `null` means the latter.
+ *
+ * Collapsing both to `""` meant an EIO or a transient failure looked exactly
+ * like an empty fstab, and the writers then built a whole new file from that
+ * assumption: /etc/fstab replaced by a single line, with root, ESP, swap and
+ * /home gone. Callers MUST abort on null rather than write.
+ */
+async function readFstab(deps: StorageDeps): Promise<string | null> {
+  try {
+    return await deps.readFile(FSTAB_PATH);
+  } catch (e) {
+    if (isNotFound(e)) return "";
+    deps.log?.(`refusing to touch /etc/fstab — could not read it: ${e}`);
+    return null;
+  }
+}
+
+const UNREADABLE = "Couldn't read /etc/fstab, so it was left untouched.";
+
+/**
+ * Replace /etc/fstab, atomically, keeping a backup of what was there.
+ *
+ * Write-to-temp then rename: an in-place truncate-then-write leaves a
+ * zero-length or half-written /etc/fstab if the machine loses power in
+ * between, and these are battery-powered handhelds where a hard power-off is
+ * routine. A truncated fstab costs /home, /boot and swap on the next boot.
+ *
+ * The backup is only taken from content we actually read, and never
+ * overwritten with nothing — it is the one recovery path, and clobbering it
+ * with `""` in exactly the case it is needed is worse than not having it.
+ */
+async function writeFstab(deps: StorageDeps, current: string, next: string): Promise<void> {
+  if (current.trim()) await deps.writeFile(FSTAB_BACKUP, current);
+  await deps.writeFile(FSTAB_TMP, next);
+  await deps.renameFile(FSTAB_TMP, FSTAB_PATH);
 }
 
 /**
@@ -436,14 +662,14 @@ export async function persistFstab(
   { uuid, mountpoint, fstype }: { uuid: string; mountpoint: string; fstype: string },
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    const current = await deps.readFile(FSTAB_PATH).catch(() => "");
+    const current = await readFstab(deps);
+    if (current === null) return { success: false, error: UNREADABLE };
     const next = addFstabEntry(current, { uuid, mountpoint, fstype });
     if (next === current) {
       deps.log?.(`fstab already persists UUID=${uuid}`);
       return { success: true };
     }
-    await deps.writeFile(FSTAB_BACKUP, current);
-    await deps.writeFile(FSTAB_PATH, next);
+    await writeFstab(deps, current, next);
     deps.log?.(`fstab: persisted UUID=${uuid} -> ${mountpoint}`);
     return { success: true };
   } catch (e) {
@@ -457,15 +683,26 @@ export async function unpersistFstab(
   { uuid }: { uuid: string },
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    const current = await deps.readFile(FSTAB_PATH).catch(() => "");
+    const current = await readFstab(deps);
+    if (current === null) return { success: false, error: UNREADABLE };
     if (!fstabHasUuid(current, uuid)) {
       deps.log?.(`fstab has no entry for UUID=${uuid}`);
       return { success: true };
     }
+    // Switching OUR toggle off is not permission to delete a line the user
+    // wrote. `removeFstabEntry` keeps unmanaged entries; say so rather than
+    // reporting a clean removal that didn't happen.
     const next = removeFstabEntry(current, uuid);
-    await deps.writeFile(FSTAB_BACKUP, current);
-    await deps.writeFile(FSTAB_PATH, next);
-    deps.log?.(`fstab: removed persistent mount for UUID=${uuid}`);
+    if (next === current) {
+      deps.log?.(`fstab entry for UUID=${uuid} isn't one of ours — leaving it alone`);
+      return {
+        success: false,
+        error:
+          "That drive is pinned by an /etc/fstab entry Loadout didn't write, so it was left alone. Edit /etc/fstab by hand to change it.",
+      };
+    }
+    await writeFstab(deps, current, next);
+    deps.log?.(`fstab: removed our persistent mount for UUID=${uuid}`);
     return { success: true };
   } catch (e) {
     return { success: false, error: String(e) };
@@ -479,9 +716,16 @@ export async function getStorageStatus(deps: StorageDeps): Promise<StorageStatus
     deps.log?.(`lsblk failed (${r.exitCode}): ${r.stderr.trim()}`);
     return { drives: [] };
   }
-  const parts = parseDataPartitions(r.stdout).filter((p) => p.size >= MIN_SIZE_BYTES);
-  const fstab = await deps.readFile(FSTAB_PATH).catch(() => "");
+  const fstab = (await readFstab(deps)) ?? "";
   const user = deps.currentUser();
+  const parts = parseDataPartitions(r.stdout)
+    .filter((p) => p.size >= MIN_SIZE_BYTES)
+    // An UNMOUNTED system partition can't be spotted by mount point, and on
+    // most distros it has no label either — but if fstab pins it somewhere
+    // that isn't a data mount root, it's the OS's. This is what keeps a
+    // dual-boot install's /boot, or a root that simply isn't mounted right
+    // now, out of the drive list.
+    .filter((p) => !isSystemMountpoint(fstabMountpointFor(fstab, p.uuid)));
 
   const drives = await Promise.all(
     parts.map(async (p): Promise<StorageDrive> => {
@@ -497,6 +741,7 @@ export async function getStorageStatus(deps: StorageDeps): Promise<StorageStatus
         suggestedMountpoint: mountPointFor({ user, label: p.label, uuid: p.uuid }),
         steamLibraryFound: p.mountpoint ? await steamLibraryAt(deps, p.mountpoint) : false,
         inFstab: fstabHasUuid(fstab, p.uuid),
+        externallyPinned: hasUnmanagedEntry(fstab, p.uuid),
       };
     }),
   );


### PR DESCRIPTION
> Split out of #277 so it can ship on its own. These are **pre-existing defects on `main`**, not regressions from that branch — but #277 converts them from a bad click into a bad boot, so they land first.

## The main one

On any distro that isn't SteamOS, the plugin listed the **root filesystem and `/boot` as game drives**, with "Mount on boot" already on. Turning one off deleted every `/etc/fstab` line carrying that UUID.

`isDataPartition` rejected a partition only by **label**. SteamOS is the one layout where that's enough — it labels its system partitions (`rootfs-A`, `var`, `home`, `esp`) *and* refers to them in fstab as `/dev/disk/by-partsets/…` rather than `UUID=`, so neither the label filter nor the fstab matcher can be fooled. Nowhere else is like that.

Verified against a stock Fedora/Bazzite/Nobara layout, before this change:

```
Fedora partitions the plugin treats as adoptable game drives:
  /dev/nvme0n1p2  label=null    fs=ext4   mounted@/boot
  /dev/nvme0n1p3  label=fedora  fs=btrfs  mounted@/
```

`/boot` is unlabelled and exactly 1 GiB — the size floor is `>=`, so it passes that too. On btrfs one filesystem UUID legitimately has many subvolume entries, so removing "the entry" for the root took out `/`, `/home` and `/var` together. Next boot: `local-fs.target` fails, emergency shell, rescue USB.

After:

```
Fedora partitions still offered as game drives: []
isDataPartition(btrfs root 'fedora') = false
isDataPartition(unlabelled /boot)    = false
```

## The rest

- **Judge by mount point, not label.** Only `/run/media/`, `/media/` and `/mnt/` are data mount roots. An *unmounted* system partition is caught by its fstab target instead.
- **`removeFstabEntry` keeps entries it didn't write.** Ownership is decided by the options field (`MANAGED_OPTIONS`), never by `UUID=` alone. The UI disables the boot toggle for a drive pinned by someone else's entry (`externallyPinned`) rather than offering a switch we'd refuse to honour.
- **Mount points are octal-escaped on write.** udisks mounts at `/run/media/<user>/<label>` verbatim, so a drive labelled `My Passport` wrote a **seven-field line**; systemd read the fstype as `Passport` and the options as `exfat`, losing `nofail` and making the mount a hard requirement of `local-fs.target`. Now: `…/My\040Passport …`, six fields.
- **A label of `..` no longer escapes the mount root.** Legal on ext4/exFAT/NTFS, matched `SAFE_LABEL`, and produced `/run/media/<user>/..` — `/run/media` itself, mounted over as root, from any USB stick.
- **Writes survive interruption.** `/etc/fstab` is replaced by write-to-temp plus `rename` rather than truncated in place; a read that *fails* is no longer treated as an empty file (ENOENT and EIO both collapsed to `""`, and the writer rebuilt fstab from that — replacing it with a single line); and the backup is never overwritten with nothing, which is what happened in exactly the case it was needed.

## Verification

Full suite **3420 + 569 passing, 0 failures**; typecheck, lint (0 errors), knip, prettier clean. **16 new tests**, including the Fedora layout above and the seven-field line.

Verified read-only on a Steam Deck against real `lsblk` and the real `/etc/fstab`: no system partition appears in the drive list, both real drives are still detected, `/etc/fstab` untouched throughout.

**Note on `MANAGED_OPTIONS`:** it lists only the option string `main` has ever written (`…device-timeout=5s`). #277 bumps that to 10s and adds the new form there, so the two stay consistent when it rebases on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFe9chsSrANSVpgXGnqwZy
