### PR TITLE
feat(recomp): 2026-09 catalog refresh — 19 new titles, 5 asset-glob repairs

### DIFF
--- a/docs/recomp-new-titles-2026-09.md
+++ b/docs/recomp-new-titles-2026-09.md
@@ -1,0 +1,120 @@
+# Recomp catalog refresh — September 2026
+
+Follow-up to `docs/recomp-new-titles-plan.md` (July 2026). Everything here
+was verified live against the GitHub API on 2026-09-09, including
+downloading the release archives to pin exact `launchCommand` paths.
+
+## The rule this sweep exists to record
+
+**Most "releases" in the 2026 recomp wave are build harnesses, not games.**
+Download the archive and look inside before writing a catalog entry.
+
+- A **real game** is a stripped ELF or AppImage of tens of MB with an
+  `assets/` directory and no toolchain.
+- A **harness** contains `CMakeLists.txt`, `recomp-ui/`, `psxrecomp/`, a
+  `README-SETUP.txt`, or a `setup.sh`. Installing one lands a source tree
+  and launches nothing.
+
+The filename does not tell you which: `-linux-x64.zip` means both things
+depending on the project. Verified examples:
+
+| Repo | Linux asset | Contents |
+|---|---|---|
+| `TechnicallyComputers/Klonoa-Door-to-Phantomile` | `kdp-0.1.3-linux-x64.zip` | 2125 files, `psxrecomp/` + `README-SETUP.txt` — harness |
+| `Unchiga/YuGiOhForbiddenMemoriesRecomp` | `ygofm-0.5.9-linux-x64.zip` | 2321 files, `recomp-ui/` — harness |
+| `Ed1z19/ValkyrieRecomp` | `ValkyrieRecomp-1.0.1-linux-x64.zip` | `CMakeLists.txt`, `codegen_setup.c` — harness |
+| `jackpoison-prog/RingOut` | `RingOut-1.5.2-steamdeck-x86_64.zip` | README: *"contains NO game data and NO game code"* — harness |
+| `mstan/ApeEscapeRecomp` | `…-linux-x86_64.AppImage` | 27 MB ELF + assets — **game** |
+| `novapowers0/BloodyRoar2Recomp` | `BloodyRoar2-US-linux-x64-*.zip` | ELF + bundled `openbios.bin` — **game** |
+
+The reason is legal as much as technical: a binary built from the user's
+disc is the game, so upstreams ship the recompiler instead.
+
+## What landed
+
+19 new installable titles, 9 fixes to existing rows, 4 regression repairs
+found by the audit, and one pipeline capability.
+
+**Pipeline**: added `GameEntry.flattenRoot` (`lib/types.ts`,
+`lib/pipeline.ts`) — an opt-in that hoists a single *version-stamped*
+top-level directory out of the extracted archive, reusing the existing
+`flattenSingleRoot()` that was previously gated on `manualImport` alone.
+Entries with a **stable** wrapper (`perfect-dark`'s `pd-x86_64-linux/`)
+must NOT set it; they encode the directory in `launchCommand` on purpose.
+
+**Not needed after all**: the July note that Mega Man 64's Linux build is
+"a nested zip→tar.gz the installer doesn't unwrap" is stale —
+`extractNestedArchives()` in `lib/pipeline-archive.ts` already handles it.
+Mega Man 64 and Donkey Kong 64 both install natively on Linux now.
+
+**Regressions the audit caught** (all the same class — upstream renamed an
+asset, the glob stopped matching, and the entry silently fell back to
+Windows-via-Proton or broke outright):
+
+- `banjo-recomp` — v1.0.2 switched `.zip` → `.tar.gz`
+- `mariokart64-recomp`, `dnzh-recomp`, `starfox64-recomp` — pkgforge-dev's
+  2026-09-01 rebuild dropped the underscores (`MarioKart_64_Recompiled-` →
+  `MarioKart64Recompiled-`). All three now anchor on the stable
+  `*Recompiled-*-anylinux-x86_64.AppImage` tail.
+- `viva-pinata-tip-recomp` (`retip_` → `retip-`) and `opentdu` (both
+  platform assets renamed)
+
+`scripts/audit-urls.ts` is what surfaces these; it is worth running on a
+schedule rather than only during a sweep. It now skips `manualImport`
+entries, which carry no `repo` and could only ever report a false 404.
+
+## Deferred, with reasons
+
+- **Klonoa, Yu-Gi-Oh! Forbidden Memories, Valkyrie Profile, Tomba!,
+  SoulCalibur II (RingOut), Mario Kart Wii** — build harnesses (above).
+  Cataloguing them needs a new `setup_package` install type that runs the
+  upstream wizard inside the `recomp-build` distrobox container (which
+  `lib/build-env.ts` already provisions for `sotn-pc`) and allowlists
+  `TechnicallyComputers/retcomm-toolchains` as a download host. RingOut is
+  the best first target: a measured 45–49 fps on SteamOS with working
+  rollback netplay. Tomba! additionally publishes two incompatible asset
+  naming schemes in one repo, which a single glob string cannot express.
+- **Super Smash Bros. Melee** — `doldecomp/melee` hit 100% matched on
+  2026-09-07 (all 19,828 functions; byte-identical GALE01 NTSC 1.02 DOL).
+  It builds a **GameCube DOL**, not a PC binary, and publishes no releases.
+  A matching decompilation recovers the source; a port is a separate
+  project on top of it. `jonrosner/melee-native` ships a Linux tarball but
+  is a one-day-old v0.1.0 prerelease **in which saving does not work**.
+  Tracked via the `super-smash-bros-melee` row's `_reason`.
+- **Wave Race 64** (`chronic8000/WaveRace64Recompiled`) — no releases;
+  upstream self-describes as unfinished.
+- **Conker** (`Conker64Recomp/conker64-recompiled`) — sole asset is 940 KB,
+  which cannot contain a game.
+- **Castlevania 64** (`spacefarergames/CV64-Recomp`) — non-semver tag
+  (`Releases`) and an unresolved AI-provenance flag on the author's output.
+- **Animal Crossing** (`flyngmt/ACGC-PC-Port`) — prerelease-only *and*
+  32-bit MinGW, needing a 32-bit Wine prefix nothing else here exercises.
+- **Mega Man X4, Pocket Monsters Stadium (JP), Beetle Adventure Racing** —
+  too early, or rolling `Continuous` tags that make versions meaningless.
+- **Tekken 3, Einhander, Strider 2, Street Fighter EX2** — require a retail
+  `SCPH1001.BIN`; there is still no BIOS-file `romInfo` capability. (Most
+  psxrecomp titles bundle MIT OpenBIOS and need no BIOS, which is what
+  unblocked the four PS1 rows that did land.)
+- **GoldenEye 007 N64** (`cblock85/GoldenEye64Recomp`) — advertises Linux,
+  publishes only macOS ARM64.
+- **GitLab-hosted canonical repos** (`sonicdcer/*`: Mario Kart 64, Star Fox
+  64, DNZH, Extreme-G) — the pipeline is GitHub-only. Keep the
+  `pkgforge-dev` AppImage mirrors; do not "fix" the repo field to GitLab.
+
+## Gotchas worth knowing next time
+
+- **`scripts/test-installers.ts --deep` is weaker than it looks.** It
+  accepts the launch binary at *any* depth in the extracted tree, so it
+  cannot catch a wrong `launchCommand` path or a missing `flattenRoot`.
+  Verify the exact `{installDir}/…` path separately.
+- **The `mstan` PS1 repos publish a rolling `shared-staging-YYYYMMDD`
+  release** that is not flagged prerelease and sorts newest, so it wins
+  over the semver tag. Assets are identically named, so globs match either
+  way — but the displayed version reads `shared-staging-…`.
+  `GameEntry.versionPattern` exists in `lib/types.ts` for exactly this and
+  is **read nowhere**; implement or delete it.
+- **Region is baked into a PS1 recompilation.** Bloody Roar II's EU and US
+  binaries are not interchangeable. Only the US row is catalogued.
+- **Two GameCube decomp repos are misleading**: Kirby Air Ride's
+  `doldecomp/kar` has more stars but died in Feb 2025 (live: `wowjinxy/KAR`),
+  and Perfect Dark moved to `perfect-dark-pc-port/perfect_dark`.

--- a/docs/recomp-new-titles-2026-09.md
+++ b/docs/recomp-new-titles-2026-09.md
@@ -60,8 +60,17 @@ Windows-via-Proton or broke outright):
   platform assets renamed)
 
 `scripts/audit-urls.ts` is what surfaces these; it is worth running on a
-schedule rather than only during a sweep. It now skips `manualImport`
-entries, which carry no `repo` and could only ever report a false 404.
+schedule rather than only during a sweep. Two fixes went in alongside:
+
+- It now checks **every declared platform** instead of returning ok on the
+  first glob that matches. The old behaviour hid exactly this regression
+  class — `banjo-recomp` declares both a Linux and a Windows glob, so while
+  its Linux asset was unmatched the audit still reported
+  "ok (matched windows)". Tightening it immediately surfaced two more
+  pre-existing breakages that had been masked: `openmw` (Windows glob) and
+  `aitd-rehaunted` (Linux glob).
+- It skips `manualImport` entries, which carry no `repo` and could only ever
+  report a false 404.
 
 ## Deferred, with reasons
 
@@ -103,6 +112,19 @@ entries, which carry no `repo` and could only ever report a false 404.
 
 ## Gotchas worth knowing next time
 
+- **A declared platform whose asset is missing from the newest release is a
+  hard install failure, not a fallback.** `getEffectivePlatformValue()`
+  commits to Linux as soon as `releaseAssets.linux` is a string, so if the
+  resolved release happens to ship Windows only, `resolveAssetUrl` throws
+  `No asset matching …` instead of falling back to the Proton build. This is
+  not hypothetical: `aitd-rehaunted` was live-broken this way (its 2.4.0
+  stable is Windows-only; Linux last appeared in a 2.3.0 *prerelease*, which
+  the resolver skips), and it was fixed here by setting `"linux": null`.
+  The same trap is latent for the `mstan` PS1 entries, whose rolling
+  `shared-staging-*` tag has occasionally carried Windows assets only. If
+  that recurs, either pin `latestAssetUrl` or drop the Linux glob until
+  upstream stabilises — and consider teaching `resolveAssetUrl` to fall back
+  to an older release that does have the platform asset.
 - **`scripts/test-installers.ts --deep` is weaker than it looks.** It
   accepts the launch binary at *any* depth in the extracted tree, so it
   cannot catch a wrong `launchCommand` path or a missing `flattenRoot`.

--- a/plugins/recomp/games.json
+++ b/plugins/recomp/games.json
@@ -63,7 +63,7 @@
       "installType": "prebuilt",
       "releaseAssets": {
         "windows": "BanjoRecompiled-*-Windows.zip",
-        "linux": "BanjoRecompiled-*-Linux-X64.zip"
+        "linux": "BanjoRecompiled-*-Linux-X64.tar.gz"
       },
       "launchCommand": {
         "windows": "{installDir}/BanjoRecompiled.exe",
@@ -75,7 +75,7 @@
         "platformer",
         "3d"
       ],
-      "latestVersion": "v1.0.1",
+      "latestVersion": "v1.0.2",
       "steamGridDbId": 35564
     },
     {
@@ -107,7 +107,7 @@
         "3d"
       ],
       "website": "https://shipofharkinian.com",
-      "latestVersion": "9.2.0",
+      "latestVersion": "9.2.3",
       "steamGridDbId": 21202
     },
     {
@@ -168,7 +168,7 @@
         "action-adventure",
         "3d"
       ],
-      "latestVersion": "v0.2.0",
+      "latestVersion": "v0.3.0",
       "steamGridDbId": 5278393
     },
     {
@@ -205,10 +205,12 @@
       "description": "Native PC port of Mega Man 64 via static recompilation. Widescreen, higher framerates, and mod support.",
       "installType": "prebuilt",
       "releaseAssets": {
-        "windows": "MegaMan64Recompiled-*-Windows.zip"
+        "windows": "MegaMan64Recompiled-*-Windows.zip",
+        "linux": "MegaMan64Recompiled-*-Linux-X64.zip"
       },
       "launchCommand": {
-        "windows": "{installDir}/MegaMan64Recompiled.exe"
+        "windows": "{installDir}/MegaMan64Recompiled.exe",
+        "linux": "{installDir}/MegaMan64Recompiled"
       },
       "tags": [
         "mega-man",
@@ -217,8 +219,7 @@
         "3d"
       ],
       "latestVersion": "v0.9.1",
-      "steamGridDbId": 37399,
-      "_reason": "Windows-only: the upstream Linux build ships as a nested zip->tar.gz the installer doesn't unwrap; the Windows build runs via Proton."
+      "steamGridDbId": 37399
     },
     {
       "id": "bmhero-recomp",
@@ -296,7 +297,7 @@
       "name": "Perfect Dark",
       "project": "Perfect Dark (native PC port)",
       "platform": "n64",
-      "repo": "fgsfdsfgs/perfect_dark",
+      "repo": "perfect-dark-pc-port/perfect_dark",
       "description": "Native PC port of Rare's Perfect Dark, built on the N64 decompilation. Adds mouselook, dual-analog support, widescreen, configurable FOV, 60+ FPS and basic mod support. On first launch you must supply your own Perfect Dark ROM (NTSC-final recommended). Linux native build; the port's release ships a per-platform folder, so this entry targets the Linux binary.",
       "installType": "rom_extract",
       "releaseAssets": {
@@ -320,7 +321,7 @@
         "fps",
         "3d"
       ],
-      "website": "https://github.com/fgsfdsfgs/perfect_dark",
+      "website": "https://github.com/perfect-dark-pc-port/perfect_dark",
       "latestVersion": "ci-dev-build",
       "steamGridDbId": 37787
     },
@@ -352,7 +353,7 @@
         "platformer",
         "3d"
       ],
-      "latestVersion": "2.0.0",
+      "latestVersion": "3.0.0",
       "steamGridDbId": 37177
     },
     {
@@ -394,7 +395,7 @@
       "description": "Native PC port of Mario Kart 64 via static recompilation. Widescreen, higher framerates, and mod support.",
       "installType": "prebuilt",
       "releaseAssets": {
-        "linux": "MarioKart_64_Recompiled-*-anylinux-x86_64.AppImage"
+        "linux": "*Recompiled-*-anylinux-x86_64.AppImage"
       },
       "launchCommand": {
         "linux": "{installDir}/MarioKart64Recompiled.appimage"
@@ -492,7 +493,7 @@
       "description": "Native PC port of Star Fox 64 via static recompilation. Widescreen, higher framerates, and mod support.",
       "installType": "prebuilt",
       "releaseAssets": {
-        "linux": "Starfox_64_Recompiled-*-anylinux-x86_64.AppImage"
+        "linux": "*Recompiled-*-anylinux-x86_64.AppImage"
       },
       "launchCommand": {
         "linux": "{installDir}/Starfox64Recompiled.appimage"
@@ -515,7 +516,7 @@
       "description": "Native PC port of Duke Nukem: Zero Hour via static recompilation.",
       "installType": "prebuilt",
       "releaseAssets": {
-        "linux": "DNZH_Recompiled-*-anylinux-x86_64.AppImage"
+        "linux": "*Recompiled-*-anylinux-x86_64.AppImage"
       },
       "launchCommand": {
         "linux": "{installDir}/DNZHRecompiled.appimage"
@@ -582,7 +583,7 @@
         "3d"
       ],
       "website": "https://2ship.equipment",
-      "latestVersion": "4.0.2",
+      "latestVersion": "5.0.1",
       "steamGridDbId": 34302
     },
     {
@@ -590,13 +591,19 @@
       "name": "Star Fox 64",
       "project": "Starship",
       "platform": "n64",
-      "repo": "harbourMasters/Starship",
-      "description": "Native PC port of Star Fox 64 via reverse engineering (HarbourMasters engine). Enhanced with modern features. First launch processes your ROM into game assets (~30s). No GitHub release binaries are published yet.",
+      "repo": "HarbourMasters/Starship",
+      "description": "Native PC port of Star Fox 64 via reverse engineering (HarbourMasters engine). Enhanced with modern features. First launch processes your ROM into game assets (~30s). Supports US 1.0 and US 1.1 Rev A ROMs; EU and JP ROMs can supply replacement voice languages alongside a US ROM.",
       "installType": "rom_extract",
-      "releaseAssets": {},
+      "releaseAssets": {
+        "windows": "Starship-*-Windows.zip",
+        "linux": "Starship-*-Linux.zip"
+      },
       "romInfo": {
-        "description": "Provide your legally owned Star Fox 64 ROM (US v1.0 or v1.1)",
-        "validChecksums": [],
+        "description": "Provide your legally owned Star Fox 64 ROM (US v1.0 or v1.1 Rev A)",
+        "validChecksums": [
+          "d8b1088520f7c5f81433292a9258c1184afa1457",
+          "09f0d105f476b00efa5303a3ebc42e60a7753b7a"
+        ],
         "extractionCommand": "",
         "placeRomAs": "sf64.z64"
       },
@@ -611,9 +618,7 @@
         "3d"
       ],
       "latestVersion": "v2.0.0",
-      "steamGridDbId": 36615,
-      "status": "in_progress",
-      "_reason": "harbourMasters/Starship publishes no GitHub release assets (only git tags); binaries distributed off-GitHub. Star Fox 64 is installable via the 'starfox64-recomp' entry instead."
+      "steamGridDbId": 36615
     },
     {
       "id": "opengoal-jak2",
@@ -863,8 +868,8 @@
       "description": "Open-source reimplementation of Test Drive Unlimited. Work in progress.",
       "installType": "rom_extract",
       "releaseAssets": {
-        "windows": "opentdu_release_Win32_vulkan.zip",
-        "linux": "opentdu_release_unix_vulkan.zip"
+        "windows": "opentdu_release_windows_x64_latest_vulkan.zip",
+        "linux": "opentdu_release_linux_vulkan.zip"
       },
       "romInfo": {
         "description": "Requires original Test Drive Unlimited game files",
@@ -2031,11 +2036,12 @@
       "project": "A decompilation of Super Smash Bros Melee brought to you by a bunch of clever folks.",
       "platform": "gc",
       "repo": "doldecomp/melee",
-      "description": "A decompilation of Super Smash Bros Melee brought to you by a bunch of clever folks.",
+      "description": "Matching decompilation of Super Smash Bros. Melee (NTSC 1.02, GALE01). Reached 100% on 2026-09-07 — all 19,828 functions match and the rebuilt DOL is byte-identical to the original.",
       "installType": "prebuilt",
       "releaseAssets": {},
       "launchCommand": {},
       "status": "in_progress",
+      "_reason": "Decompilation complete (100% as of 2026-09-07) but there is no playable PC port: the project builds a GameCube DOL for Dolphin or real hardware, not a PC binary, and publishes no releases. Port forks appeared within days — jonrosner/melee-native ships a Linux tarball — but that is a v0.1.0 prerelease in which saving does not work. Re-check before promoting.",
       "tags": [],
       "website": null,
       "steamGridDbId": 37285
@@ -2131,13 +2137,14 @@
       "id": "wind-waker",
       "name": "Wind Waker",
       "project": "Decompilation of The Legend of Zelda: The Wind Waker",
-      "platform": "unknown",
+      "platform": "gc",
       "repo": "zeldaret/tww",
       "description": "Decompilation of The Legend of Zelda: The Wind Waker",
       "installType": "prebuilt",
       "releaseAssets": {},
       "launchCommand": {},
       "status": "in_progress",
+      "_reason": "Decompilation in progress (~76% matched as of 2026-09-09). The separate sp00nznet/ww static recompilation is renderer-only by its own README — it does not yet run the game.",
       "tags": [],
       "website": "https://zeldaret.github.io/tww",
       "steamGridDbId": 5358192
@@ -2373,6 +2380,7 @@
       "releaseAssets": {},
       "launchCommand": {},
       "status": "in_progress",
+      "_reason": "Decompilation in progress (~89% matched as of 2026-09-09). No PC port exists; Pikmin 1 does have one — see 'open-nectar'.",
       "tags": [
         "cpp",
         "decompilation",
@@ -2521,6 +2529,7 @@
       "releaseAssets": {},
       "launchCommand": {},
       "status": "in_progress",
+      "_reason": "Decompilation in progress (~81% matched, ~38% fully linked as of 2026-09-09). No PC port exists.",
       "tags": [
         "cplusplus",
         "decompilation",
@@ -2673,11 +2682,12 @@
       "project": "A decompilation of Pikmin brought to you by fans of the series.",
       "platform": "gc",
       "repo": "projectPiki/pikmin",
-      "description": "A decompilation of Pikmin brought to you by fans of the series.",
+      "description": "Matching decompilation of Pikmin (GPIE01), 100% decompiled and fully linked.",
       "installType": "prebuilt",
       "releaseAssets": {},
       "launchCommand": {},
       "status": "in_progress",
+      "_reason": "Decompilation only — no binary is published here. The playable native PC port built on it is catalogued separately as 'open-nectar'.",
       "tags": [
         "cpp",
         "decompilation",
@@ -3397,12 +3407,13 @@
       "name": "Kirby Air Ride",
       "project": "A decompilation of Kirby Air Ride brought to you by a bunch of clever folks.",
       "platform": "gc",
-      "repo": "doldecomp/kar",
+      "repo": "wowjinxy/KAR",
       "description": "A decompilation of Kirby Air Ride brought to you by a bunch of clever folks.",
       "installType": "prebuilt",
       "releaseAssets": {},
       "launchCommand": {},
       "status": "in_progress",
+      "_reason": "Decompilation in early progress (~9%). Note the better-known doldecomp/kar repo has been dormant since February 2025; wowjinxy/KAR is the live effort.",
       "tags": [],
       "website": null,
       "steamGridDbId": 37983
@@ -8266,7 +8277,7 @@
         "3d"
       ],
       "website": "https://github.com/TwilitRealm/dusklight",
-      "latestVersion": "v1.1.1",
+      "latestVersion": "v1.4.1",
       "userDataDir": "~/.local/share/TwilitRealm/Dusklight",
       "mods": [
         {
@@ -8501,7 +8512,7 @@
         "3d"
       ],
       "website": "https://github.com/JRickey/BattleShip",
-      "latestVersion": "v1.5.1",
+      "latestVersion": "v1.6",
       "steamGridDbId": 33624
     },
     {
@@ -8574,7 +8585,7 @@
         "anchorChecksums": ["c5970941fcb201dda99de0d35b623827241d6b8b"]
       },
       "releaseAssets": {
-        "windows": "retip_*-windows-x64-*.zip"
+        "windows": "retip-*-windows-x64-*.zip"
       },
       "launchCommand": {
         "windows": "{installDir}/retip.exe"
@@ -8623,6 +8634,522 @@
       "website": "https://github.com/HollywoodAkeem/SVR07-Recomp",
       "latestVersion": "v1.0",
       "steamGridDbId": 5264777
+    },
+    {
+      "id": "dk64-recomp",
+      "name": "Donkey Kong 64",
+      "project": "Donkey Kong 64: Recompiled",
+      "platform": "n64",
+      "repo": "Rainchus/Donkey-Kong-64-Recompiled",
+      "description": "Native PC port of Donkey Kong 64 via static recompilation. Widescreen, higher framerates, gyro aiming and mod support. Supply your own NTSC-U 1.0 ROM on first launch.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "DK64Recompiled-Windows-Release*.zip",
+        "linux": "DK64Recompiled-Linux-X64-Release*.zip"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/DK64Recompiled.exe",
+        "linux": "{installDir}/DK64Recompiled"
+      },
+      "tags": [
+        "donkey-kong",
+        "n64",
+        "platformer",
+        "3d"
+      ],
+      "latestVersion": "1.0.2",
+      "steamGridDbId": 37695
+    },
+    {
+      "id": "snap64-recomp",
+      "name": "Pokémon Snap",
+      "project": "Snap64: Recompiled",
+      "platform": "n64",
+      "repo": "JackandBeans/Snap64Recomp",
+      "description": "Native PC port of Pokémon Snap via static recompilation. Widescreen, higher framerates and mod support. Supply your own US ROM on first launch.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "Snap64Recomp-*-win64.zip",
+        "linux": "Snap64Recomp-*-linux-x86_64.tar.gz"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/Snap64Recomp.exe",
+        "linux": "{installDir}/Snap64Recomp"
+      },
+      "flattenRoot": true,
+      "tags": [
+        "pokemon",
+        "n64",
+        "rail-shooter",
+        "3d"
+      ],
+      "latestVersion": "v1.0.2",
+      "steamGridDbId": 37585
+    },
+    {
+      "id": "sssv-recomp",
+      "name": "Space Station Silicon Valley",
+      "project": "SSSV: Recompiled",
+      "platform": "n64",
+      "repo": "Cellenseres/SSSV_Recomp",
+      "description": "Native PC port of Space Station Silicon Valley via static recompilation. Supply your own US 1.0 ROM on first launch.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "SSSVRecompiled_*_Windows.zip",
+        "linux": "SSSVRecompiled_*_Linux.tar.gz"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/SSSVRecompiled.exe",
+        "linux": "{installDir}/SSSVRecompiled"
+      },
+      "tags": [
+        "n64",
+        "platformer",
+        "puzzle",
+        "3d"
+      ],
+      "latestVersion": "v0.2.0",
+      "steamGridDbId": 35559
+    },
+    {
+      "id": "troublemakers-recomp",
+      "name": "Mischief Makers",
+      "project": "Trouble Makers (PC Recomp)",
+      "platform": "n64",
+      "repo": "ThiagoLira/trouble-makers-pc-recomp",
+      "description": "Native PC port of Mischief Makers via static recompilation. 60fps, high-resolution rendering and optional widescreen. Upstream publishes a Steam Deck-specific AppImage, which is what this entry installs. Supply your own ROM on first launch.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "TroubleMakers-Windows-X64.zip",
+        "linux": "TroubleMakers-SteamDeck-x86_64.AppImage"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/TroubleMakers.exe",
+        "linux": "{installDir}/TroubleMakers.AppImage"
+      },
+      "tags": [
+        "n64",
+        "platformer",
+        "action",
+        "2d"
+      ],
+      "latestVersion": "v0.8.2",
+      "steamGridDbId": 38272
+    },
+    {
+      "id": "lamborghini-recomp",
+      "name": "Automobili Lamborghini",
+      "project": "Automobili Lamborghini: Recompiled",
+      "platform": "n64",
+      "repo": "alondero/automobililamborghini-recomp",
+      "description": "Native PC port of Automobili Lamborghini via static recompilation. Supply your own ROM on first launch.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "lamborghini-recomp-windows-x64.zip",
+        "linux": "lamborghini-recomp-linux-x64.zip"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/lamborghini_modern.exe",
+        "linux": "{installDir}/lamborghini_modern"
+      },
+      "tags": [
+        "n64",
+        "racing",
+        "3d"
+      ],
+      "latestVersion": "v0.6.2",
+      "steamGridDbId": 38290
+    },
+    {
+      "id": "cvlod-recomp",
+      "name": "Castlevania: Legacy of Darkness",
+      "project": "LoD Recomp",
+      "platform": "n64",
+      "repo": "fliperama86/cvlod_recomp",
+      "description": "Native PC port of Castlevania: Legacy of Darkness via static recompilation. Still stabilising gameplay. Supply your own ROM on first launch.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "LodRecomp-*-windows-x64.zip",
+        "linux": "LodRecomp-*-linux-x64.tar.gz"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/LodRecomp.exe",
+        "linux": "{installDir}/LodRecomp"
+      },
+      "flattenRoot": true,
+      "tags": [
+        "castlevania",
+        "n64",
+        "action-adventure",
+        "3d"
+      ],
+      "latestVersion": "v0.2.26",
+      "steamGridDbId": 12888
+    },
+    {
+      "id": "extremeg-recomp",
+      "name": "Extreme-G",
+      "project": "Extreme-G: Recompiled",
+      "platform": "n64",
+      "repo": "pkgforge-dev/ExtremeGRecomp-AppImage",
+      "description": "Native PC port of Extreme-G via static recompilation. Installed from the pkgforge-dev AppImage rebuild — the canonical project lives on GitLab (sonicdcer/ExtremeGRecomp), which this pipeline cannot fetch from. Supply your own ROM on first launch.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "linux": "*Recompiled-*-anylinux-x86_64.AppImage"
+      },
+      "launchCommand": {
+        "linux": "{installDir}/ExtremeGRecompiled.appimage"
+      },
+      "tags": [
+        "n64",
+        "racing",
+        "3d"
+      ],
+      "latestVersion": "1.0.0",
+      "steamGridDbId": 38774
+    },
+    {
+      "id": "lighthouse",
+      "name": "Banjo-Kazooie",
+      "project": "Lighthouse",
+      "platform": "n64",
+      "repo": "HarbourMasters/Lighthouse",
+      "description": "Native PC port of Banjo-Kazooie via reverse engineering (HarbourMasters engine). First launch asks for your ROM and processes it into game assets. Supports US 1.0, US 1.1, JP and PAL ROMs; extra regions can be added as language packs.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "Lighthouse-*-Win64.zip",
+        "linux": "Lighthouse-*-Linux.zip"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/lighthouse.exe",
+        "linux": "{installDir}/lighthouse.appimage"
+      },
+      "tags": [
+        "banjo",
+        "n64",
+        "platformer",
+        "3d"
+      ],
+      "latestVersion": "1.1.0",
+      "steamGridDbId": 35564
+    },
+    {
+      "id": "golden-balloon",
+      "name": "Diddy Kong Racing",
+      "project": "Golden Balloon",
+      "platform": "n64",
+      "repo": "akratch/goldenballoon",
+      "description": "Native PC port of Diddy Kong Racing built on the decompilation. Widescreen, higher framerates and modern controls. Supply your own US v1.1 ROM on first launch.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "Golden-Balloon-*-windows-x64.zip",
+        "linux": "Golden-Balloon-*-linux-x86_64.AppImage"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/GoldenBalloon.exe",
+        "linux": "{installDir}/GoldenBalloon.AppImage"
+      },
+      "tags": [
+        "donkey-kong",
+        "n64",
+        "racing",
+        "3d"
+      ],
+      "latestVersion": "1.5.2",
+      "steamGridDbId": 36929
+    },
+    {
+      "id": "pokemon-stadium-recomp",
+      "name": "Pokémon Stadium",
+      "project": "Pokémon Stadium: Recompiled",
+      "platform": "n64",
+      "repo": "mstan/PokemonStadiumRecomp",
+      "description": "Native PC port of Pokémon Stadium via static recompilation, including Transfer Pak / GB Tower support with your own Gen 1 cartridge ROMs. Windows-only upstream; runs via Proton. Supply your own US 1.0 ROM on first launch.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "PokemonStadiumRecomp-*-win64.zip"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/PokemonStadiumRecomp.exe"
+      },
+      "tags": [
+        "pokemon",
+        "n64",
+        "strategy",
+        "3d"
+      ],
+      "latestVersion": "v0.4.7-beta",
+      "steamGridDbId": 36269,
+      "_reason": "Windows-only: upstream publishes no Linux asset; the Windows build runs via Proton."
+    },
+    {
+      "id": "roadrash64-recomp",
+      "name": "Road Rash 64",
+      "project": "Road Rash 64: Recompiled",
+      "platform": "n64",
+      "repo": "linkssy2/RoadRash64Recompiled",
+      "description": "Native PC port of Road Rash 64 via static recompilation. Windows-only upstream; runs via Proton. Supply your own ROM on first launch.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "RoadRash64Recompiled-*-Win64.zip"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/RoadRash64Recompiled.exe"
+      },
+      "flattenRoot": true,
+      "tags": [
+        "n64",
+        "racing",
+        "3d"
+      ],
+      "latestVersion": "v1.1.0",
+      "steamGridDbId": 38158,
+      "_reason": "Windows-only: upstream publishes no Linux asset; the Windows build runs via Proton."
+    },
+    {
+      "id": "ape-escape-recomp",
+      "name": "Ape Escape",
+      "project": "Ape Escape Recompiled",
+      "platform": "ps1",
+      "repo": "mstan/ApeEscapeRecomp",
+      "description": "Native PC port of Ape Escape via static recompilation (psxrecomp). Playable preview. On first launch the app asks for your own USA disc image (SCUS-94423) — a .cue/.bin pair, not a bare .iso, since .iso discards the XA sectors used for music and FMV. A retail BIOS is optional: the MIT OpenBIOS is bundled and used by default.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "ApeEscapeRecomp-*-windows-x64.zip",
+        "linux": "ApeEscapeRecomp-*-linux-x86_64.AppImage"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/ApeEscapeRecomp.exe",
+        "linux": "{installDir}/ApeEscapeRecomp.AppImage"
+      },
+      "tags": [
+        "ape-escape",
+        "ps1",
+        "platformer",
+        "3d"
+      ],
+      "latestVersion": "v0.2.1",
+      "steamGridDbId": 36806
+    },
+    {
+      "id": "megamanx6-recomp",
+      "name": "Mega Man X6",
+      "project": "Mega Man X6 Recompiled",
+      "platform": "ps1",
+      "repo": "mstan/MegaManX6Recomp",
+      "description": "Native PC port of Mega Man X6 via static recompilation (psxrecomp). On first launch the app asks for your own USA disc image — a .cue/.bin pair rather than a bare .iso. A retail BIOS is optional: the MIT OpenBIOS is bundled and used by default.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "MegaManX6Recomp-*-windows-x64.zip",
+        "linux": "MegaManX6Recomp-*-linux-x86_64.AppImage"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/MegaManX6Recomp.exe",
+        "linux": "{installDir}/MegaManX6Recomp.AppImage"
+      },
+      "tags": [
+        "mega-man",
+        "ps1",
+        "platformer",
+        "action",
+        "2d"
+      ],
+      "latestVersion": "v1.0.10",
+      "steamGridDbId": 33539
+    },
+    {
+      "id": "tomba2-recomp",
+      "name": "Tomba! 2: The Evil Swine Return",
+      "project": "Tomba! 2 Recompiled",
+      "platform": "ps1",
+      "repo": "mstan/Tomba2Recomp",
+      "description": "Native PC port of Tomba! 2 via static recompilation (psxrecomp). Adds 21:9 support and full-rate OpenGL rendering. On first launch the app asks for your own USA disc image — this is a multi-track disc, so a .cue/.bin set is required rather than a bare .iso. A retail BIOS is optional: the MIT OpenBIOS is bundled and used by default.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "Tomba2Recomp-*-windows-x64.zip",
+        "linux": "Tomba2Recomp-*-linux-x86_64.AppImage"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/Tomba2Recomp.exe",
+        "linux": "{installDir}/Tomba2Recomp.AppImage"
+      },
+      "tags": [
+        "tomba",
+        "ps1",
+        "platformer",
+        "adventure",
+        "2d"
+      ],
+      "latestVersion": "v0.0.9",
+      "steamGridDbId": 36291
+    },
+    {
+      "id": "bloodyroar2-recomp",
+      "name": "Bloody Roar II",
+      "project": "Bloody Roar II Recompiled",
+      "platform": "ps1",
+      "repo": "novapowers0/BloodyRoar2Recomp",
+      "description": "Native PC port of Bloody Roar II via static recompilation, with from-scratch widescreen and bundled enhancement mods (PGXP, fast loading, unlock-all, turbo). This entry installs the USA build (SCUS-94424); a separate European build (SLES-01722) exists upstream. The recompiler translates one specific disc's code, so the two are not interchangeable. On first launch the app asks for your own disc image; a retail BIOS is optional, as MIT OpenBIOS is bundled.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "BloodyRoar2-US-v*.zip",
+        "linux": "BloodyRoar2-US-linux-x64-*.zip"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/BloodyRoar2-US/BloodyRoar2_Recompiled_USA.exe",
+        "linux": "{installDir}/BloodyRoar2-US/BloodyRoar2_Recompiled_USA"
+      },
+      "tags": [
+        "bloody-roar",
+        "ps1",
+        "fighting",
+        "3d"
+      ],
+      "latestVersion": "v0.6.2",
+      "steamGridDbId": 34481
+    },
+    {
+      "id": "psydoom",
+      "name": "Doom",
+      "project": "PsyDoom",
+      "platform": "ps1",
+      "repo": "BodbDearg/PsyDoom",
+      "description": "Native PC port of PlayStation Doom (and Final Doom) built on a reverse engineering of the original PSX executable. Adds uncapped framerates, mouse look and modding support while preserving the PSX renderer and soundtrack. Requires your own PlayStation Doom disc image.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "PsyDoom_*_Windows_x86_64.zip",
+        "linux": "PsyDoom_*_Linux_x86_64.AppImage"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/PsyDoom.exe",
+        "linux": "{installDir}/PsyDoom.AppImage"
+      },
+      "tags": [
+        "doom",
+        "ps1",
+        "fps",
+        "3d"
+      ],
+      "latestVersion": "releases/1.1.1",
+      "steamGridDbId": 2460
+    },
+    {
+      "id": "silent-hill-pc",
+      "name": "Silent Hill",
+      "project": "Silent Hill PC Port",
+      "platform": "ps1",
+      "repo": "SlickAmogus/silent-hill-decomp",
+      "description": "Native PC port of Silent Hill built on the decompilation. Cross-platform beta with a built-in launcher, randomizer and texture/audio override support. Your disc image is staged into the port's gamedata folder; the port identifies discs by their ISO header, so USA and PAL dumps both work.",
+      "installType": "rom_extract",
+      "releaseAssets": {
+        "windows": "SHPC_beta-*.zip",
+        "linux": "SHPC-linux-x64_*.tar.gz"
+      },
+      "romInfo": {
+        "description": "Provide your legally owned Silent Hill PS1 disc image (.bin/.cue). A raw MODE2/2352 .bin preserves the XA audio and FMV a cooked .iso discards.",
+        "validChecksums": [],
+        "extractionCommand": "",
+        "fileType": "data_file",
+        "extensions": [
+          "bin",
+          "iso",
+          "img"
+        ],
+        "placeRomAs": "SHPC-linux-x64/gamedata/disc.bin"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/SilentHillPC.exe",
+        "linux": "{installDir}/SHPC-linux-x64/SilentHillPC"
+      },
+      "tags": [
+        "silent-hill",
+        "ps1",
+        "survival-horror",
+        "3d"
+      ],
+      "latestVersion": "crossplatform-beta",
+      "steamGridDbId": 37313
+    },
+    {
+      "id": "ctr-native",
+      "name": "Crash Team Racing",
+      "project": "CTR Native",
+      "platform": "ps1",
+      "repo": "CTR-tools/ctr-native",
+      "description": "Native PC port of Crash Team Racing built on the reverse engineering effort. Requires your own NTSC-U retail disc image in the common raw MODE2/2352 .bin layout — a cooked 2048-byte .iso does not preserve the XA/STR sectors the game needs for audio and video.",
+      "installType": "rom_extract",
+      "releaseAssets": {
+        "windows": "ctr-native-*-windows-x86.zip",
+        "linux": "ctr-native-*-linux-x86.tar.gz"
+      },
+      "romInfo": {
+        "description": "Provide your legally owned NTSC-U Crash Team Racing disc image as a raw MODE2/2352 .bin (data track starting at byte 0).",
+        "validChecksums": [],
+        "extractionCommand": "",
+        "fileType": "data_file",
+        "extensions": [
+          "bin",
+          "img"
+        ],
+        "placeRomAs": "assets/ctr-u.bin"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/ctr_native.exe",
+        "linux": "{installDir}/ctr_native"
+      },
+      "flattenRoot": true,
+      "tags": [
+        "crash-bandicoot",
+        "ps1",
+        "racing",
+        "3d"
+      ],
+      "latestVersion": "beta-7.1",
+      "steamGridDbId": 36474
+    },
+    {
+      "id": "open-nectar",
+      "name": "Pikmin",
+      "project": "Open Nectar",
+      "platform": "gc",
+      "repo": "SSunnKing/Open-Nectar---Pikmin-Native-PC-Port",
+      "description": "Native PC port of Pikmin built on the decompilation, with the original JAudio sound engine, photo mode and configurable Pikmin limits. Self-contained build — no system dependencies beyond OpenGL. Requires your own legal, uncompressed Pikmin USA Rev. 1 (GPIE01) dump in ISO or GCM format; compressed RVZ/GCZ/WIA images are rejected. Pre-rendered opening and ending cutscenes currently play audio without picture.",
+      "installType": "prebuilt",
+      "releaseAssets": {
+        "windows": "nectar-windows.zip",
+        "linux": "nectar-linux.tar.gz"
+      },
+      "launchCommand": {
+        "windows": "{installDir}/nectar-launcher.exe",
+        "linux": "{installDir}/nectar-linux/nectar-launcher"
+      },
+      "tags": [
+        "pikmin",
+        "gc",
+        "strategy",
+        "3d"
+      ],
+      "latestVersion": "0.3.5",
+      "steamGridDbId": 21114
+    },
+    {
+      "id": "star-fox-adventures",
+      "name": "Star Fox Adventures",
+      "project": "SFA-Decomp",
+      "platform": "gc",
+      "repo": "zcanann/SFA-Decomp",
+      "description": "Matching decompilation of Star Fox Adventures — the most advanced unfinished GameCube decompilation, at roughly 96% matched.",
+      "installType": "prebuilt",
+      "releaseAssets": {},
+      "launchCommand": {},
+      "status": "in_progress",
+      "_reason": "Decompilation in progress (~96% matched, ~99% of functions as of 2026-09-09). No PC port exists yet.",
+      "tags": [
+        "starfox",
+        "gc"
+      ],
+      "website": null,
+      "steamGridDbId": 38820
     }
   ]
 }

--- a/plugins/recomp/games.json
+++ b/plugins/recomp/games.json
@@ -957,7 +957,7 @@
       "description": "Open-source engine replacement for The Elder Scrolls III: Morrowind. Requires original game data from Steam/GOG.",
       "installType": "rom_extract",
       "releaseAssets": {
-        "windows": "OpenMW-*-win64.exe",
+        "windows": "OpenMW-*-Windows-x64.exe",
         "linux": "openmw-*-Linux-64Bit.tar.gz"
       },
       "romInfo": {
@@ -8525,11 +8525,10 @@
       "installType": "prebuilt",
       "releaseAssets": {
         "windows": "AITD_REHAUNTED_*_Win64.zip",
-        "linux": "AITD_REHAUNTED_*_Linux.tar.gz"
+        "linux": null
       },
       "launchCommand": {
-        "windows": "{installDir}/Tatou.exe",
-        "linux": "{installDir}/launch_tatou.sh"
+        "windows": "{installDir}/Tatou.exe"
       },
       "tags": [
         "alone-in-the-dark",

--- a/plugins/recomp/lib/pipeline-install.test.ts
+++ b/plugins/recomp/lib/pipeline-install.test.ts
@@ -274,3 +274,60 @@ describe("uninstallGame — orphan cleanup (FIX 2)", () => {
     expect(persisted.romPaths?.[entry.id]).toBeUndefined();
   });
 });
+
+describe("installGame — flattenRoot", () => {
+  // Simulate an upstream that wraps the whole build in a version-stamped
+  // top-level folder (Snap64Recomp-1.0.2-linux-x86_64/, LodRecomp-v…/).
+  // The wrapper name changes every release, so the entry can't encode it
+  // in `launchCommand` — `flattenRoot` hoists it instead.
+  function wrapInVersionedDir(binary: string) {
+    return async (dest: string) => {
+      const inner = join(dest, "Thing-1.2.3-linux-x86_64");
+      await mkdir(inner, { recursive: true });
+      await writeFile(join(inner, binary), "#!/bin/sh\n");
+    };
+  }
+
+  it("hoists a single top-level directory when the entry opts in", async () => {
+    const { installGame } = await import("./pipeline");
+    extractProducer = wrapInVersionedDir("test");
+
+    const entry = makeEntry({ flattenRoot: true });
+    await installGame(entry, baseState(), undefined, () => {});
+
+    const installDir = join(sandbox, "games", entry.id);
+    // `{installDir}/test` resolves — the wrapper is gone.
+    expect(existsSync(join(installDir, "test"))).toBe(true);
+    expect(existsSync(join(installDir, "Thing-1.2.3-linux-x86_64"))).toBe(false);
+  });
+
+  it("leaves a stable wrapper directory alone when the entry does not opt in", async () => {
+    const { installGame } = await import("./pipeline");
+    extractProducer = wrapInVersionedDir("test");
+
+    // No `flattenRoot` — this is the `perfect-dark` shape, where the
+    // wrapper is stable and deliberately part of `launchCommand`.
+    const entry = makeEntry();
+    await installGame(entry, baseState(), undefined, () => {});
+
+    const installDir = join(sandbox, "games", entry.id);
+    expect(existsSync(join(installDir, "Thing-1.2.3-linux-x86_64", "test"))).toBe(true);
+    expect(existsSync(join(installDir, "test"))).toBe(false);
+  });
+
+  it("is a no-op for an archive that already extracted flat", async () => {
+    const { installGame } = await import("./pipeline");
+    extractProducer = async (dest) => {
+      await mkdir(dest, { recursive: true });
+      await writeFile(join(dest, "test"), "#!/bin/sh\n");
+      await writeFile(join(dest, "readme.txt"), "hi");
+    };
+
+    const entry = makeEntry({ flattenRoot: true });
+    await installGame(entry, baseState(), undefined, () => {});
+
+    const installDir = join(sandbox, "games", entry.id);
+    expect(existsSync(join(installDir, "test"))).toBe(true);
+    expect(existsSync(join(installDir, "readme.txt"))).toBe(true);
+  });
+});

--- a/plugins/recomp/lib/pipeline-install.test.ts
+++ b/plugins/recomp/lib/pipeline-install.test.ts
@@ -331,3 +331,31 @@ describe("installGame — flattenRoot", () => {
     expect(existsSync(join(installDir, "readme.txt"))).toBe(true);
   });
 });
+
+describe("installGame — flattenRoot launch-target guard", () => {
+  it("fails loudly instead of promoting a broken install when the hoist did not happen", async () => {
+    const { installGame } = await import("./pipeline");
+    const { loadState } = await import("./state");
+
+    // Upstream added a loose top-level file beside the versioned wrapper,
+    // so flattenSingleRoot's "exactly one entry" guard makes it a no-op
+    // and `{installDir}/test` never materialises.
+    extractProducer = async (dest) => {
+      const inner = join(dest, "Thing-1.2.3-linux-x86_64");
+      await mkdir(inner, { recursive: true });
+      await writeFile(join(inner, "test"), "#!/bin/sh\n");
+      await writeFile(join(dest, "README.md"), "loose file");
+    };
+
+    const entry = makeEntry({ flattenRoot: true });
+    await expect(
+      installGame(entry, baseState(), undefined, () => {}),
+    ).rejects.toThrow(/launch target "test" was not found/);
+
+    // And it must not leave a half-installed dir or a persisted record.
+    const installDir = join(sandbox, "games", entry.id);
+    expect(existsSync(installDir)).toBe(false);
+    expect(existsSync(`${installDir}.partial`)).toBe(false);
+    expect((await loadState()).games[entry.id]).toBeUndefined();
+  });
+});

--- a/plugins/recomp/lib/pipeline.ts
+++ b/plugins/recomp/lib/pipeline.ts
@@ -617,6 +617,28 @@ export async function installGame(
     // `launchCommand` and must not be flattened.
     if (entry.manualImport || entry.flattenRoot) {
       await flattenSingleRoot(partialDir);
+      // `flattenSingleRoot` is a deliberate no-op unless the archive has
+      // EXACTLY one top-level entry and it's a directory. That guard is
+      // right, but it fails quietly: the day an upstream adds a loose
+      // top-level README beside its versioned wrapper, the hoist stops
+      // happening, `{installDir}/<binary>` no longer resolves, and
+      // `makeExecutable` also returns silently on a missing path — so a
+      // broken install would be promoted and shortcut with no error
+      // anywhere. `flattenRoot` exists precisely because these wrappers
+      // are unstable, so check the launch target before promoting.
+      const flattenedCmd = entry.launchCommand[resolvedPlatform];
+      if (flattenedCmd) {
+        const exe = resolveTemplate(flattenedCmd, partialDir, romPath).split(
+          /\s+/,
+        )[0]!;
+        if (!existsSync(exe)) {
+          throw new Error(
+            `${entry.name}: after flattening the archive root, the launch target ` +
+              `"${basename(exe)}" was not found. The upstream archive layout has ` +
+              `probably changed — this entry's flattenRoot/launchCommand needs updating.`,
+          );
+        }
+      }
     }
     onEvent({
       type: "progress", gameId, stage: "extracting",

--- a/plugins/recomp/lib/pipeline.ts
+++ b/plugins/recomp/lib/pipeline.ts
@@ -336,8 +336,10 @@ function manualImportPlatform(entry: GameEntry): PlatformName {
  * build in a single versioned top-level folder (e.g.
  * `TimeSplittersRewind_EarlyAccess_V03.3/…`), which would otherwise
  * push the launch binary one level below where the entry's
- * `launchCommand` (`{installDir}/Foo.exe`) expects it. No-op when the
- * archive extracted flat or has multiple top-level entries.
+ * `launchCommand` (`{installDir}/Foo.exe`) expects it. Several GitHub
+ * releases do the same (`Snap64Recomp-1.0.2-linux-x86_64/`), which is
+ * what `GameEntry.flattenRoot` opts into. No-op when the archive
+ * extracted flat or has multiple top-level entries.
  */
 async function flattenSingleRoot(dir: string): Promise<void> {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -608,9 +610,12 @@ export async function installGame(
         ? basename(resolveTemplate(launchCmd, partialDir))
         : undefined;
     await extractArchive(downloadPath, partialDir, appimageBasename);
-    // Manual-import archives commonly wrap the build in one versioned
-    // top-level folder; hoist it so `{installDir}/<binary>` resolves.
-    if (entry.manualImport) {
+    // Manual-import archives — and some GitHub releases — wrap the build
+    // in one versioned top-level folder; hoist it so
+    // `{installDir}/<binary>` resolves. Opt-in per entry, because
+    // entries with a *stable* wrapper (perfect-dark) encode it in
+    // `launchCommand` and must not be flattened.
+    if (entry.manualImport || entry.flattenRoot) {
       await flattenSingleRoot(partialDir);
     }
     onEvent({

--- a/plugins/recomp/lib/ranking.ts
+++ b/plugins/recomp/lib/ranking.ts
@@ -28,4 +28,5 @@ export const HEADLINE_IDS: ReadonlyArray<string> = [
   "dusklight",            // Twilight Princess (recompiled)
   "sm64-decomp",          // Super Mario 64 (Render96 HD, native) — recommended
   "sm64-render96-rt",     // Super Mario 64 (Render96 + Ray Tracing) — premium
+  "dk64-recomp",          // Donkey Kong 64 (recompiled) — 1.0 mainline N64Recomp
 ];

--- a/plugins/recomp/lib/types.ts
+++ b/plugins/recomp/lib/types.ts
@@ -286,6 +286,20 @@ export interface GameEntry {
   tags: string[];
   website?: string;
   versionPattern?: string;
+  /**
+   * Hoist a single top-level directory out of the extracted archive.
+   *
+   * Some upstreams wrap the whole build in a *version-stamped* folder
+   * (`Snap64Recomp-1.0.2-linux-x86_64/`, `LodRecomp-v0.2.26-linux-x64/`),
+   * so the wrapper's name changes every release and can't be baked into
+   * `launchCommand`. Opt in here and the launch binary sits at
+   * `{installDir}/<binary>` regardless of the release.
+   *
+   * Leave unset when the wrapper name is *stable* (`perfect-dark`'s
+   * `pd-x86_64-linux/`) — those entries encode the directory in
+   * `launchCommand` on purpose, and flattening would break them.
+   */
+  flattenRoot?: boolean;
   preservePaths?: string[];
   releaseChecksums?: Record<string, string>;
   /**

--- a/plugins/recomp/scripts/audit-urls.ts
+++ b/plugins/recomp/scripts/audit-urls.ts
@@ -100,20 +100,35 @@ async function check(g: Game): Promise<Result> {
   if (!rel) {
     return { id: g.id, repo: g.repo, ok: false, reason: "no releases published" };
   }
-  // Check linux first, then windows (Proton) — whichever is declared.
+  // Check EVERY declared platform, not just the first that matches.
+  //
+  // Returning ok on the first hit hides the exact regression this audit
+  // exists to catch: `banjo-recomp` declares both a Linux and a Windows
+  // glob, and when v1.0.2 moved the Linux asset from `.zip` to `.tar.gz`
+  // the Windows pattern still matched — so the entry would have reported
+  // "ok (matched windows)" for the whole time its Linux build was
+  // silently falling back to Proton. Linux is the platform that matters
+  // on a Deck, so a miss on ANY declared pattern is a failure.
+  const missed: string[] = [];
+  const matched: string[] = [];
   for (const plat of ["linux", "windows"] as const) {
     const pat = assets[plat];
-    if (!pat) continue;
+    if (!pat) continue; // not shipped for this platform — nothing to check
     if (rel.assets.some((a) => globToRe(pat).test(a.name))) {
-      return { id: g.id, repo: g.repo, ok: true, reason: `matched ${plat}` };
+      matched.push(plat);
+    } else {
+      missed.push(`${plat} '${pat}'`);
     }
   }
-  return {
-    id: g.id,
-    repo: g.repo,
-    ok: false,
-    reason: `no asset matches '${pattern}' in latest release`,
-  };
+  if (missed.length > 0) {
+    return {
+      id: g.id,
+      repo: g.repo,
+      ok: false,
+      reason: `no asset matches ${missed.join(" + ")} in latest release`,
+    };
+  }
+  return { id: g.id, repo: g.repo, ok: true, reason: `matched ${matched.join("+")}` };
 }
 
 // Bounded concurrency so we don't hammer the API.

--- a/plugins/recomp/scripts/audit-urls.ts
+++ b/plugins/recomp/scripts/audit-urls.ts
@@ -45,6 +45,7 @@ interface Game {
   repo: string;
   installType: string;
   releaseAssets?: Record<string, string | null>;
+  manualImport?: { pageUrl: string };
 }
 
 type Result = { id: string; repo: string; ok: boolean; reason: string };
@@ -58,9 +59,15 @@ const games: Game[] = JSON.parse(
 // intentional "in progress / not installable yet" catalog entries (they
 // surface upstream decomp/recomp projects for visibility); they're not
 // download targets, so auditing them as broken would be noise.
+//
+// `manualImport` entries are skipped for the same reason: the user
+// downloads the build from an off-GitHub page (IndieDB/ModDB), so the
+// entry carries no `repo` and the GitHub lookup can only ever 404.
 const targets = games.filter(
   (g) =>
     (g.installType === "prebuilt" || g.installType === "rom_extract") &&
+    !g.manualImport &&
+    g.repo &&
     g.releaseAssets &&
     Object.values(g.releaseAssets).some((v) => typeof v === "string" && v),
 );


### PR DESCRIPTION
## Why

The catalog had drifted since the July sweep. Five entries had **silently
stopped matching their upstream assets** — a broken glob doesn't error, it
falls back to the Windows build under Proton (or breaks outright), so this
sat unnoticed. Meanwhile the N64/PS1/GameCube scene shipped a lot: Donkey
Kong 64, Pokémon Snap, Banjo-Kazooie's decomp port, and the first genuinely
prebuilt PS1 recompilations.

Every asset name, glob and launch path here was verified live against the
GitHub API on 2026-09-09, including downloading the release archives.

## The finding worth reading

**Most "releases" in the 2026 recomp wave are build harnesses, not games.**

Klonoa's `kdp-0.1.3-linux-x64.zip` is 2,125 files of psxrecomp toolchain plus
a `README-SETUP.txt` telling you to install Python and compile the game
locally from your own `.cue`. Same for Yu-Gi-Oh! Forbidden Memories, Valkyrie
Profile, and SoulCalibur II — whose *Steam Deck* package says it outright:
*"This package contains NO game data and NO game code."*

The filename doesn't tell you which: `-linux-x64.zip` means both things
depending on the project. Cataloguing one as `prebuilt` would install a
source tree and launch nothing. `docs/recomp-new-titles-2026-09.md` records
the rule and the verified evidence table, because this is the finding most
likely to be rediscovered the hard way.

Those titles are **deferred** pending a `setup_package` install type — not
shipped broken.

## Repairs (the live bugs)

| Entry | What broke |
|---|---|
| `banjo-recomp` | v1.0.2 switched `.zip` → `.tar.gz` |
| `mariokart64-recomp`, `dnzh-recomp`, `starfox64-recomp` | pkgforge-dev's 2026-09-01 rebuild dropped the underscores (`MarioKart_64_Recompiled-` → `MarioKart64Recompiled-`). Now anchored on the stable `*Recompiled-*-anylinux-x86_64` tail |
| `viva-pinata-tip-recomp`, `opentdu` | asset prefixes renamed upstream |
| `perfect-dark` | repo transferred to `perfect-dark-pc-port` |
| `starship` | `_reason` claimed HarbourMasters publishes no release binaries — false since v2.0.0. Promoted to installable |

Two entries were held back by notes that had gone stale:

- **`megaman64-recomp`** blamed "a nested zip→tar.gz the installer doesn't
  unwrap" — but `extractNestedArchives()` has handled that for a while.
  Verified against the v0.9.1 archive; it now installs natively on Linux
  instead of via Proton. Donkey Kong 64 has the identical wrapper shape.

## New titles (19)

**N64** — Donkey Kong 64, Pokémon Snap, Space Station Silicon Valley,
Mischief Makers, Automobili Lamborghini, Castlevania: Legacy of Darkness,
Extreme-G, Lighthouse (Banjo-Kazooie), Golden Balloon (Diddy Kong Racing),
plus Pokémon Stadium and Road Rash 64 via Proton.

**PS1** — Ape Escape, Mega Man X6, Tomba! 2, Bloody Roar II, PsyDoom,
Silent Hill, CTR Native.

**GameCube** — Open Nectar (Pikmin).

## Pipeline

Adds `GameEntry.flattenRoot` — an opt-in that hoists a single
**version-stamped** top-level directory out of the extracted archive
(`Snap64Recomp-1.0.2-linux-x86_64/`, `LodRecomp-v0.2.26-linux-x64/`). It
reuses the existing `flattenSingleRoot()`, previously gated on
`manualImport` alone.

Deliberately opt-in: entries with a *stable* wrapper (`perfect-dark`'s
`pd-x86_64-linux/`) encode it in `launchCommand` on purpose and would break
under unconditional flattening.

## On Melee

`doldecomp/melee` hit 100% matched on 2026-09-07 — genuinely. But it builds
a **GameCube DOL**, not a PC binary, and publishes no releases. A matching
decompilation recovers the source; a port is a separate project on top of
it. The one Linux port fork is a day-old v0.1.0 prerelease in which saving
does not work.

Rather than stay silent on the biggest story in the scene, the
`super-smash-bros-melee` tracker row now carries that nuance in `_reason`,
alongside refreshed GameCube rows (Wind Waker, Metroid Prime, Pikmin 1/2,
Kirby Air Ride — whose better-known `doldecomp/kar` repo has been dead since
Feb 2025) and a new Star Fox Adventures row.

## Verification

- Full suite green: **4135 tests** (3546 backend / 589 UI), typecheck (both),
  lint, knip, plugin specs
- `audit-urls.ts` clean. It now checks **every declared platform** rather than
  returning ok on the first glob that matched — the lenient version reported
  "ok (matched windows)" for `banjo-recomp` throughout its Linux breakage,
  which is the very regression class this audit exists to catch. Tightening
  it uncovered two further pre-existing breakages (`openmw`, `aitd-rehaunted`),
  both fixed here. It also skips `manualImport` entries, which carry no `repo`
  and could only ever report a false 404
- **Every new entry's exact `{installDir}/…` launch path resolved against the
  real downloaded archive.** Worth noting `test-installers.ts --deep` alone
  would *not* have caught a wrong path — it accepts the launch binary at any
  depth in the tree, so it can't detect a missing `flattenRoot`
- Deployed to a Steam Deck and driven via CDP: backend logs
  `[recomp] Loaded: 492 games`, grid renders 64 installable, all 20 new
  titles present, PS1 filter working, SteamGridDB artwork resolving

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DhmYwR4VSFD1dajgSDzkN

